### PR TITLE
docs: add babel to describe HistFitter to pyhf workflow

### DIFF
--- a/docs/babel.rst
+++ b/docs/babel.rst
@@ -17,7 +17,7 @@ In order to go from `HistFitter` to `pyhf`, the first step is to extract out the
 
 The name of output workspace files depends on four parameters you define in your ``config.py``:
 
-- ``analysisName`` is from ``configMgr.analysisName``,
+- ``analysisName`` is from ``configMgr.analysisName``
 - ``prefix`` is defined in ``configMgr.addFitConfig({prefix})``, and
 - ``measurementName`` is the first measurement you define via ``fitConfig.addMeasurement(name={measurementName},...)``
 - ``channelName`` are the names of channels you define via ``fitConfig.addChannel("cuts", [{channelName}], ...)``

--- a/docs/babel.rst
+++ b/docs/babel.rst
@@ -1,6 +1,10 @@
 Translations
 ============
-One key goal of `pyhf` is to provide seamless translations from one statistical framework to us. This page details the various ways to translate from a tool you might already be using as part of an existing analysis to `pyhf`. Many of these solutions involve extracting out the `HistFactory` workspace and then running `pyhf xml2json <cli.html#pyhf-xml2json>`_ which provides a single JSON workspace that can be loaded directly into `pyhf`.
+One key goal of ``pyhf`` is to provide seamless translations between other statistical frameworks and ``pyhf``.
+This page details the various ways to translate from a tool you might already be using as part of an existing analysis to ``pyhf``.
+Many of these solutions involve extracting out the ``HistFactory`` workspace and then running |pyhf xml2json|_ which provides a single JSON workspace that can be loaded directly into ``pyhf``.
+
+.. |pyhf xml2json| replace:: ``pyhf xml2json``
 
 HistFitter
 ----------

--- a/docs/babel.rst
+++ b/docs/babel.rst
@@ -18,7 +18,7 @@ In order to go from `HistFitter` to `pyhf`, the first step is to extract out the
 The name of output workspace files depends on four parameters you define in your ``config.py``:
 
 - ``analysisName`` is from ``configMgr.analysisName``
-- ``prefix`` is defined in ``configMgr.addFitConfig({prefix})``, and
+- ``prefix`` is defined in ``configMgr.addFitConfig({prefix})``
 - ``measurementName`` is the first measurement you define via ``fitConfig.addMeasurement(name={measurementName},...)``
 - ``channelName`` are the names of channels you define via ``fitConfig.addChannel("cuts", [{channelName}], ...)``
 - ``cachePath`` is where `HistFitter` stores the cached histograms, defined by ``configMgr.histCacheFile`` which defaults to ``data/{analysisName}.root``

--- a/docs/babel.rst
+++ b/docs/babel.rst
@@ -29,7 +29,8 @@ To dump the HistFactory workspace, you will modify the above to skip the fit ``-
 
   HistFitter.py -wx -F excl config.py
 
-The ``-x`` flag tells `HistFitter` to dump the XML files into ``config/{analysisName}/``, with the top-level file being ``{prefix}.xml`` and all other files being ``{prefix}_{channelName}_cuts.xml``. The ``-w`` flag tells `HistFitter` to (re)create the `HistFactory` workspace stored in ``results/{analysisName}/{prefix}_combined_{measurementName}.root``.
+The ``-w`` flag tells `HistFitter` to (re)create the `HistFactory` workspace stored in ``results/{analysisName}/{prefix}_combined_{measurementName}.root``.
+The ``-x`` flag tells `HistFitter` to dump the XML files into ``config/{analysisName}/``, with the top-level file being ``{prefix}.xml`` and all other files being ``{prefix}_{channelName}_cuts.xml``.
 
 Typically, ``prefix = 'FitConfig'`` and ``measurementName = 'NormalMeasurement'``. For example, if the following exists in your ``config.py``
 

--- a/docs/babel.rst
+++ b/docs/babel.rst
@@ -1,0 +1,62 @@
+Translations
+============
+One key goal of `pyhf` is to provide seamless translations from one statistical framework to us. This page details the various ways to translate from a tool you might already be using as part of an existing analysis to `pyhf`. Many of these solutions involve extracting out the `HistFactory` workspace and then running `pyhf xml2json <cli.html#pyhf-xml2json>`_ which provides a single JSON workspace that can be loaded directly into `pyhf`.
+
+HistFitter
+----------
+
+In order to go from `HistFitter` to `pyhf`, the first step is to extract out the `HistFactory` workspaces. Assuming you have an existing configuration file, ``config.py``, you likely run an exclusion fit like so:
+
+.. code:: bash
+
+  HistFitter.py -f -D "before,after,corrMatrix" -F excl config.py
+
+The name of output workspace files depends on four parameters you define in your ``config.py``:
+
+- ``analysisName`` is from ``configMgr.analysisName``,
+- ``prefix`` is defined in ``configMgr.addFitConfig({prefix})``, and
+- ``measurementName`` is the first measurement you define via ``fitConfig.addMeasurement(name={measurementName},...)``
+- ``channelName`` are the names of channels you define via ``fitConfig.addChannel("cuts", [{channelName}], ...)``
+- ``cachePath`` is where `HistFitter` stores the cached histograms, defined by ``configMgr.histCacheFile`` which defaults to ``data/{analysisName}.root``
+
+To dump the HistFactory workspace, you will modify the above to skip the fit ``-f`` and plotting ``-D`` so you end up with
+
+.. code:: bash
+
+  HistFitter.py -wx -F excl config.py
+
+The ``-x`` flag tells `HistFitter` to dump the XML files into ``config/{analysisName}/``, with the top-level file being ``{prefix}.xml`` and all other files being ``{prefix}_{channelName}_cuts.xml``. The ``-w`` flag tells `HistFitter` to (re)create the `HistFactory` workspace stored in ``results/{analysisName}/{prefix}_combined_{measurementName}.root``.
+
+Typically, ``prefix = 'FitConfig'`` and ``measurementName = 'NormalMeasurement'``. For example, if the following exists in your ``config.py``
+
+.. code:: python
+
+  configMgr.analysisName = '3b_tag21.2.27-1_RW_ExpSyst_36100_multibin_bkg'
+  configMgr.histCacheFile = 'cache/{0:s}.root'.format(configMgr.analysisName)
+  # ...
+  fitConfig = configMgr.addFitConfig("Excl")
+  # ...
+  channel = fitConfig.addChannel("cuts", ['SR_0L'], 1, 0.5, 1.5)
+  # ...
+  meas1=fitConfig.addMeasurement(name="DefaultMeasurement",lumi=1.0,lumiErr=0.029)
+  meas1.addPOI("mu_SIG1")
+  # ...
+  meas2=fitConfig.addMeasurement(name="DefaultMeasurement",lumi=1.0,lumiErr=0.029)
+  meas2.addPOI("mu_SIG2")
+
+Then, you expect the following files to be made:
+
+- ``config/3b_tag21.2.27-1_RW_ExpSyst_36100_multibin_bkg/Excl.xml``
+- ``config/3b_tag21.2.27-1_RW_ExpSyst_36100_multibin_bkg/Excl_SR_0L_cuts.xml``
+- ``cache/3b_tag21.2.27-1_RW_ExpSyst_36100_multibin_bkg.root``
+- ``results/3b_tag21.2.27-1_RW_ExpSyst_36100_multibin_bkg/Excl_combined_DefaultMeasurement.root``
+
+These are all the files you need in order to use `pyhf xml2json <cli.html#pyhf-xml2json>`_. At this point, you could run
+
+.. code:: bash
+
+    pyhf xml2json config/3b_tag21.2.27-1_RW_ExpSyst_36100_multibin_bkg/Excl.xml
+
+which will read all of the XML files and load the histogram data from the histogram cache.
+
+The `HistFactory` workspace in ``results/`` contains all of the information necessary to rebuild the XML files again. For debugging purposes, the `pyhf` developers will often ask for your workspace file, which means ``results/3b_tag21.2.27-1_RW_ExpSyst_36100_multibin_bkg/Excl_combined_DefaultMeasurement.root``. If you want to generate the XML, you can open this file in ``ROOT`` and run ``DefaultMeasurement->PrintXML()`` which puts all of the XML files into the current directory you are in.

--- a/docs/babel.rst
+++ b/docs/babel.rst
@@ -7,7 +7,7 @@ Many of these solutions involve extracting out the ``HistFactory`` workspace and
 HistFitter
 ----------
 
-In order to go from `HistFitter` to `pyhf`, the first step is to extract out the `HistFactory` workspaces. Assuming you have an existing configuration file, ``config.py``, you likely run an exclusion fit like so:
+In order to go from ``HistFitter`` to ``pyhf``, the first step is to extract out the ``HistFactory`` workspaces. Assuming you have an existing configuration file, ``config.py``, you likely run an exclusion fit like so:
 
 .. code:: bash
 
@@ -19,7 +19,7 @@ The name of output workspace files depends on four parameters you define in your
 - ``prefix`` is defined in ``configMgr.addFitConfig({prefix})``
 - ``measurementName`` is the first measurement you define via ``fitConfig.addMeasurement(name={measurementName},...)``
 - ``channelName`` are the names of channels you define via ``fitConfig.addChannel("cuts", [{channelName}], ...)``
-- ``cachePath`` is where `HistFitter` stores the cached histograms, defined by ``configMgr.histCacheFile`` which defaults to ``data/{analysisName}.root``
+- ``cachePath`` is where ``HistFitter`` stores the cached histograms, defined by ``configMgr.histCacheFile`` which defaults to ``data/{analysisName}.root``
 
 To dump the HistFactory workspace, you will modify the above to skip the fit ``-f`` and plotting ``-D`` so you end up with
 
@@ -27,8 +27,8 @@ To dump the HistFactory workspace, you will modify the above to skip the fit ``-
 
   HistFitter.py -wx -F excl config.py
 
-The ``-w`` flag tells `HistFitter` to (re)create the `HistFactory` workspace stored in ``results/{analysisName}/{prefix}_combined_{measurementName}.root``.
-The ``-x`` flag tells `HistFitter` to dump the XML files into ``config/{analysisName}/``, with the top-level file being ``{prefix}.xml`` and all other files being ``{prefix}_{channelName}_cuts.xml``.
+The ``-w`` flag tells ``HistFitter`` to (re)create the ``HistFactory`` workspace stored in ``results/{analysisName}/{prefix}_combined_{measurementName}.root``.
+The ``-x`` flag tells ``HistFitter`` to dump the XML files into ``config/{analysisName}/``, with the top-level file being ``{prefix}.xml`` and all other files being ``{prefix}_{channelName}_cuts.xml``.
 
 Typically, ``prefix = 'FitConfig'`` and ``measurementName = 'NormalMeasurement'``. For example, if the following exists in your ``config.py``
 
@@ -64,4 +64,4 @@ These are all the files you need in order to use `pyhf xml2json <cli.html#pyhf-x
 
 which will read all of the XML files and load the histogram data from the histogram cache.
 
-The `HistFactory` workspace in ``results/`` contains all of the information necessary to rebuild the XML files again. For debugging purposes, the `pyhf` developers will often ask for your workspace file, which means ``results/3b_tag21.2.27-1_RW_ExpSyst_36100_multibin_bkg/Excl_combined_DefaultMeasurement.root``. If you want to generate the XML, you can open this file in ``ROOT`` and run ``DefaultMeasurement->PrintXML()`` which puts all of the XML files into the current directory you are in.
+The ``HistFactory`` workspace in ``results/`` contains all of the information necessary to rebuild the XML files again. For debugging purposes, the ``pyhf`` developers will often ask for your workspace file, which means ``results/3b_tag21.2.27-1_RW_ExpSyst_36100_multibin_bkg/Excl_combined_DefaultMeasurement.root``. If you want to generate the XML, you can open this file in ``ROOT`` and run ``DefaultMeasurement->PrintXML()`` which puts all of the XML files into the current directory you are in.

--- a/docs/babel.rst
+++ b/docs/babel.rst
@@ -2,9 +2,7 @@ Translations
 ============
 One key goal of ``pyhf`` is to provide seamless translations between other statistical frameworks and ``pyhf``.
 This page details the various ways to translate from a tool you might already be using as part of an existing analysis to ``pyhf``.
-Many of these solutions involve extracting out the ``HistFactory`` workspace and then running |pyhf xml2json|_ which provides a single JSON workspace that can be loaded directly into ``pyhf``.
-
-.. |pyhf xml2json| replace:: ``pyhf xml2json``
+Many of these solutions involve extracting out the ``HistFactory`` workspace and then running `pyhf xml2json <cli.html#pyhf-xml2json>`_ which provides a single JSON workspace that can be loaded directly into ``pyhf``.
 
 HistFitter
 ----------

--- a/docs/babel.rst
+++ b/docs/babel.rst
@@ -31,6 +31,8 @@ Typically, ``prefix = 'FitConfig'`` and ``measurementName = 'NormalMeasurement'`
 
 .. code:: python
 
+  from configManager import configMgr
+  # ...
   configMgr.analysisName = '3b_tag21.2.27-1_RW_ExpSyst_36100_multibin_bkg'
   configMgr.histCacheFile = 'cache/{0:s}.root'.format(configMgr.analysisName)
   # ...

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@
    installation
    development
    faq
+   babel
    cli
    api
    citations


### PR DESCRIPTION
# Description

This adds documentation in `docs/babel.rst` that describe how to extract the HistFactory workspaces for use by `pyhf xml2json`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add documentation for HistFitter users on extracting HistFactory workspaces
```