### PR TITLE
feat: Migrate to TensorFlow v2.0

### DIFF
--- a/docs/governance/ROADMAP.md
+++ b/docs/governance/ROADMAP.md
@@ -65,7 +65,7 @@ The roadmap will be executed over mostly Quarter 3 of 2019 through Quarter 1 of 
    - [ ] Add better Model creation [2019-Q4 → 2020-Q1]
    - [ ] Add background model support (Issue #514) [2019-Q4 → 2020-Q1]
    - [ ] Develop interface for the optimizers similar to tensor/backend [2019-Q4 → 2020-Q1]
-   - [ ] Migrate to TensorFlow v2.0 (PR #541) [2019-Q4]
+   - [x] Migrate to TensorFlow v2.0 (PR #541) [2019-Q4]
    - [ ] Drop Python 2.7 support at end of 2019 (Issue #469) [2019-Q4 (last week of December 2019)]
    - [ ] Finalize public API [2020-Q1]
    - [ ] Integrate pyfitcore/Statisfactory API [2020-Q1]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md
 extras_require = {
     'tensorflow': [
         'tensorflow~=2.0',
-        'tensorflow-probability==0.8.0rc0',
+        'tensorflow-probability~=0.8',
         'numpy<2.0,>=1.16.0',
     ],
     'torch': ['torch~=1.2'],

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md
     long_description = readme_md.read()
 
 extras_require = {
-    'tensorflow': [
-        'tensorflow~=2.0',
-        'tensorflow-probability~=0.8',
-        'numpy<2.0,>=1.16.0',
-    ],
+    'tensorflow': ['tensorflow~=2.0', 'tensorflow-probability~=0.8'],
     'torch': ['torch~=1.2'],
     'xmlio': ['uproot'],
     'minuit': ['iminuit'],

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,9 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md
 
 extras_require = {
     'tensorflow': [
-        # Temporarily pin to get TF 2.0 RCs
-        'tensorflow==2.0.0-rc0',
+        'tensorflow~=2.0',
         'tensorflow-probability==0.8.0rc0',
-        'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
+        'numpy<2.0,>=1.16.0',
     ],
     'torch': ['torch~=1.2'],
     'xmlio': ['uproot'],

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,12 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md
     long_description = readme_md.read()
 
 extras_require = {
-    'tensorflow': ['tensorflow~=1.15', 'tensorflow-probability~=0.8', 'numpy~=1.16'],
+    'tensorflow': [
+        # Temporarily pin to get TF 2.0 RCs
+        'tensorflow==2.0.0-rc0',
+        'tensorflow-probability==0.8.0rc0',
+        'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
+    ],
     'torch': ['torch~=1.2'],
     'xmlio': ['uproot'],
     'minuit': ['iminuit'],

--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -68,9 +68,7 @@ def cls(
     if backend in ['pytorch', 'torch']:
         set_backend(tensor.pytorch_backend(float='float64'))
     elif backend in ['tensorflow', 'tf']:
-        from tensorflow.compat.v1 import Session
-
-        set_backend(tensor.tensorflow_backend(session=Session(), float='float64'))
+        set_backend(tensor.tensorflow_backend(float='float64'))
     tensorlib, _ = get_backend()
 
     optconf = {k: v for item in optconf for k, v in item.items()}

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -162,7 +162,8 @@ class tensorflow_backend(object):
         tensor = tensor_in
         # If already a tensor then done
         try:
-            tensor.op
+            # Use a tensor attribute that isn't meaningless when eager execution is enabled
+            tensor.device
         except AttributeError:
             tensor = tf.convert_to_tensor(tensor_in)
             # Ensure non-empty tensor shape for consistency

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -25,7 +25,6 @@ class tensorflow_backend(object):
             >>> import pyhf
             >>> pyhf.set_backend("tensorflow")
             >>> a = pyhf.tensorlib.astensor([-2, -1, 0, 1, 2])
-            ...
             >>> t = pyhf.tensorlib.clip(a, -1, 1)
             >>> print(t)
             tf.Tensor([-1. -1.  0.  1.  1.], shape=(5,), dtype=float32)
@@ -51,16 +50,13 @@ class tensorflow_backend(object):
 
         Example:
             >>> import pyhf
-            >>> import tensorflow as tf
-            >>> sess = tf.compat.v1.Session()
-            ...
-            >>> pyhf.set_backend("tensorflow", _session=sess)
+            >>> pyhf.set_backend("tensorflow")
             >>> a = pyhf.tensorlib.astensor([[1.0], [2.0]])
-            >>> with sess.as_default():
-            ...   sess.run(pyhf.tensorlib.tile(a, (1, 2)))
-            ...
-            array([[1., 1.],
-                   [2., 2.]], dtype=float32)
+            >>> t = pyhf.tensorlib.tile(a, (1, 2))
+            >>> print(t)
+            tf.Tensor(
+            [[1. 1.]
+             [2. 2.]], shape=(2, 2), dtype=float32)
 
         Args:
             tensor_in (`Tensor`): The tensor to be repeated

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -332,20 +332,15 @@ class tensorflow_backend(object):
 
         Example:
             >>> import pyhf
-            >>> import tensorflow as tf
-            >>> sess = tf.compat.v1.Session()
-            >>> pyhf.set_backend("tensorflow", _session=sess)
-            ...
-            >>> with sess.as_default():
-            ...     sess.run(pyhf.tensorlib.poisson(5., 6.))
-            ...
-            0.16062315
+            >>> pyhf.set_backend("tensorflow")
+            >>> t = pyhf.tensorlib.poisson(5., 6.)
+            >>> print(t)
+            tf.Tensor(0.16062315, shape=(), dtype=float32)
             >>> values = pyhf.tensorlib.astensor([5., 9.])
             >>> rates = pyhf.tensorlib.astensor([6., 8.])
-            >>> with sess.as_default():
-            ...     sess.run(pyhf.tensorlib.poisson(values, rates))
-            ...
-            array([0.16062315, 0.12407687], dtype=float32)
+            >>> t = pyhf.tensorlib.poisson(values, rates)
+            >>> print(t)
+            tf.Tensor([0.16062315 0.12407687], shape=(2,), dtype=float32)
 
         Args:
             n (`tensor` or `float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -10,7 +10,6 @@ class tensorflow_backend(object):
     """TensorFlow backend for pyhf"""
 
     def __init__(self, **kwargs):
-        self.session = kwargs.get('session')
         self.name = 'tensorflow'
         self.dtypemap = {
             'float': getattr(tf, kwargs.get('float', 'float32')),

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -23,15 +23,12 @@ class tensorflow_backend(object):
 
         Example:
             >>> import pyhf
-            >>> import tensorflow as tf
-            >>> sess = tf.compat.v1.Session()
-            ...
-            >>> pyhf.set_backend("tensorflow", _session=sess)
+            >>> pyhf.set_backend("tensorflow")
             >>> a = pyhf.tensorlib.astensor([-2, -1, 0, 1, 2])
-            >>> with sess.as_default():
-            ...   sess.run(pyhf.tensorlib.clip(a, -1, 1))
             ...
-            array([-1., -1.,  0.,  1.,  1.], dtype=float32)
+            >>> t = pyhf.tensorlib.clip(a, -1, 1)
+            >>> print(t)
+            tf.Tensor([-1. -1.  0.  1.  1.], shape=(5,), dtype=float32)
 
         Args:
             tensor_in (`tensor`): The input tensor object

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -391,21 +391,16 @@ class tensorflow_backend(object):
 
         Example:
             >>> import pyhf
-            >>> import tensorflow as tf
-            >>> sess = tf.compat.v1.Session()
-            >>> pyhf.set_backend("tensorflow", _session=sess)
-            ...
-            >>> with sess.as_default():
-            ...     sess.run(pyhf.tensorlib.normal(0.5, 0., 1.))
-            ...
-            0.35206532
+            >>> pyhf.set_backend("tensorflow")
+            >>> t = pyhf.tensorlib.normal(0.5, 0., 1.)
+            >>> print(t)
+            tf.Tensor(0.35206532, shape=(), dtype=float32)
             >>> values = pyhf.tensorlib.astensor([0.5, 2.0])
             >>> means = pyhf.tensorlib.astensor([0., 2.3])
             >>> sigmas = pyhf.tensorlib.astensor([1., 0.8])
-            >>> with sess.as_default():
-            ...     sess.run(pyhf.tensorlib.normal(values, means, sigmas))
-            ...
-            array([0.35206532, 0.46481887], dtype=float32)
+            >>> t = pyhf.tensorlib.normal(values, means, sigmas)
+            >>> print(t)
+            tf.Tensor([0.35206532 0.46481887], shape=(2,), dtype=float32)
 
         Args:
             x (`tensor` or `float`): The value at which to evaluate the Normal distribution p.d.f.

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -303,20 +303,15 @@ class tensorflow_backend(object):
 
         Example:
             >>> import pyhf
-            >>> import tensorflow as tf
-            >>> sess = tf.compat.v1.Session()
-            >>> pyhf.set_backend("tensorflow", _session=sess)
-            ...
-            >>> with sess.as_default():
-            ...     sess.run(pyhf.tensorlib.poisson_logpdf(5., 6.))
-            ...
-            -1.8286943
+            >>> pyhf.set_backend("tensorflow")
+            >>> t = pyhf.tensorlib.poisson_logpdf(5., 6.)
+            >>> print(t)
+            tf.Tensor(-1.8286943, shape=(), dtype=float32)
             >>> values = pyhf.tensorlib.astensor([5., 9.])
             >>> rates = pyhf.tensorlib.astensor([6., 8.])
-            >>> with sess.as_default():
-            ...     sess.run(pyhf.tensorlib.poisson_logpdf(values, rates))
-            ...
-            array([-1.8286943, -2.086854 ], dtype=float32)
+            >>> t = pyhf.tensorlib.poisson_logpdf(values, rates)
+            >>> print(t)
+            tf.Tensor([-1.8286943 -2.086854 ], shape=(2,), dtype=float32)
 
         Args:
             n (`tensor` or `float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -245,7 +245,7 @@ class tensorflow_backend(object):
 
         Returns:
             TensorFlow Tensor: The result of the mask being applied to the tensors.
-            
+
         """
         return tf.where(mask, tensor_in_1, tensor_in_2)
 
@@ -472,17 +472,13 @@ class tensorflow_backend(object):
 
         Example:
             >>> import pyhf
-            >>> import tensorflow as tf
-            >>> sess = tf.compat.v1.Session()
-            ...
-            >>> pyhf.set_backend("tensorflow", _session=sess)
+            >>> pyhf.set_backend("tensorflow")
             >>> rates = pyhf.tensorlib.astensor([5, 8])
             >>> values = pyhf.tensorlib.astensor([4, 9])
             >>> poissons = pyhf.tensorlib.poisson_dist(rates)
-            >>> with sess.as_default():
-            ...   sess.run(poissons.log_prob(values))
-            ...
-            array([-1.7403021, -2.086854 ], dtype=float32)
+            >>> t = poissons.log_prob(values)
+            >>> print(t)
+            tf.Tensor([-1.7403021 -2.086854 ], shape=(2,), dtype=float32)
 
         Args:
             rate (`tensor` or `float`): The mean of the Poisson distribution (the expected number of events)
@@ -499,18 +495,14 @@ class tensorflow_backend(object):
 
         Example:
             >>> import pyhf
-            >>> import tensorflow as tf
-            >>> sess = tf.compat.v1.Session()
-            ...
-            >>> pyhf.set_backend("tensorflow", _session=sess)
+            >>> pyhf.set_backend("tensorflow")
             >>> means = pyhf.tensorlib.astensor([5, 8])
             >>> stds = pyhf.tensorlib.astensor([1, 0.5])
             >>> values = pyhf.tensorlib.astensor([4, 9])
             >>> normals = pyhf.tensorlib.normal_dist(means, stds)
-            >>> with sess.as_default():
-            ...   sess.run(normals.log_prob(values))
-            ...
-            array([-1.4189385, -2.2257915], dtype=float32)
+            >>> t = normals.log_prob(values)
+            >>> print(t)
+            tf.Tensor([-1.4189385 -2.2257915], shape=(2,), dtype=float32)
 
         Args:
             mu (`tensor` or `float`): The mean of the Normal distribution

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -361,21 +361,16 @@ class tensorflow_backend(object):
 
         Example:
             >>> import pyhf
-            >>> import tensorflow as tf
-            >>> sess = tf.compat.v1.Session()
-            >>> pyhf.set_backend("tensorflow", _session=sess)
-            ...
-            >>> with sess.as_default():
-            ...     sess.run(pyhf.tensorlib.normal_logpdf(0.5, 0., 1.))
-            ...
-            -1.0439385
+            >>> pyhf.set_backend("tensorflow")
+            >>> t = pyhf.tensorlib.normal_logpdf(0.5, 0., 1.)
+            >>> print(t)
+            tf.Tensor(-1.0439385, shape=(), dtype=float32)
             >>> values = pyhf.tensorlib.astensor([0.5, 2.0])
             >>> means = pyhf.tensorlib.astensor([0., 2.3])
             >>> sigmas = pyhf.tensorlib.astensor([1., 0.8])
-            >>> with sess.as_default():
-            ...     sess.run(pyhf.tensorlib.normal_logpdf(values, means, sigmas))
-            ...
-            array([-1.0439385, -0.7661075], dtype=float32)
+            >>> t = pyhf.tensorlib.normal_logpdf(values, means, sigmas)
+            >>> print(t)
+            tf.Tensor([-1.0439385 -0.7661075], shape=(2,), dtype=float32)
 
         Args:
             x (`tensor` or `float`): The value at which to evaluate the Normal distribution p.d.f.

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -108,7 +108,7 @@ class tensorflow_backend(object):
 
     def tolist(self, tensor_in):
         try:
-            return self.session.run(tensor_in).tolist()
+            return tensor_in.numpy().tolist()
         except AttributeError as err:
             if isinstance(tensor_in, list):
                 return tensor_in

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -100,20 +100,6 @@ class tensorflow_backend(object):
             if isinstance(tensor_in, list):
                 return tensor_in
             raise
-        except RuntimeError as err:
-            # if no tensor operations have been added to the graph, but we want
-            # to pass-through a list, then we need to catch the runtime error
-            # First, see if the input tensor is just a vanilla python list and
-            # return it instead
-            if "graph is empty" in str(err) and isinstance(tensor_in, list):
-                return tensor_in
-            raise
-        except TypeError:
-            # if a tensor operation has been added to the graph, but we want to
-            # pass-through a list, we need to catch the type error
-            if isinstance(tensor_in, list):
-                return tensor_in
-            raise
 
     def outer(self, tensor_in_1, tensor_in_2):
         tensor_in_1 = (

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -223,7 +223,31 @@ class tensorflow_backend(object):
         return tf.stack(sequence, axis=axis)
 
     def where(self, mask, tensor_in_1, tensor_in_2):
-        return tf.compat.v2.where(mask, tensor_in_1, tensor_in_2)
+        """
+        Apply a boolean selection mask to the elements of the input tensors.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("tensorflow")
+            >>> t = pyhf.tensorlib.where(
+            ...     pyhf.tensorlib.astensor([1, 0, 1], dtype='bool'),
+            ...     pyhf.tensorlib.astensor([1, 1, 1]),
+            ...     pyhf.tensorlib.astensor([2, 2, 2]),
+            ... )
+            >>> print(t)
+            tf.Tensor([1. 2. 1.], shape=(3,), dtype=float32)
+
+        Args:
+            mask (bool): Boolean mask (boolean or tensor object of booleans)
+            tensor_in_1 (Tensor): Tensor object
+            tensor_in_2 (Tensor): Tensor object
+
+        Returns:
+            TensorFlow Tensor: The result of the mask being applied to the tensors.
+            
+        """
+        return tf.where(mask, tensor_in_1, tensor_in_2)
 
     def concatenate(self, sequence, axis=0):
         """

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -101,7 +101,7 @@ class tensorflow_backend(object):
     def tolist(self, tensor_in):
         try:
             return tensor_in.numpy().tolist()
-        except AttributeError as err:
+        except AttributeError:
             if isinstance(tensor_in, list):
                 return tensor_in
             raise

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -419,19 +419,14 @@ class tensorflow_backend(object):
 
         Example:
             >>> import pyhf
-            >>> import tensorflow as tf
-            >>> sess = tf.compat.v1.Session()
-            ...
-            >>> pyhf.set_backend("tensorflow", _session=sess)
-            >>> with sess.as_default():
-            ...   sess.run(pyhf.tensorlib.normal_cdf(0.8))
-            ...
-            0.7881446
+            >>> pyhf.set_backend("tensorflow")
+            >>> t = pyhf.tensorlib.normal_cdf(0.8)
+            >>> print(t)
+            tf.Tensor(0.7881446, shape=(), dtype=float32)
             >>> values = pyhf.tensorlib.astensor([0.8, 2.0])
-            >>> with sess.as_default():
-            ...   sess.run(pyhf.tensorlib.normal_cdf(values))
-            ...
-            array([0.7881446 , 0.97724986], dtype=float32)
+            >>> t = pyhf.tensorlib.normal_cdf(values)
+            >>> print(t)
+            tf.Tensor([0.7881446  0.97724986], shape=(2,), dtype=float32)
 
         Args:
             x (`tensor` or `float`): The observed value of the random variable to evaluate the CDF for

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -244,15 +244,15 @@ class tensorflow_backend(object):
 
         Example:
             >>> import pyhf
-            >>> import tensorflow as tf
-            >>> sess = tf.compat.v1.Session()
-            ...
-            >>> pyhf.set_backend("tensorflow", _session=sess)
-            >>> tf.Session().run(pyhf.tensorlib.simple_broadcast(
+            >>> pyhf.set_backend("tensorflow")
+            >>> b = pyhf.tensorlib.simple_broadcast(
             ...   pyhf.tensorlib.astensor([1]),
             ...   pyhf.tensorlib.astensor([2, 3, 4]),
-            ...   pyhf.tensorlib.astensor([5, 6, 7])))
-            [array([1., 1., 1.], dtype=float32), array([2., 3., 4.], dtype=float32), array([5., 6., 7.], dtype=float32)]
+            ...   pyhf.tensorlib.astensor([5, 6, 7]))
+            >>> print([str(t) for t in b]) # doctest: +NORMALIZE_WHITESPACE
+            ['tf.Tensor([1. 1. 1.], shape=(3,), dtype=float32)',
+             'tf.Tensor([2. 3. 4.], shape=(3,), dtype=float32)',
+             'tf.Tensor([5. 6. 7.], shape=(3,), dtype=float32)']
 
         Args:
             args (Array of Tensors): Sequence of arrays

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -104,10 +104,6 @@ class tensorflow_backend(object):
         except AttributeError as err:
             if isinstance(tensor_in, list):
                 return tensor_in
-            if "no attribute 'run'" in str(err):
-                raise RuntimeError(
-                    'evaluation of tensor requested via .tolist() but no session defined'
-                )
             raise
         except RuntimeError as err:
             # if no tensor operations have been added to the graph, but we want

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -74,18 +74,13 @@ class tensorflow_backend(object):
 
         Example:
             >>> import pyhf
-            >>> import tensorflow as tf
-            >>> sess = tf.compat.v1.Session()
-            ...
-            >>> pyhf.set_backend("tensorflow", _session=sess)
+            >>> pyhf.set_backend("tensorflow")
             >>> tensorlib = pyhf.tensorlib
             >>> a = tensorlib.astensor([4])
             >>> b = tensorlib.astensor([5])
-            >>> compare = tensorlib.conditional((a < b)[0], lambda: a + b, lambda: a - b)
-            >>> with sess.as_default():
-            ...     sess.run(compare)
-            ...
-            array([9.], dtype=float32)
+            >>> t = tensorlib.conditional((a < b)[0], lambda: a + b, lambda: a - b)
+            >>> print(t)
+            tf.Tensor([9.], shape=(1,), dtype=float32)
 
         Args:
             predicate (`scalar`): The logical condition that determines which callable to evaluate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 import pyhf
-import tensorflow as tf
 import sys
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def reset_backend():
         (pyhf.tensor.numpy_backend(), None),
         (pyhf.tensor.pytorch_backend(), None),
         (pyhf.tensor.pytorch_backend(float='float64', int='int64'), None),
-        (pyhf.tensor.tensorflow_backend(session=tf.compat.v1.Session()), None),
+        (pyhf.tensor.tensorflow_backend(), None),
         (
             pyhf.tensor.numpy_backend(poisson_from_normal=True),
             pyhf.optimize.minuit_optimizer(),
@@ -92,9 +92,6 @@ def backend(request):
 
     # actual execution here, after all checks is done
     pyhf.set_backend(*request.param)
-    if isinstance(pyhf.tensorlib, pyhf.tensor.tensorflow_backend):
-        tf.compat.v1.reset_default_graph()
-        pyhf.tensorlib.session = tf.compat.v1.Session()
 
     yield request.param
 

--- a/tests/test_backend_consistency.py
+++ b/tests/test_backend_consistency.py
@@ -1,5 +1,4 @@
 import pyhf
-import tensorflow as tf
 import numpy as np
 import pytest
 

--- a/tests/test_backend_consistency.py
+++ b/tests/test_backend_consistency.py
@@ -106,15 +106,12 @@ def test_hypotest_q_mu(
 
     backends = [
         pyhf.tensor.numpy_backend(),
-        pyhf.tensor.tensorflow_backend(session=tf.compat.v1.Session()),
+        pyhf.tensor.tensorflow_backend(),
         pyhf.tensor.pytorch_backend(),
     ]
 
     test_statistic = []
     for backend in backends:
-        if backend.name == 'tensorflow':
-            tf.reset_default_graph()
-            backend.session = tf.compat.v1.Session()
         pyhf.set_backend(backend)
 
         q_mu = pyhf.infer.test_statistics.qmu(

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 import numpy as np
+import tensorflow as tf
 import pyhf
 from pyhf.simplemodels import hepdata_like
 
@@ -147,13 +148,13 @@ def test_shape(backend):
     assert tb.shape(tb.astensor(0.0)) == tb.shape(tb.astensor([0.0]))
     assert tb.shape(tb.astensor((1.0, 1.0))) == tb.shape(tb.astensor([1.0, 1.0]))
     assert tb.shape(tb.astensor((0.0, 0.0))) == tb.shape(tb.astensor([0.0, 0.0]))
-    with pytest.raises((ValueError, RuntimeError)):
+    with pytest.raises((ValueError, RuntimeError, tf.errors.InvalidArgumentError)):
         _ = tb.astensor([1, 2]) + tb.astensor([3, 4, 5])
-    with pytest.raises((ValueError, RuntimeError)):
+    with pytest.raises((ValueError, RuntimeError, tf.errors.InvalidArgumentError)):
         _ = tb.astensor([1, 2]) - tb.astensor([3, 4, 5])
-    with pytest.raises((ValueError, RuntimeError)):
+    with pytest.raises((ValueError, RuntimeError, tf.errors.InvalidArgumentError)):
         _ = tb.astensor([1, 2]) < tb.astensor([3, 4, 5])
-    with pytest.raises((ValueError, RuntimeError)):
+    with pytest.raises((ValueError, RuntimeError, tf.errors.InvalidArgumentError)):
         _ = tb.astensor([1, 2]) > tb.astensor([3, 4, 5])
     with pytest.raises((ValueError, RuntimeError)):
         tb.conditional(

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -296,18 +296,6 @@ def test_tensor_list_conversion(backend):
     assert tb.tolist([1, 2, 3, 4]) == [1, 2, 3, 4]
 
 
-def test_tensorflow_tolist_nosession():
-    pyhf.set_backend(pyhf.tensor.tensorflow_backend())
-    tb = pyhf.tensorlib
-
-    # this isn't covered by test_list_to_list since we need to check if it's ok
-    # without a session explicitly
-    assert tb.tolist([1, 2, 3, 4]) == [1, 2, 3, 4]
-    with pytest.raises(RuntimeError):
-        # but a tensor shouldn't
-        assert tb.tolist(tb.astensor([1, 2, 3, 4])) == [1, 2, 3, 4]
-
-
 def test_pdf_eval(backend):
     source = {
         "binning": [2, -0.5, 1.5],


### PR DESCRIPTION
# Description

Resolves #539 

Instead of adding conditional control flows through PR #535 and PR #537 in support of PR #534 , PR #534 will be delayed in favor of migrating to TensorFlow v2.0, where eager evaluation will avoid the issues that PR #535 and PR #537 addressed.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Migrate the TensorFlow backend and optimizer to TensorFlow v2.0 / deprecate TensorFlow v1.0 behavior
   - Changes evaluation from lazy (v1.0) to eager (v2.0 default)
* Require TensorFlow and TensorFlow Probability releases compatible with TensorFlow v2.0
* Simplify test configuration with deprecation of TensorFlow v1.0 Sessions
```
