### PR TITLE
feat: normfactor import/export parameter configuration

### DIFF
--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -105,6 +105,7 @@ def process_sample(
             parameter_config = {
                 'name': modtag.attrib['Name'],
                 'bounds': [[float(modtag.attrib['Low']), float(modtag.attrib['High'])]],
+                'inits': [float(modtag.attrib['Val'])],
             }
             if modtag.attrib.get('Const'):
                 parameter_config['fixed'] = modtag.attrib['Const'] == 'True'

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -282,8 +282,8 @@ def dedupe_parameters(parameters):
     duplicates = {}
     for p in parameters:
         duplicates.setdefault(p['name'], []).append(p)
-    for pname in duplicates.keys():
-        parameter_list = duplicates[pname]
+    for parname in duplicates.keys():
+        parameter_list = duplicates[parname]
         if len(parameter_list) == 1:
             continue
         elif any(p != parameter_list[0] for p in parameter_list[1:]):
@@ -291,7 +291,7 @@ def dedupe_parameters(parameters):
                 log.warning(p)
             raise RuntimeError(
                 'cannot import workspace due to incompatible parameter configurations for {0:s}.'.format(
-                    pname
+                    parname
                 )
             )
     # no errors raised, de-dupe and return

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -12,27 +12,16 @@ _ROOT_DATA_FILE = None
 
 log = logging.getLogger(__name__)
 
-
-"""
-Dear readers of this code:
-
-  You might be wondering why 'spec' gets passed through all functions now. Once
-  upon a time, it didn't. However, it turns out that NormFactor is a unique
-  case of having parameter configurations stored at the
-  modifier-definition-spec level. This means that build_modifier() needs access
-  to the measurements. The call stack is:
-
-      writexml
-          ->build_channel
-              ->build_sample
-                  ->build_modifier
-
-  Therefore, we have to thread 'spec' through all these calls.
-
-Sincerely,
-
-  Defeated Developer
-"""
+# 'spec' gets passed through all functions as NormFactor is a unique case of having
+# parameter configurations stored at the modifier-definition-spec level. This means
+# that build_modifier() needs access to the measurements. The call stack is:
+#
+#      writexml
+#          ->build_channel
+#              ->build_sample
+#                  ->build_modifier
+#
+#  Therefore, 'spec' needs to be threaded through all these calls.
 
 
 def _make_hist_name(channel, sample, modifier='', prefix='hist', suffix=''):
@@ -155,7 +144,6 @@ def build_modifier(spec, modifierspec, channelname, samplename, sampledata):
         val = 1
         low = 0
         high = 10
-        # Whatever. Let's get on with the show, shall we?
         for p in spec['measurements'][0]['config']['parameters']:
             if p['name'] == modifierspec['name']:
                 val = p['inits'][0]

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -195,13 +195,64 @@ def test_export_modifier(mocker, spec, has_root_data, attrs):
 
     mocker.patch('pyhf.writexml._ROOT_DATA_FILE')
     modifier = pyhf.writexml.build_modifier(
-        modifierspec, channelname, samplename, sampledata
+        {'measurements': [{'config': {'parameters': []}}]},
+        modifierspec,
+        channelname,
+        samplename,
+        sampledata,
     )
     # if the modifier is a staterror, it has no Name
     if 'Name' in modifier.attrib:
         assert modifier.attrib['Name'] == modifierspec['name']
     assert all(attr in modifier.attrib for attr in attrs)
     assert pyhf.writexml._ROOT_DATA_FILE.__setitem__.called == has_root_data
+
+
+@pytest.mark.parametrize(
+    "spec, normfactor_config",
+    [
+        (spec_staterror(), dict(name='mu', inits=[1.0], bounds=[[0.0, 8.0]])),
+        (spec_histosys(), dict()),
+        (spec_normsys(), dict(name='mu', inits=[2.0], bounds=[[0.0, 10.0]])),
+        (spec_shapesys(), dict(name='mu', inits=[1.0], bounds=[[5.0, 10.0]])),
+    ],
+    ids=['upper-bound', 'empty-config', 'init', 'lower-bound'],
+)
+def test_export_modifier_normfactor(mocker, spec, normfactor_config):
+    channelspec = spec['channels'][0]
+    channelname = channelspec['name']
+    samplespec = channelspec['samples'][0]
+    samplename = samplespec['name']
+    sampledata = samplespec['data']
+    modifierspec = samplespec['modifiers'][0]
+
+    mocker.patch('pyhf.writexml._ROOT_DATA_FILE')
+    modifier = pyhf.writexml.build_modifier(
+        {
+            'measurements': [
+                {
+                    'config': {
+                        'parameters': [normfactor_config] if normfactor_config else []
+                    }
+                }
+            ]
+        },
+        modifierspec,
+        channelname,
+        samplename,
+        sampledata,
+    )
+
+    assert all(attr in modifier.attrib for attr in ['Name', 'Val', 'High', 'Low'])
+    assert float(modifier.attrib['Val']) == normfactor_config.get('inits', [1.0])[0]
+    assert (
+        float(modifier.attrib['Low'])
+        == normfactor_config.get('bounds', [[0.0, 10.0]])[0][0]
+    )
+    assert (
+        float(modifier.attrib['High'])
+        == normfactor_config.get('bounds', [[0.0, 10.0]])[0][1]
+    )
 
 
 @pytest.mark.parametrize(
@@ -218,7 +269,7 @@ def test_export_sample(mocker, spec):
 
     mocker.patch('pyhf.writexml.build_modifier', return_value=ET.Element("Modifier"))
     mocker.patch('pyhf.writexml._ROOT_DATA_FILE')
-    sample = pyhf.writexml.build_sample(samplespec, channelname)
+    sample = pyhf.writexml.build_sample({}, samplespec, channelname)
     assert sample.attrib['Name'] == samplespec['name']
     assert sample.attrib['HistoName']
     assert sample.attrib['InputFile']
@@ -242,7 +293,11 @@ def test_export_sample_zerodata(mocker, spec):
     with pytest.warns(None) as record:
         for modifierspec in samplespec['modifiers']:
             modifier = pyhf.writexml.build_modifier(
-                modifierspec, channelname, samplename, sampledata
+                {'measurements': [{'config': {'parameters': []}}]},
+                modifierspec,
+                channelname,
+                samplename,
+                sampledata,
             )
     assert not record.list
 
@@ -259,7 +314,7 @@ def test_export_channel(mocker, spec):
     mocker.patch('pyhf.writexml.build_data', return_value=ET.Element("Data"))
     mocker.patch('pyhf.writexml.build_sample', return_value=ET.Element("Sample"))
     mocker.patch('pyhf.writexml._ROOT_DATA_FILE')
-    channel = pyhf.writexml.build_channel(channelspec, {})
+    channel = pyhf.writexml.build_channel({}, channelspec, {})
     assert channel.attrib['Name'] == channelspec['name']
     assert channel.attrib['InputFile']
     assert pyhf.writexml.build_data.called is False

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -115,7 +115,7 @@ def test_import_measurements():
     assert 'parameters' in measurement_configs
     assert len(measurement_configs['parameters']) == 3
     pnames = [p['name'] for p in measurement_configs['parameters']]
-    assert pnames == ['lumi', 'SigXsecOverSM', 'alpha_syst1']
+    assert sorted(pnames) == sorted(['lumi', 'SigXsecOverSM', 'alpha_syst1'])
 
     lumi_param_config = measurement_configs['parameters'][0]
     assert 'auxdata' in lumi_param_config

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -46,13 +46,13 @@ def test_process_normfactor_configs():
     poiel.text = 'mu_SIG'
     meas.append(poiel)
 
-    se = ET.Element('ParamSetting', Const='True')
-    se.text = ' '.join(['Lumi', 'mu_both', 'mu_paramSettingOnly'])
-    meas.append(se)
+    setting = ET.Element('ParamSetting', Const='True')
+    setting.text = ' '.join(['Lumi', 'mu_both', 'mu_paramSettingOnly'])
+    meas.append(setting)
 
-    se = ET.Element('ParamSetting', Val='2.0')
-    se.text = ' '.join(['mu_both'])
-    meas.append(se)
+    setting = ET.Element('ParamSetting', Val='2.0')
+    setting.text = ' '.join(['mu_both'])
+    meas.append(setting)
 
     toplvl.append(meas)
 
@@ -67,9 +67,9 @@ def test_process_normfactor_configs():
     poiel.text = 'mu_BKG'
     meas.append(poiel)
 
-    se = ET.Element('ParamSetting', Val='3.0')
-    se.text = ' '.join(['mu_both'])
-    meas.append(se)
+    setting = ET.Element('ParamSetting', Val='3.0')
+    setting.text = ' '.join(['mu_both'])
+    meas.append(setting)
 
     toplvl.append(meas)
 
@@ -118,8 +118,8 @@ def test_import_measurements():
 
     assert 'parameters' in measurement_configs
     assert len(measurement_configs['parameters']) == 3
-    pnames = [p['name'] for p in measurement_configs['parameters']]
-    assert sorted(pnames) == sorted(['lumi', 'SigXsecOverSM', 'alpha_syst1'])
+    parnames = [p['name'] for p in measurement_configs['parameters']]
+    assert sorted(parnames) == sorted(['lumi', 'SigXsecOverSM', 'alpha_syst1'])
 
     lumi_param_config = measurement_configs['parameters'][0]
     assert 'auxdata' in lumi_param_config

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -38,7 +38,7 @@ def test_import_measurements():
     measurement_configs = measurements[0]['config']
 
     assert 'parameters' in measurement_configs
-    assert len(measurement_configs['parameters']) == 2
+    assert len(measurement_configs['parameters']) == 3
     assert measurement_configs['parameters'][0]['name'] == 'lumi'
     assert measurement_configs['parameters'][1]['name'] == 'alpha_syst1'
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -15,13 +15,18 @@ def assert_equal_dictionary(d1, d2):
         else:
             assert d1[k] == d2[k]
 
+
 def test_dedupe_parameters():
-    parameters = [{'name': 'SigXsecOverSM', 'bounds': [[0.0, 10.0]]}, {'name': 'SigXsecOverSM', 'bounds': [[0.0, 10.0]]}]
+    parameters = [
+        {'name': 'SigXsecOverSM', 'bounds': [[0.0, 10.0]]},
+        {'name': 'SigXsecOverSM', 'bounds': [[0.0, 10.0]]},
+    ]
     assert len(pyhf.readxml.dedupe_parameters(parameters)) == 1
     parameters[1]['bounds'] = [[0.0, 2.0]]
     with pytest.raises(RuntimeError) as excinfo:
         pyhf.readxml.dedupe_parameters(parameters)
         assert 'SigXsecOverSM' in str(excinfo.value)
+
 
 def test_import_measurements():
     parsed_xml = pyhf.readxml.parse(

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -85,18 +85,22 @@ def test_process_normfactor_configs():
         m['name']: {k['name']: k for k in m['config']['parameters']} for m in result
     }
     assert result
+
     # make sure ParamSetting configs override NormFactor configs
     assert result['NormalMeasurement']['mu_both']['fixed']
     assert result['NormalMeasurement']['mu_both']['inits'] == [2.0]
     assert result['NormalMeasurement']['mu_both']['bounds'] == [[1.0, 5.0]]
+
     # make sure ParamSetting is doing the right thing
     assert result['NormalMeasurement']['mu_paramSettingOnly']['fixed']
     assert 'inits' not in result['NormalMeasurement']['mu_paramSettingOnly']
     assert 'bounds' not in result['NormalMeasurement']['mu_paramSettingOnly']
+
     # make sure our code doesn't accidentally override other parameter configs
     assert not result['NormalMeasurement']['mu_otherConfigOnly']['fixed']
     assert result['NormalMeasurement']['mu_otherConfigOnly']['inits'] == [1.0]
     assert result['NormalMeasurement']['mu_otherConfigOnly']['bounds'] == [[0.0, 10.0]]
+
     # make sure settings from one measurement don't leak to other
     assert not result['ParallelMeasurement']['mu_both']['fixed']
     assert result['ParallelMeasurement']['mu_both']['inits'] == [3.0]

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -4,6 +4,7 @@ import numpy as np
 import uproot
 import os
 import pytest
+import xml.etree.cElementTree as ET
 
 
 def assert_equal_dictionary(d1, d2):
@@ -28,6 +29,80 @@ def test_dedupe_parameters():
         assert 'SigXsecOverSM' in str(excinfo.value)
 
 
+def test_process_normfactor_configs():
+    # Check to see if mu_ttbar NormFactor is overridden correctly
+    # - ParamSetting has a config for it
+    # - other_parameter_configs has a config for it
+    # Make sure that when two measurements exist, we're copying things across correctly
+    toplvl = ET.Element("Combination")
+    meas = ET.Element(
+        "Measurement",
+        Name='NormalMeasurement',
+        Lumi=str(1.0),
+        LumiRelErr=str(0.017),
+        ExportOnly=str(True),
+    )
+    poiel = ET.Element('POI')
+    poiel.text = 'mu_SIG'
+    meas.append(poiel)
+
+    se = ET.Element('ParamSetting', Const='True')
+    se.text = ' '.join(['Lumi', 'mu_both', 'mu_paramSettingOnly'])
+    meas.append(se)
+
+    se = ET.Element('ParamSetting', Val='2.0')
+    se.text = ' '.join(['mu_both'])
+    meas.append(se)
+
+    toplvl.append(meas)
+
+    meas = ET.Element(
+        "Measurement",
+        Name='ParallelMeasurement',
+        Lumi=str(1.0),
+        LumiRelErr=str(0.017),
+        ExportOnly=str(True),
+    )
+    poiel = ET.Element('POI')
+    poiel.text = 'mu_BKG'
+    meas.append(poiel)
+
+    se = ET.Element('ParamSetting', Val='3.0')
+    se.text = ' '.join(['mu_both'])
+    meas.append(se)
+
+    toplvl.append(meas)
+
+    other_parameter_configs = [
+        dict(name='mu_both', inits=[1.0], bounds=[[1.0, 5.0]], fixed=False),
+        dict(name='mu_otherConfigOnly', inits=[1.0], bounds=[[0.0, 10.0]], fixed=False),
+    ]
+
+    result = pyhf.readxml.process_measurements(
+        toplvl, other_parameter_configs=other_parameter_configs
+    )
+    result = {
+        m['name']: {k['name']: k for k in m['config']['parameters']} for m in result
+    }
+    assert result
+    # make sure ParamSetting configs override NormFactor configs
+    assert result['NormalMeasurement']['mu_both']['fixed']
+    assert result['NormalMeasurement']['mu_both']['inits'] == [2.0]
+    assert result['NormalMeasurement']['mu_both']['bounds'] == [[1.0, 5.0]]
+    # make sure ParamSetting is doing the right thing
+    assert result['NormalMeasurement']['mu_paramSettingOnly']['fixed']
+    assert 'inits' not in result['NormalMeasurement']['mu_paramSettingOnly']
+    assert 'bounds' not in result['NormalMeasurement']['mu_paramSettingOnly']
+    # make sure our code doesn't accidentally override other parameter configs
+    assert result['NormalMeasurement']['mu_otherConfigOnly']['fixed'] == False
+    assert result['NormalMeasurement']['mu_otherConfigOnly']['inits'] == [1.0]
+    assert result['NormalMeasurement']['mu_otherConfigOnly']['bounds'] == [[0.0, 10.0]]
+    # make sure settings from one measurement don't leak to other
+    assert result['ParallelMeasurement']['mu_both']['fixed'] == False
+    assert result['ParallelMeasurement']['mu_both']['inits'] == [3.0]
+    assert result['ParallelMeasurement']['mu_both']['bounds'] == [[1.0, 5.0]]
+
+
 def test_import_measurements():
     parsed_xml = pyhf.readxml.parse(
         'validation/xmlimport_input/config/example.xml', 'validation/xmlimport_input/'
@@ -39,8 +114,8 @@ def test_import_measurements():
 
     assert 'parameters' in measurement_configs
     assert len(measurement_configs['parameters']) == 3
-    assert measurement_configs['parameters'][0]['name'] == 'lumi'
-    assert measurement_configs['parameters'][1]['name'] == 'alpha_syst1'
+    pnames = [p['name'] for p in measurement_configs['parameters']]
+    assert pnames == ['lumi', 'SigXsecOverSM', 'alpha_syst1']
 
     lumi_param_config = measurement_configs['parameters'][0]
     assert 'auxdata' in lumi_param_config

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -193,3 +193,22 @@ def test_import_shapesys():
     assert channels['channel1']['samples'][1]['modifiers'][1]['data'] == pytest.approx(
         [10.0, 1.5e-5]
     )
+
+
+def test_import_normfactor_bounds():
+    parsed_xml = pyhf.readxml.parse(
+        'validation/xmlimport_input2/config/example.xml', 'validation/xmlimport_input2'
+    )
+
+    ws = pyhf.Workspace(parsed_xml)
+    assert ('SigXsecOverSM', 'normfactor') in ws.modifiers
+    parameters = [
+        p
+        for p in ws.get_measurement(measurement_name='GaussExample')['config'][
+            'parameters'
+        ]
+        if p['name'] == 'SigXsecOverSM'
+    ]
+    assert len(parameters) == 1
+    parameter = parameters[0]
+    assert parameter['bounds'] == [[0, 10]]

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -15,6 +15,13 @@ def assert_equal_dictionary(d1, d2):
         else:
             assert d1[k] == d2[k]
 
+def test_dedupe_parameters():
+    parameters = [{'name': 'SigXsecOverSM', 'bounds': [[0.0, 10.0]]}, {'name': 'SigXsecOverSM', 'bounds': [[0.0, 10.0]]}]
+    assert len(pyhf.readxml.dedupe_parameters(parameters)) == 1
+    parameters[1]['bounds'] = [[0.0, 2.0]]
+    with pytest.raises(RuntimeError) as excinfo:
+        pyhf.readxml.dedupe_parameters(parameters)
+        assert 'SigXsecOverSM' in str(excinfo.value)
 
 def test_import_measurements():
     parsed_xml = pyhf.readxml.parse(

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -94,11 +94,11 @@ def test_process_normfactor_configs():
     assert 'inits' not in result['NormalMeasurement']['mu_paramSettingOnly']
     assert 'bounds' not in result['NormalMeasurement']['mu_paramSettingOnly']
     # make sure our code doesn't accidentally override other parameter configs
-    assert result['NormalMeasurement']['mu_otherConfigOnly']['fixed'] == False
+    assert not result['NormalMeasurement']['mu_otherConfigOnly']['fixed']
     assert result['NormalMeasurement']['mu_otherConfigOnly']['inits'] == [1.0]
     assert result['NormalMeasurement']['mu_otherConfigOnly']['bounds'] == [[0.0, 10.0]]
     # make sure settings from one measurement don't leak to other
-    assert result['ParallelMeasurement']['mu_both']['fixed'] == False
+    assert not result['ParallelMeasurement']['mu_both']['fixed']
     assert result['ParallelMeasurement']['mu_both']['inits'] == [3.0]
     assert result['ParallelMeasurement']['mu_both']['bounds'] == [[1.0, 5.0]]
 


### PR DESCRIPTION
# Description

This resolves #661. This allows for importing xml/exporting json of the NormFactor parameter configurations. 

A very strong assumption is made on import (checked via deduplication) that NormFactors (and the set of parameter configs grabbed from the channel specifications) do not conflict with one another. These parameter configurations are stored for all measurements.

A second assumption on import is that NormFactors defined `const` in ParamSetting override NormFactor settings.

A strong assumption is made on export that, for NormFactor, the first measurement should have all the same parameter configurations as the rest of the measurements (if there are more than one measurement). The Val/Low/High parameter configuration is only extracted from the first measurement and stored in the resulting XML.

This is done in such a way that our pyhf JSON spec does not need to change.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* normfactor parameter configurations (Val, High, Low) are now imported/exported
```