### PR TITLE
refactor: standalone spec parsing for parameters

### DIFF
--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -76,9 +76,16 @@ def _paramset_requirements_from_spec(spec, channel_nbins):
             )
         _paramsets_user_configs[parameter.pop('name')] = parameter
 
-    return reduce_paramsets_requirements(
+    _reqs = reduce_paramsets_requirements(
         _paramsets_requirements, _paramsets_user_configs
     )
+
+    _sets = {}
+    for param_name, paramset_requirements in _reqs.items():
+        paramset_type = paramset_requirements.get('paramset_type')
+        paramset = paramset_type(**paramset_requirements)
+        _sets[param_name] = paramset
+    return _sets
 
 
 class _ModelConfig(_ChannelSummaryMixin):
@@ -151,9 +158,7 @@ class _ModelConfig(_ChannelSummaryMixin):
         self.par_map[param_name] = {'slice': sl, 'paramset': paramset}
 
     def _create_and_register_paramsets(self, required_paramsets):
-        for param_name, paramset_requirements in required_paramsets.items():
-            paramset_type = paramset_requirements.get('paramset_type')
-            paramset = paramset_type(**paramset_requirements)
+        for param_name, paramset in required_paramsets.items():
             self._register_paramset(param_name, paramset)
 
 

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -17,7 +17,7 @@ from .mixins import _ChannelSummaryMixin
 log = logging.getLogger(__name__)
 
 
-def _paramset_requirements_from_spec(spec, channel_nbins):
+def _paramset_requirements_from_channelspec(spec, channel_nbins):
     # bookkeep all requirements for paramsets we need to build
     _paramsets_requirements = {}
     # need to keep track in which order we added the constraints
@@ -65,6 +65,14 @@ def _paramset_requirements_from_spec(spec, channel_nbins):
                 _paramsets_requirements.setdefault(modifier_def['name'], []).append(
                     paramset_requirements
                 )
+    return _paramsets_requirements
+
+
+def _paramset_requirements_from_modelspec(spec, channel_nbins):
+    _paramsets_requirements = _paramset_requirements_from_channelspec(
+        spec, channel_nbins
+    )
+
     # build up a dictionary of the parameter configurations provided by the user
     _paramsets_user_configs = {}
     for parameter in spec.get('parameters', []):
@@ -212,7 +220,9 @@ def _nominal_and_modifiers_from_spec(config, spec):
 class _ModelConfig(_ChannelSummaryMixin):
     def __init__(self, spec, **config_kwargs):
         super(_ModelConfig, self).__init__(channels=spec['channels'])
-        _required_paramsets = _paramset_requirements_from_spec(spec, self.channel_nbins)
+        _required_paramsets = _paramset_requirements_from_modelspec(
+            spec, self.channel_nbins
+        )
 
         poiname = config_kwargs.get('poiname', 'mu')
         default_modifier_settings = {'normsys': {'interpcode': 'code1'}}

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -93,21 +93,19 @@ class _ModelConfig(_ChannelSummaryMixin):
         super(_ModelConfig, self).__init__(channels=spec['channels'])
         poiname = config_kwargs.get('poiname', 'mu')
 
-        self.par_map = {}
-        self.par_order = []
-        self.next_index = 0
-        self.poi_name = None
-        self.poi_index = None
-        self.auxdata = []
-        self.auxdata_order = []
+        _required_paramsets = _paramset_requirements_from_spec(spec, self.channel_nbins)
 
         default_modifier_settings = {'normsys': {'interpcode': 'code1'}}
-
         self.modifier_settings = (
             config_kwargs.get('modifier_settings') or default_modifier_settings
         )
 
-        _required_paramsets = _paramset_requirements_from_spec(spec, self.channel_nbins)
+        self.par_map = {}
+        self.par_order = []
+        self.poi_name = None
+        self.poi_index = None
+        self.auxdata = []
+        self.auxdata_order = []
 
         self._create_and_register_paramsets(_required_paramsets)
         self.set_poi(poiname)
@@ -144,22 +142,20 @@ class _ModelConfig(_ChannelSummaryMixin):
         self.poi_name = name
         self.poi_index = s.start
 
-    def _register_paramset(self, param_name, paramset):
-        """Allocates the nuisance parameters and stores paramset into a modifier map."""
-        log.info(
-            'adding modifier %s (%s new nuisance parameters)',
-            param_name,
-            paramset.n_parameters,
-        )
-
-        sl = slice(self.next_index, self.next_index + paramset.n_parameters)
-        self.next_index = self.next_index + paramset.n_parameters
-        self.par_order.append(param_name)
-        self.par_map[param_name] = {'slice': sl, 'paramset': paramset}
-
     def _create_and_register_paramsets(self, required_paramsets):
+        next_index = 0
         for param_name, paramset in required_paramsets.items():
-            self._register_paramset(param_name, paramset)
+            log.info(
+                'adding modifier %s (%s new nuisance parameters)',
+                param_name,
+                paramset.n_parameters,
+            )
+
+            sl = slice(next_index, next_index + paramset.n_parameters)
+            next_index = next_index + paramset.n_parameters
+
+            self.par_order.append(param_name)
+            self.par_map[param_name] = {'slice': sl, 'paramset': paramset}
 
 
 class _ConstraintModel(object):

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -88,7 +88,7 @@ def _paramset_requirements_from_spec(spec, channel_nbins):
     return _sets
 
 
-def _create_nominal_and_modifiers_from_spec(config, spec):
+def _nominal_and_modifiers_from_spec(config, spec):
     default_data_makers = {
         'histosys': lambda: {'hi_data': [], 'lo_data': [], 'nom_data': [], 'mask': [],},
         'lumi': lambda: {'mask': []},
@@ -534,7 +534,7 @@ class Model(object):
         # build up our representation of the specification
         self.config = _ModelConfig(self.spec, **config_kwargs)
 
-        mega_mods, _nominal_rates = _create_nominal_and_modifiers_from_spec(
+        mega_mods, _nominal_rates = _nominal_and_modifiers_from_spec(
             self.config, self.spec
         )
         self.main_model = _MainModel(

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -91,10 +91,9 @@ def _paramset_requirements_from_spec(spec, channel_nbins):
 class _ModelConfig(_ChannelSummaryMixin):
     def __init__(self, spec, **config_kwargs):
         super(_ModelConfig, self).__init__(channels=spec['channels'])
-        poiname = config_kwargs.get('poiname', 'mu')
-
         _required_paramsets = _paramset_requirements_from_spec(spec, self.channel_nbins)
 
+        poiname = config_kwargs.get('poiname', 'mu')
         default_modifier_settings = {'normsys': {'interpcode': 'code1'}}
         self.modifier_settings = (
             config_kwargs.get('modifier_settings') or default_modifier_settings


### PR DESCRIPTION
# Description

this simplifies the `_ModelConfig` `__init__` method and encapsulates the code that needs the JSON structure (somewhat related to #742 ) so that it could be replaced maybe by something non-JSON-y

This is a simple refactor.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* refactor spec usage into standalone parsing function
```