### PR TITLE
docs: Improve discussion of publication workflow

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -46,29 +46,14 @@ Publishing
 ----------
 
 Publishing to `PyPI <https://pypi.org/project/pyhf/>`__ and `TestPyPI <https://test.pypi.org/project/pyhf/>`__
-is automated through the `PyPA's PyPI publish GitHub Action <https://github.com/pypa/gh-action-pypi-publish>`__.
-Publishing a release to PyPI begins with creating a new branch :code:`release/cut-<release tag>`
-and then from that branch running
-
-.. code-block:: console
-
-    bumpversion [major|minor|patch]
-
-to update the release version and get a tagged commit.
-Then, push only the branch to GitHub and open a PR to ensure that the code
-you are going to publish is indeed stable.
-Once the PR has passed all checks and has been approved, a maintainer should merge
-the branch from the command line
-
-.. code-block:: console
-
-    git checkout master
-    git merge release/cut-<release tag>
-
-and then push the commit and tag to :code:`master` with
-
-.. code-block:: console
-
-    git push origin master <release tag>
-
-which will both merge and close the PR and start the release publication workflow.
+is automated through the `PyPA's PyPI publish GitHub Action <https://github.com/pypa/gh-action-pypi-publish>`__
+and the ``pyhf`` `Tag Creator GitHub Actions workflow <https://github.com/scikit-hep/pyhf/blob/master/.github/workflows/tag.yml>`__.
+A release can be created from any PR created by a core developer by adding a
+``bumpversion`` tag to it that corresponds to the release type:
+`major <https://github.com/scikit-hep/pyhf/labels/bumpversion%2Fmajor>`__,
+`minor <https://github.com/scikit-hep/pyhf/labels/bumpversion%2Fminor>`__,
+`patch <https://github.com/scikit-hep/pyhf/labels/bumpversion%2Fpatch>`__.
+Once the PR is tagged with the label, the GitHub Actions bot will post a comment
+with information on the actions it will take once the PR is merged. When the PR
+has been reviewed, approved, and merged, the Tag Creator workflow will automatically
+create a new release with ``bumpversion`` and then deploy the release to PyPI.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -19,24 +19,6 @@ Then setup the Git pre-commit hook for `Black <https://github.com/psf/black>`__ 
 
     pre-commit install
 
-Publishing
-----------
-
-Publishing to `PyPI <https://pypi.org/project/pyhf/>`__ and `TestPyPI <https://test.pypi.org/project/pyhf/>`__
-is automated through the `PyPA's PyPI publish GitHub Action <https://github.com/pypa/gh-action-pypi-publish>`__.
-To publish a release to PyPI one simply needs to run
-
-.. code-block:: console
-
-    bumpversion [major|minor|patch]
-
-to update the release version and get a tagged commit and then push the commit
-and tag to :code:`master` with
-
-.. code-block:: console
-
-    git push origin master --tags
-
 Testing
 -------
 
@@ -59,3 +41,34 @@ available by the ``datadir`` fixture. Therefore, one can do:
 which will load the copy of ``text.txt`` in the temporary directory. This also
 works for parameterizations as this will effectively sandbox the file
 modifications made.
+
+Publishing
+----------
+
+Publishing to `PyPI <https://pypi.org/project/pyhf/>`__ and `TestPyPI <https://test.pypi.org/project/pyhf/>`__
+is automated through the `PyPA's PyPI publish GitHub Action <https://github.com/pypa/gh-action-pypi-publish>`__.
+Publishing a release to PyPI begins with creating a new branch :code:`release/cut-<release tag>`
+and then from that branch running
+
+.. code-block:: console
+
+    bumpversion [major|minor|patch]
+
+to update the release version and get a tagged commit.
+Then, push only the branch to GitHub and open a PR to ensure that the code
+you are going to publish is indeed stable.
+Once the PR has passed all checks and has been approved, a maintainer should merge
+the branch from the command line
+
+.. code-block:: console
+
+    git checkout master
+    git merge release/cut-<release tag>
+
+and then push the commit and tag to :code:`master` with
+
+.. code-block:: console
+
+    git push origin master <release tag>
+
+which will both merge and close the PR and start the release publication workflow.


### PR DESCRIPTION
# Description

Extend and improve the instructions for validating and then publishing a release using GitHub Actions.

This follows up on [some discussion](https://github.com/scikit-hep/pyhf/pull/638#discussion_r346845955) on PR #638 with @webknjaz and advocates for locally merging on the command line so as to avoid a merge commit (as the branch would be just ahead of `master` and so can easily fastforward).

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-improve-publishing-docs/development.html

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update the instructions for validating and then publishing a release using GitHub Actions
```
