### PR TITLE
ci: Use pydocstyle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,8 @@ jobs:
         sudo apt-get -qq install pandoc
     - name: Check docstrings
       run: |
-        pydocstyle --select D1 src/pyhf/probability.py
-        pydocstyle --select D102 src/pyhf/pdf.py
+        # Group 1 is related to docstrings
+        pydocstyle --select D1 src/pyhf/pdf.py src/pyhf/probability.py
     - name: Test and build docs
       run: |
         python -m doctest README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,8 @@ jobs:
         sudo apt-get -qq install pandoc
     - name: Check docstrings
       run: |
-        # Group 1 is related to docstrings
         pydocstyle --select D1 src/pyhf/probability.py
+        pydocstyle --select D102 src/pyhf/pdf.py
     - name: Test and build docs
       run: |
         python -m doctest README.md

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Computational Backends:
 
 Available Optimizers
 
-| NumPy                    | Tensorflow                 | PyTorch                    | MxNet |
-| :----------------------- | :------------------------- | :------------------------- | :---- |
-| SLSQP (`scipy.optimize`) | Newton's Method (autodiff) | Newton's Method (autodiff) | N/A   |
-| MINUIT (`iminuit`)       | .                          | .                          | .     |
+| NumPy                    | Tensorflow                 | PyTorch                    |
+| :----------------------- | :------------------------- | :------------------------- |
+| SLSQP (`scipy.optimize`) | Newton's Method (autodiff) | Newton's Method (autodiff) |
+| MINUIT (`iminuit`)       | .                          | .                          |
 
 
 ## Todo

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -219,7 +219,7 @@ class _ConstraintModel(object):
 
     def make_pdf(self, pars):
         """
-        Construct a  pdf object for a given set of parameter values.
+        Construct a pdf object for a given set of parameter values.
 
         Args:
             pars (`tensor`): The model parameters
@@ -656,7 +656,7 @@ class Model(object):
 
     def make_pdf(self, pars):
         """
-        Construct a  pdf object for a given set of parameter values.
+        Construct a pdf object for a given set of parameter values.
 
         Args:
             pars (`tensor`): The model parameters

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -397,7 +397,7 @@ class Model(object):
         Construct a pyhf Model.
 
         Args:
-            spec (`jsonable`): The JSON specification
+            spec (`jsonable`): The HistFactory JSON specification
             batch_size (`None` or `int`): Number of simultaneous (batched) Models to compute.
             config_kwargs: Possible keyword arguments for the model configuration
 

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -628,7 +628,7 @@ class Model(object):
 
     def constraint_logpdf(self, auxdata, pars):
         """
-        Compute the log value of the constraint term.
+        Compute the log value of the constraint pdf.
 
         Args:
             auxdata (`tensor`): The auxiliary measurement data

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -136,7 +136,7 @@ class _ModelConfig(_ChannelSummaryMixin):
         self.poi_index = s.start
 
     def _register_paramset(self, param_name, paramset):
-        """Allocates n nuisance parameters and stores paramset > modifier map."""
+        """Allocates the nuisance parameters and stores paramset into a modifier map."""
         log.info(
             'adding modifier %s (%s new nuisance parameters)',
             param_name,
@@ -365,7 +365,7 @@ class _MainModel(object):
 
         So in the end we only make 3 calls to pdfs
 
-            1. The main pdf of data and modified rates
+            1. The pdf of data and modified rates
             2. All Gaussian constraint as one call
             3. All Poisson constraints as one call
 
@@ -583,7 +583,7 @@ class Model(object):
             pars (`tensor`): The parameter values
 
         Returns:
-            Tensor: The expected auxiliary data
+            Tensor: The expected data of the auxiliary pdf
 
         """
         return self.make_pdf(pars)[1].expected_data()
@@ -593,31 +593,31 @@ class Model(object):
 
     @property
     def nominal_rates(self):
-        """Nominal value of bin rates of the main measurment."""
+        """Nominal value of bin rates of the main model."""
         return self.main_model.nominal_rates
 
     def expected_actualdata(self, pars):
         """
-        Compute the expected value of the main measurements.
+        Compute the expected value of the main model.
 
         Args:
             pars (`tensor`): The parameter values
 
         Returns:
-            Tensor: The expected main data
+            Tensor: The expected data of the main model (no auxiliary data)
 
         """
         return self.make_pdf(pars)[0].expected_data()
 
     def expected_data(self, pars, include_auxdata=True):
         """
-        Compute the expected value of the main measurements.
+        Compute the expected value of the main model
 
         Args:
             pars (`tensor`): The parameter values
 
         Returns:
-            Tensor: The expected main data
+            Tensor: The expected data of the main and auxiliary model
 
         """
         tensorlib, _ = get_backend()
@@ -727,7 +727,7 @@ class Model(object):
 
     def pdf(self, pars, data):
         """
-        Compute the value of the full density.
+        Compute the density at a given observed point in data space of the full model.
 
         Args:
             pars (`tensor`): The parameter values

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -394,7 +394,7 @@ class Model(object):
 
     def __init__(self, spec, batch_size=None, **config_kwargs):
         """
-        Construct a pyhf Model.
+        Construct a HistFactory Model.
 
         Args:
             spec (`jsonable`): The HistFactory JSON specification

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -253,7 +253,7 @@ class _ConstraintModel(object):
             pars (`tensor`): The model parameters
 
         Returns:
-            log pdf value: the log of the pdf value
+            log pdf value: The log of the pdf value
 
         """
         simpdf = self.make_pdf(pars)
@@ -322,7 +322,7 @@ class _MainModel(object):
             pars (`tensor`): The model parameters
 
         Returns:
-            log pdf value: the log of the pdf value
+            log pdf value: The log of the pdf value
 
         """
         return self.make_pdf(pars).log_prob(maindata)
@@ -397,12 +397,12 @@ class Model(object):
         Construct a pyhf Model.
 
         Args:
-            spec (`jsonable`): a json specification
+            spec (`jsonable`): The JSON specification
             batch_size (`None` or `int`): Number of simultaneous (batched) Models to compute.
-            config_kwargs: possible keyword arguments for the model configuration
+            config_kwargs: Possible keyword arguments for the model configuration
 
         Returns:
-            model (`Model`): the Model instance.
+            model (`Model`): The Model instance.
 
         """
         self.batch_size = batch_size
@@ -580,10 +580,10 @@ class Model(object):
         Compute the expected value of the auxiliary measurements.
 
         Args:
-            pars (`tensor`): the parameter values
+            pars (`tensor`): The parameter values
 
         Returns:
-            data (`tensor`): the expected auxiliary data
+            data (`tensor`): The expected auxiliary data
 
         """
         return self.make_pdf(pars)[1].expected_data()
@@ -601,10 +601,10 @@ class Model(object):
         Compute the expected value of the main measurements.
 
         Args:
-            pars (`tensor`): the parameter values
+            pars (`tensor`): The parameter values
 
         Returns:
-            data (`tensor`): the expected main data
+            data (`tensor`): The expected main data
 
         """
         return self.make_pdf(pars)[0].expected_data()
@@ -614,10 +614,10 @@ class Model(object):
         Compute the expected value of the main measurements.
 
         Args:
-            pars (`tensor`): the parameter values
+            pars (`tensor`): The parameter values
 
         Returns:
-            data (`tensor`): the expected main data
+            data (`tensor`): The expected main data
 
         """
         tensorlib, _ = get_backend()
@@ -631,11 +631,11 @@ class Model(object):
         Compute the log value of the constraint term.
 
         Args:
-            auxdata (`tensor`): the auxiliary measurement data
-            pars (`tensor`): the parameter values
+            auxdata (`tensor`): The auxiliary measurement data
+            pars (`tensor`): The parameter values
 
         Returns:
-            value (`float` or `tensor`): the log density value
+            value (`float` or `tensor`): The log density value
 
         """
         return self.make_pdf(pars)[1].log_prob(auxdata)
@@ -645,11 +645,11 @@ class Model(object):
         Compute the log value of the main term.
 
         Args:
-            maindata (`tensor`): the main measurement data
-            pars (`tensor`): the parameter values
+            maindata (`tensor`): The main measurement data
+            pars (`tensor`): The parameter values
 
         Returns:
-            value (`float` or `tensor`): the log density value
+            value (`float` or `tensor`): The log density value
 
         """
         return self.make_pdf(pars)[0].log_prob(maindata)
@@ -683,11 +683,11 @@ class Model(object):
         Compute the log value of the full density.
 
         Args:
-            pars (`tensor`): the parameter values
-            data (`tensor`): the measurement data
+            pars (`tensor`): The parameter values
+            data (`tensor`): The measurement data
 
         Returns:
-            value (`float` or `tensor`): the log density value
+            value (`float` or `tensor`): The log density value
 
         """
         try:
@@ -730,11 +730,11 @@ class Model(object):
         Compute the value of the full density.
 
         Args:
-            pars (`tensor`): the parameter values
-            data (`tensor`): the measurement data
+            pars (`tensor`): The parameter values
+            data (`tensor`): The measurement data
 
         Returns:
-            value (`float` or `tensor`): the density value
+            value (`float` or `tensor`): The density value
 
         """
         tensorlib, _ = get_backend()

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -212,7 +212,7 @@ class _ConstraintModel(object):
         Indicate whether the model has a constraint.
 
         Returns:
-            flag (`bool`): Whether the model has a constraint term
+            Bool: Whether the model has a constraint term
 
         """
         return self.constraints_gaussian.has_pdf() or self.constraints_poisson.has_pdf()
@@ -253,7 +253,7 @@ class _ConstraintModel(object):
             pars (`tensor`): The model parameters
 
         Returns:
-            log pdf value: The log of the pdf value
+            Tensor: The log of the pdf value
 
         """
         simpdf = self.make_pdf(pars)
@@ -304,7 +304,7 @@ class _MainModel(object):
         Indicate whether the main model exists.
 
         Returns:
-            flag (`bool`): Whether the model has a Main Model component (yes it does)
+            Bool: Whether the model has a Main Model component (yes it does)
 
         """
         return True
@@ -322,7 +322,7 @@ class _MainModel(object):
             pars (`tensor`): The model parameters
 
         Returns:
-            log pdf value: The log of the pdf value
+            Tensor: The log of the pdf value
 
         """
         return self.make_pdf(pars).log_prob(maindata)
@@ -583,7 +583,7 @@ class Model(object):
             pars (`tensor`): The parameter values
 
         Returns:
-            data (`tensor`): The expected auxiliary data
+            Tensor: The expected auxiliary data
 
         """
         return self.make_pdf(pars)[1].expected_data()
@@ -604,7 +604,7 @@ class Model(object):
             pars (`tensor`): The parameter values
 
         Returns:
-            data (`tensor`): The expected main data
+            Tensor: The expected main data
 
         """
         return self.make_pdf(pars)[0].expected_data()
@@ -617,7 +617,7 @@ class Model(object):
             pars (`tensor`): The parameter values
 
         Returns:
-            data (`tensor`): The expected main data
+            Tensor: The expected main data
 
         """
         tensorlib, _ = get_backend()
@@ -635,7 +635,7 @@ class Model(object):
             pars (`tensor`): The parameter values
 
         Returns:
-            value (`float` or `tensor`): The log density value
+            Tensor: The log density value
 
         """
         return self.make_pdf(pars)[1].log_prob(auxdata)
@@ -649,7 +649,7 @@ class Model(object):
             pars (`tensor`): The parameter values
 
         Returns:
-            value (`float` or `tensor`): The log density value
+            Tensor: The log density value
 
         """
         return self.make_pdf(pars)[0].log_prob(maindata)
@@ -687,7 +687,7 @@ class Model(object):
             data (`tensor`): The measurement data
 
         Returns:
-            value (`float` or `tensor`): The log density value
+            Tensor: The log density value
 
         """
         try:
@@ -734,7 +734,7 @@ class Model(object):
             data (`tensor`): The measurement data
 
         Returns:
-            value (`float` or `tensor`): The density value
+            Tensor: The density value
 
         """
         tensorlib, _ = get_backend()

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -209,7 +209,7 @@ class _ConstraintModel(object):
 
     def has_pdf(self):
         """
-        Indicate whether the model has a constraint.
+        Indicate whether this model has a constraint.
 
         Returns:
             Bool: Whether the model has a constraint term


### PR DESCRIPTION
# Description

* adds `pydocstyle` testing (on pdf.py only for now) to CI
* makes pdf.py pass pydocstyle

Adresses #97 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add pydocstyle to "develop" environment requirements
* Add pydocstyle testing (on pdf.py only for now) to CI
* Add docstrings to all public classes and methods in 'pdf.py'
```
