### PR TITLE
refactor: Reorder mega mods to be indexed first by modifier then by sample

### DIFF
--- a/src/pyhf/modifiers/histosys.py
+++ b/src/pyhf/modifiers/histosys.py
@@ -47,16 +47,16 @@ class histosys_combined(object):
         self._histosys_histoset = [
             [
                 [
-                    mega_mods[s][m]['data']['lo_data'],
-                    mega_mods[s][m]['data']['nom_data'],
-                    mega_mods[s][m]['data']['hi_data'],
+                    mega_mods[m][s]['data']['lo_data'],
+                    mega_mods[m][s]['data']['nom_data'],
+                    mega_mods[m][s]['data']['hi_data'],
                 ]
                 for s in pdfconfig.samples
             ]
             for m in keys
         ]
         self._histosys_mask = [
-            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples] for m in keys
+            [[mega_mods[m][s]['data']['mask']] for s in pdfconfig.samples] for m in keys
         ]
 
         if histosys_mods:

--- a/src/pyhf/modifiers/lumi.py
+++ b/src/pyhf/modifiers/lumi.py
@@ -40,7 +40,7 @@ class lumi_combined(object):
         self.param_viewer = ParamViewer(parfield_shape, pdfconfig.par_map, lumi_mods)
 
         self._lumi_mask = [
-            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples] for m in keys
+            [[mega_mods[m][s]['data']['mask']] for s in pdfconfig.samples] for m in keys
         ]
         self._precompute()
         events.subscribe('tensorlib_changed')(self._precompute)

--- a/src/pyhf/modifiers/normfactor.py
+++ b/src/pyhf/modifiers/normfactor.py
@@ -39,7 +39,7 @@ class normfactor_combined(object):
         )
 
         self._normfactor_mask = [
-            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples] for m in keys
+            [[mega_mods[m][s]['data']['mask']] for s in pdfconfig.samples] for m in keys
         ]
         self._precompute()
         events.subscribe('tensorlib_changed')(self._precompute)

--- a/src/pyhf/modifiers/normsys.py
+++ b/src/pyhf/modifiers/normsys.py
@@ -45,16 +45,16 @@ class normsys_combined(object):
         self._normsys_histoset = [
             [
                 [
-                    mega_mods[s][m]['data']['lo'],
-                    mega_mods[s][m]['data']['nom_data'],
-                    mega_mods[s][m]['data']['hi'],
+                    mega_mods[m][s]['data']['lo'],
+                    mega_mods[m][s]['data']['nom_data'],
+                    mega_mods[m][s]['data']['hi'],
                 ]
                 for s in pdfconfig.samples
             ]
             for m in keys
         ]
         self._normsys_mask = [
-            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples] for m in keys
+            [[mega_mods[m][s]['data']['mask']] for s in pdfconfig.samples] for m in keys
         ]
 
         if normsys_mods:

--- a/src/pyhf/modifiers/shapefactor.py
+++ b/src/pyhf/modifiers/shapefactor.py
@@ -72,7 +72,7 @@ class shapefactor_combined(object):
         )
 
         self._shapefactor_mask = [
-            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples] for m in keys
+            [[mega_mods[m][s]['data']['mask']] for s in pdfconfig.samples] for m in keys
         ]
 
         global_concatenated_bin_indices = [

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -41,14 +41,14 @@ class shapesys_combined(object):
         )
 
         self._shapesys_mask = [
-            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples] for m in keys
+            [[mega_mods[m][s]['data']['mask']] for s in pdfconfig.samples] for m in keys
         ]
         self.__shapesys_uncrt = default_backend.astensor(
             [
                 [
                     [
-                        mega_mods[s][m]['data']['uncrt'],
-                        mega_mods[s][m]['data']['nom_data'],
+                        mega_mods[m][s]['data']['uncrt'],
+                        mega_mods[m][s]['data']['nom_data'],
                     ]
                     for s in pdfconfig.samples
                 ]

--- a/src/pyhf/modifiers/staterror.py
+++ b/src/pyhf/modifiers/staterror.py
@@ -36,14 +36,14 @@ class staterror_combined(object):
         )
 
         self._staterror_mask = [
-            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples] for m in keys
+            [[mega_mods[m][s]['data']['mask']] for s in pdfconfig.samples] for m in keys
         ]
         self.__staterror_uncrt = default_backend.astensor(
             [
                 [
                     [
-                        mega_mods[s][m]['data']['uncrt'],
-                        mega_mods[s][m]['data']['nom_data'],
+                        mega_mods[m][s]['data']['uncrt'],
+                        mega_mods[m][s]['data']['nom_data'],
                     ]
                     for s in pdfconfig.samples
                 ]

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -466,9 +466,9 @@ class Model(object):
         # set up the entire structure
         mega_mods = {}
         for m, mtype in config.modifiers:
-            key = '{}/{}'.format(mtype, m)
             for s in config.samples:
-                mega_mods.setdefault(s, {})[key] = {
+                key = '{}/{}'.format(mtype, m)
+                mega_mods.setdefault(key, {})[s] = {
                     'type': mtype,
                     'name': m,
                     'data': default_data_makers[mtype](),
@@ -510,35 +510,35 @@ class Model(object):
                         lo_data = thismod['data']['lo_data'] if thismod else nom
                         hi_data = thismod['data']['hi_data'] if thismod else nom
                         maskval = True if thismod else False
-                        mega_mods[s][key]['data']['lo_data'] += lo_data
-                        mega_mods[s][key]['data']['hi_data'] += hi_data
-                        mega_mods[s][key]['data']['nom_data'] += nom
-                        mega_mods[s][key]['data']['mask'] += [maskval] * len(
+                        mega_mods[key][s]['data']['lo_data'] += lo_data
+                        mega_mods[key][s]['data']['hi_data'] += hi_data
+                        mega_mods[key][s]['data']['nom_data'] += nom
+                        mega_mods[key][s]['data']['mask'] += [maskval] * len(
                             nom
                         )  # broadcasting
                     elif mtype == 'normsys':
                         maskval = True if thismod else False
                         lo_factor = thismod['data']['lo'] if thismod else 1.0
                         hi_factor = thismod['data']['hi'] if thismod else 1.0
-                        mega_mods[s][key]['data']['nom_data'] += [1.0] * len(nom)
-                        mega_mods[s][key]['data']['lo'] += [lo_factor] * len(
+                        mega_mods[key][s]['data']['nom_data'] += [1.0] * len(nom)
+                        mega_mods[key][s]['data']['lo'] += [lo_factor] * len(
                             nom
                         )  # broadcasting
-                        mega_mods[s][key]['data']['hi'] += [hi_factor] * len(nom)
-                        mega_mods[s][key]['data']['mask'] += [maskval] * len(
+                        mega_mods[key][s]['data']['hi'] += [hi_factor] * len(nom)
+                        mega_mods[key][s]['data']['mask'] += [maskval] * len(
                             nom
                         )  # broadcasting
                     elif mtype in ['normfactor', 'shapefactor', 'lumi']:
                         maskval = True if thismod else False
-                        mega_mods[s][key]['data']['mask'] += [maskval] * len(
+                        mega_mods[key][s]['data']['mask'] += [maskval] * len(
                             nom
                         )  # broadcasting
                     elif mtype in ['shapesys', 'staterror']:
                         uncrt = thismod['data'] if thismod else [0.0] * len(nom)
                         maskval = [True if thismod else False] * len(nom)
-                        mega_mods[s][key]['data']['mask'] += maskval
-                        mega_mods[s][key]['data']['uncrt'] += uncrt
-                        mega_mods[s][key]['data']['nom_data'] += nom
+                        mega_mods[key][s]['data']['mask'] += maskval
+                        mega_mods[key][s]['data']['uncrt'] += uncrt
+                        mega_mods[key][s]['data']['nom_data'] += nom
                     else:
                         raise RuntimeError(
                             'not sure how to combine {mtype} into the mega-channel'.format(
@@ -548,7 +548,6 @@ class Model(object):
             sample_dict = {
                 'name': 'mega_{}'.format(s),
                 'nom': mega_nom,
-                'modifiers': list(mega_mods[s].values()),
             }
             mega_samples[s] = sample_dict
 

--- a/tests/test_combined_modifiers.py
+++ b/tests/test_combined_modifiers.py
@@ -75,7 +75,7 @@ def test_histosys(backend):
                     'nom_data': [10, 10, 10],
                     'mask': [True, True, True],
                 },
-            }
+            },
         },
         'histosys/world': {
             'signal': {
@@ -241,7 +241,7 @@ def test_lumi(backend):
                 'type': 'lumi',
                 'name': 'lumi',
                 'data': {'mask': [True, True, True]},
-            }
+            },
         },
     }
 
@@ -392,7 +392,7 @@ def test_shapesys(backend):
                     'nom_data': [10, 10, 10],
                     'uncrt': [1, 0, 0],
                 },
-            }
+            },
         },
         'shapesys/shapesys2': {
             'signal': {
@@ -455,7 +455,7 @@ def test_normfactor(backend):
                 'type': 'normfactor',
                 'name': 'mu1',
                 'data': {'mask': [True, False, False]},
-            }
+            },
         },
         'normfactor/mu2': {
             'signal': {
@@ -467,8 +467,8 @@ def test_normfactor(backend):
                 'type': 'normfactor',
                 'name': 'mu2',
                 'data': {'mask': [False, True, True]},
-            }
-        }
+            },
+        },
     }
     hsc = normfactor_combined(
         [('mu1', 'normfactor'), ('mu2', 'normfactor')], mc, mega_mods
@@ -532,9 +532,9 @@ def test_shapefactor(backend):
                 'data': {'mask': [True, False, False]},
             },
             'background': {
-                    'type': 'shapefactor',
-                    'name': 'shapefac1',
-                    'data': {'mask': [True, False, False]},
+                'type': 'shapefactor',
+                'name': 'shapefac1',
+                'data': {'mask': [True, False, False]},
             },
         },
         'shapefactor/shapefac2': {
@@ -544,9 +544,9 @@ def test_shapefactor(backend):
                 'data': {'mask': [False, True, True]},
             },
             'background': {
-                    'type': 'normfactor',
-                    'name': 'shapefac2',
-                    'data': {'mask': [False, True, True]},
+                'type': 'normfactor',
+                'name': 'shapefac2',
+                'data': {'mask': [False, True, True]},
             },
         },
     }

--- a/tests/test_combined_modifiers.py
+++ b/tests/test_combined_modifiers.py
@@ -55,8 +55,8 @@ def test_histosys(backend):
     )
 
     mega_mods = {
-        'signal': {
-            'histosys/hello': {
+        'histosys/hello': {
+            'signal': {
                 'type': 'histosys',
                 'name': 'hello',
                 'data': {
@@ -66,7 +66,19 @@ def test_histosys(backend):
                     'mask': [True, True, True],
                 },
             },
-            'histosys/world': {
+            'background': {
+                'type': 'histosys',
+                'name': 'hello',
+                'data': {
+                    'hi_data': [11, 12, 13],
+                    'lo_data': [9, 8, 7],
+                    'nom_data': [10, 10, 10],
+                    'mask': [True, True, True],
+                },
+            }
+        },
+        'histosys/world': {
+            'signal': {
                 'type': 'histosys',
                 'name': 'world',
                 'data': {
@@ -76,19 +88,7 @@ def test_histosys(backend):
                     'mask': [True, True, True],
                 },
             },
-        },
-        'background': {
-            'histosys/hello': {
-                'type': 'histosys',
-                'name': 'hello',
-                'data': {
-                    'hi_data': [11, 12, 13],
-                    'lo_data': [9, 8, 7],
-                    'nom_data': [10, 10, 10],
-                    'mask': [True, True, True],
-                },
-            },
-            'histosys/world': {
+            'background': {
                 'type': 'histosys',
                 'name': 'world',
                 'data': {
@@ -144,8 +144,8 @@ def test_normsys(backend):
     )
 
     mega_mods = {
-        'signal': {
-            'normsys/hello': {
+        'normsys/hello': {
+            'signal': {
                 'type': 'normsys',
                 'name': 'hello',
                 'data': {
@@ -155,19 +155,7 @@ def test_normsys(backend):
                     'mask': [True, True, True],
                 },
             },
-            'normsys/world': {
-                'type': 'v',
-                'name': 'world',
-                'data': {
-                    'hi': [1.3] * 3,
-                    'lo': [0.7] * 3,
-                    'nom_data': [1, 1, 1],
-                    'mask': [True, True, True],
-                },
-            },
-        },
-        'background': {
-            'normsys/hello': {
+            'background': {
                 'type': 'normsys',
                 'name': 'hello',
                 'data': {
@@ -177,7 +165,19 @@ def test_normsys(backend):
                     'mask': [True, True, True],
                 },
             },
-            'normsys/world': {
+        },
+        'normsys/world': {
+            'signal': {
+                'type': 'v',
+                'name': 'world',
+                'data': {
+                    'hi': [1.3] * 3,
+                    'lo': [0.7] * 3,
+                    'nom_data': [1, 1, 1],
+                    'mask': [True, True, True],
+                },
+            },
+            'background': {
                 'type': 'normsys',
                 'name': 'world',
                 'data': {
@@ -231,15 +231,13 @@ def test_lumi(backend):
     )
 
     mega_mods = {
-        'signal': {
-            'lumi/lumi': {
+        'lumi/lumi': {
+            'signal': {
                 'type': 'lumi',
                 'name': 'lumi',
                 'data': {'mask': [True, True, True]},
-            }
-        },
-        'background': {
-            'lumi/lumi': {
+            },
+            'background': {
                 'type': 'lumi',
                 'name': 'lumi',
                 'data': {'mask': [True, True, True]},
@@ -291,8 +289,8 @@ def test_stat(backend):
     )
 
     mega_mods = {
-        'signal': {
-            'staterror/staterror_chan1': {
+        'staterror/staterror_chan1': {
+            'signal': {
                 'type': 'staterror',
                 'name': 'staterror_chan1',
                 'data': {
@@ -301,7 +299,18 @@ def test_stat(backend):
                     'uncrt': [1, 0, 0],
                 },
             },
-            'staterror/staterror_chan2': {
+            'background': {
+                'type': 'staterror',
+                'name': 'staterror_chan1',
+                'data': {
+                    'mask': [True, False, False],
+                    'nom_data': [10, 10, 10],
+                    'uncrt': [1, 0, 0],
+                },
+            },
+        },
+        'staterror/staterror_chan2': {
+            'signal': {
                 'type': 'staterror',
                 'name': 'staterror_chan2',
                 'data': {
@@ -310,18 +319,7 @@ def test_stat(backend):
                     'uncrt': [0, 1, 1],
                 },
             },
-        },
-        'background': {
-            'staterror/staterror_chan1': {
-                'type': 'staterror',
-                'name': 'staterror_chan1',
-                'data': {
-                    'mask': [True, False, False],
-                    'nom_data': [10, 10, 10],
-                    'uncrt': [1, 0, 0],
-                },
-            },
-            'staterror/staterror_chan2': {
+            'background': {
                 'type': 'staterror',
                 'name': 'staterror_chan2',
                 'data': {
@@ -376,8 +374,8 @@ def test_shapesys(backend):
     )
 
     mega_mods = {
-        'signal': {
-            'shapesys/shapesys1': {
+        'shapesys/shapesys1': {
+            'signal': {
                 'type': 'shapesys',
                 'name': 'shapesys1',
                 'data': {
@@ -386,7 +384,18 @@ def test_shapesys(backend):
                     'uncrt': [1, 0, 0],
                 },
             },
-            'shapesys/shapesys2': {
+            'background': {
+                'type': 'shapesys',
+                'name': 'shapesys1',
+                'data': {
+                    'mask': [True, False, False],
+                    'nom_data': [10, 10, 10],
+                    'uncrt': [1, 0, 0],
+                },
+            }
+        },
+        'shapesys/shapesys2': {
+            'signal': {
                 'type': 'shapesys',
                 'name': 'shapesys1',
                 'data': {
@@ -395,18 +404,7 @@ def test_shapesys(backend):
                     'uncrt': [0, 1, 1],
                 },
             },
-        },
-        'background': {
-            'shapesys/shapesys1': {
-                'type': 'shapesys',
-                'name': 'shapesys1',
-                'data': {
-                    'mask': [True, False, False],
-                    'nom_data': [10, 10, 10],
-                    'uncrt': [1, 0, 0],
-                },
-            },
-            'shapesys/shapesys2': {
+            'background': {
                 'type': 'shapesys',
                 'name': 'shapesys1',
                 'data': {
@@ -447,30 +445,30 @@ def test_normfactor(backend):
     )
 
     mega_mods = {
-        'signal': {
-            'normfactor/mu1': {
+        'normfactor/mu1': {
+            'signal': {
                 'type': 'normfactor',
                 'name': 'mu1',
                 'data': {'mask': [True, False, False]},
             },
-            'normfactor/mu2': {
-                'type': 'normfactor',
-                'name': 'mu2',
-                'data': {'mask': [False, True, True]},
-            },
-        },
-        'background': {
-            'normfactor/mu1': {
+            'background': {
                 'type': 'normfactor',
                 'name': 'mu1',
                 'data': {'mask': [True, False, False]},
-            },
-            'normfactor/mu2': {
+            }
+        },
+        'normfactor/mu2': {
+            'signal': {
                 'type': 'normfactor',
                 'name': 'mu2',
                 'data': {'mask': [False, True, True]},
             },
-        },
+            'background': {
+                'type': 'normfactor',
+                'name': 'mu2',
+                'data': {'mask': [False, True, True]},
+            }
+        }
     }
     hsc = normfactor_combined(
         [('mu1', 'normfactor'), ('mu2', 'normfactor')], mc, mega_mods
@@ -527,31 +525,32 @@ def test_shapefactor(backend):
     )
 
     mega_mods = {
-        'signal': {
-            'shapefactor/shapefac1': {
+        'shapefactor/shapefac1': {
+            'signal': {
                 'type': 'shapefactor',
                 'name': 'shapefac1',
                 'data': {'mask': [True, False, False]},
             },
-            'shapefactor/shapefac2': {
-                'type': 'shapefactor',
-                'name': 'shapefac2',
-                'data': {'mask': [False, True, True]},
+            'background': {
+                    'type': 'shapefactor',
+                    'name': 'shapefac1',
+                    'data': {'mask': [True, False, False]},
             },
         },
-        'background': {
-            'shapefactor/shapefac1': {
+        'shapefactor/shapefac2': {
+            'signal': {
                 'type': 'shapefactor',
-                'name': 'shapefac1',
-                'data': {'mask': [True, False, False]},
-            },
-            'shapefactor/shapefac2': {
-                'type': 'normfactor',
                 'name': 'shapefac2',
                 'data': {'mask': [False, True, True]},
+            },
+            'background': {
+                    'type': 'normfactor',
+                    'name': 'shapefac2',
+                    'data': {'mask': [False, True, True]},
             },
         },
     }
+
     hsc = shapefactor_combined(
         [('shapefac1', 'shapefactor'), ('shapefac2', 'shapefactor')], mc, mega_mods
     )


### PR DESCRIPTION
# Description

This reorders mega mods to be first indexed by modifier name and then by sample. This should make it connect pyhf to (differentiable) upstream tools, as typically they will be able to process all samples for a given systematic setting (modifier) in one go

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* change order of samples and modifier names in mega mods
* preparation for connecting to differentiable upstream
```