### PR TITLE
docs: Add copy buttons to code snippets in docs with sphinx-copybutton

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,7 @@ extensions = [
     'nbsphinx',
     'm2r',
     'sphinx_issues',
+    'sphinx_copybutton',
     'xref',
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -290,6 +290,9 @@ html_extra_path = ['_extras']
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'pyhfdoc'
 
+# sphinx-copybutton configuration
+copybutton_prompt_text = ">>> "
+
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ extras_require['docs'] = sorted(
             'nbsphinx',
             'ipywidgets',
             'sphinx-issues',
-            'sphinx-copybutton',
+            'sphinx-copybutton>0.2.8',
             'm2r',
         ]
     )

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ extras_require['docs'] = sorted(
             'nbsphinx',
             'ipywidgets',
             'sphinx-issues',
+            'sphinx-copybutton',
             'm2r',
         ]
     )

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ extras_require['docs'] = sorted(
             'nbsphinx',
             'ipywidgets',
             'sphinx-issues',
-            'sphinx-copybutton>0.2.8',
+            'sphinx-copybutton>0.2.9',
             'm2r',
         ]
     )


### PR DESCRIPTION
# Description

Add [`sphinx-copybutton`](https://sphinx-copybutton.readthedocs.io/en/latest/) to the `docs` extra to add copy buttons to all code snippet blocks.

Thanks [for tweeting](https://twitter.com/choldgraf/status/1213167082176577542?s=11) and for the great work, @choldgraf!

This makes all of our docstrings even nicer now as the copy button removes the Python REPL prompts:

[![cropped_view](https://user-images.githubusercontent.com/5142394/71749229-738fb480-2e3a-11ea-80dd-fc95e7520546.png)](https://scikit-hep.org/pyhf/_generated/pyhf.tensor.pytorch_backend.pytorch_backend.html#pyhf.tensor.pytorch_backend.pytorch_backend.clip)

so that when pasted you get
```python
import pyhf
pyhf.set_backend("pytorch")
a = pyhf.tensorlib.astensor([-2, -1, 0, 1, 2])
pyhf.tensorlib.clip(a, -1, 1)
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add sphinx-copybutton to docs extra
* Enable sphinx-copybutton in docs to add copy buttons to code snippets
```
