### PR TITLE
refactor: Create 'backends' extra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[docs]
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[docs,test]
         python -m pip list
         sudo apt-get update
         sudo apt-get -qq install pandoc

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,11 +12,11 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 
-# pip install .[develop]
+# pip install .[docs]
 python:
   version: 3.7
   install:
     - method: pip
       path: .
       extra_requirements:
-        - develop
+        - docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,11 +111,7 @@ language = None
 #
 # today_fmt = '%B %d, %Y'
 
-autodoc_mock_imports = [
-    'tensorflow',
-    'torch',
-    'iminuit',
-    'tensorflow_probability']
+autodoc_mock_imports = ['tensorflow', 'torch', 'iminuit', 'tensorflow_probability']
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,6 +111,12 @@ language = None
 #
 # today_fmt = '%B %d, %Y'
 
+autodoc_mock_imports = [
+    'tensorflow',
+    'torch',
+    'iminuit',
+    'tensorflow_probability']
+
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -50,7 +50,7 @@ Install latest stable release from `PyPI <https://pypi.org/project/pyhf/>`__...
 
 .. code-block:: console
 
-    pip install pyhf[tensorflow,torch]
+    pip install pyhf[backends]
 
 
 ... with xml import/export functionality
@@ -90,7 +90,7 @@ Install latest development version from `GitHub <https://github.com/scikit-hep/p
 
 .. code-block:: console
 
-    pip install --ignore-installed -U "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf[tensorflow,torch]"
+    pip install --ignore-installed -U "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf[backends]"
 
 
 ... with xml import/export functionality

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,18 @@ extras_require = {
     'xmlio': ['uproot'],
     'minuit': ['iminuit'],
 }
-extras_require['test'] = sorted(
+extras_require['backends'] = sorted(
     set(
         extras_require['tensorflow']
         + extras_require['torch']
-        + extras_require['xmlio']
         + extras_require['minuit']
+    )
+)
+
+extras_require['test'] = sorted(
+    set(
+        extras_require['backends']
+        + extras_require['xmlio']
         + [
             'pyflakes',
             'pytest~=3.5',
@@ -43,13 +49,13 @@ extras_require['test'] = sorted(
 )
 extras_require['docs'] = sorted(
     set(
-        extras_require['test']
-        + [
+        [
             'sphinx',
             'sphinxcontrib-bibtex',
             'sphinx-click',
             'sphinx_rtd_theme',
             'nbsphinx',
+            'ipywidgets',
             'sphinx-issues',
             'm2r',
         ]
@@ -58,6 +64,7 @@ extras_require['docs'] = sorted(
 extras_require['develop'] = sorted(
     set(
         extras_require['docs']
+        + extras_require['test']
         + ['nbdime', 'bumpversion', 'ipython', 'pre-commit', 'twine']
     )
 )


### PR DESCRIPTION
# Description

This allows RTD to only build and mock the necessary things (also makes it so docs can build without needing to install all the packages that pyhf depends on!)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Create a 'backends' extra for installing all the supported backends
* Make the docs and test options for installing separate
* Mock the packages that are not needed to build the docs, but to make sure all pyhf modules are imported
```