### PR TITLE
feat: Add Channel summary mixin, JSON-serializable workspace object

### DIFF
--- a/src/pyhf/commandline.py
+++ b/src/pyhf/commandline.py
@@ -149,7 +149,7 @@ def inspect(workspace, output_file, measurement):
 
     result['measurements'] = [
         (m['name'], m['config']['poi'], [p['name'] for p in m['config']['parameters']])
-        for m in w.spec.get('measurements')
+        for m in w.get('measurements')
     ]
 
     maxlen_channels = max(map(len, default_model.config.channels))

--- a/src/pyhf/mixins.py
+++ b/src/pyhf/mixins.py
@@ -1,0 +1,45 @@
+import logging
+
+logging.basicConfig()
+log = logging.getLogger(__name__)
+
+
+class _ChannelSummaryMixin(object):
+    """
+    A mixin that provides summary data of the provided channels.
+
+    This mixin will forward all other information to other classes defined in the Child class.
+
+    Args:
+      **channels: A list of channels to provide summary information about. Follows the `defs.json#/definitions/channel` schema.
+    """
+
+    def __init__(self, *args, **kwargs):
+        channels = kwargs.pop('channels')
+        super(_ChannelSummaryMixin, self).__init__(*args, **kwargs)
+        self.channels = []
+        self.samples = []
+        self.parameters = []
+        self.modifiers = []
+        # keep track of the width of each channel (how many bins)
+        self.channel_nbins = {}
+        # need to keep track in which order we added the constraints
+        # so that we can generate correctly-ordered data
+        for channel in channels:
+            self.channels.append(channel['name'])
+            self.channel_nbins[channel['name']] = len(channel['samples'][0]['data'])
+            for sample in channel['samples']:
+                self.samples.append(sample['name'])
+                for modifier_def in sample['modifiers']:
+                    self.parameters.append(modifier_def['name'])
+                    self.modifiers.append(
+                        (
+                            modifier_def['name'],  # mod name
+                            modifier_def['type'],  # mod type
+                        )
+                    )
+
+        self.channels = sorted(list(set(self.channels)))
+        self.samples = sorted(list(set(self.samples)))
+        self.parameters = sorted(list(set(self.parameters)))
+        self.modifiers = sorted(list(set(self.modifiers)))

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -30,6 +30,11 @@ class Workspace(_ChannelSummaryMixin, dict):
         for obs in self['observations']:
             self.observations[obs['name']] = obs['data']
 
+    def __eq__(self, other):
+        if not isinstance(other, Workspace):
+            return False
+        return dict(self) == dict(other)
+
     def __repr__(self):
         return object.__repr__(self)
 

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -1,9 +1,6 @@
 import logging
 import jsonpatch
 from copy import deepcopy
-from collections import (
-    UserDict,
-)  # underlying dict is accessible as an attribute (self.data)
 from . import exceptions
 from . import utils
 from .pdf import Model
@@ -13,7 +10,7 @@ logging.basicConfig()
 log = logging.getLogger(__name__)
 
 
-class Workspace(_ChannelSummaryMixin, UserDict):
+class Workspace(_ChannelSummaryMixin, dict):
     """
     A JSON-serializable object that is built from an object that follows the `workspace.json` schema.
     """
@@ -24,7 +21,7 @@ class Workspace(_ChannelSummaryMixin, UserDict):
         self.version = config_kwargs.pop('version', None)
         # run jsonschema validation of input specification against the (provided) schema
         log.info("Validating spec against schema: {0:s}".format(self.schema))
-        utils.validate(self.data, self.schema, version=self.version)
+        utils.validate(self, self.schema, version=self.version)
 
         self.measurement_names = []
         for measurement in self.get('measurements', []):

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -8,26 +8,25 @@ logging.basicConfig()
 log = logging.getLogger(__name__)
 
 
-class Workspace(object):
+class Workspace(dict):
     """
-    An object that is built from a JSON spec that follows `workspace.json`.
+    A JSON-serializable object that is built from an object that follows the `workspace.json` schema.
     """
 
     def __init__(self, spec, **config_kwargs):
-        self.spec = spec
-
+        super(Workspace, self).__init__(spec)
         self.schema = config_kwargs.pop('schema', 'workspace.json')
         self.version = config_kwargs.pop('version', None)
         # run jsonschema validation of input specification against the (provided) schema
         log.info("Validating spec against schema: {0:s}".format(self.schema))
-        utils.validate(self.spec, self.schema, version=self.version)
+        utils.validate(self, self.schema, version=self.version)
 
         self.measurement_names = []
-        for measurement in self.spec.get('measurements', []):
+        for measurement in self.get('measurements', []):
             self.measurement_names.append(measurement['name'])
 
         self.observations = {}
-        for obs in self.spec['observations']:
+        for obs in self['observations']:
             self.observations[obs['name']] = obs['data']
 
     # NB: this is a wrapper function to validate the returned measurement object against the spec
@@ -79,19 +78,19 @@ class Workspace(object):
                             measurement_name
                         )
                     )
-                return self.spec['measurements'][
+                return self['measurements'][
                     self.measurement_names.index(measurement_name)
                 ]
 
             measurement_index = config_kwargs.get('measurement_index')
             if measurement_index:
-                return self.spec['measurements'][measurement_index]
+                return self['measurements'][measurement_index]
 
             if len(self.measurement_names) > 1:
                 log.warning(
                     'multiple measurements defined. Taking the first measurement.'
                 )
-            return self.spec['measurements'][0]
+            return self['measurements'][0]
 
         raise exceptions.InvalidMeasurement(
             "A measurement was not given to create the Model."
@@ -116,7 +115,7 @@ class Workspace(object):
         patches = config_kwargs.get('patches', [])
 
         modelspec = {
-            'channels': self.spec['channels'],
+            'channels': self['channels'],
             'parameters': measurement['config']['parameters'],
         }
         for patch in patches:

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -1,6 +1,5 @@
 import logging
 import jsonpatch
-from copy import deepcopy
 from . import exceptions
 from . import utils
 from .pdf import Model

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -7,18 +7,19 @@ from collections import (
 from . import exceptions
 from . import utils
 from .pdf import Model
+from .mixins import _ChannelSummaryMixin
 
 logging.basicConfig()
 log = logging.getLogger(__name__)
 
 
-class Workspace(UserDict):
+class Workspace(_ChannelSummaryMixin, UserDict):
     """
     A JSON-serializable object that is built from an object that follows the `workspace.json` schema.
     """
 
     def __init__(self, spec, **config_kwargs):
-        super(Workspace, self).__init__(spec)
+        super(Workspace, self).__init__(spec, channels=spec['channels'])
         self.schema = config_kwargs.pop('schema', 'workspace.json')
         self.version = config_kwargs.pop('version', None)
         # run jsonschema validation of input specification against the (provided) schema

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -1,5 +1,9 @@
 import logging
 import jsonpatch
+from copy import deepcopy
+from collections import (
+    UserDict,
+)  # underlying dict is accessible as an attribute (self.data)
 from . import exceptions
 from . import utils
 from .pdf import Model
@@ -8,7 +12,7 @@ logging.basicConfig()
 log = logging.getLogger(__name__)
 
 
-class Workspace(dict):
+class Workspace(UserDict):
     """
     A JSON-serializable object that is built from an object that follows the `workspace.json` schema.
     """
@@ -19,7 +23,7 @@ class Workspace(dict):
         self.version = config_kwargs.pop('version', None)
         # run jsonschema validation of input specification against the (provided) schema
         log.info("Validating spec against schema: {0:s}".format(self.schema))
-        utils.validate(self, self.schema, version=self.version)
+        utils.validate(self.data, self.schema, version=self.version)
 
         self.measurement_names = []
         for measurement in self.get('measurements', []):

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -35,6 +35,9 @@ class Workspace(_ChannelSummaryMixin, dict):
             return False
         return dict(self) == dict(other)
 
+    def __ne__(self, other):
+        return not self == other
+
     def __repr__(self):
         return object.__repr__(self)
 

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -31,6 +31,9 @@ class Workspace(_ChannelSummaryMixin, dict):
         for obs in self['observations']:
             self.observations[obs['name']] = obs['data']
 
+    def __repr__(self):
+        return object.__repr__(self)
+
     # NB: this is a wrapper function to validate the returned measurement object against the spec
     def get_measurement(self, **config_kwargs):
         """

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,0 +1,47 @@
+import pyhf
+import pyhf.readxml
+import pytest
+
+
+@pytest.fixture(
+    scope='session',
+    params=[
+        ('validation/xmlimport_input/config/example.xml', 'validation/xmlimport_input/')
+    ],
+    ids=['example-one'],
+)
+def spec(request):
+    return pyhf.readxml.parse(*request.param)
+
+
+def test_channel_summary_mixin(spec):
+    assert 'channels' in spec
+    mixin = pyhf.mixins._ChannelSummaryMixin(channels=spec['channels'])
+    assert mixin.channel_nbins == {'channel1': 2}
+    assert mixin.channels == ['channel1']
+    assert mixin.modifiers == [
+        ('SigXsecOverSM', 'normfactor'),
+        ('lumi', 'lumi'),
+        ('staterror_channel1', 'staterror'),
+        ('syst1', 'normsys'),
+        ('syst2', 'normsys'),
+        ('syst3', 'normsys'),
+    ]
+    assert mixin.parameters == [
+        'SigXsecOverSM',
+        'lumi',
+        'staterror_channel1',
+        'syst1',
+        'syst2',
+        'syst3',
+    ]
+    assert mixin.samples == ['background1', 'background2', 'signal']
+
+
+def test_channel_summary_mixin_empty():
+    mixin = pyhf.mixins._ChannelSummaryMixin(channels=[])
+    assert mixin.channel_nbins == {}
+    assert mixin.channels == []
+    assert mixin.modifiers == []
+    assert mixin.parameters == []
+    assert mixin.samples == []

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -101,6 +101,11 @@ def test_get_measurement_schema_validation(mocker, workspace_factory):
     assert pyhf.utils.validate.call_args[0][1] == 'measurement.json'
 
 
+def test_get_workspace_repr(workspace_factory):
+    w = workspace_factory()
+    assert 'pyhf.workspace.Workspace' in str(w)
+
+
 def test_get_workspace_model_default(workspace_factory):
     w = workspace_factory()
     m = w.model()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -121,3 +121,7 @@ def test_get_workspace_data_bad_model(workspace_factory, caplog):
         with pytest.raises(KeyError):
             assert w.data(m)
             assert 'Invalid channel' in caplog.text
+
+
+def test_json_serializable(workspace_factory):
+    assert json.dumps(workspace_factory())

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -65,6 +65,12 @@ def test_get_measurement_fake(workspace_factory):
     assert m
 
 
+def test_get_measurement_nonexist(workspace_factory):
+    w = workspace_factory()
+    with pytest.raises(pyhf.exceptions.InvalidMeasurement):
+        m = w.get_measurement(measurement_name='nonexistent_measurement')
+
+
 def test_get_workspace_measurement_priority(workspace_factory):
     w = workspace_factory()
 


### PR DESCRIPTION
# Description

This adds a channel summary mixin to be used by any object that needs a summary of the channel information in the spec they're using. This will apply to both `pyhf.Workspace` and `pyhf.pdf._ModelConfig`.

The end goal, if it's not obvious, is that unlike `pyhf.Model` which doesn't currently have a spec.. I want the `pyhf.Workspace` to be a "light" layer on top of the `workspace.json` spec we have. This means that we should do (directly)

```python
spec = pyhf.Workspace(json.load(open('spec.json')))
assert spec['version'] == 1.0.0
assert 'signal' in spec.samples
```

where it quacks like a python dictionary, but has some extra niceties such as being able to build a model from it, or listing summary information about itself. 

You might ask, well, why not just provide a `pyhf.Workspace::to_json()` method instead?

- this will break when doing nested `json.dump()` calls

Or some sort of `__json__` that gets called?

- all python json libraries do something different and the one we use doesn't call any magic function and instead expects that we pass in a custom encoder/decoder to the `json.dump()` calls...

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add Channel Summary mixin
* Make the pyhf.Workspace JSON-serializable
```