### PR TITLE
store tests in a jsonnet library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ extras_require = {
         'nbsphinx',
         'm2r',
         'jsonpatch',
+        'jsonnet',
         'ipython<7',  # jupyter_console and ipython clash in dependency requirement -- downgrade ipython for now
     ]
 }

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -363,75 +363,7 @@ def source_2bin_2channel_coupledhisto():
 
 @pytest.fixture(scope='module')
 def spec_2bin_2channel_coupledhistosys(source=source_2bin_2channel_coupledhisto()):
-    spec = {
-        'channels': [
-            {
-                'name': 'signal',
-                'samples': [
-                    {
-                        'name': 'signal',
-                        'data': source['channels']['signal']['bindata']['sig'],
-                        'modifiers': [
-                            {
-                                'name': 'mu',
-                                'type': 'normfactor',
-                                'data': None
-                            }
-                        ]
-                    },
-                    {
-                        'name': 'bkg1',
-                        'data': source['channels']['signal']['bindata']['bkg1'],
-                        'modifiers': [
-                            {
-                                'name': 'coupled_histosys',
-                                'type': 'histosys',
-                                'data': {
-                                    'lo_data': source['channels']['signal']['bindata']['bkg1_dn'],
-                                    'hi_data': source['channels']['signal']['bindata']['bkg1_up']
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        'name': 'bkg2',
-                        'data': source['channels']['signal']['bindata']['bkg2'],
-                        'modifiers': [
-                            {
-                                'name': 'coupled_histosys',
-                                'type': 'histosys',
-                                'data': {
-                                    'lo_data': source['channels']['signal']['bindata']['bkg2_dn'],
-                                    'hi_data': source['channels']['signal']['bindata']['bkg2_up']
-                                }
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                'name': 'control',
-                'samples': [
-                    {
-                        'name': 'background',
-                        'data': source['channels']['control']['bindata']['bkg1'],
-                        'modifiers': [
-                            {
-                                'name': 'coupled_histosys',
-                                'type': 'histosys',
-                                'data': {
-                                    'lo_data': source['channels']['control']['bindata']['bkg1_dn'],
-                                    'hi_data': source['channels']['control']['bindata']['bkg1_up']
-                                }
-                            }
-                        ]
-                    }
-                ]
-            }
-        ]
-    }
-    return spec
-
+    return render_template('two_bin_two_channel_coupledhistosys_test',source)
 
 @pytest.fixture(scope='module')
 def expected_result_2bin_2channel_coupledhistosys(mu=1.):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -78,39 +78,7 @@ def source_1bin_normsys():
 
 @pytest.fixture(scope='module')
 def spec_1bin_normsys(source=source_1bin_normsys()):
-    spec = {
-        'channels': [
-            {
-                'name': 'singlechannel',
-                'samples': [
-                    {
-                        'name': 'signal',
-                        'data': source['bindata']['sig'],
-                        'modifiers': [
-                            {
-                                'name': 'mu',
-                                'type': 'normfactor',
-                                'data': None
-                            }
-                        ]
-                    },
-                    {
-                        'name': 'background',
-                        'data': source['bindata']['bkg'],
-                        'modifiers': [
-                            {
-                                'name': 'bkg_norm',
-                                'type': 'normsys',
-                                'data': {'lo': 0.90, 'hi': 1.10}
-                            }
-                        ]
-                    }
-                ]
-            }
-        ]
-    }
-    return spec
-
+    return render_template('simple',source)
 
 @pytest.fixture(scope='module')
 def expected_result_1bin_normsys(mu=1.):
@@ -153,42 +121,7 @@ def source_2bin_histosys_example2():
 
 @pytest.fixture(scope='module')
 def spec_2bin_histosys(source=source_2bin_histosys_example2()):
-    spec = {
-        'channels': [
-            {
-                'name': 'singlechannel',
-                'samples': [
-                    {
-                        'name': 'signal',
-                        'data': source['bindata']['sig'],
-                        'modifiers': [
-                            {
-                                'name': 'mu',
-                                'type': 'normfactor',
-                                'data': None
-                            }
-                        ]
-                    },
-                    {
-                        'name': 'background',
-                        'data': source['bindata']['bkg'],
-                        'modifiers': [
-                            {
-                                'name': 'bkg_norm',
-                                'type': 'histosys',
-                                'data': {
-                                    'lo_data': source['bindata']['bkgsys_dn'],
-                                    'hi_data': source['bindata']['bkgsys_up']
-                                }
-                            }
-                        ]
-                    }
-                ]
-            }
-        ]
-    }
-    return spec
-
+    return render_template('histosys_test',source)
 
 @pytest.fixture(scope='module')
 def expected_result_2bin_histosys(mu=1):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -6,8 +6,7 @@ import _jsonnet
 def render_template(template, source):
     template_path = 'validation/templates.libsonnet'
     to_render = '''
-local templates = std.extVar("templates");
-templates.{template} {{
+std.extVar("templates").{template} {{
     source:: {source}
 }}
 '''.format(

--- a/validation/templates.libsonnet
+++ b/validation/templates.libsonnet
@@ -42,5 +42,41 @@
             {"config": {"poi": "mu"}, "name": "HelloWorld"}
             ]
         },
+    },
+    histosys_test: {
+        local model = self.source,
+        local channel = "singlechannel",
+        'channels': [
+            {
+                'name': 'singlechannel',
+                'samples': [
+                    {
+                        'name': 'signal',
+                        'data': model.bindata.sig,
+                        'modifiers': [
+                            {
+                                'name': 'mu',
+                                'type': 'normfactor',
+                                'data': null
+                            }
+                        ]
+                    },
+                    {
+                        'name': 'background',
+                        'data': model.bindata.bkg,
+                        'modifiers': [
+                            {
+                                'name': 'bkg_norm',
+                                'type': 'histosys',
+                                'data': {
+                                    'lo_data': model.bindata.bkgsys_dn,
+                                    'hi_data': model.bindata.bkgsys_up
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/validation/templates.libsonnet
+++ b/validation/templates.libsonnet
@@ -1,0 +1,46 @@
+{
+    simple: {
+        local model = self.source,
+        local channel = "singlechannel",
+        "channels": [
+            {
+                "name": channel,
+                "samples": [
+                    {
+                        "data": model.bindata.sig,
+                        "modifiers": [
+                            {
+                                "data": null,
+                                "name": "mu",
+                                "type": "normfactor"
+                            }
+                        ],
+                        "name": "signal"
+                    },
+                    {
+                        "data": model.bindata.bkg,
+                        "modifiers": [
+                            {
+                                "data": {
+                                    "lo": 0.9,
+                                    "hi": 1.1
+                                },
+                                "name": "bkg_norm",
+                                "type": "normsys"
+                            }
+                        ],
+                        "name": "background"
+                    }
+                ]
+            }
+        ],
+        "data" : {
+            [channel]: model.bindata.data
+        },
+        "toplvl": {
+            "measurements": [
+            {"config": {"poi": "mu"}, "name": "HelloWorld"}
+            ]
+        },
+    }
+}

--- a/validation/templates.libsonnet
+++ b/validation/templates.libsonnet
@@ -78,5 +78,74 @@
                 ]
             }
         ]
+    },
+    two_bin_two_channel_coupledhistosys_test: {
+        local model = self.source,
+        local channel = "singlechannel",
+        'channels': [
+            {
+                'name': 'signal',
+                'samples': [
+                    {
+                        'name': 'signal',
+                        'data': model.channels.signal.bindata.sig,
+                        'modifiers': [
+                            {
+                                'name': 'mu',
+                                'type': 'normfactor',
+                                'data': null
+                            }
+                        ]
+                    },
+                    {
+                        'name': 'bkg1',
+                        'data': model.channels.signal.bindata.bkg1,
+                        'modifiers': [
+                            {
+                                'name': 'coupled_histosys',
+                                'type': 'histosys',
+                                'data': {
+                                    'lo_data': model.channels.signal.bindata.bkg1_dn,
+                                    'hi_data': model.channels.signal.bindata.bkg1_up
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        'name': 'bkg2',
+                        'data': model.channels.signal.bindata.bkg2,
+                        'modifiers': [
+                            {
+                                'name': 'coupled_histosys',
+                                'type': 'histosys',
+                                'data': {
+                                    'lo_data': model.channels.signal.bindata.bkg2_dn,
+                                    'hi_data': model.channels.signal.bindata.bkg2_up
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                'name': 'control',
+                'samples': [
+                    {
+                        'name': 'background',
+                        'data': model.channels.control.bindata.bkg1,
+                        'modifiers': [
+                            {
+                                'name': 'coupled_histosys',
+                                'type': 'histosys',
+                                'data': {
+                                    'lo_data': model.channels.control.bindata.bkg1_dn,
+                                    'hi_data': model.channels.control.bindata.bkg1_up
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
     }
 }


### PR DESCRIPTION
# Description

A nice way to store spec templates is to use jsonnet  https://github.com/google/jsonnet

I added this here as a demo for the tests, but actually I was thinking maybe we could use this in the CLI as well

this works

```
cat << EOF| jsonnet - --ext-code-file templates=validation/templates.libsonnet|pyhf cls
std.extVar("templates").simple {
    source:: { bindata: {
        sig: [10], bkg: [50], data: [51]
    }}
}
EOF
```

e.g. the tempates in `pyhf.simplemodels` could acutally be jsonnet templates

related to #264 


# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
- [ ] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR
