### PR TITLE
feat: Combine is taught about formal data (outer) join methods

### DIFF
--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -239,7 +239,11 @@ def rename(workspace, output_file, channel, sample, modifier, measurement):
 @click.argument('workspace-one', default='-')
 @click.argument('workspace-two', default='-')
 @click.option(
-    '-j', '--join', default='outer', type=click.Choice(Workspace.valid_joins),
+    '-j',
+    '--join',
+    default='none',
+    type=click.Choice(Workspace.valid_joins),
+    help='The join operation to apply when combining the two workspaces.',
 )
 @click.option(
     '--output-file',

--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -239,11 +239,14 @@ def rename(workspace, output_file, channel, sample, modifier, measurement):
 @click.argument('workspace-one', default='-')
 @click.argument('workspace-two', default='-')
 @click.option(
+    '-j', '--join', default='outer', type=click.Choice(Workspace.valid_joins),
+)
+@click.option(
     '--output-file',
     help='The location of the output json file. If not specified, prints to screen.',
     default=None,
 )
-def combine(workspace_one, workspace_two, output_file):
+def combine(workspace_one, workspace_two, join, output_file):
     """
     Combine two workspaces into a single workspace.
 
@@ -257,7 +260,7 @@ def combine(workspace_one, workspace_two, output_file):
 
     ws_one = Workspace(spec_one)
     ws_two = Workspace(spec_two)
-    combined_ws = Workspace.combine(ws_one, ws_two)
+    combined_ws = Workspace.combine(ws_one, ws_two, join=join)
 
     if output_file is None:
         click.echo(json.dumps(combined_ws, indent=4, sort_keys=True))

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -395,6 +395,13 @@ class Workspace(_ChannelSummaryMixin, dict):
                 joined_items.append(right_item)
             return joined_items
 
+        def _join_versions(join, left_version, right_version):
+            if left_version != right_version:
+                raise exceptions.InvalidWorkspaceOperation(
+                    f"Workspaces of different versions cannot be combined: {left_version} != {right_version}"
+                )
+            return left_version
+
         def _join_channels(join, left_channels, right_channels):
             joined_channels = _join_items(join, left_channels, right_channels)
             if join == 'none':
@@ -419,6 +426,8 @@ class Workspace(_ChannelSummaryMixin, dict):
                     )
             return joined_channels
 
+        new_version = _join_versions(join, left['version'], right['version'])
+
         common_measurements = set(left.measurement_names).intersection(
             right.measurement_names
         )
@@ -435,12 +444,6 @@ class Workspace(_ChannelSummaryMixin, dict):
                         for m, i in zip(common_measurements, incompatible_poi)
                         if incompatible_poi
                     ]
-                )
-            )
-        if left.version != right.version:
-            raise exceptions.InvalidWorkspaceOperation(
-                "Workspaces of different versions cannot be combined: {} != {}".format(
-                    left.version, right.version
                 )
             )
 
@@ -509,6 +512,6 @@ class Workspace(_ChannelSummaryMixin, dict):
                 left_measurements + right_measurements + merged_measurements
             ),
             'observations': left['observations'] + right['observations'],
-            'version': left['version'],
+            'version': new_version,
         }
         return Workspace(newspec)

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -34,20 +34,21 @@ def _join_items(join, left_items, right_items, key='name'):
 
     """
     if join == 'right outer':
-        left_items, right_items = right_items, left_items
-    joined_items = copy.deepcopy(left_items)
-    for right_item in right_items:
-        # outer join: merge left and right, matching where possible
-        if join == 'outer' and right_item in left_items:
+        primary_items, secondary_items = right_items, left_items
+    else:
+        primary_items, secondary_items = left_items, right_items
+    joined_items = copy.deepcopy(primary_items)
+    for secondary_item in secondary_items:
+        # outer join: merge primary and secondary, matching where possible
+        if join == 'outer' and secondary_item in primary_items:
             continue
-        # left(right) outer join: only add right(left) if existing item (by name) is not in left(right)
-        # NB: we switch left/right if using a right outer join so we only ever check the "right"
+        # left/right outer join: only add secondary if existing item (by key value) is not in primary
         # NB: this will be slow for large numbers of items
-        elif join in ['left outer', 'right outer'] and right_item[key] in [
+        elif join in ['left outer', 'right outer'] and secondary_item[key] in [
             item[key] for item in joined_items
         ]:
             continue
-        joined_items.append(copy.deepcopy(right_item))
+        joined_items.append(copy.deepcopy(secondary_item))
     return joined_items
 
 

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -25,9 +25,9 @@ def _join_items(join, left_items, right_items, key='name'):
     This is meant to be as generic as possible for any pairs of lists of dictionaries for many join operations.
 
     Args:
-        join (str): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
-        left_items (list): A list of dictionaries to join on the left
-        right_items (list): A list of dictionaries to join on the right
+        join (`str`): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
+        left_items (`list`): A list of dictionaries to join on the left
+        right_items (`list`): A list of dictionaries to join on the right
 
     Returns:
         :obj:`list`: A joined list of dictionaries.
@@ -60,9 +60,9 @@ def _join_versions(join, left_version, right_version):
       ~pyhf.exceptions.InvalidWorkspaceOperation: Versions are incompatible.
 
     Args:
-        join (str): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
-        left_version (str): The left workspace version.
-        right_version (str): The right workspace version.
+        join (`str`): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
+        left_version (`str`): The left workspace version.
+        right_version (`str`): The right workspace version.
 
     Returns:
         :obj:`str`: The workspace version.
@@ -83,9 +83,9 @@ def _join_channels(join, left_channels, right_channels):
       ~pyhf.exceptions.InvalidWorkspaceOperation: Channel specifications are incompatible.
 
     Args:
-        join (str): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
-        left_channels (list): The left channel specification.
-        right_channels (list): The right channel specification.
+        join (`str`): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
+        left_channels (`list`): The left channel specification.
+        right_channels (`list`): The right channel specification.
 
     Returns:
         :obj:`list`: A joined list of channels. Each channel follows the :obj:`defs.json#channel` `schema <https://scikit-hep.org/pyhf/likelihood.html#channel>`__
@@ -124,9 +124,9 @@ def _join_observations(join, left_observations, right_observations):
       ~pyhf.exceptions.InvalidWorkspaceOperation: Observation specifications are incompatible.
 
     Args:
-        join (str): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
-        left_observations (list): The left observation specification.
-        right_observations (list): The right observation specification.
+        join (`str`): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
+        left_observations (`list`): The left observation specification.
+        right_observations (`list`): The right observation specification.
 
     Returns:
         :obj:`list`: A joined list of observations. Each observation follows the :obj:`defs.json#observation` `schema <https://scikit-hep.org/pyhf/likelihood.html#observations>`__
@@ -166,10 +166,10 @@ def _join_parameter_configs(measurement_name, join, left_parameters, right_param
       ~pyhf.exceptions.InvalidWorkspaceOperation: Parameter configuration specifications are incompatible.
 
     Args:
-        measurement_name (str): The name of the measurement being joined (a detail for raising exceptions correctly)
-        join (str): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
-        left_parameters (list): The left parameter configuration specification.
-        right_parameters (list): The right parameter configuration specification.
+        measurement_name (`str`): The name of the measurement being joined (a detail for raising exceptions correctly)
+        join (`str`): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
+        left_parameters (`list`): The left parameter configuration specification.
+        right_parameters (`list`): The right parameter configuration specification.
 
     Returns:
         :obj:`list`: A joined list of parameter configurations. Each parameter configuration follows the :obj:`defs.json#config` schema
@@ -209,9 +209,9 @@ def _join_measurements(join, left_measurements, right_measurements):
       ~pyhf.exceptions.InvalidWorkspaceOperation: Measurement specifications are incompatible.
 
     Args:
-        join (str): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
-        left_measurements (list): The left measurement specification.
-        right_measurements (list): The right measurement specification.
+        join (`str`): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
+        left_measurements (`list`): The left measurement specification.
+        right_measurements (`list`): The right measurement specification.
 
     Returns:
         :obj:`list`: A joined list of measurements. Each measurement follows the :obj:`defs.json#measurement` `schema <https://scikit-hep.org/pyhf/likelihood.html#measurements>`__
@@ -322,9 +322,9 @@ class Workspace(_ChannelSummaryMixin, dict):
           ~pyhf.exceptions.InvalidMeasurement: If the measurement was not found
 
         Args:
-            poi_name (str): The name of the parameter of interest to create a new measurement from
-            measurement_name (str): The name of the measurement to use
-            measurement_index (int): The index of the measurement to use
+            poi_name (`str`): The name of the parameter of interest to create a new measurement from
+            measurement_name (`str`): The name of the measurement to use
+            measurement_index (`int`): The index of the measurement to use
 
         Returns:
             :obj:`dict`: A measurement object adhering to the schema defs.json#/definitions/measurement

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -366,7 +366,7 @@ class Workspace(_ChannelSummaryMixin, dict):
         Args:
             left (~pyhf.workspace.Workspace): A workspace
             right (~pyhf.workspace.Workspace): Another workspace
-            join (:obj:`str`): How to join the two workspaces. Pick from "outer", "left_outer", or "right_outer".
+            join (:obj:`str`): How to join the two workspaces. Pick from "outer", "left outer", or "right outer".
 
         Returns:
             ~pyhf.workspace.Workspace: A new combined workspace object

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -374,7 +374,7 @@ class Workspace(_ChannelSummaryMixin, dict):
         """
         if join not in Workspace.valid_joins:
             raise ValueError(
-                f"Workspaces must be joined using one of the valid join operations ({Workspace.valid_joins}): {join}"
+                f"Workspaces must be joined using one of the valid join operations ({Workspace.valid_joins}); not {join}"
             )
 
         def _join_items(join, left_items, right_items):
@@ -429,7 +429,7 @@ class Workspace(_ChannelSummaryMixin, dict):
         ]
         if any(incompatible_poi):
             raise exceptions.InvalidWorkspaceOperation(
-                "Workspaces cannot have any measurements with incompatible POI: {}".format(
+                "Workspaces cannot have the same measurements with incompatible POI: {}".format(
                     [
                         m
                         for m, i in zip(common_measurements, incompatible_poi)

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -625,6 +625,10 @@ class Workspace(_ChannelSummaryMixin, dict):
             raise ValueError(
                 f"Workspaces must be joined using one of the valid join operations ({Workspace.valid_joins}); not {join}"
             )
+        if join in ['left outer', 'right outer']:
+            log.warning(
+                "You are using an unsafe join operation. This will silence exceptions that might be raised during a normal 'outer' operation."
+            )
 
         new_version = _join_versions(join, left['version'], right['version'])
         new_channels = _join_channels(join, left['channels'], right['channels'])

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -459,7 +459,16 @@ class Workspace(_ChannelSummaryMixin, dict):
             joined_parameter_configs = _join_items(
                 join, left_parameters, right_parameters
             )
-            if join == 'outer':
+            if join == 'none':
+                common_parameter_configs = set(
+                    p['name'] for p in left_parameters
+                ).intersection(p['name'] for p in right_parameters)
+                if common_parameter_configs:
+                    raise exceptions.InvalidWorkspaceOperation(
+                        f"Workspaces cannot have a measurement ({measurement_name}) specifying different configs for the same parameter: {common_parameter_configs}. You can also try a different join operation: {Workspace.valid_joins}."
+                    )
+
+            elif join == 'outer':
                 counted_parameter_configs = collections.Counter(
                     parameter['name'] for parameter in joined_parameter_configs
                 )

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -134,9 +134,9 @@ def _join_observations(join, left_observations, right_observations):
     """
     joined_observations = _join_items(join, left_observations, right_observations)
     if join == 'none':
-        common_observations = set(c['name'] for c in left_observations).intersection(
-            c['name'] for c in right_observations
-        )
+        common_observations = set(
+            obs['name'] for obs in left_observations
+        ).intersection(obs['name'] for obs in right_observations)
         if common_observations:
             raise exceptions.InvalidWorkspaceOperation(
                 f"Workspaces cannot have any observations in common with the same name: {common_observations}. You can also try a different join operation: {Workspace.valid_joins}."
@@ -219,9 +219,9 @@ def _join_measurements(join, left_measurements, right_measurements):
     """
     joined_measurements = _join_items(join, left_measurements, right_measurements)
     if join == 'none':
-        common_measurements = set(c['name'] for c in left_measurements).intersection(
-            c['name'] for c in right_measurements
-        )
+        common_measurements = set(
+            meas['name'] for meas in left_measurements
+        ).intersection(meas['name'] for meas in right_measurements)
         if common_measurements:
             raise exceptions.InvalidWorkspaceOperation(
                 f"Workspaces cannot have any measurements in common with the same name: {common_measurements}. You can also try a different join operation: {Workspace.valid_joins}."

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -427,6 +427,7 @@ class Workspace(_ChannelSummaryMixin, dict):
             return joined_channels
 
         new_version = _join_versions(join, left['version'], right['version'])
+        new_channels = _join_channels(join, left['channels'], right['channels'])
 
         common_measurements = set(left.measurement_names).intersection(
             right.measurement_names
@@ -507,7 +508,7 @@ class Workspace(_ChannelSummaryMixin, dict):
         ]
 
         newspec = {
-            'channels': _join_channels(join, left['channels'], right['channels']),
+            'channels': new_channels,
             'measurements': (
                 left_measurements + right_measurements + merged_measurements
             ),

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -23,7 +23,7 @@ class Workspace(_ChannelSummaryMixin, dict):
     A JSON-serializable object that is built from an object that follows the :obj:`workspace.json` `schema <https://scikit-hep.org/pyhf/likelihood.html#workspace>`__.
     """
 
-    valid_joins = ['outer', 'left outer', 'right outer']
+    valid_joins = ['none', 'outer', 'left outer', 'right outer']
 
     def __init__(self, spec, **config_kwargs):
         """Workspaces hold the model, data and measurements."""
@@ -341,7 +341,7 @@ class Workspace(_ChannelSummaryMixin, dict):
         )
 
     @classmethod
-    def combine(cls, left, right, join='outer'):
+    def combine(cls, left, right, join='none'):
         """
         Return a new workspace specification that is the combination of the two workspaces.
 
@@ -366,7 +366,7 @@ class Workspace(_ChannelSummaryMixin, dict):
         Args:
             left (~pyhf.workspace.Workspace): A workspace
             right (~pyhf.workspace.Workspace): Another workspace
-            join (:obj:`str`): How to join the two workspaces. Pick from "outer", "left outer", or "right outer".
+            join (:obj:`str`): How to join the two workspaces. Pick from "none", "outer", "left outer", or "right outer".
 
         Returns:
             ~pyhf.workspace.Workspace: A new combined workspace object

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -279,7 +279,7 @@ class Workspace(_ChannelSummaryMixin, dict):
             ],
             'observations': [
                 dict(
-                    observation,
+                    copy.deepcopy(observation),
                     name=rename_channels.get(observation['name'], observation['name']),
                 )
                 for observation in self['observations']

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -358,7 +358,7 @@ def test_combine_workspace_duplicate_parameter_configs(workspace_factory):
     assert len(combined_parameter_configs) == len(set(combined_parameter_configs))
 
 
-def test_combine_workspace_ordering(workspace_factory):
+def test_combine_workspace_parameter_configs_ordering(workspace_factory):
     ws = workspace_factory()
     new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
         measurements=['GammaExample', 'ConstExample', 'LogNormExample']

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -358,6 +358,19 @@ def test_combine_workspace_duplicate_parameter_configs(workspace_factory):
     assert len(combined_parameter_configs) == len(set(combined_parameter_configs))
 
 
+def test_combine_workspace_ordering(workspace_factory):
+    ws = workspace_factory()
+    new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
+        measurements=['GammaExample', 'ConstExample', 'LogNormExample']
+    )
+    assert (
+        ws.get_measurement(measurement_name='GaussExample')['config']['parameters']
+        == new_ws.get_measurement(measurement_name='GaussExample')['config'][
+            'parameters'
+        ]
+    )
+
+
 def test_combine_workspace_deepcopied(workspace_factory):
     ws = workspace_factory()
     new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -389,6 +389,15 @@ def test_combine_workspace_deepcopied(workspace_factory):
     )
 
 
+def test_combine_workspace_invalid_join_operation(workspace_factory):
+    ws = workspace_factory()
+    new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
+        measurements=['GammaExample', 'ConstExample', 'LogNormExample']
+    )
+    with pytest.raises(ValueError):
+        pyhf.Workspace.combine(ws, new_ws, join='fake join operation')
+
+
 def test_combine_workspace_incompatible_parameter_configs_outer_join(workspace_factory):
     ws = workspace_factory()
     new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -287,7 +287,7 @@ def test_combine_workspace_same_channels_incompatible_structure(
         measurements={'GaussExample': 'GaussExample2'},
     ).prune(measurements=['GammaExample', 'ConstExample', 'LogNormExample'])
     with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
-        pyhf.Workspace.combine(ws, new_ws)
+        pyhf.Workspace.combine(ws, new_ws, join=join)
     assert 'channel1' in str(excinfo.value)
     assert 'channel2' not in str(excinfo.value)
 
@@ -309,7 +309,7 @@ def test_combine_workspace_incompatible_poi(workspace_factory):
         modifiers={new_ws.get_measurement()['config']['poi']: 'renamedPOI'}
     )
     with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
-        pyhf.Workspace.combine(ws, new_ws)
+        pyhf.Workspace.combine(ws, new_ws, join='none')
     assert 'GaussExample' in str(excinfo.value)
 
 
@@ -349,7 +349,7 @@ def test_combine_workspace_duplicate_parameter_configs(workspace_factory):
         measurements=['GammaExample', 'ConstExample', 'LogNormExample']
     )
     with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
-        pyhf.Workspace.combine(ws, new_ws)
+        pyhf.Workspace.combine(ws, new_ws, join='none')
     assert 'GaussExample' in str(excinfo.value)
     assert 'lumi' in str(excinfo.value)
 
@@ -518,7 +518,7 @@ def test_combine_workspace(workspace_factory, join):
             'LogNormExample': 'OtherLogNormExample',
         },
     )
-    combined = pyhf.Workspace.combine(ws, new_ws)
+    combined = pyhf.Workspace.combine(ws, new_ws, join=join)
     assert set(combined.channels) == set(ws.channels + new_ws.channels)
     assert set(combined.samples) == set(ws.samples + new_ws.samples)
     assert set(combined.parameters) == set(ws.parameters + new_ws.parameters)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -322,6 +322,42 @@ def test_combine_workspace_diff_version(workspace_factory):
         pyhf.Workspace.combine(ws, new_ws)
 
 
+def test_combine_workspace_duplicate_parameter_configs(workspace_factory):
+    ws = workspace_factory()
+    new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
+        measurements=['GammaExample', 'ConstExample', 'LogNormExample']
+    )
+    combined = pyhf.Workspace.combine(ws, new_ws)
+
+    poi = ws.get_measurement(measurement_name='GaussExample')['config']['poi']
+    ws_parameter_configs = [
+        parameter['name']
+        for parameter in ws.get_measurement(measurement_name='GaussExample')['config'][
+            'parameters'
+        ]
+    ]
+    new_ws_parameter_configs = [
+        parameter['name']
+        for parameter in new_ws.get_measurement(measurement_name='GaussExample')[
+            'config'
+        ]['parameters']
+    ]
+    combined_parameter_configs = [
+        parameter['name']
+        for parameter in combined.get_measurement(measurement_name='GaussExample')[
+            'config'
+        ]['parameters']
+    ]
+
+    assert poi in ws_parameter_configs
+    assert poi in new_ws_parameter_configs
+    assert poi in combined_parameter_configs
+    assert 'lumi' in ws_parameter_configs
+    assert 'lumi' in new_ws_parameter_configs
+    assert 'lumi' in combined_parameter_configs
+    assert len(combined_parameter_configs) == len(set(combined_parameter_configs))
+
+
 def test_combine_workspace(workspace_factory):
     ws = workspace_factory()
     new_ws = ws.rename(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -499,6 +499,96 @@ def test_combine_workspace_incompatible_parameter_configs_right_outer_join(
     )
 
 
+@pytest.mark.parametrize("join", ['none', 'outer'])
+def test_combine_workspace_incompatible_observations(workspace_factory, join):
+    ws = workspace_factory()
+    new_ws = ws.rename(
+        channels={'channel1': 'channel3', 'channel2': 'channel4'},
+        samples={
+            'background1': 'background3',
+            'background2': 'background4',
+            'signal': 'signal2',
+        },
+        modifiers={
+            'syst1': 'syst4',
+            'bkg1Shape': 'bkg3Shape',
+            'bkg2Shape': 'bkg4Shape',
+        },
+        measurements={
+            'GaussExample': 'OtherGaussExample',
+            'GammaExample': 'OtherGammaExample',
+            'ConstExample': 'OtherConstExample',
+            'LogNormExample': 'OtherLogNormExample',
+        },
+    )
+    new_ws['observations'][0]['name'] = ws['observations'][0]['name']
+    new_ws['observations'][0]['data'][0] = -10.0
+    with pytest.raises(pyhf.exceptions.InvalidSpecification) as excinfo:
+        pyhf.Workspace.combine(ws, new_ws, join=join)
+    assert ws['observations'][0]['name'] in str(excinfo.value)
+    assert 'observations' in str(excinfo.value)
+
+
+def test_combine_workspace_incompatible_observations_left_outer(workspace_factory):
+    ws = workspace_factory()
+    new_ws = ws.rename(
+        channels={'channel1': 'channel3', 'channel2': 'channel4'},
+        samples={
+            'background1': 'background3',
+            'background2': 'background4',
+            'signal': 'signal2',
+        },
+        modifiers={
+            'syst1': 'syst4',
+            'bkg1Shape': 'bkg3Shape',
+            'bkg2Shape': 'bkg4Shape',
+        },
+        measurements={
+            'GaussExample': 'OtherGaussExample',
+            'GammaExample': 'OtherGammaExample',
+            'ConstExample': 'OtherConstExample',
+            'LogNormExample': 'OtherLogNormExample',
+        },
+    )
+    new_ws['observations'][0]['name'] = ws['observations'][0]['name']
+    new_ws['observations'][0]['data'][0] = -10.0
+    combined = pyhf.Workspace.combine(ws, new_ws, join='left outer')
+    assert (
+        combined.observations[ws['observations'][0]['name']]
+        == ws['observations'][0]['data']
+    )
+
+
+def test_combine_workspace_incompatible_observations_right_outer(workspace_factory):
+    ws = workspace_factory()
+    new_ws = ws.rename(
+        channels={'channel1': 'channel3', 'channel2': 'channel4'},
+        samples={
+            'background1': 'background3',
+            'background2': 'background4',
+            'signal': 'signal2',
+        },
+        modifiers={
+            'syst1': 'syst4',
+            'bkg1Shape': 'bkg3Shape',
+            'bkg2Shape': 'bkg4Shape',
+        },
+        measurements={
+            'GaussExample': 'OtherGaussExample',
+            'GammaExample': 'OtherGammaExample',
+            'ConstExample': 'OtherConstExample',
+            'LogNormExample': 'OtherLogNormExample',
+        },
+    )
+    new_ws['observations'][0]['name'] = ws['observations'][0]['name']
+    new_ws['observations'][0]['data'][0] = -10.0
+    combined = pyhf.Workspace.combine(ws, new_ws, join='right outer')
+    assert (
+        combined.observations[ws['observations'][0]['name']]
+        == new_ws['observations'][0]['data']
+    )
+
+
 @pytest.mark.parametrize("join", pyhf.Workspace.valid_joins)
 def test_combine_workspace(workspace_factory, join):
     ws = workspace_factory()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -358,7 +358,7 @@ def test_combine_workspace_duplicate_parameter_configs(workspace_factory):
     assert len(combined_parameter_configs) == len(set(combined_parameter_configs))
 
 
-def test_combine_workspace_incompatible_parameter_configs(workspace_factory):
+def test_combine_workspace_deepcopied(workspace_factory):
     ws = workspace_factory()
     new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
         measurements=['GammaExample', 'ConstExample', 'LogNormExample']
@@ -374,6 +374,16 @@ def test_combine_workspace_incompatible_parameter_configs(workspace_factory):
             'parameters'
         ][0]['bounds']
     )
+
+
+def test_combine_workspace_incompatible_parameter_configs(workspace_factory):
+    ws = workspace_factory()
+    new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
+        measurements=['GammaExample', 'ConstExample', 'LogNormExample']
+    )
+    new_ws.get_measurement(measurement_name='GaussExample')['config']['parameters'][0][
+        'bounds'
+    ] = [[0.0, 1.0]]
     with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation):
         pyhf.Workspace.combine(ws, new_ws)
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -300,6 +300,16 @@ def test_combine_workspace_same_channels_outer_join(workspace_factory, join):
     assert 'channel1' in combined.channels
 
 
+@pytest.mark.parametrize("join", ['left outer', 'right outer'])
+def test_combine_workspace_same_channels_outer_join_unsafe(
+    workspace_factory, join, caplog
+):
+    ws = workspace_factory()
+    new_ws = ws.rename(channels={'channel2': 'channel3'})
+    pyhf.Workspace.combine(ws, new_ws, join=join)
+    assert 'using an unsafe join operation' in caplog.text
+
+
 @pytest.mark.parametrize("join", ['none', 'outer'])
 def test_combine_workspace_incompatible_poi(workspace_factory, join):
     ws = workspace_factory()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -413,7 +413,7 @@ def test_combine_workspace_observation_ordering(workspace_factory):
     new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
         measurements=['GammaExample', 'ConstExample', 'LogNormExample']
     )
-    assert ws['observations'][0] == new_ws['observations'][0]
+    assert ws['observations'][0]['data'] == new_ws['observations'][0]['data']
 
 
 def test_combine_workspace_deepcopied(workspace_factory):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -533,7 +533,7 @@ def test_combine_workspace_incompatible_observations(workspace_factory, join):
     )
     new_ws['observations'][0]['name'] = ws['observations'][0]['name']
     new_ws['observations'][0]['data'][0] = -10.0
-    with pytest.raises(pyhf.exceptions.InvalidSpecification) as excinfo:
+    with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
         pyhf.Workspace.combine(ws, new_ws, join=join)
     assert ws['observations'][0]['name'] in str(excinfo.value)
     assert 'observations' in str(excinfo.value)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -275,13 +275,21 @@ def test_rename_measurement(workspace_factory):
     assert renamed in new_ws.measurement_names
 
 
-def test_combine_workspace_same_channels(workspace_factory):
+def test_combine_workspace_same_channels_outer_join(workspace_factory):
     ws = workspace_factory()
     new_ws = ws.rename(channels={'channel2': 'channel3'})
     with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
         pyhf.Workspace.combine(ws, new_ws)
     assert 'channel1' in str(excinfo.value)
     assert 'channel2' not in str(excinfo.value)
+
+
+@pytest.mark.parametrize("join", ['left outer', 'right outer'])
+def test_combine_workspace_same_channels_leftright_outer_join(workspace_factory, join):
+    ws = workspace_factory()
+    new_ws = ws.rename(channels={'channel2': 'channel3'})
+    combined = pyhf.Workspace.combine(ws, new_ws, join=join)
+    assert 'channel1' in combined.channels
 
 
 def test_combine_workspace_incompatible_poi(workspace_factory):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -353,7 +353,6 @@ def test_combine_workspace_duplicate_parameter_configs(workspace_factory, join):
     with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
         pyhf.Workspace.combine(ws, new_ws, join=join)
     assert 'GaussExample' in str(excinfo.value)
-    assert 'lumi' in str(excinfo.value)
 
 
 @pytest.mark.parametrize("join", ['outer', 'left outer', 'right outer'])
@@ -447,8 +446,24 @@ def test_combine_workspace_invalid_join_operation(workspace_factory, join):
     assert join in str(excinfo.value)
 
 
-@pytest.mark.parametrize("join", ['none', 'outer'])
+@pytest.mark.parametrize("join", ['none'])
 def test_combine_workspace_incompatible_parameter_configs(workspace_factory, join):
+    ws = workspace_factory()
+    new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
+        measurements=['GammaExample', 'ConstExample', 'LogNormExample']
+    )
+    new_ws.get_measurement(measurement_name='GaussExample')['config']['parameters'][0][
+        'bounds'
+    ] = [[0.0, 1.0]]
+    with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
+        pyhf.Workspace.combine(ws, new_ws, join=join)
+    assert 'GaussExample' in str(excinfo.value)
+
+
+@pytest.mark.parametrize("join", ['outer'])
+def test_combine_workspace_incompatible_parameter_configs_outer_join(
+    workspace_factory, join
+):
     ws = workspace_factory()
     new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
         measurements=['GammaExample', 'ConstExample', 'LogNormExample']

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -376,7 +376,7 @@ def test_combine_workspace_deepcopied(workspace_factory):
     )
 
 
-def test_combine_workspace_incompatible_parameter_configs(workspace_factory):
+def test_combine_workspace_incompatible_parameter_configs_outer_join(workspace_factory):
     ws = workspace_factory()
     new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
         measurements=['GammaExample', 'ConstExample', 'LogNormExample']
@@ -386,6 +386,48 @@ def test_combine_workspace_incompatible_parameter_configs(workspace_factory):
     ] = [[0.0, 1.0]]
     with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation):
         pyhf.Workspace.combine(ws, new_ws)
+
+
+def test_combine_workspace_incompatible_parameter_configs_left_outer_join(
+    workspace_factory,
+):
+    ws = workspace_factory()
+    new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
+        measurements=['GammaExample', 'ConstExample', 'LogNormExample']
+    )
+    new_ws.get_measurement(measurement_name='GaussExample')['config']['parameters'][0][
+        'bounds'
+    ] = [[0.0, 1.0]]
+    combined = pyhf.Workspace.combine(ws, new_ws, join='left outer')
+    assert (
+        combined.get_measurement(measurement_name='GaussExample')['config'][
+            'parameters'
+        ][0]
+        == ws.get_measurement(measurement_name='GaussExample')['config']['parameters'][
+            0
+        ]
+    )
+
+
+def test_combine_workspace_incompatible_parameter_configs_right_outer_join(
+    workspace_factory,
+):
+    ws = workspace_factory()
+    new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
+        measurements=['GammaExample', 'ConstExample', 'LogNormExample']
+    )
+    new_ws.get_measurement(measurement_name='GaussExample')['config']['parameters'][0][
+        'bounds'
+    ] = [[0.0, 1.0]]
+    combined = pyhf.Workspace.combine(ws, new_ws, join='right outer')
+    assert (
+        combined.get_measurement(measurement_name='GaussExample')['config'][
+            'parameters'
+        ][0]
+        == new_ws.get_measurement(measurement_name='GaussExample')['config'][
+            'parameters'
+        ][0]
+    )
 
 
 def test_combine_workspace(workspace_factory):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -300,7 +300,8 @@ def test_combine_workspace_same_channels_outer_join(workspace_factory, join):
     assert 'channel1' in combined.channels
 
 
-def test_combine_workspace_incompatible_poi(workspace_factory):
+@pytest.mark.parametrize("join", ['none', 'outer'])
+def test_combine_workspace_incompatible_poi(workspace_factory, join):
     ws = workspace_factory()
     new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
         measurements=['GammaExample', 'ConstExample', 'LogNormExample']
@@ -309,7 +310,7 @@ def test_combine_workspace_incompatible_poi(workspace_factory):
         modifiers={new_ws.get_measurement()['config']['poi']: 'renamedPOI'}
     )
     with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
-        pyhf.Workspace.combine(ws, new_ws, join='none')
+        pyhf.Workspace.combine(ws, new_ws, join=join)
     assert 'GaussExample' in str(excinfo.value)
 
 
@@ -343,13 +344,14 @@ def test_combine_workspace_diff_version(workspace_factory, join):
     assert '1.2.0' in str(excinfo.value)
 
 
-def test_combine_workspace_duplicate_parameter_configs(workspace_factory):
+@pytest.mark.parametrize("join", ['none'])
+def test_combine_workspace_duplicate_parameter_configs(workspace_factory, join):
     ws = workspace_factory()
     new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
         measurements=['GammaExample', 'ConstExample', 'LogNormExample']
     )
     with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
-        pyhf.Workspace.combine(ws, new_ws, join='none')
+        pyhf.Workspace.combine(ws, new_ws, join=join)
     assert 'GaussExample' in str(excinfo.value)
     assert 'lumi' in str(excinfo.value)
 
@@ -424,14 +426,15 @@ def test_combine_workspace_deepcopied(workspace_factory):
     )
 
 
-def test_combine_workspace_invalid_join_operation(workspace_factory):
+@pytest.mark.parametrize("join", ['fake join operation'])
+def test_combine_workspace_invalid_join_operation(workspace_factory, join):
     ws = workspace_factory()
     new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
         measurements=['GammaExample', 'ConstExample', 'LogNormExample']
     )
     with pytest.raises(ValueError) as excinfo:
-        pyhf.Workspace.combine(ws, new_ws, join='fake join operation')
-    assert 'fake join operation' in str(excinfo.value)
+        pyhf.Workspace.combine(ws, new_ws, join=join)
+    assert join in str(excinfo.value)
 
 
 @pytest.mark.parametrize("join", ['none', 'outer'])

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -358,6 +358,26 @@ def test_combine_workspace_duplicate_parameter_configs(workspace_factory):
     assert len(combined_parameter_configs) == len(set(combined_parameter_configs))
 
 
+def test_combine_workspace_incompatible_parameter_configs(workspace_factory):
+    ws = workspace_factory()
+    new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
+        measurements=['GammaExample', 'ConstExample', 'LogNormExample']
+    )
+    new_ws.get_measurement(measurement_name='GaussExample')['config']['parameters'][0][
+        'bounds'
+    ] = [[0.0, 1.0]]
+    assert (
+        ws.get_measurement(measurement_name='GaussExample')['config']['parameters'][0][
+            'bounds'
+        ]
+        != new_ws.get_measurement(measurement_name='GaussExample')['config'][
+            'parameters'
+        ][0]['bounds']
+    )
+    with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation):
+        pyhf.Workspace.combine(ws, new_ws)
+
+
 def test_combine_workspace(workspace_factory):
     ws = workspace_factory()
     new_ws = ws.rename(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -336,7 +336,7 @@ def test_combine_workspace_diff_version(workspace_factory, join):
             'GammaExample': 'OtherGammaExample',
         },
     )
-    new_ws.version = '1.2.0'
+    new_ws['version'] = '1.2.0'
     with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
         pyhf.Workspace.combine(ws, new_ws, join=join)
     assert '1.0.0' in str(excinfo.value)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -408,6 +408,14 @@ def test_combine_workspace_parameter_configs_ordering(workspace_factory):
     )
 
 
+def test_combine_workspace_observation_ordering(workspace_factory):
+    ws = workspace_factory()
+    new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
+        measurements=['GammaExample', 'ConstExample', 'LogNormExample']
+    )
+    assert ws['observations'][0] == new_ws['observations'][0]
+
+
 def test_combine_workspace_deepcopied(workspace_factory):
     ws = workspace_factory()
     new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
@@ -416,6 +424,7 @@ def test_combine_workspace_deepcopied(workspace_factory):
     new_ws.get_measurement(measurement_name='GaussExample')['config']['parameters'][0][
         'bounds'
     ] = [[0.0, 1.0]]
+    new_ws['observations'][0]['data'][0] = -10.0
     assert (
         ws.get_measurement(measurement_name='GaussExample')['config']['parameters'][0][
             'bounds'
@@ -424,6 +433,7 @@ def test_combine_workspace_deepcopied(workspace_factory):
             'parameters'
         ][0]['bounds']
     )
+    assert ws['observations'][0]['data'] != new_ws['observations'][0]['data']
 
 
 @pytest.mark.parametrize("join", ['fake join operation'])

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -281,8 +281,10 @@ def test_combine_workspace_same_channels_incompatible_structure(
 ):
     ws = workspace_factory()
     new_ws = ws.rename(
-        channels={'channel2': 'channel3'}, samples={'signal': 'signal_other'}
-    )
+        channels={'channel2': 'channel3'},
+        samples={'signal': 'signal_other'},
+        measurements={'GaussExample': 'GaussExample2'},
+    ).prune(measurements=['GammaExample', 'ConstExample', 'LogNormExample'])
     with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
         pyhf.Workspace.combine(ws, new_ws)
     assert 'channel1' in str(excinfo.value)
@@ -340,8 +342,10 @@ def test_combine_workspace_duplicate_parameter_configs(workspace_factory):
     new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
         measurements=['GammaExample', 'ConstExample', 'LogNormExample']
     )
-    with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation):
+    with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
         pyhf.Workspace.combine(ws, new_ws)
+    assert 'GaussExample' in str(excinfo.value)
+    assert 'lumi' in str(excinfo.value)
 
 
 @pytest.mark.parametrize("join", ['outer', 'left outer', 'right outer'])
@@ -478,7 +482,8 @@ def test_combine_workspace_incompatible_parameter_configs_right_outer_join(
     )
 
 
-def test_combine_workspace(workspace_factory):
+@pytest.mark.parametrize("join", pyhf.Workspace.valid_joins)
+def test_combine_workspace(workspace_factory, join):
     ws = workspace_factory()
     new_ws = ws.rename(
         channels={'channel1': 'channel3', 'channel2': 'channel4'},
@@ -493,6 +498,8 @@ def test_combine_workspace(workspace_factory):
             'bkg2Shape': 'bkg4Shape',
         },
         measurements={
+            'GaussExample': 'OtherGaussExample',
+            'GammaExample': 'OtherGammaExample',
             'ConstExample': 'OtherConstExample',
             'LogNormExample': 'OtherLogNormExample',
         },

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -275,11 +275,20 @@ def test_rename_measurement(workspace_factory):
     assert renamed in new_ws.measurement_names
 
 
-def test_combine_workspace_same_channels_outer_join(workspace_factory):
+def test_combine_workspace_same_channels(workspace_factory):
     ws = workspace_factory()
     new_ws = ws.rename(channels={'channel2': 'channel3'})
     with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
         pyhf.Workspace.combine(ws, new_ws)
+    assert 'channel1' in str(excinfo.value)
+    assert 'channel2' not in str(excinfo.value)
+
+
+def test_combine_workspace_same_channels_outer_join(workspace_factory):
+    ws = workspace_factory()
+    new_ws = ws.rename(channels={'channel2': 'channel3'})
+    with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
+        pyhf.Workspace.combine(ws, new_ws, join='outer')
     assert 'channel1' in str(excinfo.value)
     assert 'channel2' not in str(excinfo.value)
 
@@ -406,7 +415,7 @@ def test_combine_workspace_invalid_join_operation(workspace_factory):
         pyhf.Workspace.combine(ws, new_ws, join='fake join operation')
 
 
-def test_combine_workspace_incompatible_parameter_configs_outer_join(workspace_factory):
+def test_combine_workspace_incompatible_parameter_configs(workspace_factory):
     ws = workspace_factory()
     new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
         measurements=['GammaExample', 'ConstExample', 'LogNormExample']
@@ -416,6 +425,18 @@ def test_combine_workspace_incompatible_parameter_configs_outer_join(workspace_f
     ] = [[0.0, 1.0]]
     with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation):
         pyhf.Workspace.combine(ws, new_ws)
+
+
+def test_combine_workspace_incompatible_parameter_configs_outer_join(workspace_factory):
+    ws = workspace_factory()
+    new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
+        measurements=['GammaExample', 'ConstExample', 'LogNormExample']
+    )
+    new_ws.get_measurement(measurement_name='GaussExample')['config']['parameters'][0][
+        'bounds'
+    ] = [[0.0, 1.0]]
+    with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation):
+        pyhf.Workspace.combine(ws, new_ws, join='outer')
 
 
 def test_combine_workspace_incompatible_parameter_configs_left_outer_join(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -411,9 +411,3 @@ def test_combine_workspace(workspace_factory):
     assert set(combined.channels) == set(ws.channels + new_ws.channels)
     assert set(combined.samples) == set(ws.samples + new_ws.samples)
     assert set(combined.parameters) == set(ws.parameters + new_ws.parameters)
-    combined_measurement = combined.get_measurement(measurement_name='GaussExample')
-    assert len(combined_measurement['config']['parameters']) == len(
-        ws.get_measurement(measurement_name='GaussExample')['config']['parameters']
-    ) + len(
-        new_ws.get_measurement(measurement_name='GaussExample')['config']['parameters']
-    )

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -305,7 +305,7 @@ def test_combine_workspace_incompatible_poi(workspace_factory):
     new_ws = ws.rename(channels={'channel1': 'channel3', 'channel2': 'channel4'}).prune(
         measurements=['GammaExample', 'ConstExample', 'LogNormExample']
     )
-    new_ws = ws.rename(
+    new_ws = new_ws.rename(
         modifiers={new_ws.get_measurement()['config']['poi']: 'renamedPOI'}
     )
     with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -313,7 +313,8 @@ def test_combine_workspace_incompatible_poi(workspace_factory):
     assert 'GaussExample' in str(excinfo.value)
 
 
-def test_combine_workspace_diff_version(workspace_factory):
+@pytest.mark.parametrize("join", ['none', 'outer', 'left outer', 'right outer'])
+def test_combine_workspace_diff_version(workspace_factory, join):
     ws = workspace_factory()
     ws.version = '1.0.0'
     new_ws = ws.rename(
@@ -337,7 +338,7 @@ def test_combine_workspace_diff_version(workspace_factory):
     )
     new_ws.version = '1.2.0'
     with pytest.raises(pyhf.exceptions.InvalidWorkspaceOperation) as excinfo:
-        pyhf.Workspace.combine(ws, new_ws)
+        pyhf.Workspace.combine(ws, new_ws, join=join)
     assert '1.0.0' in str(excinfo.value)
     assert '1.2.0' in str(excinfo.value)
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -276,6 +276,45 @@ def test_rename_measurement(workspace_factory):
     assert renamed in new_ws.measurement_names
 
 
+@pytest.fixture(scope='session')
+def join_items():
+    left = [{'name': 'left', 'key': 'value'}, {'name': 'common', 'key': 'left'}]
+    right = [{'name': 'right', 'key': 'value'}, {'name': 'common', 'key': 'right'}]
+    return (left, right)
+
+
+def test_join_items_none(join_items):
+    left_items, right_items = join_items
+    joined = pyhf.workspace._join_items('none', left_items, right_items, key='name')
+    assert all(left in joined for left in left_items)
+    assert all(right in joined for right in right_items)
+
+
+def test_join_items_outer(join_items):
+    left_items, right_items = join_items
+    joined = pyhf.workspace._join_items('outer', left_items, right_items, key='name')
+    assert all(left in joined for left in left_items)
+    assert all(right in joined for right in right_items)
+
+
+def test_join_items_left_outer(join_items):
+    left_items, right_items = join_items
+    joined = pyhf.workspace._join_items(
+        'left outer', left_items, right_items, key='name'
+    )
+    assert all(left in joined for left in left_items)
+    assert not all(right in joined for right in right_items)
+
+
+def test_join_items_right_outer(join_items):
+    left_items, right_items = join_items
+    joined = pyhf.workspace._join_items(
+        'right outer', left_items, right_items, key='name'
+    )
+    assert not all(left in joined for left in left_items)
+    assert all(right in joined for right in right_items)
+
+
 @pytest.mark.parametrize("join", ['none', 'outer'])
 def test_combine_workspace_same_channels_incompatible_structure(
     workspace_factory, join


### PR DESCRIPTION
# Description

This PR will resolve a nagging issue with @kratsg about dealing with combining workspaces. The hardest thing is that there is not necessarily one right way to combine (or join) two workspaces. Considering this, `pyhf combine` will now support (as of this PR) four methods.

1. none
2. outer
3. left outer
4. right outer

Before, `pyhf combine` was doing a mixture of (1) and (2) above: `none` and `outer`. Now, the code is cleaned up to separate the two logic better.

A `none` will only check for duplicated data structures (by name) between the two workspaces and refuse to combine if any names are in common. This uses the summary data provided by `_ChannelSummaryMixin`.

An `outer` join will join both workspaces and any duplicated data structures will be merged together if they are fully identical and not mutually incompatible. This is simply done by asking if the two underlying dictionary objects are equivalent.

A `left outer` (or `right outer`) will join both workspaces using the left (or right) workspace as preference in the case any conflicts arise during the procedure of an `outer` join.

Additionally, a lot of exceptions/error messages are clarified in the process.

This will fix #749 and fix #695.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Workspace combination now allows for more robust join operations with a variation of outer join supported
* Some refactoring of Workspace.combine was done to support a future clean-up
```