### PR TITLE
feat: Add ENTRYPOINT to pyhf Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,3 +6,4 @@ RUN cd /code && \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
     python -m pip install --no-cache-dir -e .[xmlio] && \
     python -m pip list
+ENTRYPOINT ["/usr/local/bin/pyhf"]


### PR DESCRIPTION
# Description

Enables

```
jsonpatch lhood.json patch.json | docker run -i pyhf/pyhf cls
```


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add ENTRYPOINT to the pyhf Dockerfile to run the pyhf CLI by default
```