### PR TITLE
Add six and jsonschema to required libraries for install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     'click>=6.0',  # for console scripts,
     'tqdm',  # for readxml
     'six',  # for modifiers
-    'jsonschema>=v3.0.0a2',  # for utils
+    'jsonschema>=v3.0.0a2',  # for utils, alpha-release for draft 6
   ],
   extras_require = {
     'xmlimport': [
@@ -52,8 +52,7 @@ setup(
        'sphinxcontrib-napoleon',
        'sphinx_rtd_theme',
        'nbsphinx',
-       'jsonpatch',
-       'jsonschema>=v3.0.0a2'  # alpha-release for draft 6
+       'jsonpatch'
     ]
   },
   entry_points = {


### PR DESCRIPTION
Resolves #227 and resolves #223. `pyhf.modifiers` imports from `six` on the very fist line, so as long as Python2 is still supported by pyhf then `six` will need to be a required dependency. Similarly `pyhf.utils` needs `jsonschema`.

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
