### PR TITLE
fix: Add Altair dependency to Binder postBuild

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,1 +1,2 @@
-pip install --upgrade .[complete]
+python -m pip install --upgrade .[complete]
+python -m pip install altair


### PR DESCRIPTION
# Description

PR #699 got merged before I could implement @cranmer's [comment](https://github.com/scikit-hep/pyhf/pull/699#issuecomment-567546289). This addresses it by adding Altair in the Binder `postBuild`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* pip install Altair dependency in Binder postBuild (amends PR #699)
* Use python -m pip for best pip practices
```
