### PR TITLE
fix: Public release canary should be using [backends] option

### DIFF
--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install from PyPI
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install pyhf[tensorflow,torch,minuit,xmlio]
+        python -m pip install pyhf[backends,xmlio]
         python -m pip install 'pytest~=3.5' pytest-cov
         python -m pip list
     - name: Canary test public API


### PR DESCRIPTION
# Description

The public release canary is failing when we added `jax` because `jax` wasn't added as an install there. Instead, switch to using the `backends` option for this purpose.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
- switch to using the [backends] option for public release canary test
```