### PR TITLE
ci: use personal access token for gh-pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,4 +112,4 @@ jobs:
         target_branch: gh-pages
         build_dir: docs/_build/html
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_PAT: ${{ secrets.GITHUB_PAT }}


### PR DESCRIPTION
# Description

From the [ghaction-github-pages](https://github.com/crazy-max/ghaction-github-pages) section of the README on [Limitations of GitHub Actions](https://github.com/crazy-max/ghaction-github-pages#warning-limitation):

> Currently, `GITHUB_TOKEN` [does not suffice to trigger a page build](https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/m-p/26869) on a **public repository** (propagate content to the GitHub content-delivery network). You must therefore create a custom [Personal Access Token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) and use it through the `GITHUB_PAT` environment variable:
>
>```yaml
>- name: Deploy
>  if: success()
>  uses: crazy-max/ghaction-github-pages@v1
>  with:
>    target_branch: gh-pages
>    build_dir: public
>  env:
>    GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
>```

This PR switches to use a PAT.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Github actions won't trigger gh-pages pushes to be built, use a personal access token instead
```