### PR TITLE
ci: Add test build of the Docker image to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,13 @@ jobs:
         build_dir: docs/_build/html
       env:
         GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+
+  docker:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1.2.0
+    - name: Build Docker image
+      run: |
+        docker build . --file docker/Dockerfile --tag pyhf:${{ GITHUB_SHA }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,4 +122,4 @@ jobs:
     - uses: actions/checkout@v1.2.0
     - name: Build Docker image
       run: |
-        docker build . --file docker/Dockerfile --tag pyhf:${{ GITHUB_SHA }}
+        docker build . --file docker/Dockerfile --tag pyhf:$GITHUB_SHA


### PR DESCRIPTION
# Description

Resolves #681 

Following up PR #680, add a test build of the Docker image ~~on `pull_request` events~~ to the CI to ensure that it should get properly built by Docker Cloud

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add a test build of the Docker image to the CI 
```
