### PR TITLE
ci: Pin GitHub Actions release versions to stable tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: [3.6, 3.7]
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1.2.0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -62,7 +62,7 @@ jobs:
         python-version: [3.7]
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1.2.0
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
@@ -84,7 +84,7 @@ jobs:
         python-version: [3.7]
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1.2.0
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
     - name: Report coverage with Codecov
       if: github.event_name == 'push' && matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
-      uses: codecov/codecov-action@master
+      uses: codecov/codecov-action@v1.0.4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml

--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1.2.0
     - name: Trigger Binder build
       run: |
         # Use Binder build API to trigger repo2docker to build image on GKE and OVH Binder Federation clusters

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build and publish Python distro to (Test)PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1.2.0
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: [3.7]
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1.2.0
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
# Description

With the release of the [beta of `v2` of the GitHub checkout action](https://github.com/actions/checkout/releases/tag/v2-beta) breaking the CI it is probably worth pinning all GitHub Actions to stable releases instead of `@master`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Pin checkout action to release v1.2.0
* Pin codecov action to release v1.0.4
```
