### PR TITLE
feat: Add backend option to pyhf CLI

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -9,10 +9,10 @@ Questions
 Is it possible to set the backend from the CLI?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Not at the moment. `Pull Requests <https://github.com/scikit-hep/pyhf/compare>`__ are welcome.
-
-See also:
-  - :issue:`266`
+Yes.
+Use the :code:`--backend` option for :code:`pyhf cls` to specify a tensor backend.
+The default backend is NumPy.
+For more information see :code:`pyhf cls --help`.
 
 Troubleshooting
 ---------------

--- a/src/pyhf/cli/stats.py
+++ b/src/pyhf/cli/stats.py
@@ -5,7 +5,7 @@ import json
 
 from ..utils import hypotest, EqDelimStringParamType
 from ..workspace import Workspace
-from . import tensor, get_backend, set_backend, optimize
+from .. import tensor, get_backend, set_backend, optimize
 
 logging.basicConfig()
 log = logging.getLogger(__name__)

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -172,7 +172,7 @@ def pvals_from_teststat(sqrtqmu_v, sqrtqmuA_v, qtilde=False):
             return nullval, altval
 
         nullval, altval = tensorlib.conditional(
-            tensorlib.less(sqrtqmu_v, sqrtqmuA_v)[0], _true_case, _false_case
+            (sqrtqmu_v < sqrtqmuA_v)[0], _true_case, _false_case
         )
     CLsb = 1 - tensorlib.normal_cdf(nullval)
     CLb = 1 - tensorlib.normal_cdf(altval)

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -172,9 +172,7 @@ def pvals_from_teststat(sqrtqmu_v, sqrtqmuA_v, qtilde=False):
             return nullval, altval
 
         nullval, altval = tensorlib.conditional(
-            tensorlib.less(sqrtqmu_v[0], sqrtqmuA_v[0]),
-            _sqrtqmu_v_case,
-            _sqrtqmuA_v_case,
+            tensorlib.less(sqrtqmu_v, sqrtqmuA_v)[0], _sqrtqmu_v_case, _sqrtqmuA_v_case
         )
     CLsb = 1 - tensorlib.normal_cdf(nullval)
     CLb = 1 - tensorlib.normal_cdf(altval)

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -158,14 +158,24 @@ def pvals_from_teststat(sqrtqmu_v, sqrtqmuA_v, qtilde=False):
         nullval = sqrtqmu_v
         altval = -(sqrtqmuA_v - sqrtqmu_v)
     else:  # qtilde
-        if sqrtqmu_v < sqrtqmuA_v:
+
+        def _sqrtqmu_v_case():
             nullval = sqrtqmu_v
             altval = -(sqrtqmuA_v - sqrtqmu_v)
-        else:
+            return nullval, altval
+
+        def _sqrtqmuA_v_case():
             qmu = tensorlib.power(sqrtqmu_v, 2)
             qmu_A = tensorlib.power(sqrtqmuA_v, 2)
             nullval = (qmu + qmu_A) / (2 * sqrtqmuA_v)
             altval = (qmu - qmu_A) / (2 * sqrtqmuA_v)
+            return nullval, altval
+
+        nullval, altval = tensorlib.conditional(
+            tensorlib.less(sqrtqmu_v[0], sqrtqmuA_v[0]),
+            _sqrtqmu_v_case,
+            _sqrtqmuA_v_case,
+        )
     CLsb = 1 - tensorlib.normal_cdf(nullval)
     CLb = 1 - tensorlib.normal_cdf(altval)
     CLs = CLsb / CLb

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -159,12 +159,12 @@ def pvals_from_teststat(sqrtqmu_v, sqrtqmuA_v, qtilde=False):
         altval = -(sqrtqmuA_v - sqrtqmu_v)
     else:  # qtilde
 
-        def _sqrtqmu_v_case():
+        def _true_case():
             nullval = sqrtqmu_v
             altval = -(sqrtqmuA_v - sqrtqmu_v)
             return nullval, altval
 
-        def _sqrtqmuA_v_case():
+        def _false_case():
             qmu = tensorlib.power(sqrtqmu_v, 2)
             qmu_A = tensorlib.power(sqrtqmuA_v, 2)
             nullval = (qmu + qmu_A) / (2 * sqrtqmuA_v)
@@ -172,7 +172,7 @@ def pvals_from_teststat(sqrtqmu_v, sqrtqmuA_v, qtilde=False):
             return nullval, altval
 
         nullval, altval = tensorlib.conditional(
-            tensorlib.less(sqrtqmu_v, sqrtqmuA_v)[0], _sqrtqmu_v_case, _sqrtqmuA_v_case
+            tensorlib.less(sqrtqmu_v, sqrtqmuA_v)[0], _true_case, _false_case
         )
     CLsb = 1 - tensorlib.normal_cdf(nullval)
     CLb = 1 - tensorlib.normal_cdf(altval)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -99,6 +99,26 @@ def test_import_prepHistFactory_and_cls(tmpdir, script_runner):
         assert 'CLs_exp' in d
 
 
+@pytest.mark.parametrize(
+    "backend", ["numpy", "tensorflow", "pytorch"],
+)
+def test_cls_backend_option(tmpdir, script_runner, backend):
+    temp = tmpdir.join("parsed_output.json")
+    command = 'pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s}'.format(
+        temp.strpath
+    )
+    ret = script_runner.run(*shlex.split(command))
+
+    command = 'pyhf cls --backend {0:s} {1:s}'.format(backend, temp.strpath)
+    ret = script_runner.run(*shlex.split(command))
+
+    assert ret.success
+    d = json.loads(ret.stdout)
+    assert d
+    assert 'CLs_obs' in d
+    assert 'CLs_exp' in d
+
+
 def test_import_and_export(tmpdir, script_runner):
     temp = tmpdir.join("parsed_output.json")
     command = 'pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s}'.format(


### PR DESCRIPTION
# Description

Add ability to change the computational backend used by `pyhf` from the command line with a `--backend` flag.

**Example:**

```
$ curl -sL https://git.io/fjxXE | pyhf cls
{
    "CLs_exp": [
        0.07807427911686152,
        0.17472571775474582,
        0.35998495263681274,
        0.6343568235898907,
        0.8809947004472013
    ],
    "CLs_obs": 0.3599845631401913
}
$ curl -sL https://git.io/fjxXE | pyhf cls --backend pytorch
{
    "CLs_exp": [
        0.07808291912078857,
        0.1747395098209381,
        0.36000293493270874,
        0.6343730092048645,
        0.8810024857521057
    ],
    "CLs_obs": 0.3600029945373535
}
$ curl -sL https://git.io/fjxXE | pyhf cls --backend tensorflow
{
    "CLs_exp": [
        0.0780724585056305,
        0.17472276091575623,
        0.35998106002807617,
        0.6343533396720886,
        0.8809930086135864
    ],
    "CLs_obs": 0.35998106002807617
}
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add backend option for the pyhf cls command line API
* Add tests to test_scripts.py to cover the pyhf cls backend option
* Answer the FAQ on setting the backend at the CLI
```
