### PR TITLE
Update TensorFlow and TensorFlow Probability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md
 
 extras_require = {
     'tensorflow': [
-        'tensorflow<1.12.0,>=1.10.0',
-        'tensorflow-probability==0.3.0',
+        'tensorflow>=1.12.0',
+        'tensorflow-probability>=0.5.0',
         'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
         'setuptools<=39.1.0',
     ],


### PR DESCRIPTION
# Description

Resolves #330 and resolves #361

TensorFlow Probability `v0.5.0` has the continuous approximation to the Poisson distribution that pyhf requested of the tfp team. tfp `v0.5.0` requires TensorFlow `v1.12` or later.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- Update TensorFlow Probability to v0.5.0 which has the continuous approximation to the Poisson distribution that pyhf requested of the tfp team. c.f. PR #302 and https://github.com/tensorflow/probability/issues/182
- Update TensorFlow to v1.12. This is both desired and tfp v0.5.0 requires TensorFlow v1.12 or later.
```
