### PR TITLE
feat: Improve JAX caching

### DIFF
--- a/src/pyhf/optimize/opt_jax.py
+++ b/src/pyhf/optimize/opt_jax.py
@@ -75,6 +75,6 @@ class jax_optimizer(AutoDiffOptimizerMixin):
                 tuple(fixed_idx),
                 tuple(variable_idx),
             )
-            return onp.asarray(a), onp.asarray(b)
+            return onp.asarray(objective), onp.asarray(grad)
 
         return tv, fixed_values_tensor, func, variable_init, variable_bounds

--- a/src/pyhf/optimize/opt_jax.py
+++ b/src/pyhf/optimize/opt_jax.py
@@ -66,7 +66,7 @@ class jax_optimizer(AutoDiffOptimizerMixin):
 
         def func(pars):
             # need to conver to tuple to make args hashable
-            a, b = _jitted_objective_and_grad(
+            objective, grad = _jitted_objective_and_grad(
                 pars,
                 data,
                 fixed_values_tensor,


### PR DESCRIPTION
# Description

np.asarray(jax_array) and jax.np.asarray(np_array) seem to be particularly expensive operations (compared to the same in e.g. torch)

This introduces a patch to cache the creation of _Tensorviewer (the same index combinations are used multiple times) in the JAX optimizer

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
- [ ] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR
