### PR TITLE
fix: Correct iminuit optimizer verbose setting typo

### DIFF
--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -18,7 +18,7 @@ class minuit_optimizer(object):
             verbose (`bool`): print verbose output during minimization
         
         """
-        self.verbose = 0
+        self.verbose = verbose
         self.ncall = ncall
         self.errordef = errordef
         self.steps = steps


### PR DESCRIPTION
# Description

It seems there's a typo in the minuit optimiser and it can never be set verbose. This MR should fix it.

Note that I have problems setting up all the test dependencies (notably tensorflow 1 seems to be hard to install these days now that v2 is default). Let's see what GitHub Actions have to say.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [ ] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR
