### PR TITLE
feat: Drop Python 2.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [2.7, 3.6, 3.7]
+        python-version: [3.6, 3.7]
 
     steps:
     - uses: actions/checkout@v1.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,6 @@ jobs:
         file: ./coverage.xml
         flags: unittests
     - name: Test Contrib module with pytest
-      if: matrix.python-version != 2.7
       run: |
         python -m pytest -r sx tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
     - name: Run benchmarks

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -14,6 +14,13 @@ Use the :code:`--backend` option for :code:`pyhf cls` to specify a tensor backen
 The default backend is NumPy.
 For more information see :code:`pyhf cls --help`.
 
+Does ``pyhf`` support Python 2?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+No.
+Like the rest of the Python community, as of January 2020 ``pyhf`` no longer supports Python 2.
+The last release of ``pyhf`` that was compatible with Python 2.7 is `v0.3.2 <https://pypi.org/project/pyhf/0.3.2/>`__.
+
+
 Troubleshooting
 ---------------
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -18,7 +18,7 @@ Does ``pyhf`` support Python 2?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 No.
 Like the rest of the Python community, as of January 2020 ``pyhf`` no longer supports Python 2.
-The last release of ``pyhf`` that was compatible with Python 2.7 is `v0.3.2 <https://pypi.org/project/pyhf/0.3.2/>`__.
+The last release of ``pyhf`` that was compatible with Python 2.7 is `v0.3.3 <https://pypi.org/project/pyhf/0.3.3/>`__.
 
 I only have access to Python 2. How can I use ``pyhf``?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -20,6 +20,15 @@ No.
 Like the rest of the Python community, as of January 2020 ``pyhf`` no longer supports Python 2.
 The last release of ``pyhf`` that was compatible with Python 2.7 is `v0.3.2 <https://pypi.org/project/pyhf/0.3.2/>`__.
 
+I only have access to Python 2. How can I use ``pyhf``?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``pyhf`` should be able to be used as a standalone step in any analysis, and its environment need not be the same as the rest of the analysis.
+As Python 2 is not supported it is suggested that you setup a Python 3 runtime on whatever machine you're using.
+If you're using a cluster, talk with your system administrators to get their help in doing so.
+If you are unable to get a Python 3 runtime, versioned Docker images of ``pyhf`` are distributed through `Docker Hub <https://hub.docker.com/r/pyhf/pyhf>`__.
+
+Once you have Python 3 installed, see the `installation <installation.rst>`__ page to get started.
 
 Troubleshooting
 ---------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -18,7 +18,7 @@ Does ``pyhf`` support Python 2?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 No.
 Like the rest of the Python community, as of January 2020 ``pyhf`` no longer supports Python 2.
-The last release of ``pyhf`` that was compatible with Python 2.7 is `v0.3.3 <https://pypi.org/project/pyhf/0.3.3/>`__.
+The last release of ``pyhf`` that was compatible with Python 2.7 is `v0.3.4 <https://pypi.org/project/pyhf/0.3.4/>`__.
 
 I only have access to Python 2. How can I use ``pyhf``?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -23,7 +23,7 @@ The last release of ``pyhf`` that was compatible with Python 2.7 is `v0.3.4 <htt
 I only have access to Python 2. How can I use ``pyhf``?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``pyhf`` should be able to be used as a standalone step in any analysis, and its environment need not be the same as the rest of the analysis.
+It is recommended that ``pyhf`` is used as a standalone step in any analysis, and its environment need not be the same as the rest of the analysis.
 As Python 2 is not supported it is suggested that you setup a Python 3 runtime on whatever machine you're using.
 If you're using a cluster, talk with your system administrators to get their help in doing so.
 If you are unable to get a Python 3 runtime, versioned Docker images of ``pyhf`` are distributed through `Docker Hub <https://hub.docker.com/r/pyhf/pyhf>`__.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -17,8 +17,12 @@ For more information see :code:`pyhf cls --help`.
 Does ``pyhf`` support Python 2?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 No.
-Like the rest of the Python community, as of January 2020 ``pyhf`` no longer supports Python 2.
-The last release of ``pyhf`` that was compatible with Python 2.7 is `v0.3.4 <https://pypi.org/project/pyhf/0.3.4/>`__.
+Like the rest of the Python community, as of January 2020 the latest releases of ``pyhf`` no longer support Python 2.
+The last release of ``pyhf`` that was compatible with Python 2.7 is `v0.3.4 <https://pypi.org/project/pyhf/0.3.4/>`__, which can be installed with
+
+    .. code-block:: console
+
+        python -m pip install pyhf~=0.3
 
 I only have access to Python 2. How can I use ``pyhf``?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -32,7 +32,7 @@ As Python 2 is not supported it is suggested that you setup a Python 3 runtime o
 If you're using a cluster, talk with your system administrators to get their help in doing so.
 If you are unable to get a Python 3 runtime, versioned Docker images of ``pyhf`` are distributed through `Docker Hub <https://hub.docker.com/r/pyhf/pyhf>`__.
 
-Once you have Python 3 installed, see the `installation <installation.html>`__ page to get started.
+Once you have Python 3 installed, see the :ref:`installation` page to get started.
 
 Troubleshooting
 ---------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -32,7 +32,7 @@ As Python 2 is not supported it is suggested that you setup a Python 3 runtime o
 If you're using a cluster, talk with your system administrators to get their help in doing so.
 If you are unable to get a Python 3 runtime, versioned Docker images of ``pyhf`` are distributed through `Docker Hub <https://hub.docker.com/r/pyhf/pyhf>`__.
 
-Once you have Python 3 installed, see the `installation <installation.rst>`__ page to get started.
+Once you have Python 3 installed, see the `installation <installation.html>`__ page to get started.
 
 Troubleshooting
 ---------------

--- a/docs/governance/ROADMAP.md
+++ b/docs/governance/ROADMAP.md
@@ -66,7 +66,7 @@ The roadmap will be executed over mostly Quarter 3 of 2019 through Quarter 1 of 
    - [ ] Add background model support (Issue #514) [2019-Q4 → 2020-Q1]
    - [ ] Develop interface for the optimizers similar to tensor/backend [2019-Q4 → 2020-Q1]
    - [x] Migrate to TensorFlow v2.0 (PR #541) [2019-Q4]
-   - [ ] Drop Python 2.7 support at end of 2019 (Issue #469) [2019-Q4 (last week of December 2019)]
+   - [x] Drop Python 2.7 support at end of 2019 (Issue #469) [2019-Q4 (last week of December 2019)]
    - [ ] Finalize public API [2020-Q1]
    - [ ] Integrate pyfitcore/Statisfactory API [2020-Q1]
 4. **Research**

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,12 +8,6 @@ To install, we suggest first setting up a `virtual environment <https://packagin
     # Python3
     python3 -m venv pyhf
 
-
-.. code-block:: console
-
-    # Python2
-    virtualenv --python=$(which python) pyhf
-
 and activating it
 
 .. code-block:: console

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,3 +1,5 @@
+..  _installation:
+
 Installation
 ============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,8 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
-py36 = false  # Python 2 is still supported
+target-version = ['py36', 'py37', 'py38']
 skip-string-normalization = true
-skip-numeric-underscore-normalization = true  # Python 2 is still supported
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
     package_dir={'': 'src'},
     packages=find_packages(where='src'),
     include_package_data=True,
-    python_requires="!=2.*, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
+    python_requires=">=3.6",
     install_requires=[
         'scipy',  # requires numpy, which is required by pyhf and tensorflow
         'click>=6.0',  # for console scripts,

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
     package_dir={'': 'src'},
     packages=find_packages(where='src'),
     include_package_data=True,
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
+    python_requires="!=2.*, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
     install_requires=[
         'scipy',  # requires numpy, which is required by pyhf and tensorflow
         'click>=6.0',  # for console scripts,

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,7 @@
 from setuptools import setup, find_packages
 from os import path
-import sys
 
 this_directory = path.abspath(path.dirname(__file__))
-if sys.version_info.major < 3:
-    from io import open
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md:
     long_description = readme_md.read()
 
@@ -88,8 +85,6 @@ setup(
     license='Apache',
     keywords='physics fitting numpy scipy tensorflow pytorch',
     classifiers=[
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/src/pyhf/cli/rootio.py
+++ b/src/pyhf/cli/rootio.py
@@ -8,14 +8,6 @@ import jsonpatch
 logging.basicConfig()
 log = logging.getLogger(__name__)
 
-# This is only needed for Python 2/3 compatibility
-def ensure_dirs(path):
-    try:
-        os.makedirs(path, exist_ok=True)  # lgtm [py/call/wrong-named-argument]
-    except TypeError:
-        if not os.path.exists(path):
-            os.makedirs(path)
-
 
 @click.group(name='rootio')
 def cli():
@@ -77,14 +69,14 @@ def json2xml(workspace, output_dir, specroot, dataroot, resultprefix, patch):
         )
     from .. import writexml
 
-    ensure_dirs(output_dir)
+    os.makedirs(output_dir, exist_ok=True)
     with click.open_file(workspace, 'r') as specstream:
         spec = json.load(specstream)
         for pfile in patch:
             patch = json.loads(click.open_file(pfile, 'r').read())
             spec = jsonpatch.JsonPatch(patch).apply(spec)
-        ensure_dirs(os.path.join(output_dir, specroot))
-        ensure_dirs(os.path.join(output_dir, dataroot))
+        os.makedirs(os.path.join(output_dir, specroot), exist_ok=True)
+        os.makedirs(os.path.join(output_dir, dataroot), exist_ok=True)
         with click.open_file(
             os.path.join(output_dir, '{0:s}.xml'.format(resultprefix)), 'w'
         ) as outstream:

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -59,5 +59,5 @@ def fixed_poi_fit(poi_val, data, pdf, init_pars=None, par_bounds=None, **kwargs)
         init_pars,
         par_bounds,
         [(pdf.config.poi_index, poi_val)],
-        **kwargs
+        **kwargs,
     )

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -52,7 +52,7 @@ class minuit_optimizer(object):
             errordef=1,
             use_array_call=True,
             forced_parameters=parnames,
-            **kwargs
+            **kwargs,
         )
         return mm
 

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -287,7 +287,7 @@ class _MainModel(object):
                 config,
                 mega_mods,
                 batch_size=self.batch_size,
-                **config.modifier_settings.get(k, {})
+                **config.modifier_settings.get(k, {}),
             )
             for k, c in modifiers.combined.items()
         }

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -40,7 +40,7 @@ def test_multichannel_coupled_histos(common_kwargs):
     pm.execute_notebook(
         'docs/examples/notebooks/multichannel-coupled-histo.ipynb',
         parameters={'validation_datadir': 'validation/data'},
-        **common_kwargs
+        **common_kwargs,
     )
 
 
@@ -48,7 +48,7 @@ def test_multibinpois(common_kwargs):
     pm.execute_notebook(
         'docs/examples/notebooks/multiBinPois.ipynb',
         parameters={'validation_datadir': 'validation/data'},
-        **common_kwargs
+        **common_kwargs,
     )
     nb = sb.read_notebook(common_kwargs['output_path'])
     assert nb.scraps['number_2d_successpoints'].data > 200

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -25,12 +25,11 @@ def test_xml_importexport(common_kwargs):
 
 
 def test_statisticalanalysis(common_kwargs):
-    if sys.version_info.major > 2:
-        # The Binder example uses specific relative paths
-        cwd = os.getcwd()
-        os.chdir(os.path.join(cwd, 'docs/examples/notebooks/binderexample'))
-        pm.execute_notebook('StatisticalAnalysis.ipynb', **common_kwargs)
-        os.chdir(cwd)
+    # The Binder example uses specific relative paths
+    cwd = os.getcwd()
+    os.chdir(os.path.join(cwd, 'docs/examples/notebooks/binderexample'))
+    pm.execute_notebook('StatisticalAnalysis.ipynb', **common_kwargs)
+    os.chdir(cwd)
 
 
 def test_shapefactor(common_kwargs):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -136,10 +136,11 @@ def test_import_and_export(tmpdir, script_runner):
 def test_patch(tmpdir, script_runner):
     patch = tmpdir.join('patch.json')
 
-    patchcontent = u'''
+    patch.write(
+        u'''
 [{"op": "replace", "path": "/channels/0/samples/0/data", "value": [5,6]}]
     '''
-    patch.write(patchcontent)
+    )
 
     temp = tmpdir.join("parsed_output.json")
     command = 'pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s}'.format(
@@ -157,23 +158,15 @@ def test_patch(tmpdir, script_runner):
     ret = script_runner.run(*shlex.split(command))
     assert ret.success
 
-    import io
-
     command = 'pyhf cls {0:s} --patch -'.format(temp.strpath, patch.strpath)
 
-    pipefile = io.StringIO(
-        patchcontent
-    )  # python 2.7 pytest-files are not file-like enough
-    ret = script_runner.run(*shlex.split(command), stdin=pipefile)
+    ret = script_runner.run(*shlex.split(command), stdin=patch)
     assert ret.success
 
     command = 'pyhf json2xml {0:s} --output-dir {1:s} --patch -'.format(
         temp.strpath, tmpdir.mkdir('output_2').strpath, patch.strpath
     )
-    pipefile = io.StringIO(
-        patchcontent
-    )  # python 2.7 pytest-files are not file-like enough
-    ret = script_runner.run(*shlex.split(command), stdin=pipefile)
+    ret = script_runner.run(*shlex.split(command), stdin=patch)
     assert ret.success
 
 


### PR DESCRIPTION
# Description

Resolves #469

On ~~December 28th, 2019~~ January 13th, 2020 pyhf will drop support for Python 2.7. This PR implements that change.

This PR makes the codebase Python 3 _only_. I think that this is fine to do, given that pyhf is currently something a standalone tool that is run as in independent step in an analysis. So if a user only has access to Python 2 we can suggest that:

* If the user is on LXPLUS then they can setup Python 3 environment (there is a Red Hat Python 3.6 runtime with `source scl_source enable rh-python36`) and use that, as thanks to uproot any step that involves pyhf can be run in isolation from any ENV that requires ROOT
* If they are running on a local machine then we can try and point them to the best resources on how to get a Python 3 runtime with minimal pain
* Worst case scenario we can tell people to use our Docker image until there is a better solution

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Drop Python 2.7 support for pyhf
* Add no Python 2.7 support to FAQ and link to last supported release
```