### PR TITLE
ci: Add Codecov threshold tolerance

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.2%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ ignore = [
     '.*',
     'pyproject.toml',
     'pytest.ini',
+    'codecov.yml',
     'CODE_OF_CONDUCT.md',
     'CONTRIBUTING.md',
 ]


### PR DESCRIPTION
# Description

Allow a `0.2%` tolerance on the project coverage and still allow CI to pass.

This PR has been demoed/tested in PR #690 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add codecov.yml file to allows a 0.2% tolerance on the project coverage
* Add codecov.yml to the MANIFEST ignore
```
