### PR TITLE
refactor: Add better segmented environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[complete]
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[tensorflow,torch,minuit,xmlio,test]
         python -m pip list
     - name: Lint with Pyflakes
       if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
@@ -70,7 +70,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[tensorflow,torch,minuit,xmlio,test]
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[complete]
         python -m pip list
     - name: Test example notebooks
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[tensorflow,torch,minuit,xmlio,test,docs]
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[docs]
         python -m pip list
         sudo apt-get update
         sudo apt-get -qq install pandoc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[tensorflow,torch,minuit,xmlio,test]
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[test]
         python -m pip list
     - name: Lint with Pyflakes
       if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[test,docs]
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[tensorflow,torch,minuit,xmlio,test,docs]
         python -m pip list
         sudo apt-get update
         sudo apt-get -qq install pandoc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[complete]
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[tensorflow,torch,minuit,xmlio,test]
         python -m pip list
     - name: Test example notebooks
       run: |
@@ -92,7 +92,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[develop]
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[test,docs]
         python -m pip list
         sudo apt-get update
         sudo apt-get -qq install pandoc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install --ignore-installed -U -q --no-cache-dir -e .[complete]
-        pip list
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[complete]
+        python -m pip list
     - name: Lint with Pyflakes
       if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
       run: |
@@ -70,8 +70,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install --ignore-installed -U -q --no-cache-dir -e .[complete]
-        pip list
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[complete]
+        python -m pip list
     - name: Test example notebooks
       run: |
         python -m pytest -r sx tests/test_notebooks.py
@@ -92,8 +92,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install --ignore-installed -U -q --no-cache-dir -e .[develop]
-        pip list
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[develop]
+        python -m pip list
         sudo apt-get update
         sudo apt-get -qq install pandoc
     - name: Check docstrings

--- a/setup.py
+++ b/setup.py
@@ -13,47 +13,53 @@ extras_require = {
     'torch': ['torch~=1.2'],
     'xmlio': ['uproot'],
     'minuit': ['iminuit'],
-    'test': [
-        'pyflakes',
-        'pytest~=3.5',
-        'pytest-cov>=2.5.1',
-        'pytest-mock',
-        'pytest-benchmark[histogram]',
-        'pytest-console-scripts',
-        'pydocstyle',
-        'coverage>=4.0',  # coveralls
-        'papermill~=1.0',
-        'nteract-scrapbook~=0.2',
-        'check-manifest',
-        'matplotlib',
-        'jupyter',
-        'uproot~=3.3',
-        'graphviz',
-        'jsonpatch',
-        'black;python_version>="3.6"',  # Black is Python3 only
-    ],
-    '_docs': [
-        'sphinx',
-        'sphinxcontrib-bibtex',
-        'sphinxcontrib-napoleon',
-        'sphinx_rtd_theme',
-        'nbsphinx',
-        'sphinx-issues',
-        'm2r',
-    ],
-    '_develop': ['nbdime', 'bumpversion', 'ipython', 'pre-commit', 'twine'],
 }
-extras_require['docs'] = sorted(
+extras_require['test'] = sorted(
     set(
         extras_require['tensorflow']
         + extras_require['torch']
         + extras_require['xmlio']
         + extras_require['minuit']
-        + extras_require['_docs']
+        + [
+            'pyflakes',
+            'pytest~=3.5',
+            'pytest-cov>=2.5.1',
+            'pytest-mock',
+            'pytest-benchmark[histogram]',
+            'pytest-console-scripts',
+            'pydocstyle',
+            'coverage>=4.0',  # coveralls
+            'papermill~=1.0',
+            'nteract-scrapbook~=0.2',
+            'check-manifest',
+            'matplotlib',
+            'jupyter',
+            'uproot~=3.3',
+            'graphviz',
+            'jsonpatch',
+            'black;python_version>="3.6"',  # Black is Python3 only
+        ]
+    )
+)
+extras_require['docs'] = sorted(
+    set(
+        extras_require['test']
+        + [
+            'sphinx',
+            'sphinxcontrib-bibtex',
+            'sphinxcontrib-napoleon',
+            'sphinx_rtd_theme',
+            'nbsphinx',
+            'sphinx-issues',
+            'm2r',
+        ]
     )
 )
 extras_require['develop'] = sorted(
-    set(extras_require['test'] + extras_require['docs'] + extras_require['_develop'])
+    set(
+        extras_require['docs']
+        + ['nbdime', 'bumpversion', 'ipython', 'pre-commit', 'twine']
+    )
 )
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_require = {
     'torch': ['torch~=1.2'],
     'xmlio': ['uproot'],
     'minuit': ['iminuit'],
-    'develop': [
+    'test': [
         'pyflakes',
         'pytest~=3.5',
         'pytest-cov>=2.5.1',
@@ -22,14 +22,17 @@ extras_require = {
         'pytest-console-scripts',
         'pydocstyle',
         'coverage>=4.0',  # coveralls
-        'matplotlib',
-        'jupyter',
-        'nbdime',
-        'uproot~=3.3',
         'papermill~=1.0',
         'nteract-scrapbook~=0.2',
+        'check-manifest',
+        'matplotlib',
+        'jupyter',
+        'uproot~=3.3',
         'graphviz',
-        'bumpversion',
+        'jsonpatch',
+        'black;python_version>="3.6"',  # Black is Python3 only
+    ],
+    'docs': [
         'sphinx',
         'sphinxcontrib-bibtex',
         'sphinxcontrib-napoleon',
@@ -37,14 +40,12 @@ extras_require = {
         'nbsphinx',
         'sphinx-issues',
         'm2r',
-        'jsonpatch',
-        'ipython',
-        'pre-commit',
-        'black;python_version>="3.6"',  # Black is Python3 only
-        'twine',
-        'check-manifest',
     ],
+    '_develop': ['nbdime', 'bumpversion', 'ipython', 'pre-commit', 'twine'],
 }
+extras_require['develop'] = sorted(
+    set(extras_require['test'] + extras_require['docs'] + extras_require['_develop'])
+)
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ extras_require = {
         'jsonpatch',
         'black;python_version>="3.6"',  # Black is Python3 only
     ],
-    'docs': [
+    '_docs': [
         'sphinx',
         'sphinxcontrib-bibtex',
         'sphinxcontrib-napoleon',
@@ -43,6 +43,15 @@ extras_require = {
     ],
     '_develop': ['nbdime', 'bumpversion', 'ipython', 'pre-commit', 'twine'],
 }
+extras_require['docs'] = sorted(
+    set(
+        extras_require['tensorflow']
+        + extras_require['torch']
+        + extras_require['xmlio']
+        + extras_require['minuit']
+        + extras_require['_docs']
+    )
+)
 extras_require['develop'] = sorted(
     set(extras_require['test'] + extras_require['docs'] + extras_require['_develop'])
 )


### PR DESCRIPTION
# Description

Add further segmented `test`, `docs`, and `develop` environments in `setup.py` to avoid having to install unneeded dependencies.

This makes very little difference in terms of core developer operations, but the finer segmentation makes it easier to understand what all the dependencies a core developer would install are meant for.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Redistribute the "develop" environment into separate "test", "docs", and "develop" environments
   - "docs" contains all of the backend environments to successfully build all the API docs
   - "develop" still combines "test", "docs", and the "develop" dependencies together
* Use more specific environments for testing in CI to make environment dependencies more clear
* In doing so, fix the API section of the docs by building the docs in an environment with all the backends
   - Fixes bug introduced in PR #527
```