### PR TITLE
ci: Use Python 3 scipy Alpine image for base Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM matthewfeickert/python3-scipy-alpine:latest
+FROM matthewfeickert/python3-scipy-alpine:scipy-1.2.1
 COPY . /code
 RUN cd /code && \
     apk add --no-cache git && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM matthewfeickert/python3-scipy-alpine:scipy-1.2.1 # PR 697
+FROM matthewfeickert/python3-scipy-alpine:scipy-1.2.1
 COPY . /code
 RUN cd /code && \
     apk add --no-cache git && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM matthewfeickert/python3-scipy-alpine:scipy-1.2.1
+FROM matthewfeickert/python3-scipy-alpine:scipy-1.2.1 # PR 697
 COPY . /code
 RUN cd /code && \
     apk add --no-cache git && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alectolytic/scipy
+FROM matthewfeickert/python3-scipy-alpine:latest
 COPY . /code
 RUN cd /code && \
     apk add --no-cache git && \


### PR DESCRIPTION
# Description

Resolves #692 

To be able to drop Python 2 we will need to move away from the Python 2.7 Alpine Docker image that is used as the base image for the pyhf Docker image. This replaces it with a [Python 3 Docker image](https://github.com/matthewfeickert/python3-scipy-alpine).

This image uses the `py3-scipy` `apk` package, and so while not quite as small as the installed form PyPI scipy image (Python 2.7) it is just a few MB larger and could be brought down

```
$ docker images | grep scipy
matthewfeickert/python3-scipy-alpine                     latest              fba7df6a582c        2 hours ago         292MB
alectolytic/scipy                                        latest              00f11a79976b        15 months ago       276MB
```

which I think is pretty good.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use a Python 3 Apline image with scipy as the base image for the pyhf Docker image
   - c.f. https://github.com/matthewfeickert/python3-scipy-alpine
```
