### PR TITLE
fix: Promote check on PR merge to job level

### DIFF
--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -8,9 +8,9 @@ jobs:
   binder:
     name: Trigger Binder build
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged
     steps:
     - uses: actions/checkout@master
-      if: github.event.pull_request.merged
     - name: Trigger Binder build
       run: |
         # Use Binder build API to trigger repo2docker to build image on GKE and OVH Binder Federation clusters


### PR DESCRIPTION
# Description

Promoting

```yaml
if: github.event.pull_request.merged
```
to the job level avoids errors like

https://github.com/scikit-hep/pyhf/pull/645/checks?check_run_id=312835964

or having to have the check for every step in the job

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Promote github.event.pull_request.merged check to the job level to avoid errors
```
