### PR TITLE
test: Add public API canary tests to CI and nightly tests for current PyPI release

### DIFF
--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -1,8 +1,6 @@
 name: Current Release
 
 on:
-  # Later remove push
-  push:
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -26,6 +26,6 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install pyhf[complete]
         pip list
-    - name: Test public API
+    - name: Canary test public API
       run: |
         python -m pytest -r sx tests/test_public_api.py

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -9,11 +9,11 @@ jobs:
 
   pypi_release:
 
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest]
         python-version: [3.7]
-    runs-on: ${{ matrix.platform }}
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -30,4 +30,4 @@ jobs:
         pip list
     - name: Test public API
       run: |
-        python -m pytest -r sx tests/test_init.py
+        python -m pytest -r sx tests/test_public_api.py

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -24,8 +24,8 @@ jobs:
     - name: Install from PyPI
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install pyhf[tensorflow,torch,minuit,xmlio]
-        pip list
+        python -m pip install pyhf[tensorflow,torch,minuit,xmlio]
+        python -m pip list
     - name: Canary test public API
       run: |
         python -m pytest -r sx tests/test_public_api.py

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -1,0 +1,33 @@
+name: Current Release
+
+on:
+  # Later remove push
+  push:
+  # Run daily at 0:01 UTC
+  schedule:
+  - cron:  '1 0 * * *'
+
+jobs:
+
+  pypi_release:
+
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macOS-latest]
+        python-version: [3.7]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install from PyPI
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install pyhf[xmlio,tensorflow,torch]
+        pip list
+    - name: Test public API
+      run: |
+        python -m pytest -r sx tests/test_init.py

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install from PyPI
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install pyhf[xmlio,tensorflow,torch]
+        pip install pyhf[complete]
         pip list
     - name: Test public API
       run: |

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install from PyPI
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install pyhf[complete]
+        pip install pyhf[tensorflow,torch,minuit,xmlio]
         pip list
     - name: Canary test public API
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ docs/_*/
 *.py[co]
 __pycache__
 *.egg-info
+*.eggs
 *~
 *.bak
 .ipynb_checkpoints

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def reset_backend():
     params=[
         (pyhf.tensor.numpy_backend(), None),
         (pyhf.tensor.pytorch_backend(), None),
-        (pyhf.tensor.tensorflow_backend(session=tf.Session()), None),
+        (pyhf.tensor.tensorflow_backend(session=tf.compat.v1.Session()), None),
         (
             pyhf.tensor.numpy_backend(poisson_from_normal=True),
             pyhf.optimize.minuit_optimizer(),
@@ -92,7 +92,7 @@ def backend(request):
     pyhf.set_backend(*request.param)
     if isinstance(pyhf.tensorlib, pyhf.tensor.tensorflow_backend):
         tf.compat.v1.reset_default_graph()
-        pyhf.tensorlib.session = tf.Session()
+        pyhf.tensorlib.session = tf.compat.v1.Session()
 
     yield request.param
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,11 +1,41 @@
+import pytest
 import pyhf
 import numpy as np
 
 
-def test_smoketest(backend):
+@pytest.fixture(scope='function')
+def model_setup(backend):
     np.random.seed(0)
-    n_bins = 500
+    n_bins = 100
     model = pyhf.simplemodels.hepdata_like([10] * n_bins, [50] * n_bins, [1] * n_bins)
-    parameters = model.config.suggested_init()
-    data = np.random.randint(50, 60, size=n_bins).tolist() + model.config.auxdata
-    model.logpdf(parameters, data)
+    init_pars = model.config.suggested_init()
+    observations = np.random.randint(50, 60, size=n_bins).tolist()
+    data = observations + model.config.auxdata
+    return model, data, init_pars
+
+
+def test_logpprob(backend, model_setup):
+    model, data, init_pars = model_setup
+    model.logpdf(init_pars, data)
+
+
+def test_hypotest(backend, model_setup):
+    model, data, init_pars = model_setup
+    mu = 1.0
+    pyhf.utils.hypotest(
+        mu,
+        data,
+        model,
+        init_pars,
+        model.config.suggested_bounds(),
+        return_expected_set=True,
+        return_test_statistics=True,
+    )
+
+
+def test_prob_models(backend):
+    tb, _ = backend
+    pyhf.probability.Poisson(tb.astensor([10.0])).log_prob(tb.astensor(2.0))
+    pyhf.probability.Normal(tb.astensor([10.0]), tb.astensor([1])).log_prob(
+        tb.astensor(2.0)
+    )

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -39,3 +39,31 @@ def test_prob_models(backend):
     pyhf.probability.Normal(tb.astensor([10.0]), tb.astensor([1])).log_prob(
         tb.astensor(2.0)
     )
+
+
+def test_pdf_batched(backend):
+    tb, _ = backend
+    source = {
+        "binning": [2, -0.5, 1.5],
+        "bindata": {"data": [55.0], "bkg": [50.0], "bkgerr": [7.0], "sig": [10.0]},
+    }
+    pdf = pyhf.simplemodels.hepdata_like(
+        source['bindata']['sig'],
+        source['bindata']['bkg'],
+        source['bindata']['bkgerr'],
+        batch_size=2,
+    )
+
+    pars = [pdf.config.suggested_init()] * 2
+    data = source['bindata']['data'] + pdf.config.auxdata
+
+    assert tb.tolist(pdf.pdf(pars, data)) == pytest.approx(
+        [0.002417118312751542] * 2, 2.5e-05
+    )
+    assert tb.tolist(pdf.expected_data(pars))
+    assert tb.tolist(pdf.expected_data(pars)[0]) == pytest.approx(
+        [60.0, 51.020408630], 1e-08
+    )
+    assert tb.tolist(pdf.expected_data(pars)[1]) == pytest.approx(
+        [60.0, 51.020408630], 1e-08
+    )

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -47,23 +47,15 @@ def test_pdf_batched(backend):
         "binning": [2, -0.5, 1.5],
         "bindata": {"data": [55.0], "bkg": [50.0], "bkgerr": [7.0], "sig": [10.0]},
     }
-    pdf = pyhf.simplemodels.hepdata_like(
+    model = pyhf.simplemodels.hepdata_like(
         source['bindata']['sig'],
         source['bindata']['bkg'],
         source['bindata']['bkgerr'],
         batch_size=2,
     )
 
-    pars = [pdf.config.suggested_init()] * 2
-    data = source['bindata']['data'] + pdf.config.auxdata
+    pars = [model.config.suggested_init()] * 2
+    data = source['bindata']['data'] + model.config.auxdata
 
-    assert tb.tolist(pdf.pdf(pars, data)) == pytest.approx(
-        [0.002417118312751542] * 2, 2.5e-05
-    )
-    assert tb.tolist(pdf.expected_data(pars))
-    assert tb.tolist(pdf.expected_data(pars)[0]) == pytest.approx(
-        [60.0, 51.020408630], 1e-08
-    )
-    assert tb.tolist(pdf.expected_data(pars)[1]) == pytest.approx(
-        [60.0, 51.020408630], 1e-08
-    )
+    model.pdf(pars, data)
+    model.expected_data(pars)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,11 @@
+import pyhf
+import numpy as np
+
+
+def test_smoketest(backend):
+    np.random.seed(0)
+    n_bins = 500
+    model = pyhf.simplemodels.hepdata_like([10] * n_bins, [50] * n_bins, [1] * n_bins)
+    parameters = model.config.suggested_init()
+    data = np.random.randint(50, 60, size=n_bins).tolist() + model.config.auxdata
+    model.logpdf(parameters, data)


### PR DESCRIPTION
# Description

- Resolves #609 
- Resolves #605 

Add canary tests and GitHub Actions workflow to check if the current release of pyhf on PyPI is functional and able to work with the current API.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add GitHub Actions workflow to nightly check if the current release of pyhf on PyPI is valid for the public API
* Add canary tests of the public API
   - Runs on both GitHub in CI and in against the releases from PyPI
* Use tf.compat.v1.Session to avoid warning
```
