### PR TITLE
feat: pyhf spec CLI

### DIFF
--- a/docs/_templates/modifierclass.rst
+++ b/docs/_templates/modifierclass.rst
@@ -22,7 +22,9 @@
    .. rubric:: Methods
 
    {% for item in methods %}
+   {% if item not in inherited_members %}
    .. automethod:: {{ name }}.{{ item }}
+   {% endif %}
    {%- endfor %}
    {% endif %}
    {% endblock %}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -121,8 +121,17 @@ Various exceptions, apart from standard python exceptions, that are raised from 
    :nosignatures:
    :template: modifierclass.rst
 
-   InvalidInterpCode
+   InvalidMeasurement
+   InvalidNameReuse
+   InvalidSpecification
+   InvalidWorkspaceOperation
+   InvalidModel
    InvalidModifier
+   InvalidInterpCode
+   ImportBackendError
+   InvalidOptimizer
+   InvalidPdfParameters
+   InvalidPdfData
 
 Utilities
 ---------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,5 +1,5 @@
-API
-===
+Python API
+==========
 
 Top-Level
 ---------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,16 +34,16 @@ Probability Distribution Functions (PDFs)
 Making Models from PDFs
 -----------------------
 
-.. currentmodule:: pyhf.pdf
+.. currentmodule:: pyhf
 
 .. autosummary::
    :toctree: _generated/
    :nosignatures:
    :template: modifierclass.rst
 
-   Workspace
-   Model
-   _ModelConfig
+   ~pdf.Model
+   ~pdf._ModelConfig
+   ~workspace.Workspace
 
 Backends
 --------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,6 @@
+Command Line API
+================
+
+.. click:: pyhf.cli.cli:pyhf
+   :prog: pyhf
+   :show-nested:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
     'sphinxcontrib.bibtex',
-    'sphinxcontrib.napoleon',
+    'sphinx.ext.napoleon',
     'nbsphinx',
     'm2r',
     'sphinx_issues',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,7 @@ extensions = [
     'sphinx.ext.githubpages',
     'sphinxcontrib.bibtex',
     'sphinx.ext.napoleon',
+    'sphinx_click.ext',
     'nbsphinx',
     'm2r',
     'sphinx_issues',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@
    installation
    development
    faq
+   cli
    api
    citations
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ extras_require['docs'] = sorted(
         + [
             'sphinx',
             'sphinxcontrib-bibtex',
-            'sphinxcontrib-napoleon',
             'sphinx_rtd_theme',
             'nbsphinx',
             'sphinx-issues',

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ extras_require['docs'] = sorted(
         + [
             'sphinx',
             'sphinxcontrib-bibtex',
+            'sphinx-click',
             'sphinx_rtd_theme',
             'nbsphinx',
             'sphinx-issues',

--- a/src/pyhf/cli/cli.py
+++ b/src/pyhf/cli/cli.py
@@ -22,6 +22,7 @@ pyhf.add_command(rootio.xml2json)
 # pyhf.add_command(spec.cli)
 pyhf.add_command(spec.inspect)
 pyhf.add_command(spec.prune)
+pyhf.add_command(spec.rename)
 
 # pyhf.add_command(stats.cli)
 pyhf.add_command(stats.cls)

--- a/src/pyhf/cli/cli.py
+++ b/src/pyhf/cli/cli.py
@@ -21,6 +21,7 @@ pyhf.add_command(rootio.xml2json)
 
 # pyhf.add_command(spec.cli)
 pyhf.add_command(spec.inspect)
+pyhf.add_command(spec.prune)
 
 # pyhf.add_command(stats.cli)
 pyhf.add_command(stats.cls)

--- a/src/pyhf/cli/cli.py
+++ b/src/pyhf/cli/cli.py
@@ -23,6 +23,7 @@ pyhf.add_command(rootio.xml2json)
 pyhf.add_command(spec.inspect)
 pyhf.add_command(spec.prune)
 pyhf.add_command(spec.rename)
+pyhf.add_command(spec.combine)
 
 # pyhf.add_command(stats.cli)
 pyhf.add_command(stats.cls)

--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -122,3 +122,38 @@ def inspect(workspace, output_file, measurement):
         with open(output_file, 'w+') as out_file:
             json.dump(result, out_file, indent=4, sort_keys=True)
         log.debug("Written to {0:s}".format(output_file))
+
+
+@cli.command()
+@click.argument('workspace', default='-')
+@click.option(
+    '--output-file',
+    help='The location of the output json file. If not specified, prints to screen.',
+    default=None,
+)
+@click.option('-c', '--channel', default=[], multiple=True)
+@click.option('-s', '--sample', default=[], multiple=True)
+@click.option('-m', '--modifier', default=[], multiple=True)
+@click.option('-t', '--modifier-type', default=[], multiple=True)
+@click.option('-e', '--measurement', default=[], multiple=True)
+def prune(
+    workspace, output_file, channel, sample, modifier, modifier_type, measurement
+):
+    with click.open_file(workspace, 'r') as specstream:
+        spec = json.load(specstream)
+
+    ws = Workspace(spec)
+    pruned_ws = ws.prune(
+        channels=channel,
+        samples=sample,
+        modifiers=modifier,
+        modifier_types=modifier_type,
+        measurements=measurement,
+    )
+
+    if output_file is None:
+        click.echo(json.dumps(pruned_ws, indent=4, sort_keys=True))
+    else:
+        with open(output_file, 'w+') as out_file:
+            json.dump(pruned_ws, out_file, indent=4, sort_keys=True)
+        log.debug("Written to {0:s}".format(output_file))

--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -202,7 +202,6 @@ def prune(
     metavar='<PATTERN> <REPLACE>...',
 )
 @click.option(
-    '-e',
     '--measurement',
     default=[],
     multiple=True,

--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -243,7 +243,7 @@ def combine(workspace_one, workspace_two, output_file):
 
     ws_one = Workspace(spec_one)
     ws_two = Workspace(spec_two)
-    combined_ws = ws_one + ws_two
+    combined_ws = ws_one.combine(ws_two)
 
     if output_file is None:
         click.echo(json.dumps(combined_ws, indent=4, sort_keys=True))

--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -131,11 +131,19 @@ def inspect(workspace, output_file, measurement):
     help='The location of the output json file. If not specified, prints to screen.',
     default=None,
 )
-@click.option('-c', '--channel', default=[], multiple=True)
-@click.option('-s', '--sample', default=[], multiple=True)
-@click.option('-m', '--modifier', default=[], multiple=True)
-@click.option('-t', '--modifier-type', default=[], multiple=True)
-@click.option('-e', '--measurement', default=[], multiple=True)
+@click.option('-c', '--channel', default=[], multiple=True, metavar='<CHANNEL>...')
+@click.option('-s', '--sample', default=[], multiple=True, metavar='<SAMPLE>...')
+@click.option('-m', '--modifier', default=[], multiple=True, metavar='<MODIFIER>...')
+@click.option(
+    '-t',
+    '--modifier-type',
+    default=[],
+    multiple=True,
+    type=click.Choice(modifiers.uncombined.keys()),
+)
+@click.option(
+    '-e', '--measurement', default=[], multiple=True, metavar='<MEASUREMENT>...'
+)
 def prune(
     workspace, output_file, channel, sample, modifier, modifier_type, measurement
 ):
@@ -149,6 +157,65 @@ def prune(
         modifiers=modifier,
         modifier_types=modifier_type,
         measurements=measurement,
+    )
+
+    if output_file is None:
+        click.echo(json.dumps(pruned_ws, indent=4, sort_keys=True))
+    else:
+        with open(output_file, 'w+') as out_file:
+            json.dump(pruned_ws, out_file, indent=4, sort_keys=True)
+        log.debug("Written to {0:s}".format(output_file))
+
+
+@cli.command()
+@click.argument('workspace', default='-')
+@click.option(
+    '--output-file',
+    help='The location of the output json file. If not specified, prints to screen.',
+    default=None,
+)
+@click.option(
+    '-c',
+    '--channel',
+    default=[],
+    multiple=True,
+    type=click.Tuple([str, str]),
+    metavar='<PATTERN> <REPLACE>...',
+)
+@click.option(
+    '-s',
+    '--sample',
+    default=[],
+    multiple=True,
+    type=click.Tuple([str, str]),
+    metavar='<PATTERN> <REPLACE>...',
+)
+@click.option(
+    '-m',
+    '--modifier',
+    default=[],
+    multiple=True,
+    type=click.Tuple([str, str]),
+    metavar='<PATTERN> <REPLACE>...',
+)
+@click.option(
+    '-e',
+    '--measurement',
+    default=[],
+    multiple=True,
+    type=click.Tuple([str, str]),
+    metavar='<PATTERN> <REPLACE>...',
+)
+def rename(workspace, output_file, channel, sample, modifier, measurement):
+    with click.open_file(workspace, 'r') as specstream:
+        spec = json.load(specstream)
+
+    ws = Workspace(spec)
+    renamed_ws = ws.prune(
+        channels=dict(channel),
+        samples=dict(sample),
+        modifiers=dict(modifier),
+        measurements=dict(measurement),
     )
 
     if output_file is None:

--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -224,3 +224,30 @@ def rename(workspace, output_file, channel, sample, modifier, measurement):
         with open(output_file, 'w+') as out_file:
             json.dump(renamed_ws, out_file, indent=4, sort_keys=True)
         log.debug("Written to {0:s}".format(output_file))
+
+
+@cli.command()
+@click.argument('workspace-one', default='-')
+@click.argument('workspace-two', default='-')
+@click.option(
+    '--output-file',
+    help='The location of the output json file. If not specified, prints to screen.',
+    default=None,
+)
+def combine(workspace_one, workspace_two, output_file):
+    with click.open_file(workspace_one, 'r') as specstream:
+        spec_one = json.load(specstream)
+
+    with click.open_file(workspace_two, 'r') as specstream:
+        spec_two = json.load(specstream)
+
+    ws_one = Workspace(spec_one)
+    ws_two = Workspace(spec_two)
+    combined_ws = ws_one + ws_two
+
+    if output_file is None:
+        click.echo(json.dumps(combined_ws, indent=4, sort_keys=True))
+    else:
+        with open(output_file, 'w+') as out_file:
+            json.dump(combined_ws, out_file, indent=4, sort_keys=True)
+        log.debug("Written to {0:s}".format(output_file))

--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -243,7 +243,7 @@ def combine(workspace_one, workspace_two, output_file):
 
     ws_one = Workspace(spec_one)
     ws_two = Workspace(spec_two)
-    combined_ws = ws_one.combine(ws_two)
+    combined_ws = Workspace.combine(ws_one, ws_two)
 
     if output_file is None:
         click.echo(json.dumps(combined_ws, indent=4, sort_keys=True))

--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -141,9 +141,7 @@ def inspect(workspace, output_file, measurement):
     multiple=True,
     type=click.Choice(modifiers.uncombined.keys()),
 )
-@click.option(
-    '--measurement', default=[], multiple=True, metavar='<MEASUREMENT>...'
-)
+@click.option('--measurement', default=[], multiple=True, metavar='<MEASUREMENT>...')
 def prune(
     workspace, output_file, channel, sample, modifier, modifier_type, measurement
 ):

--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -211,7 +211,7 @@ def rename(workspace, output_file, channel, sample, modifier, measurement):
         spec = json.load(specstream)
 
     ws = Workspace(spec)
-    renamed_ws = ws.prune(
+    renamed_ws = ws.rename(
         channels=dict(channel),
         samples=dict(sample),
         modifiers=dict(modifier),

--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -219,8 +219,8 @@ def rename(workspace, output_file, channel, sample, modifier, measurement):
     )
 
     if output_file is None:
-        click.echo(json.dumps(pruned_ws, indent=4, sort_keys=True))
+        click.echo(json.dumps(renamed_ws, indent=4, sort_keys=True))
     else:
         with open(output_file, 'w+') as out_file:
-            json.dump(pruned_ws, out_file, indent=4, sort_keys=True)
+            json.dump(renamed_ws, out_file, indent=4, sort_keys=True)
         log.debug("Written to {0:s}".format(output_file))

--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -142,11 +142,16 @@ def inspect(workspace, output_file, measurement):
     type=click.Choice(modifiers.uncombined.keys()),
 )
 @click.option(
-    '-e', '--measurement', default=[], multiple=True, metavar='<MEASUREMENT>...'
+    '--measurement', default=[], multiple=True, metavar='<MEASUREMENT>...'
 )
 def prune(
     workspace, output_file, channel, sample, modifier, modifier_type, measurement
 ):
+    """
+    Prune components from the workspace.
+
+    See :func:`pyhf.workspace.Workspace.prune` for more information.
+    """
     with click.open_file(workspace, 'r') as specstream:
         spec = json.load(specstream)
 
@@ -207,6 +212,11 @@ def prune(
     metavar='<PATTERN> <REPLACE>...',
 )
 def rename(workspace, output_file, channel, sample, modifier, measurement):
+    """
+    Rename components of the workspace.
+
+    See :func:`pyhf.workspace.Workspace.rename` for more information.
+    """
     with click.open_file(workspace, 'r') as specstream:
         spec = json.load(specstream)
 
@@ -235,6 +245,11 @@ def rename(workspace, output_file, channel, sample, modifier, measurement):
     default=None,
 )
 def combine(workspace_one, workspace_two, output_file):
+    """
+    Combine two workspaces into a single workspace.
+
+    See :func:`pyhf.workspace.Workspace.combine` for more information.
+    """
     with click.open_file(workspace_one, 'r') as specstream:
         spec_one = json.load(specstream)
 

--- a/src/pyhf/exceptions/__init__.py
+++ b/src/pyhf/exceptions/__init__.py
@@ -35,9 +35,7 @@ class InvalidSpecification(Exception):
 
 
 class InvalidWorkspaceOperation(Exception):
-    """
-  InvalidWorkspaceOperation is raised when an operation on a workspace fails.
-  """
+    """InvalidWorkspaceOperation is raised when an operation on a workspace fails."""
 
 
 class InvalidModel(Exception):

--- a/src/pyhf/exceptions/__init__.py
+++ b/src/pyhf/exceptions/__init__.py
@@ -34,6 +34,12 @@ class InvalidSpecification(Exception):
         super(InvalidSpecification, self).__init__(message)
 
 
+class InvalidWorkspaceOperation(Exception):
+    """
+  InvalidWorkspaceOperation is raised when an operation on a workspace fails.
+  """
+
+
 class InvalidModel(Exception):
     """
     InvalidModel is raised when a given model does not have the right configuration, even though it validates correctly against the schema.

--- a/src/pyhf/schemas/1.0.0/model.json
+++ b/src/pyhf/schemas/1.0.0/model.json
@@ -3,7 +3,7 @@
     "$id": "https://scikit-hep.org/pyhf/schemas/1.0.0/model.json",
     "type": "object",
     "properties": {
-        "channels": { "type": "array", "items": {"$ref": "defs.json#/definitions/channel"} },
+        "channels": { "type": "array", "items": {"$ref": "defs.json#/definitions/channel"}, "minItems": 1 },
         "parameters": { "type": "array", "items": {"$ref": "defs.json#/definitions/parameter"} }
     },
     "additionalProperties": false,

--- a/src/pyhf/schemas/1.0.0/workspace.json
+++ b/src/pyhf/schemas/1.0.0/workspace.json
@@ -3,9 +3,9 @@
     "$id": "https://scikit-hep.org/pyhf/schemas/1.0.0/workspace.json",
     "type": "object",
     "properties": {
-        "channels": { "type": "array", "items": {"$ref": "defs.json#/definitions/channel"} },
-        "measurements": { "type": "array", "items": {"$ref": "defs.json#/definitions/measurement"} },
-        "observations": { "type": "array", "items": {"$ref": "defs.json#/definitions/observation" } },
+        "channels": { "type": "array", "items": {"$ref": "defs.json#/definitions/channel"}, "minItems": 1 },
+        "measurements": { "type": "array", "items": {"$ref": "defs.json#/definitions/measurement"}, "minItems": 1 },
+        "observations": { "type": "array", "items": {"$ref": "defs.json#/definitions/observation" }, "minItems": 1 },
         "version": { "const": "1.0.0" }
     },
     "additionalProperties": false,

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -307,22 +307,24 @@ class Workspace(_ChannelSummaryMixin, dict):
             rename_measurements=measurements,
         )
 
-    def combine(self, other):
+    @classmethod
+    def combine(left, right):
         """
-        Return a new workspace specification that is the combination of this workspace and other workspace.
+        Return a new workspace specification that is the combination of the two workspaces.
 
         The new workspace must also be a valid workspace.
 
         A combination of workspaces is done by joining the set of channels. If the workspaces share any channels or measurements in common, do not combine.
 
         Args:
-            other: A :class:`~pyhf.workspace.Workspace` object.
+            left (~pyhf.workspace.Workspace): A workspace
+            right (~pyhf.workspace.Workspace): Another workspace
 
         Returns:
             ~pyhf.workspace.Workspace: A new combined workspace object
 
         """
-        common_channels = set(self.channels).intersection(other.channels)
+        common_channels = set(left.channels).intersection(right.channels)
         if common_channels:
             raise exceptions.InvalidWorkspaceOperation(
                 "Workspaces cannot have any channels in common: {}".format(
@@ -330,8 +332,8 @@ class Workspace(_ChannelSummaryMixin, dict):
                 )
             )
 
-        common_measurements = set(self.measurement_names).intersection(
-            other.measurement_names
+        common_measurements = set(left.measurement_names).intersection(
+            right.measurement_names
         )
         if common_measurements:
             raise exceptions.InvalidWorkspaceOperation(
@@ -339,10 +341,17 @@ class Workspace(_ChannelSummaryMixin, dict):
                     common_measurements
                 )
             )
+        if left.version != right.version:
+            raise exceptions.InvalidWorkspaceOperation(
+                "Workspaces of different versions cannot be combined: {} != {}".format(
+                    left.version, right.version
+                )
+            )
+
         newspec = {
-            'channels': self['channels'] + other['channels'],
-            'measurements': self['measurements'] + other['measurements'],
-            'observations': self['observations'] + other['observations'],
-            'version': self['version'],
+            'channels': left['channels'] + right['channels'],
+            'measurements': left['measurements'] + right['measurements'],
+            'observations': left['observations'] + right['observations'],
+            'version': left['version'],
         }
         return Workspace(newspec)

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -218,3 +218,16 @@ class Workspace(_ChannelSummaryMixin, dict):
             'version': self['version'],
         }
         return Workspace(newspec)
+
+    def rename(self, modifiers=[], samples=[], channels=[]):
+        """
+        Return a new workspace specification with certain elements renamed. This will not modify the original workspace.
+
+        The renamed workspace must also be a valid workspace.
+
+        Args:
+          modifiers: A list of modifiers to prune.
+          samples: A list of samples to prune.
+          channels: A list of channels to prune.
+        """
+        return Workspace(self)

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -317,4 +317,20 @@ class Workspace(_ChannelSummaryMixin, dict):
                     common_channels
                 )
             )
-        return Workspace(self)
+
+        common_measurements = set(self.measurement_names).intersection(
+            other.measurement_names
+        )
+        if common_measurements:
+            raise exceptions.InvalidWorkspaceOperation(
+                "Workspaces cannot have any measurements in common: {}".format(
+                    common_measurements
+                )
+            )
+        newspec = {
+            'channels': self['channels'] + other['channels'],
+            'measurements': self['measurements'] + other['measurements'],
+            'observations': self['observations'] + other['observations'],
+            'version': self['version'],
+        }
+        return Workspace(newspec)

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -308,7 +308,7 @@ class Workspace(_ChannelSummaryMixin, dict):
         )
 
     @classmethod
-    def combine(left, right):
+    def combine(cls, left, right):
         """
         Return a new workspace specification that is the combination of the two workspaces.
 

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -293,6 +293,12 @@ class Workspace(_ChannelSummaryMixin, dict):
             rename_measurements=measurements,
         )
 
+    def __iadd__(self, other):
+        """
+        See pyhf.Workspace.combine.
+        """
+        return self.combine(other)
+
     def __add__(self, other):
         """
         See pyhf.Workspace.combine.

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -189,6 +189,10 @@ class Workspace(_ChannelSummaryMixin, dict):
             rename_samples: A dictionary mapping old sample name to new sample name.
             rename_channels: A dictionary mapping old channel name to new channel name.
             rename_measurements: A dictionary mapping old measurement name to new measurement name.
+
+        Returns:
+            pyhf.Workspace: A new workspace object with the specified components removed or renamed
+
         """
         newspec = {
             'channels': [
@@ -265,6 +269,10 @@ class Workspace(_ChannelSummaryMixin, dict):
             samples: A string or a list of samples to prune.
             channels: A string or a list of channels to prune.
             measurements: A string or a list of measurements to prune.
+
+        Returns:
+            pyhf.Workspace: A new workspace object with the specified components removed
+
         """
         return self._prune_and_rename(
             prune_modifiers=modifiers,
@@ -285,6 +293,10 @@ class Workspace(_ChannelSummaryMixin, dict):
             samples: A dictionary mapping old sample name to new sample name.
             channels: A dictionary mapping old channel name to new channel name.
             measurements: A dictionary mapping old measurement name to new measurement name.
+
+        Returns:
+            pyhf.Workspace: A new workspace object with the specified components renamed
+
         """
         return self._prune_and_rename(
             rename_modifiers=modifiers,
@@ -303,6 +315,10 @@ class Workspace(_ChannelSummaryMixin, dict):
 
         Args:
             other: A pyhf.Workspace object.
+
+        Returns:
+            pyhf.Workspace: A new combined workspace object
+
         """
         common_channels = set(self.channels).intersection(other.channels)
         if common_channels:

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -179,7 +179,7 @@ class Workspace(_ChannelSummaryMixin, dict):
         """
         Return a new, pruned, renamed workspace specification. This will not modify the original workspace.
 
-        The pruned, renamed workspace must also be a valid workspace.
+        Pruning removes pieces of the workspace whose name or type matches the user-provided lists. The pruned, renamed workspace must also be a valid workspace.
 
         Args:
             prune_modifiers: A :obj:`str` or a :obj:`list` of modifiers to prune.

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -280,12 +280,7 @@ class Workspace(_ChannelSummaryMixin, dict):
 
     def __add__(self, other):
         """
-        Return a new workspace specification that is the combination of this workspace and other workspace.
-
-        The new workspace must also be a valid workspace.
-
-        Args:
-            other: A pyhf.Workspace object.
+        See pyhf.Workspace.combine.
         """
         return self.combine(other)
 
@@ -295,7 +290,16 @@ class Workspace(_ChannelSummaryMixin, dict):
 
         The new workspace must also be a valid workspace.
 
+        A combination of workspaces is done by joining the set of channels. If the workspaces share any channels in common, do not combine.
+
         Args:
             other: A pyhf.Workspace object.
         """
+        common_channels = set(self.channels).intersection(other.channels)
+        if common_channels:
+            raise exceptions.InvalidWorkspaceOperation(
+                "Workspaces cannot have any channels in common: {}".format(
+                    common_channels
+                )
+            )
         return Workspace(self)

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -344,39 +344,3 @@ class Workspace(_ChannelSummaryMixin, dict):
             'version': self['version'],
         }
         return Workspace(newspec)
-
-    def __iadd__(self, other):
-        """
-        See pyhf.Workspace.combine.
-        """
-        return self.combine(other)
-
-    def __add__(self, other):
-        """
-        See pyhf.Workspace.combine.
-        """
-        return self.combine(other)
-
-    def __isub__(self, other):
-        """
-        See pyhf.Workspace.prune.
-        """
-        return self.prune(
-            modifiers=other,
-            modifier_types=other,
-            samples=other,
-            channels=other,
-            measurements=other,
-        )
-
-    def __sub__(self, other):
-        """
-        See pyhf.Workspace.prune.
-        """
-        return self.prune(
-            modifiers=other,
-            modifier_types=other,
-            samples=other,
-            channels=other,
-            measurements=other,
-        )

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -50,7 +50,9 @@ class Workspace(_ChannelSummaryMixin, dict):
           2. if the measurement name is given, find the measurement for the given name
           3. if the measurement index is given, return the measurement at that index
           4. if there are measurements but none of the above have been specified, return the 0th measurement
-          5. otherwise, raises :exception:`pyhf.exceptions.InvalidMeasurement`
+
+        Raises:
+          ~pyhf.exceptions.InvalidMeasurement: If the measurement was not found
 
         Args:
             poi_name (str): The name of the parameter of interest to create a new measurement from

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -178,13 +178,13 @@ class Workspace(_ChannelSummaryMixin, dict):
         The pruned, renamed workspace must also be a valid workspace.
 
         Args:
-          prune_modifiers: A list of modifiers to prune.
-          prune_modifier_types: A list of modifier types to prune.
-          prune_samples: A list of samples to prune.
-          prune_channels: A list of channels to prune.
-          rename_modifiers: A dictionary mapping old modifier name to new modifier name.
-          rename_samples: A dictionary mapping old sample name to new sample name.
-          rename_channels: A dictionary mapping old channel name to new channel name.
+            prune_modifiers: A list of modifiers to prune.
+            prune_modifier_types: A list of modifier types to prune.
+            prune_samples: A list of samples to prune.
+            prune_channels: A list of channels to prune.
+            rename_modifiers: A dictionary mapping old modifier name to new modifier name.
+            rename_samples: A dictionary mapping old sample name to new sample name.
+            rename_channels: A dictionary mapping old channel name to new channel name.
         """
         newspec = {
             'channels': [
@@ -251,10 +251,10 @@ class Workspace(_ChannelSummaryMixin, dict):
         The pruned workspace must also be a valid workspace.
 
         Args:
-          modifiers: A list of modifiers to prune.
-          modifier_types: A list of modifier types to prune.
-          samples: A list of samples to prune.
-          channels: A list of channels to prune.
+            modifiers: A list of modifiers to prune.
+            modifier_types: A list of modifier types to prune.
+            samples: A list of samples to prune.
+            channels: A list of channels to prune.
         """
         return self._prune_and_rename(
             prune_modifiers=modifiers,
@@ -270,10 +270,32 @@ class Workspace(_ChannelSummaryMixin, dict):
         The renamed workspace must also be a valid workspace.
 
         Args:
-          modifiers: A dictionary mapping old modifier name to new modifier name.
-          samples: A dictionary mapping old sample name to new sample name.
-          channels: A dictionary mapping old channel name to new channel name.
+            modifiers: A dictionary mapping old modifier name to new modifier name.
+            samples: A dictionary mapping old sample name to new sample name.
+            channels: A dictionary mapping old channel name to new channel name.
         """
         return self._prune_and_rename(
             rename_modifiers=modifiers, rename_samples=samples, rename_channels=channels
         )
+
+    def __add__(self, other):
+        """
+        Return a new workspace specification that is the combination of this workspace and other workspace.
+
+        The new workspace must also be a valid workspace.
+
+        Args:
+            other: A pyhf.Workspace object.
+        """
+        return self.combine(other)
+
+    def combine(self, other):
+        """
+        Return a new workspace specification that is the combination of this workspace and other workspace.
+
+        The new workspace must also be a valid workspace.
+
+        Args:
+            other: A pyhf.Workspace object.
+        """
+        return Workspace(self)

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -162,25 +162,17 @@ class Workspace(_ChannelSummaryMixin, dict):
             observed_data += model.config.auxdata
         return observed_data
 
-    def prune(
-        self,
-        modifiers=[],
-        modifier_types=[],
-        samples=[],
-        channels=[],
-        return_workspace=False,
-    ):
+    def prune(self, modifiers=[], modifier_types=[], samples=[], channels=[]):
         """
         Return a new, pruned workspace specification. This will not modify the original workspace.
 
-        This is not guaranteed to be a valid workspace after pruning unless `return_workspace` is flagged.
+        The pruned workspace must also be a valid workspace.
 
         Args:
           modifiers: A list of modifiers to prune.
           modifier_types: A list of modifier types to prune.
           samples: A list of samples to prune.
           channels: A list of channels to prune.
-          return_workspace: Returns a new workspace object
         """
         newspec = {
             'channels': [
@@ -212,9 +204,9 @@ class Workspace(_ChannelSummaryMixin, dict):
                             parameter
                             for parameter in measurement['config']['parameters']
                             if parameter['name'] not in modifiers
-                        ]
+                        ],
+                        'poi': measurement['config']['poi'],
                     },
-                    'poi': measurement['config']['poi'],
                 }
                 for measurement in self['measurements']
             ],
@@ -225,4 +217,4 @@ class Workspace(_ChannelSummaryMixin, dict):
             ],
             'version': self['version'],
         }
-        return Workspace(newspec) if return_workspace else newspec
+        return Workspace(newspec)

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -50,15 +50,15 @@ class Workspace(_ChannelSummaryMixin, dict):
           2. if the measurement name is given, find the measurement for the given name
           3. if the measurement index is given, return the measurement at that index
           4. if there are measurements but none of the above have been specified, return the 0th measurement
-          5. otherwise, raises `InvalidMeasurement`
+          5. otherwise, raises :exception:`pyhf.exceptions.InvalidMeasurement`
 
         Args:
-            poi_name: The name of the parameter of interest to create a new measurement from
-            measurement_name: The name of the measurement to use
-            measurement_index: The index of the measurement to use
+            poi_name (str): The name of the parameter of interest to create a new measurement from
+            measurement_name (str): The name of the measurement to use
+            measurement_index (int): The index of the measurement to use
 
         Returns:
-            measurement: A measurement object adhering to the schema defs.json#/definitions/measurement
+            :obj:`dict`: A measurement object adhering to the schema defs.json#/definitions/measurement
 
         """
         m = self._get_measurement(**config_kwargs)
@@ -116,7 +116,7 @@ class Workspace(_ChannelSummaryMixin, dict):
             patches: A list of JSON patches to apply to the model specification
 
         Returns:
-            model: A model object adhering to the schema model.json
+            ~pyhf.pdf.Model: A model object adhering to the schema model.json
 
         """
         measurement = self.get_measurement(**config_kwargs)
@@ -142,11 +142,11 @@ class Workspace(_ChannelSummaryMixin, dict):
         The model is needed as the order of the data depends on the order of the channels in the model.
 
         Args:
-            model: A model object adhering to the schema model.json
-            with_aux: Whether to include auxiliary data from the model or not
+            model (~pyhf.pdf.Model): A model object adhering to the schema model.json
+            with_aux (bool): Whether to include auxiliary data from the model or not
 
         Returns:
-            data: A list of numbers
+            :obj:`list`: data
         """
 
         try:
@@ -180,18 +180,18 @@ class Workspace(_ChannelSummaryMixin, dict):
         The pruned, renamed workspace must also be a valid workspace.
 
         Args:
-            prune_modifiers: A string or a list of modifiers to prune.
-            prune_modifier_types: A string or a list of modifier types to prune.
-            prune_samples: A string or a list of samples to prune.
-            prune_channels: A string or a list of channels to prune.
-            prune_measurements: A string or a list of measurements to prune.
-            rename_modifiers: A dictionary mapping old modifier name to new modifier name.
-            rename_samples: A dictionary mapping old sample name to new sample name.
-            rename_channels: A dictionary mapping old channel name to new channel name.
-            rename_measurements: A dictionary mapping old measurement name to new measurement name.
+            prune_modifiers: A :obj:`str` or a :obj:`list` of modifiers to prune.
+            prune_modifier_types: A :obj:`str` or a :obj:`list` of modifier types to prune.
+            prune_samples: A :obj:`str` or a :obj:`list` of samples to prune.
+            prune_channels: A :obj:`str` or a :obj:`list` of channels to prune.
+            prune_measurements: A :obj:`str` or a :obj:`list` of measurements to prune.
+            rename_modifiers: A :obj:`dict` mapping old modifier name to new modifier name.
+            rename_samples: A :obj:`dict` mapping old sample name to new sample name.
+            rename_channels: A :obj:`dict` mapping old channel name to new channel name.
+            rename_measurements: A :obj:`dict` mapping old measurement name to new measurement name.
 
         Returns:
-            pyhf.Workspace: A new workspace object with the specified components removed or renamed
+            ~pyhf.workspace.Workspace: A new workspace object with the specified components removed or renamed
 
         """
         newspec = {
@@ -264,14 +264,14 @@ class Workspace(_ChannelSummaryMixin, dict):
         The pruned workspace must also be a valid workspace.
 
         Args:
-            modifiers: A string or a list of modifiers to prune.
-            modifier_types: A string or a list of modifier types to prune.
-            samples: A string or a list of samples to prune.
-            channels: A string or a list of channels to prune.
-            measurements: A string or a list of measurements to prune.
+            modifiers: A :obj:`str` or a :obj:`list` of modifiers to prune.
+            modifier_types: A :obj:`str` or a :obj:`list` of modifier types to prune.
+            samples: A :obj:`str` or a :obj:`list` of samples to prune.
+            channels: A :obj:`str` or a :obj:`list` of channels to prune.
+            measurements: A :obj:`str` or a :obj:`list` of measurements to prune.
 
         Returns:
-            pyhf.Workspace: A new workspace object with the specified components removed
+            ~pyhf.workspace.Workspace: A new workspace object with the specified components removed
 
         """
         return self._prune_and_rename(
@@ -289,13 +289,13 @@ class Workspace(_ChannelSummaryMixin, dict):
         The renamed workspace must also be a valid workspace.
 
         Args:
-            modifiers: A dictionary mapping old modifier name to new modifier name.
-            samples: A dictionary mapping old sample name to new sample name.
-            channels: A dictionary mapping old channel name to new channel name.
-            measurements: A dictionary mapping old measurement name to new measurement name.
+            modifiers: A :obj:`dict` mapping old modifier name to new modifier name.
+            samples: A :obj:`dict` mapping old sample name to new sample name.
+            channels: A :obj:`dict` mapping old channel name to new channel name.
+            measurements: A :obj:`dict` mapping old measurement name to new measurement name.
 
         Returns:
-            pyhf.Workspace: A new workspace object with the specified components renamed
+            ~pyhf.workspace.Workspace: A new workspace object with the specified components renamed
 
         """
         return self._prune_and_rename(
@@ -314,10 +314,10 @@ class Workspace(_ChannelSummaryMixin, dict):
         A combination of workspaces is done by joining the set of channels. If the workspaces share any channels or measurements in common, do not combine.
 
         Args:
-            other: A pyhf.Workspace object.
+            other: A :class:`~pyhf.workspace.Workspace` object.
 
         Returns:
-            pyhf.Workspace: A new combined workspace object
+            ~pyhf.workspace.Workspace: A new combined workspace object
 
         """
         common_channels = set(self.channels).intersection(other.channels)

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -1,8 +1,5 @@
 import logging
 import jsonpatch
-from collections import (
-    UserDict,
-)  # underlying dict is accessible as an attribute (self.data)
 from . import exceptions
 from . import utils
 from .pdf import Model
@@ -23,7 +20,7 @@ class Workspace(_ChannelSummaryMixin, dict):
         self.version = config_kwargs.pop('version', None)
         # run jsonschema validation of input specification against the (provided) schema
         log.info("Validating spec against schema: {0:s}".format(self.schema))
-        utils.validate(self.data, self.schema, version=self.version)
+        utils.validate(self, self.schema, version=self.version)
 
         self.measurement_names = []
         for measurement in self.get('measurements', []):
@@ -204,7 +201,7 @@ class Workspace(_ChannelSummaryMixin, dict):
                         if sample['name'] not in samples
                     ],
                 }
-                for channel in self.data['channels']
+                for channel in self['channels']
                 if channel['name'] not in channels
             ],
             'measurements': [
@@ -219,13 +216,13 @@ class Workspace(_ChannelSummaryMixin, dict):
                     },
                     'poi': measurement['config']['poi'],
                 }
-                for measurement in self.data['measurements']
+                for measurement in self['measurements']
             ],
             'observations': [
                 observation
-                for observation in self.data['observations']
+                for observation in self['observations']
                 if observation['name'] not in channels
             ],
-            'version': self.data['version'],
+            'version': self['version'],
         }
         return Workspace(newspec) if return_workspace else newspec

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -165,7 +165,14 @@ class Workspace(_ChannelSummaryMixin, dict):
             observed_data += model.config.auxdata
         return observed_data
 
-    def prune(self, modifiers=[], samples=[], channels=[], return_workspace=False):
+    def prune(
+        self,
+        modifiers=[],
+        modifier_types=[],
+        samples=[],
+        channels=[],
+        return_workspace=False,
+    ):
         """
         Return a new, pruned workspace specification. This will not modify the original workspace.
 
@@ -173,6 +180,7 @@ class Workspace(_ChannelSummaryMixin, dict):
 
         Args:
           modifiers: A list of modifiers to prune.
+          modifier_types: A list of modifier types to prune.
           samples: A list of samples to prune.
           channels: A list of channels to prune.
           return_workspace: Returns a new workspace object
@@ -189,6 +197,7 @@ class Workspace(_ChannelSummaryMixin, dict):
                                 modifier
                                 for modifier in sample['modifiers']
                                 if modifier['name'] not in modifiers
+                                and modifier['type'] not in modifier_types
                             ],
                         }
                         for sample in channel['samples']

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -252,7 +252,9 @@ class Workspace(_ChannelSummaryMixin, dict):
                             for parameter in measurement['config']['parameters']
                             if parameter['name'] not in prune_modifiers
                         ],
-                        'poi': measurement['config']['poi'],
+                        'poi': rename_modifiers.get(
+                            measurement['config']['poi'], measurement['config']['poi']
+                        ),
                     },
                 }
                 for measurement in self['measurements']

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -180,11 +180,11 @@ class Workspace(_ChannelSummaryMixin, dict):
         The pruned, renamed workspace must also be a valid workspace.
 
         Args:
-            prune_modifiers: A list of modifiers to prune.
-            prune_modifier_types: A list of modifier types to prune.
-            prune_samples: A list of samples to prune.
-            prune_channels: A list of channels to prune.
-            prune_measurements: A list of measurements to prune.
+            prune_modifiers: A string or a list of modifiers to prune.
+            prune_modifier_types: A string or a list of modifier types to prune.
+            prune_samples: A string or a list of samples to prune.
+            prune_channels: A string or a list of channels to prune.
+            prune_measurements: A string or a list of measurements to prune.
             rename_modifiers: A dictionary mapping old modifier name to new modifier name.
             rename_samples: A dictionary mapping old sample name to new sample name.
             rename_channels: A dictionary mapping old channel name to new channel name.
@@ -260,11 +260,11 @@ class Workspace(_ChannelSummaryMixin, dict):
         The pruned workspace must also be a valid workspace.
 
         Args:
-            modifiers: A list of modifiers to prune.
-            modifier_types: A list of modifier types to prune.
-            samples: A list of samples to prune.
-            channels: A list of channels to prune.
-            measurements: A list of measurements to prune.
+            modifiers: A string or a list of modifiers to prune.
+            modifier_types: A string or a list of modifier types to prune.
+            samples: A string or a list of samples to prune.
+            channels: A string or a list of channels to prune.
+            measurements: A string or a list of measurements to prune.
         """
         return self._prune_and_rename(
             prune_modifiers=modifiers,
@@ -292,18 +292,6 @@ class Workspace(_ChannelSummaryMixin, dict):
             rename_channels=channels,
             rename_measurements=measurements,
         )
-
-    def __iadd__(self, other):
-        """
-        See pyhf.Workspace.combine.
-        """
-        return self.combine(other)
-
-    def __add__(self, other):
-        """
-        See pyhf.Workspace.combine.
-        """
-        return self.combine(other)
 
     def combine(self, other):
         """
@@ -340,3 +328,39 @@ class Workspace(_ChannelSummaryMixin, dict):
             'version': self['version'],
         }
         return Workspace(newspec)
+
+    def __iadd__(self, other):
+        """
+        See pyhf.Workspace.combine.
+        """
+        return self.combine(other)
+
+    def __add__(self, other):
+        """
+        See pyhf.Workspace.combine.
+        """
+        return self.combine(other)
+
+    def __isub__(self, other):
+        """
+        See pyhf.Workspace.prune.
+        """
+        return self.prune(
+            modifiers=other,
+            modifier_types=other,
+            samples=other,
+            channels=other,
+            measurements=other,
+        )
+
+    def __sub__(self, other):
+        """
+        See pyhf.Workspace.prune.
+        """
+        return self.prune(
+            modifiers=other,
+            modifier_types=other,
+            samples=other,
+            channels=other,
+            measurements=other,
+        )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2,6 +2,12 @@ import pyhf
 import pytest
 
 
+def test_no_channels():
+    spec = {'channels': []}
+    with pytest.raises(pyhf.exceptions.InvalidSpecification):
+        pyhf.Model(spec)
+
+
 def test_no_samples():
     spec = {'channels': [{'name': 'channel', 'samples': []}]}
     with pytest.raises(pyhf.exceptions.InvalidSpecification):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -326,3 +326,45 @@ def test_prune_outfile(tmpdir, script_runner):
     pruned_ws = pyhf.Workspace(pruned_spec)
     assert 'GammaExample' not in pruned_ws.measurement_names
     assert 'staterror_channel1' not in pruned_ws.parameters
+
+
+def test_rename(tmpdir, script_runner):
+    temp = tmpdir.join("parsed_output.json")
+    command = 'pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s} --hide-progress'.format(
+        temp.strpath
+    )
+    ret = script_runner.run(*shlex.split(command))
+
+    command = 'pyhf rename -m staterror_channel1 staterror_channelone -e GammaExample GamEx {0:s}'.format(
+        temp.strpath
+    )
+    ret = script_runner.run(*shlex.split(command))
+    assert ret.success
+
+
+def test_rename_outfile(tmpdir, script_runner):
+    temp = tmpdir.join("parsed_output.json")
+    command = 'pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s} --hide-progress'.format(
+        temp.strpath
+    )
+    ret = script_runner.run(*shlex.split(command))
+
+    tempout = tmpdir.join("rename_output.json")
+    command = 'pyhf rename -m staterror_channel1 staterror_channelone -e GammaExample GamEx {0:s} --output-file {1:s}'.format(
+        temp.strpath, tempout.strpath
+    )
+    ret = script_runner.run(*shlex.split(command))
+    assert ret.success
+
+    spec = json.loads(temp.read())
+    ws = pyhf.Workspace(spec)
+    assert 'GammaExample' in ws.measurement_names
+    assert 'GamEx' not in ws.measurement_names
+    assert 'staterror_channel1' in ws.parameters
+    assert 'staterror_channelone' not in ws.parameters
+    renamed_spec = json.loads(tempout.read())
+    renamed_ws = pyhf.Workspace(renamed_spec)
+    assert 'GammaExample' not in renamed_ws.measurement_names
+    assert 'GamEx' in renamed_ws.measurement_names
+    assert 'staterror_channel1' not in renamed_ws.parameters
+    assert 'staterror_channelone' in renamed_ws.parameters

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -297,7 +297,7 @@ def test_prune(tmpdir, script_runner):
     )
     ret = script_runner.run(*shlex.split(command))
 
-    command = 'pyhf prune -m staterror_channel1 -e GammaExample {0:s}'.format(
+    command = 'pyhf prune -m staterror_channel1 --measurement GammaExample {0:s}'.format(
         temp.strpath
     )
     ret = script_runner.run(*shlex.split(command))
@@ -312,7 +312,7 @@ def test_prune_outfile(tmpdir, script_runner):
     ret = script_runner.run(*shlex.split(command))
 
     tempout = tmpdir.join("prune_output.json")
-    command = 'pyhf prune -m staterror_channel1 -e GammaExample {0:s} --output-file {1:s}'.format(
+    command = 'pyhf prune -m staterror_channel1 --measurement GammaExample {0:s} --output-file {1:s}'.format(
         temp.strpath, tempout.strpath
     )
     ret = script_runner.run(*shlex.split(command))
@@ -335,7 +335,7 @@ def test_rename(tmpdir, script_runner):
     )
     ret = script_runner.run(*shlex.split(command))
 
-    command = 'pyhf rename -m staterror_channel1 staterror_channelone -e GammaExample GamEx {0:s}'.format(
+    command = 'pyhf rename -m staterror_channel1 staterror_channelone --measurement GammaExample GamEx {0:s}'.format(
         temp.strpath
     )
     ret = script_runner.run(*shlex.split(command))
@@ -350,7 +350,7 @@ def test_rename_outfile(tmpdir, script_runner):
     ret = script_runner.run(*shlex.split(command))
 
     tempout = tmpdir.join("rename_output.json")
-    command = 'pyhf rename -m staterror_channel1 staterror_channelone -e GammaExample GamEx {0:s} --output-file {1:s}'.format(
+    command = 'pyhf rename -m staterror_channel1 staterror_channelone --measurement GammaExample GamEx {0:s} --output-file {1:s}'.format(
         temp.strpath, tempout.strpath
     )
     ret = script_runner.run(*shlex.split(command))
@@ -389,7 +389,9 @@ def test_combine(tmpdir, script_runner):
     command = 'pyhf rename {0:s} {1:s} {2:s} --output-file {3:s}'.format(
         temp_1.strpath,
         ''.join(' -c ' + ' '.join(item) for item in rename_channels.items()),
-        ''.join(' -e ' + ' '.join(item) for item in rename_measurements.items()),
+        ''.join(
+            ' --measurement ' + ' '.join(item) for item in rename_measurements.items()
+        ),
         temp_2.strpath,
     )
     ret = script_runner.run(*shlex.split(command))
@@ -418,7 +420,9 @@ def test_combine_outfile(tmpdir, script_runner):
     command = 'pyhf rename {0:s} {1:s} {2:s} --output-file {3:s}'.format(
         temp_1.strpath,
         ''.join(' -c ' + ' '.join(item) for item in rename_channels.items()),
-        ''.join(' -e ' + ' '.join(item) for item in rename_measurements.items()),
+        ''.join(
+            ' --measurement ' + ' '.join(item) for item in rename_measurements.items()
+        ),
         temp_2.strpath,
     )
     ret = script_runner.run(*shlex.split(command))

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -156,10 +156,6 @@ def test_prune_channel(workspace_factory):
             new_ws = ws.prune(channels=channel)
         with pytest.raises(pyhf.exceptions.InvalidSpecification):
             new_ws = ws.prune(channels=[channel])
-        with pytest.raises(pyhf.exceptions.InvalidSpecification):
-            new_ws = ws - channel
-        with pytest.raises(pyhf.exceptions.InvalidSpecification):
-            new_ws = ws - [channel]
     else:
         new_ws = ws.prune(channels=channel)
         assert channel not in new_ws.channels
@@ -167,11 +163,6 @@ def test_prune_channel(workspace_factory):
 
         new_ws_list = ws.prune(channels=[channel])
         assert new_ws_list == new_ws
-        new_ws_sub = ws - channel
-        assert new_ws_sub == new_ws
-        new_ws_isub = workspace_factory()
-        new_ws_isub -= channel
-        assert new_ws_isub == new_ws
 
 
 def test_prune_sample(workspace_factory):
@@ -183,11 +174,6 @@ def test_prune_sample(workspace_factory):
 
     new_ws_list = ws.prune(samples=[sample])
     assert new_ws_list == new_ws
-    new_ws_sub = ws - sample
-    assert new_ws_sub == new_ws
-    new_ws_isub = workspace_factory()
-    new_ws_isub -= sample
-    assert new_ws_isub == new_ws
 
 
 def test_prune_modifier(workspace_factory):
@@ -226,10 +212,6 @@ def test_prune_measurements(workspace_factory):
             new_ws = ws.prune(measurements=measurement)
         with pytest.raises(pyhf.exceptions.InvalidSpecification):
             new_ws = ws.prune(measurements=[measurement])
-        with pytest.raises(pyhf.exceptions.InvalidSpecification):
-            new_ws = ws - measurement
-        with pytest.raises(pyhf.exceptions.InvalidSpecification):
-            new_ws = ws - [measurement]
     else:
         new_ws = ws.prune(measurements=[measurement])
         assert new_ws
@@ -237,11 +219,6 @@ def test_prune_measurements(workspace_factory):
 
         new_ws_list = ws.prune(measurements=[measurement])
         assert new_ws_list == new_ws
-        new_ws_sub = ws - measurement
-        assert new_ws_sub == new_ws
-        new_ws_isub = workspace_factory()
-        new_ws_isub -= measurement
-        assert new_ws_isub == new_ws
 
 
 def test_rename_channel(workspace_factory):
@@ -333,10 +310,3 @@ def test_combine_workspace(workspace_factory):
     assert set(combined_combine.channels) == set(ws.channels + new_ws.channels)
     assert set(combined_combine.samples) == set(ws.samples + new_ws.samples)
     assert set(combined_combine.parameters) == set(ws.parameters + new_ws.parameters)
-    # check adding
-    combined_add = ws + new_ws
-    assert combined_add == combined_combine
-    # check "incrementing"
-    combined_increment = workspace_factory()
-    combined_increment += new_ws
-    assert combined_increment == combined_combine

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -221,6 +221,15 @@ def test_rename_modifier(workspace_factory):
     assert renamed in new_ws.parameters
 
 
+def test_combine_workspace_same_channels(workspace_factory):
+    ws = workspace_factory()
+    new_ws = ws.rename(channels={'channel2': 'channel3'})
+    with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
+        combined = ws.combine(new_ws)
+    assert 'channel1' in str(excinfo.value)
+    assert 'channel2' not in str(excinfo.value)
+
+
 def test_combine_workspace(workspace_factory):
     ws = workspace_factory()
     new_ws = ws.rename(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -253,6 +253,17 @@ def test_rename_modifier(workspace_factory):
     assert renamed in new_ws.parameters
 
 
+def test_rename_poi(workspace_factory):
+    ws = workspace_factory()
+    poi = ws.get_measurement()['config']['poi']
+    renamed = 'renamedPoi'
+    assert renamed not in ws.parameters
+    new_ws = ws.rename(modifiers={poi: renamed})
+    assert poi not in new_ws.parameters
+    assert renamed in new_ws.parameters
+    assert new_ws.get_measurement()['config']['poi'] == renamed
+
+
 def test_rename_measurement(workspace_factory):
     ws = workspace_factory()
     measurement = ws.measurement_names[0]

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -267,7 +267,7 @@ def test_combine_workspace_same_channels(workspace_factory):
     ws = workspace_factory()
     new_ws = ws.rename(channels={'channel2': 'channel3'})
     with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
-        combined = ws.combine(new_ws)
+        combined = pyhf.Workspace.combine(ws, new_ws)
     assert 'channel1' in str(excinfo.value)
     assert 'channel2' not in str(excinfo.value)
 
@@ -278,11 +278,37 @@ def test_combine_workspace_same_measurements(workspace_factory):
         measurements=['GammaExample', 'ConstExample', 'LogNormExample']
     )
     with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
-        combined = ws.combine(new_ws)
+        combined = pyhf.Workspace.combine(ws, new_ws)
     assert 'GaussExample' in str(excinfo.value)
     assert 'GammaExample' not in str(excinfo.value)
     assert 'ConstExample' not in str(excinfo.value)
     assert 'LogNormExample' not in str(excinfo.value)
+
+
+def test_combine_workspace_diff_version(workspace_factory):
+    ws = workspace_factory()
+    new_ws = ws.rename(
+        channels={'channel1': 'channel3', 'channel2': 'channel4'},
+        samples={
+            'background1': 'background3',
+            'background2': 'background4',
+            'signal': 'signal2',
+        },
+        modifiers={
+            'syst1': 'syst4',
+            'bkg1Shape': 'bkg3Shape',
+            'bkg2Shape': 'bkg4Shape',
+        },
+        measurements={
+            'ConstExample': 'OtherConstExample',
+            'LogNormExample': 'OtherLogNormExample',
+            'GaussExample': 'OtherGaussExample',
+            'GammaExample': 'OtherGammaExample',
+        },
+    )
+    new_ws.version = '0.0.0'
+    with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
+        combined = pyhf.Workspace.combine(ws, new_ws)
 
 
 def test_combine_workspace(workspace_factory):
@@ -306,7 +332,7 @@ def test_combine_workspace(workspace_factory):
             'GammaExample': 'OtherGammaExample',
         },
     )
-    combined_combine = ws.combine(new_ws)
+    combined_combine = pyhf.Workspace.combine(ws, new_ws)
     assert set(combined_combine.channels) == set(ws.channels + new_ws.channels)
     assert set(combined_combine.samples) == set(ws.samples + new_ws.samples)
     assert set(combined_combine.parameters) == set(ws.parameters + new_ws.parameters)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -153,25 +153,47 @@ def test_prune_channel(workspace_factory):
     channel = ws.channels[0]
     if len(ws.channels) == 1:
         with pytest.raises(pyhf.exceptions.InvalidSpecification):
+            new_ws = ws.prune(channels=channel)
+        with pytest.raises(pyhf.exceptions.InvalidSpecification):
             new_ws = ws.prune(channels=[channel])
+        with pytest.raises(pyhf.exceptions.InvalidSpecification):
+            new_ws = ws - channel
+        with pytest.raises(pyhf.exceptions.InvalidSpecification):
+            new_ws = ws - [channel]
     else:
         new_ws = ws.prune(channels=channel)
         assert channel not in new_ws.channels
         assert channel not in [obs['name'] for obs in new_ws['observations']]
 
+        new_ws_list = ws.prune(channels=[channel])
+        assert new_ws_list == new_ws
+        new_ws_sub = ws - channel
+        assert new_ws_sub == new_ws
+        new_ws_isub = workspace_factory()
+        new_ws_isub -= channel
+        assert new_ws_isub == new_ws
+
 
 def test_prune_sample(workspace_factory):
     ws = workspace_factory()
     sample = ws.samples[1]
-    new_ws = ws.prune(samples=[sample])
+    new_ws = ws.prune(samples=sample)
     assert new_ws
     assert sample not in new_ws.samples
+
+    new_ws_list = ws.prune(samples=[sample])
+    assert new_ws_list == new_ws
+    new_ws_sub = ws - sample
+    assert new_ws_sub == new_ws
+    new_ws_isub = workspace_factory()
+    new_ws_isub -= sample
+    assert new_ws_isub == new_ws
 
 
 def test_prune_modifier(workspace_factory):
     ws = workspace_factory()
     modifier = 'lumi'
-    new_ws = ws.prune(modifiers=[modifier])
+    new_ws = ws.prune(modifiers=modifier)
     assert new_ws
     assert modifier not in new_ws.parameters
     assert modifier not in [
@@ -180,21 +202,46 @@ def test_prune_modifier(workspace_factory):
         for p in measurement['config']['parameters']
     ]
 
+    new_ws_list = ws.prune(modifiers=[modifier])
+    assert new_ws_list == new_ws
+
 
 def test_prune_modifier_type(workspace_factory):
     ws = workspace_factory()
     modifier_type = 'lumi'
-    new_ws = ws.prune(modifier_types=[modifier_type])
+    new_ws = ws.prune(modifier_types=modifier_type)
     assert new_ws
     assert modifier_type not in [item[1] for item in new_ws.modifiers]
+
+    new_ws_list = ws.prune(modifier_types=[modifier_type])
+    assert new_ws_list == new_ws
 
 
 def test_prune_measurements(workspace_factory):
     ws = workspace_factory()
-    measurement = 'lumi'
-    new_ws = ws.prune(measurements=[measurement])
-    assert new_ws
-    assert measurement not in new_ws.measurement_names
+    measurement = ws.measurement_names[0]
+
+    if len(ws.measurement_names) == 1:
+        with pytest.raises(pyhf.exceptions.InvalidSpecification):
+            new_ws = ws.prune(measurements=measurement)
+        with pytest.raises(pyhf.exceptions.InvalidSpecification):
+            new_ws = ws.prune(measurements=[measurement])
+        with pytest.raises(pyhf.exceptions.InvalidSpecification):
+            new_ws = ws - measurement
+        with pytest.raises(pyhf.exceptions.InvalidSpecification):
+            new_ws = ws - [measurement]
+    else:
+        new_ws = ws.prune(measurements=[measurement])
+        assert new_ws
+        assert measurement not in new_ws.measurement_names
+
+        new_ws_list = ws.prune(measurements=[measurement])
+        assert new_ws_list == new_ws
+        new_ws_sub = ws - measurement
+        assert new_ws_sub == new_ws
+        new_ws_isub = workspace_factory()
+        new_ws_isub -= measurement
+        assert new_ws_isub == new_ws
 
 
 def test_rename_channel(workspace_factory):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -162,10 +162,57 @@ def test_prune_channel(workspace_factory):
 def test_prune_sample(workspace_factory):
     ws = workspace_factory()
     sample = ws.samples[1]
-    assert ws.prune(samples=[sample])
+    new_ws = ws.prune(samples=[sample])
+    assert new_ws
+    assert sample not in new_ws.samples
 
 
 def test_prune_modifier(workspace_factory):
     ws = workspace_factory()
+    modifier = 'lumi'
+    new_ws = ws.prune(modifiers=[modifier])
+    assert new_ws
+    assert modifier not in new_ws.parameters
+    assert modifier not in [
+        p['name']
+        for measurement in new_ws['measurements']
+        for p in measurement['config']['parameters']
+    ]
+
+
+def test_prune_modifier_type(workspace_factory):
+    ws = workspace_factory()
+    modifier_type = 'lumi'
+    new_ws = ws.prune(modifier_types=[modifier_type])
+    assert new_ws
+    assert modifier_type not in [item[1] for item in new_ws.modifiers]
+
+
+def test_rename_channel(spec):
+    ws = workspace_factory()
+    channel = ws.channels[0]
+    renamed = 'renamedChannel'
+    assert renamed not in ws.channels
+    new_ws = ws.prune(channels={channel: renamed})
+    assert channel not in new_ws.channels
+    assert renamed in new_ws.channels
+
+
+def test_rename_sample(spec):
+    ws = workspace_factory()
+    sample = ws.samples[1]
+    renamed = 'renamedSample'
+    assert renamed not in ws.samples
+    new_ws = ws.prune(samples={sample: renamed})
+    assert sample not in new_ws.samples
+    assert renamed in new_ws.samples
+
+
+def test_rename_modifier(spec):
+    ws = workspace_factory()
     modifier = ws.parameters[0]
-    assert ws.prune(modifiers=[modifier])
+    renamed = 'renamedModifier'
+    assert renamed not in ws.parameters
+    new_ws = ws.prune(modifiers={modifier: renamed})
+    assert modifier not in new_ws.parameters
+    assert renamed in new_ws.parameters

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -233,6 +233,7 @@ def test_combine_workspace_same_channels(workspace_factory):
 def test_combine_workspace(workspace_factory):
     ws = workspace_factory()
     new_ws = ws.rename(
+        channels={'channel1': 'channel3', 'channel2': 'channel4'},
         samples={
             'background1': 'background3',
             'background2': 'background4',

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -219,3 +219,29 @@ def test_rename_modifier(workspace_factory):
     new_ws = ws.rename(modifiers={modifier: renamed})
     assert modifier not in new_ws.parameters
     assert renamed in new_ws.parameters
+
+
+def test_combine_workspace(workspace_factory):
+    ws = workspace_factory()
+    new_ws = ws.rename(
+        samples={
+            'background1': 'background3',
+            'background2': 'background4',
+            'signal': 'signal2',
+        },
+        modifiers={
+            'syst1': 'syst4',
+            'bkg1Shape': 'bkg3Shape',
+            'bkg2Shape': 'bkg4Shape',
+        },
+    )
+    combined_combine = ws.combine(new_ws)
+    assert set(combined_combine.channels) == set(ws.channels + new_ws.channels)
+    assert set(combined_combine.samples) == set(ws.samples + new_ws.samples)
+    assert set(combined_combine.parameters) == set(ws.parameters + new_ws.parameters)
+    # check adding
+    combined_add = ws + new_ws
+    assert combined_add == combined_combine
+    assert set(combined_add.channels) == set(ws.channels + new_ws.channels)
+    assert set(combined_add.samples) == set(ws.samples + new_ws.samples)
+    assert set(combined_add.parameters) == set(ws.parameters + new_ws.parameters)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -275,6 +275,12 @@ def test_combine_workspace(workspace_factory):
             'bkg1Shape': 'bkg3Shape',
             'bkg2Shape': 'bkg4Shape',
         },
+        measurements={
+            'ConstExample': 'OtherConstExample',
+            'LogNormExample': 'OtherLogNormExample',
+            'GaussExample': 'OtherGaussExample',
+            'GammaExample': 'OtherGammaExample',
+        },
     )
     combined_combine = ws.combine(new_ws)
     assert set(combined_combine.channels) == set(ws.channels + new_ws.channels)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -289,6 +289,7 @@ def test_combine_workspace(workspace_factory):
     # check adding
     combined_add = ws + new_ws
     assert combined_add == combined_combine
-    assert set(combined_add.channels) == set(ws.channels + new_ws.channels)
-    assert set(combined_add.samples) == set(ws.samples + new_ws.samples)
-    assert set(combined_add.parameters) == set(ws.parameters + new_ws.parameters)
+    # check "incrementing"
+    combined_increment = workspace_factory()
+    combined_increment += new_ws
+    assert combined_increment == combined_combine

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -189,6 +189,14 @@ def test_prune_modifier_type(workspace_factory):
     assert modifier_type not in [item[1] for item in new_ws.modifiers]
 
 
+def test_prune_measurements(workspace_factory):
+    ws = workspace_factory()
+    measurement = 'lumi'
+    new_ws = ws.prune(measurements=[measurement])
+    assert new_ws
+    assert measurement not in new_ws.measurement_names
+
+
 def test_rename_channel(workspace_factory):
     ws = workspace_factory()
     channel = ws.channels[0]
@@ -221,6 +229,16 @@ def test_rename_modifier(workspace_factory):
     assert renamed in new_ws.parameters
 
 
+def test_rename_measurement(workspace_factory):
+    ws = workspace_factory()
+    measurement = ws.measurement_names[0]
+    renamed = 'renamedMeasurement'
+    assert renamed not in ws.measurement_names
+    new_ws = ws.rename(measurements={measurement: renamed})
+    assert measurement not in new_ws.measurement_names
+    assert renamed in new_ws.measurement_names
+
+
 def test_combine_workspace_same_channels(workspace_factory):
     ws = workspace_factory()
     new_ws = ws.rename(channels={'channel2': 'channel3'})
@@ -228,6 +246,19 @@ def test_combine_workspace_same_channels(workspace_factory):
         combined = ws.combine(new_ws)
     assert 'channel1' in str(excinfo.value)
     assert 'channel2' not in str(excinfo.value)
+
+
+def test_combine_workspace_same_measurements(workspace_factory):
+    ws = workspace_factory()
+    new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
+        measurements=['GammaExample', 'ConstExample', 'LogNormExample']
+    )
+    with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
+        combined = ws.combine(new_ws)
+    assert 'GaussExample' in str(excinfo.value)
+    assert 'GammaExample' not in str(excinfo.value)
+    assert 'ConstExample' not in str(excinfo.value)
+    assert 'LogNormExample' not in str(excinfo.value)
 
 
 def test_combine_workspace(workspace_factory):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -136,3 +136,36 @@ def test_get_workspace_data_bad_model(workspace_factory, caplog):
 
 def test_json_serializable(workspace_factory):
     assert json.dumps(workspace_factory())
+
+
+def test_prune_nothing(workspace_factory):
+    ws = workspace_factory()
+    new_ws = ws.prune(
+        channels=['fake-name'],
+        samples=['fake-sample'],
+        modifiers=['fake-modifier'],
+        modifier_types=['fake-type'],
+    )
+
+
+def test_prune_channel(workspace_factory):
+    ws = workspace_factory()
+    channel = ws.channels[0]
+    if len(ws.channels) == 1:
+        with pytest.raises(pyhf.exceptions.InvalidSpecification):
+            new_ws = ws.prune(channels=[channel])
+    else:
+        new_ws = ws.prune(channels=channel)
+        assert channel not in new_ws.channels
+
+
+def test_prune_sample(workspace_factory):
+    ws = workspace_factory()
+    sample = ws.samples[1]
+    assert ws.prune(samples=[sample])
+
+
+def test_prune_modifier(workspace_factory):
+    ws = workspace_factory()
+    modifier = ws.parameters[0]
+    assert ws.prune(modifiers=[modifier])

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -157,6 +157,7 @@ def test_prune_channel(workspace_factory):
     else:
         new_ws = ws.prune(channels=channel)
         assert channel not in new_ws.channels
+        assert channel not in [obs['name'] for obs in new_ws['observations']]
 
 
 def test_prune_sample(workspace_factory):
@@ -188,31 +189,33 @@ def test_prune_modifier_type(workspace_factory):
     assert modifier_type not in [item[1] for item in new_ws.modifiers]
 
 
-def test_rename_channel(spec):
+def test_rename_channel(workspace_factory):
     ws = workspace_factory()
     channel = ws.channels[0]
     renamed = 'renamedChannel'
     assert renamed not in ws.channels
-    new_ws = ws.prune(channels={channel: renamed})
+    new_ws = ws.rename(channels={channel: renamed})
     assert channel not in new_ws.channels
     assert renamed in new_ws.channels
+    assert channel not in [obs['name'] for obs in new_ws['observations']]
+    assert renamed in [obs['name'] for obs in new_ws['observations']]
 
 
-def test_rename_sample(spec):
+def test_rename_sample(workspace_factory):
     ws = workspace_factory()
     sample = ws.samples[1]
     renamed = 'renamedSample'
     assert renamed not in ws.samples
-    new_ws = ws.prune(samples={sample: renamed})
+    new_ws = ws.rename(samples={sample: renamed})
     assert sample not in new_ws.samples
     assert renamed in new_ws.samples
 
 
-def test_rename_modifier(spec):
+def test_rename_modifier(workspace_factory):
     ws = workspace_factory()
     modifier = ws.parameters[0]
     renamed = 'renamedModifier'
     assert renamed not in ws.parameters
-    new_ws = ws.prune(modifiers={modifier: renamed})
+    new_ws = ws.rename(modifiers={modifier: renamed})
     assert modifier not in new_ws.parameters
     assert renamed in new_ws.parameters


### PR DESCRIPTION
# Description

- [x] `pyhf prune --channel ... --sample ... --modifier ... --modifier-type ... --measurement ... spec.json`
- [x] `pyhf rename --channel ... --sample ... --modifier ... --measurement ... spec.json`
- [x] `pyhf combine left.json right.json`

This requires:
- #657
- #656

Addresses (but does not resolve) an issue in #660 with `pyhf.Workspace` not showing up in our docs.

Resolves #663.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add specification operations to the workspace (prune, rename, combine)
* Add CLI entrypoints for prune, rename, combine
* Add API docs
* Update doc dependencies
* Fix docstrings for workspace.py
```