### PR TITLE
docs: Directly link to GitHub project page from docs website

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 # pure-python fitting/limit-setting/interval estimation HistFactory-style
 
+[![GitHub Project](https://img.shields.io/badge/GitHub--blue?style=social&logo=GitHub)](https://github.com/scikit-hep/pyhf)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1169739.svg)](https://doi.org/10.5281/zenodo.1169739)
 
 [![GitHub Actions Status: CI](https://github.com/scikit-hep/pyhf/workflows/CI/CD/badge.svg)](https://github.com/scikit-hep/pyhf/actions?query=workflow%3ACI%2FCD+branch%3Amaster)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@
 
 .. raw:: html
 
-   <a class="github-fork-ribbon right-top fixed" href="https://github.com/scikit-hep/pyhf/fork" data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>
+   <a class="github-fork-ribbon right-top fixed" href="https://github.com/scikit-hep/pyhf/" data-ribbon="Check us out on GitHub" title="Check us out on GitHub">Check us out on GitHub</a>
 
 .. mdinclude:: ../README.md
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@
 
 .. raw:: html
 
-   <a class="github-fork-ribbon right-top fixed" href="https://github.com/scikit-hep/pyhf/" data-ribbon="Check us out on GitHub" title="Check us out on GitHub">Check us out on GitHub</a>
+   <a class="github-fork-ribbon right-top fixed" href="https://github.com/scikit-hep/pyhf/fork" data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>
 
 .. mdinclude:: ../README.md
 


### PR DESCRIPTION
# Description

Resolves #713 

To make it easier to get from the docs website to the GitHub project page, ~~convert the "Fork me on GitHub" ribbon on the docs page to a "Check us out on GitHub" ribbon. This makes forking the project 2 steps rather than 1, but I don't think that's in anyway a serious issue.~~ add a badge to the README that links to the GitHub project and uses the shields.io social style:

[![GitHub Project](https://img.shields.io/badge/GitHub--blue?style=social&logo=GitHub)](https://github.com/scikit-hep/pyhf)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add a badge to the README that links to the GitHub project
```
