### PR TITLE
fix: Correct order of Codecov reporting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,6 @@ jobs:
     - name: Test with pytest
       run: |
         python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
-    - name: Test Contrib
-      if: matrix.python-version != 2.7
-      run: |
-        python -m pytest -r sx tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
     - name: Report coverage with Codecov
       if: github.event_name == 'push' && matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v1.0.5
@@ -53,6 +49,10 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         flags: unittests
+    - name: Test Contrib module with pytest
+      if: matrix.python-version != 2.7
+      run: |
+        python -m pytest -r sx tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
     - name: Run benchmarks
       if: github.event_name == 'schedule' && matrix.python-version == 3.7
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         python -m pytest -r sx tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
     - name: Report coverage with Codecov
       if: github.event_name == 'push' && matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
-      uses: codecov/codecov-action@v1.0.4
+      uses: codecov/codecov-action@v1.0.5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml


### PR DESCRIPTION
# Description

Move the reporting of coverage with Codecov to be after the main test suite is run to ensure the correct `coverage.xml` file is uploaded by Codecov. Fixes PR #694.

In PR #694 the testing of the `pyhf.contrib` module was added, but this runs `pytest` again and overwrites the `coverage.xml` file that previously existed. So the coverage that Codecov uploads is the coverage of `pyhf.contrib` and not the rest of the `src` directory.

The final result of this is that coverage reporting is fixed, and `pyhf.contrib` is tested without having coverage reporting &mdash; which is the desired behavior.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Report coverage of src with Codecov before the coverage.xml is overwritten by testing pyhf.contrib
   - Amends PR #694
* Update Codecov GitHub Actions app to v1.0.5
```
