### PR TITLE
fix: Add missing pytest dependencies to Current Release tests

### DIFF
--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -1,6 +1,7 @@
 name: Current Release
 
 on:
+  pull_request:
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pyhf[tensorflow,torch,minuit,xmlio]
+        python -m pip install pytest
         python -m pip list
     - name: Canary test public API
       run: |

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pyhf[tensorflow,torch,minuit,xmlio]
-        python -m pip install pytest pytest-cov
+        python -m pip install 'pytest~=3.5' pytest-cov
         python -m pip list
     - name: Canary test public API
       run: |

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pyhf[tensorflow,torch,minuit,xmlio]
-        python -m pip install pytest
+        python -m pip install pytest pytest-cov
         python -m pip list
     - name: Canary test public API
       run: |


### PR DESCRIPTION
# Description

Install missing `pytest` (`v3`) and `pytest-cov` to ["Current release" tests](https://github.com/scikit-hep/pyhf/blob/0e56c6c2e4470b5dc2ad8fb02d1afeeb4184ec18/.github/workflows/release_tests.yml). This was forgotten in PR #611

Please describe the purpose of this pull request in some detail. Reference and link to any relevant issues or pull requests.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add pytest dependency to install
   - pytest is regulated to be below v4.0 as pyhf isn't compliant with modern pytest
* Fixes bug introduced in PR #611
* Run "Current release" tests on PRs as well as on a daily schedule
```
