### PR TITLE
ci: workflow that runs bumpversion and pushes when issue filed

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,52 @@
+name: Tag Creator
+on:
+  issues:
+    types: [opened]
+jobs:
+  tag_master:
+    if: >-
+      startsWith( github.event.issue.title, 'bumpversion:' ) &&
+      && (
+        contains( github.event.issue.title, 'major' ) ||
+        contains( github.event.issue.title, 'minor' ) ||
+        contains( github.event.issue.title, 'patch' )
+      )
+      && (
+        github.event.issue.user.login == 'lukasheinrich' ||
+        github.event.issue.user.login == 'matthewfeickert' ||
+        github.event.issue.user.login == 'kratsg'
+      )
+    env:
+      IS_MAJOR: >-
+          ${{ contains( github.event.issue.title, 'major' ) }}
+      IS_MINOR: >-
+          ${{ contains( github.event.issue.title, 'minor' ) }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: install bumpversion
+      run: |
+      python -m pip install --upgrade pip setuptools wheel
+      pip install bumpversion
+    - name: set up git user
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+    - name: run bumpversion
+      run: |
+        if [ $IS_MAJOR == 'true' ]
+        then
+          bumpversion major
+        elif [ $IS_MINOR == 'true' ]
+        then
+          bumpversion minor
+        else
+          bumpversion patch
+        fi
+    - name: push changes
+      run: |
+        git rev-parse HEAD
+        git rev-parse master
+        git describe --tags
+        git rev-list -n 1 $(git describe --tags)
+        git status

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -94,7 +94,7 @@ jobs:
         github.event.action == 'closed' && github.event.pull_request.merged
       uses: ad-m/github-push-action@v0.5.0
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.GITHUB_PAT }}
     - name: Comment that something failed
       if: failure()
       uses: actions/github@v1.0.0

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -88,9 +88,8 @@ jobs:
       uses: actions/github-script@v0.3.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-      script: |
-        echo "abc"
-        github.issues.createComment({...context.issue, body: "I've queued this up. When it gets merged, I'll create a ${{ env['BV_PART'] }} release from ${{ env['OLD_TAG'] }} → ${{ env['NEW_TAG'] }} which includes the following ${{ env['NUM_CHANGES'] }} change(s) [including this PR]:<br />${{ env['CHANGES'] }}<br />If you make any more changes, you probably want to re-trigger me again by removing the `bumpversion/${{ env['BV_PART'] }}` label and then adding it back again."})
+        script: |
+          github.issues.createComment({...context.issue, body: "I've queued this up. When it gets merged, I'll create a ${{ env['BV_PART'] }} release from ${{ env['OLD_TAG'] }} → ${{ env['NEW_TAG'] }} which includes the following ${{ env['NUM_CHANGES'] }} change(s) [including this PR]:<br />${{ env['CHANGES'] }}<br />If you make any more changes, you probably want to re-trigger me again by removing the `bumpversion/${{ env['BV_PART'] }}` label and then adding it back again."})
     - name: Push changes
       if: >-
         github.event.action == 'closed' && github.event.pull_request.merged
@@ -102,9 +101,9 @@ jobs:
       uses: actions/github-script@v0.3.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-      script: |
-        github.issues.createComment({...context.issue, body: ":cry: Something went wrong. I am not able to push. Check the [Actions pipeline](https://github.com/${{ github.repository }}/actions?query=workflow%3A%22Tag+Creator%22) to see what happened. If you make any more changes, you probably want to re-trigger me again by adding the `bumpversion/${{ env['BV_PART'] }}` label again."})
-        github.issues.removeLabels({...context.issue, "bumpversion/${{ env['BV_PART'] }}" })
+        script: |
+          github.issues.createComment({...context.issue, body: ":cry: Something went wrong. I am not able to push. Check the [Actions pipeline](https://github.com/${{ github.repository }}/actions?query=workflow%3A%22Tag+Creator%22) to see what happened. If you make any more changes, you probably want to re-trigger me again by adding the `bumpversion/${{ env['BV_PART'] }}` label again."})
+          github.issues.removeLabels({...context.issue, "bumpversion/${{ env['BV_PART'] }}" })
 
   always_job:
     name: Always run job

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -43,7 +43,7 @@ jobs:
           echo "::set-env name=BV_PART::patch"
         fi
     - name: Checkout repository
-      uses: actions/checkout@master
+      uses: actions/checkout@v1.2.0
     - name: Set up git user
       run: |
         git config --local user.email "action@github.com"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Install bumpversion
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install bumpversion
+        python -m pip install bumpversion
     - name: Run bumpversion ${{ env['BV_PART'] }}
       run: |
         OLD_TAG=$(git describe --tags --abbrev=0)

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -20,6 +20,8 @@ jobs:
         contains( github.event.pull_request.labels.*.name, 'bumpversion/major' ) ||
         contains( github.event.pull_request.labels.*.name, 'bumpversion/minor' ) ||
         contains( github.event.pull_request.labels.*.name, 'bumpversion/patch' )
+      ) && (
+        contains( ['lukasheinrich', 'matthewfeickert', 'kratsg'], github.event.sender.login )
       )
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,52 +1,104 @@
+# NB: release notes inspired by https://blogs.sap.com/2018/06/22/generating-release-notes-from-git-commit-messages-using-basic-shell-commands-gitgrep/
 name: Tag Creator
 on:
   issues:
     types: [opened]
 jobs:
-  tag_master:
+  bumpversion:
     if: >-
-      startsWith( github.event.issue.title, 'bumpversion:' ) &&
-      && (
-        contains( github.event.issue.title, 'major' ) ||
-        contains( github.event.issue.title, 'minor' ) ||
-        contains( github.event.issue.title, 'patch' )
-      )
-      && (
+      (
+        startsWith( github.event.issue.title, '[bumpversion:major]' ) ||
+        startsWith( github.event.issue.title, '[bumpversion:minor]' ) ||
+        startsWith( github.event.issue.title, '[bumpversion:patch]' )
+      ) && (
         github.event.issue.user.login == 'lukasheinrich' ||
         github.event.issue.user.login == 'matthewfeickert' ||
         github.event.issue.user.login == 'kratsg'
       )
     env:
       IS_MAJOR: >-
-          ${{ contains( github.event.issue.title, 'major' ) }}
+          ${{ startsWith( github.event.issue.title, '[bumpversion:major]' ) }}
       IS_MINOR: >-
-          ${{ contains( github.event.issue.title, 'minor' ) }}
+          ${{ startsWith( github.event.issue.title, '[bumpversion:minor]' ) }}
+      IS_PATCH: >-
+          ${{ startsWith( github.event.issue.title, '[bumpversion:patch]' ) }}
     runs-on: ubuntu-latest
     steps:
+    - name: determine part
+      run: |
+        if [ $IS_MAJOR == 'true' ]
+        then
+          echo "::set-env name=BV_PART::major"
+        elif [ $IS_MINOR == 'true' ]
+        then
+          echo "::set-env name=BV_PART::minor"
+        else
+          echo "::set-env name=BV_PART::patch"
+        fi
+    - name: add bumpversion/${{ env['BV_PART'] }} label
+      uses: actions/github@v1.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        args: label bumpversion/${{ env['BV_PART'] }}
     - uses: actions/checkout@master
+    - name: Prepare repository
+      run: git checkout "${GITHUB_REF:11}"
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
     - name: install bumpversion
       run: |
-      python -m pip install --upgrade pip setuptools wheel
-      pip install bumpversion
+        python -m pip install --upgrade pip setuptools wheel
+        pip install bumpversion
     - name: set up git user
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-    - name: run bumpversion
+    - name: run bumpversion ${{ env['BV_PART'] }}
+      env:
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
+        ISSUE_DESCRIPTION: ${{ github.event.issue.description }}
       run: |
-        if [ $IS_MAJOR == 'true' ]
-        then
-          bumpversion major
-        elif [ $IS_MINOR == 'true' ]
-        then
-          bumpversion minor
-        else
-          bumpversion patch
-        fi
+        echo "bumpversion $BV_PART"
+        OLD_TAG=$(git describe --tags --abbrev=0)
+        echo "::set-env name=OLD_TAG::$OLD_TAG"
+        bumpversion $BV_PART --message "Bump version: {current_version} → {new_version}
+
+        Resolves #${ISSUE_NUMBER} via GitHub Actions."
+        NEW_TAG=$(git describe --tags --abbrev=0)
+        echo "::set-env name=NEW_TAG::$NEW_TAG"
+        git tag -n99 -l $NEW_TAG
+
+        CHANGES="$(git log --pretty=format:'%s' $OLD_TAG..HEAD -i -E --grep='^([a-z]*?):' | sed 's/^/  - /')"
+        NUM_CHANGES=$(echo -n "$CHANGES" | grep -c '^')
+        echo "::set-env name=NUM_CHANGES::$NUM_CHANGES"
+        git tag $NEW_TAG $NEW_TAG^{} -f -m "$(printf "This is a $BV_PART release from $OLD_TAG → $NEW_TAG.\n\nChanges:\n$CHANGES")"
+        git tag -n99 -l $NEW_TAG
+    - name: comment on issue
+      uses: actions/github@v1.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        args: |
+          comment "This is a ${{ env['BV_PART'] }} release from ${{ env['OLD_TAG'] }} → [${{ env['NUM_CHANGES'] }} change(s)] → ${{ env['NEW_TAG'] }}. I'm going to attempt to push now."
     - name: push changes
-      run: |
-        git rev-parse HEAD
-        git rev-parse master
-        git describe --tags
-        git rev-list -n 1 $(git describe --tags)
-        git status
+      uses: ad-m/github-push-action@v0.5.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: comment that it failed
+      if: failure()
+      uses: actions/github@v1.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        args: |
+          comment ":cry: Something went wrong. I wasn't able to push. Check the [Actions pipeline](https://github.com/${{ github.repository }}/actions?query=workflow%3A%22Tag+Creator%22) to see what happened."
+
+  always_job:
+    name: Always run job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Always run
+        run: echo "This job is used to prevent the workflow status from showing as failed when all other jobs are skipped. See https://github.community/t5/GitHub-Actions/Workflow-is-failing-if-no-job-can-be-ran-due-to-condition/m-p/38085 for more information."

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,30 +1,33 @@
 # NB: release notes inspired by https://blogs.sap.com/2018/06/22/generating-release-notes-from-git-commit-messages-using-basic-shell-commands-gitgrep/
 name: Tag Creator
 on:
-  issues:
-    types: [opened]
+  pull_request:
+    types: [labeled, closed]
+env:
+  IS_MAJOR: >-
+      ${{ contains( github.event.pull_request.labels.*.name, 'bumpversion/major' ) }}
+  IS_MINOR: >-
+      ${{ contains( github.event.pull_request.labels.*.name, 'bumpversion/minor' ) }}
+  IS_PATCH: >-
+      ${{ contains( github.event.pull_request.labels.*.name, 'bumpversion/patch' ) }}
+  PR_NUMBER: ${{ github.event.pull_request.number }}
+  PR_TITLE: ${{ github.event.pull_request.title }}
+  GITHUB_HEAD_REF: ${{ github.head_ref }}
 jobs:
   bumpversion:
     if: >-
       (
-        startsWith( github.event.issue.title, '[bumpversion:major]' ) ||
-        startsWith( github.event.issue.title, '[bumpversion:minor]' ) ||
-        startsWith( github.event.issue.title, '[bumpversion:patch]' )
-      ) && (
-        github.event.issue.user.login == 'lukasheinrich' ||
-        github.event.issue.user.login == 'matthewfeickert' ||
-        github.event.issue.user.login == 'kratsg'
+        contains( github.event.pull_request.labels.*.name, 'bumpversion/major' ) ||
+        contains( github.event.pull_request.labels.*.name, 'bumpversion/minor' ) ||
+        contains( github.event.pull_request.labels.*.name, 'bumpversion/patch' )
       )
-    env:
-      IS_MAJOR: >-
-          ${{ startsWith( github.event.issue.title, '[bumpversion:major]' ) }}
-      IS_MINOR: >-
-          ${{ startsWith( github.event.issue.title, '[bumpversion:minor]' ) }}
-      IS_PATCH: >-
-          ${{ startsWith( github.event.issue.title, '[bumpversion:patch]' ) }}
     runs-on: ubuntu-latest
     steps:
-    - name: determine part
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    - name: Determine version part
       run: |
         if [ $IS_MAJOR == 'true' ]
         then
@@ -35,66 +38,69 @@ jobs:
         else
           echo "::set-env name=BV_PART::patch"
         fi
-    - name: add bumpversion/${{ env['BV_PART'] }} label
-      uses: actions/github@v1.0.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        args: label bumpversion/${{ env['BV_PART'] }}
-    - uses: actions/checkout@master
-    - name: Prepare repository
-      run: git checkout "${GITHUB_REF:11}"
+    - name: Checkout repository
+      uses: actions/checkout@master
+    - name: Set up git user
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+    - name: Checkout master
+      run: git checkout master
+    - name: Squash and merge PR#${{ github.event.pull_request.number }} to master
+      if: github.event.action == 'labeled'
+      run: |
+        git merge --squash "origin/${GITHUB_HEAD_REF}"
+        git commit -m "${PR_TITLE} (#${PR_NUMBER})"
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
-    - name: install bumpversion
+    - name: Install bumpversion
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install bumpversion
-    - name: set up git user
+    - name: Run bumpversion ${{ env['BV_PART'] }}
       run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-    - name: run bumpversion ${{ env['BV_PART'] }}
-      env:
-        ISSUE_NUMBER: ${{ github.event.issue.number }}
-        ISSUE_DESCRIPTION: ${{ github.event.issue.description }}
-      run: |
-        echo "bumpversion $BV_PART"
         OLD_TAG=$(git describe --tags --abbrev=0)
-        echo "::set-env name=OLD_TAG::$OLD_TAG"
+        echo "::set-env name=OLD_TAG::${OLD_TAG}"
         bumpversion $BV_PART --message "Bump version: {current_version} → {new_version}
 
-        Resolves #${ISSUE_NUMBER} via GitHub Actions."
+        Triggered by #${PR_NUMBER} via GitHub Actions."
         NEW_TAG=$(git describe --tags --abbrev=0)
-        echo "::set-env name=NEW_TAG::$NEW_TAG"
+        echo "::set-env name=NEW_TAG::${NEW_TAG}"
         git tag -n99 -l $NEW_TAG
 
-        CHANGES="$(git log --pretty=format:'%s' $OLD_TAG..HEAD -i -E --grep='^([a-z]*?):' | sed 's/^/  - /')"
+        CHANGES=$(git log --pretty=format:'%s' $OLD_TAG..HEAD -i -E --grep='^([a-z]*?):')
+        CHANGES_NEWLINE="$(echo "${CHANGES}" | sed -e 's/^/  - /')"
+        SANITIZED_CHANGES=$(echo "${CHANGES}" | sed -e 's/^/<li>/' -e 's|$|</li>|' -e 's/(#[0-9]\+)//' )
+        echo "::set-env name=CHANGES::${SANITIZED_CHANGES//$'\n'/}"
         NUM_CHANGES=$(echo -n "$CHANGES" | grep -c '^')
-        echo "::set-env name=NUM_CHANGES::$NUM_CHANGES"
-        git tag $NEW_TAG $NEW_TAG^{} -f -m "$(printf "This is a $BV_PART release from $OLD_TAG → $NEW_TAG.\n\nChanges:\n$CHANGES")"
+        echo "::set-env name=NUM_CHANGES::${NUM_CHANGES}"
+        git tag $NEW_TAG $NEW_TAG^{} -f -m "$(printf "This is a $BV_PART release from $OLD_TAG → $NEW_TAG.\n\nChanges:\n$CHANGES_NEWLINE")"
         git tag -n99 -l $NEW_TAG
-    - name: comment on issue
+    - name: Comment on issue
+      if: >-
+        github.event.action == 'labeled'
       uses: actions/github@v1.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         args: |
-          comment "This is a ${{ env['BV_PART'] }} release from ${{ env['OLD_TAG'] }} → [${{ env['NUM_CHANGES'] }} change(s)] → ${{ env['NEW_TAG'] }}. I'm going to attempt to push now."
-    - name: push changes
+          comment "I've queued this up. When it gets merged, I'll create a ${{ env['BV_PART'] }} release from ${{ env['OLD_TAG'] }} → ${{ env['NEW_TAG'] }} which includes the following ${{ env['NUM_CHANGES'] }} change(s) [including this PR]:<br />${{ env['CHANGES'] }}<br />If you make any more changes, you probably want to re-trigger me again by removing the `bumpversion/${{ env['BV_PART'] }}` label and then adding it back again."
+    - name: Push changes
+      if: >-
+        github.event.action == 'closed' && github.event.pull_request.merged
       uses: ad-m/github-push-action@v0.5.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-    - name: comment that it failed
+    - name: Comment that it failed
       if: failure()
       uses: actions/github@v1.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         args: |
-          comment ":cry: Something went wrong. I wasn't able to push. Check the [Actions pipeline](https://github.com/${{ github.repository }}/actions?query=workflow%3A%22Tag+Creator%22) to see what happened."
+          comment ":cry: Something went wrong. I am not able to push. Check the [Actions pipeline](https://github.com/${{ github.repository }}/actions?query=workflow%3A%22Tag+Creator%22) to see what happened. If you make any more changes, you probably want to re-trigger me again by removing the `bumpversion/${{ env['BV_PART'] }}` label and then adding it back again."
 
   always_job:
     name: Always run job

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -85,12 +85,12 @@ jobs:
     - name: Comment on issue
       if: >-
         github.event.action == 'labeled'
-      uses: actions/github@v1.0.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: actions/github-script@v0.3.0
       with:
-        args: |
-          comment "I've queued this up. When it gets merged, I'll create a ${{ env['BV_PART'] }} release from ${{ env['OLD_TAG'] }} → ${{ env['NEW_TAG'] }} which includes the following ${{ env['NUM_CHANGES'] }} change(s) [including this PR]:<br />${{ env['CHANGES'] }}<br />If you make any more changes, you probably want to re-trigger me again by removing the `bumpversion/${{ env['BV_PART'] }}` label and then adding it back again."
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+      script: |
+        echo "abc"
+        github.issues.createComment({...context.issue, body: "I've queued this up. When it gets merged, I'll create a ${{ env['BV_PART'] }} release from ${{ env['OLD_TAG'] }} → ${{ env['NEW_TAG'] }} which includes the following ${{ env['NUM_CHANGES'] }} change(s) [including this PR]:<br />${{ env['CHANGES'] }}<br />If you make any more changes, you probably want to re-trigger me again by removing the `bumpversion/${{ env['BV_PART'] }}` label and then adding it back again."})
     - name: Push changes
       if: >-
         github.event.action == 'closed' && github.event.pull_request.merged
@@ -99,12 +99,12 @@ jobs:
         github_token: ${{ secrets.GITHUB_PAT }}
     - name: Comment that something failed
       if: failure()
-      uses: actions/github@v1.0.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: actions/github-script@v0.3.0
       with:
-        args: |
-          comment ":cry: Something went wrong. I am not able to push. Check the [Actions pipeline](https://github.com/${{ github.repository }}/actions?query=workflow%3A%22Tag+Creator%22) to see what happened. If you make any more changes, you probably want to re-trigger me again by removing the `bumpversion/${{ env['BV_PART'] }}` label and then adding it back again."
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+      script: |
+        github.issues.createComment({...context.issue, body: ":cry: Something went wrong. I am not able to push. Check the [Actions pipeline](https://github.com/${{ github.repository }}/actions?query=workflow%3A%22Tag+Creator%22) to see what happened. If you make any more changes, you probably want to re-trigger me again by adding the `bumpversion/${{ env['BV_PART'] }}` label again."})
+        github.issues.removeLabels({...context.issue, "bumpversion/${{ env['BV_PART'] }}" })
 
   always_job:
     name: Always run job

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Comment on issue
       if: >-
         github.event.action == 'labeled'
-      uses: actions/github-script@v0.3.0
+      uses: actions/github-script@0.3.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -98,7 +98,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_PAT }}
     - name: Comment that something failed
       if: failure()
-      uses: actions/github-script@v0.3.0
+      uses: actions/github-script@0.3.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -21,7 +21,9 @@ jobs:
         contains( github.event.pull_request.labels.*.name, 'bumpversion/minor' ) ||
         contains( github.event.pull_request.labels.*.name, 'bumpversion/patch' )
       ) && (
-        contains( ['lukasheinrich', 'matthewfeickert', 'kratsg'], github.event.sender.login )
+        github.event.sender.login == 'lukasheinrich' ||
+        github.event.sender.login == 'matthewfeickert' ||
+        github.event.sender.login == 'kratsg'
       )
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -93,7 +93,7 @@ jobs:
       uses: ad-m/github-push-action@v0.5.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Comment that it failed
+    - name: Comment that something failed
       if: failure()
       uses: actions/github@v1.0.0
       env:


### PR DESCRIPTION
# Description

When a PR is labeled with one of the following:

- `bumpversion/major`
- `bumpversion/minor`
- `bumpversion/patch`

The workflow will trigger. This will run `bumpversion $part`, update the commit to refer to the issue number filed, and update the tag to summarize the commits since the previous tag to the new tag.

The changes will be commit messages that follow the semantic format `$semantic: $description`.

When the PR is merged in, then the commit and tag will be pushed to master as well (using a personal access token) which will trigger the publish release.

Successful action (PR from branch):
- [on labeling PR](https://github.com/kratsg/github-action-test/runs/315583006)
- [on merging labeled PR](https://github.com/kratsg/github-action-test/runs/315585704)

Failed action (PR from fork):
- [on labeling PR](https://github.com/kratsg/github-action-test/runs/315572210)
- [on merging labeled PR](https://github.com/kratsg/github-action-test/runs/315581175)

For the failing ones -- it fails on labeling PR because the branch name is from a fork, so cannot be checked out locally. It fails on merging labeled PR because the `secrets.GITHUB_TOKEN` does not have the necessary permissions (which is probably a little confusing to me - @webknjaz?).

In any case, I think we could probably impose the policy that any PR which gets tagged for a release should come from people who have write access to the repo. Since this is actually an improvement over just an `issue` - because a PR is also an issue - it means we can do a PR with an empty commit, discuss, label it - to ensure that it can succeed, and then merge the PR.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add tag workflow that relies on tagging a PR with a specific label
```