### PR TITLE
fix: Add git to Docker image during build to avoid setuptools-scm error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,6 @@
 FROM alectolytic/scipy
-ADD . /code
-RUN cd /code;pip install -e .
+COPY . /code
+RUN cd /code && \
+    rm -rf .git && \
+    python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
+    python -m pip install --no-cache-dir -e .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,5 +4,5 @@ RUN cd /code && \
     apk add --no-cache git && \
     rm -rf /var/cache/apk/* && \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
-    python -m pip install --no-cache-dir -e . && \
+    python -m pip install --no-cache-dir -e .[xmlio] && \
     python -m pip list

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 FROM alectolytic/scipy
 COPY . /code
 RUN cd /code && \
-    apk add git && \
+    apk add --no-cache git && \
+    rm -rf /var/cache/apk/* && \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
     python -m pip install --no-cache-dir -e .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM alectolytic/scipy
 COPY . /code
 RUN cd /code && \
-    rm -rf .git && \
+    apk add git && \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
     python -m pip install --no-cache-dir -e .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,4 +4,5 @@ RUN cd /code && \
     apk add --no-cache git && \
     rm -rf /var/cache/apk/* && \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
-    python -m pip install --no-cache-dir -e .
+    python -m pip install --no-cache-dir -e . && \
+    python -m pip list


### PR DESCRIPTION
# Description

In PR #676 the `_is_test_pypi` was removed as it was discovered that it wasn't needed for CI to pass. However, removing it caused issues in the Docker image build on Docker Hub as a result of `setuptools-scm` looking for `.git`

>     LookupError: setuptools-scm was unable to detect version for '/code'.
>    
>    Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.

 Adding git to the image fixes these problems.

Also use `COPY` instead of `ADD` as `COPY` is considered best practice over using `ADD` unless `ADD`'s tar and remote URL capabilities are needed.
c.f.
- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy
- https://stackoverflow.com/a/24958548/8931942

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* apk add git to image to avoid setuptools-scm error
* Use COPY for best practices
* Add 'xmlio' extra in install to add ROOT file read support
* Use python -m pip for best pip practices
```
