### PR TITLE
docs: Add Stack Overflow question section

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ To uninstall run
 python -m pip uninstall pyhf
 ```
 
+## Questions
+
+If you have a question about the use of `pyhf` not covered in [the documentation](https://scikit-hep.org/pyhf/), please ask a question on [Stack Overflow](https://stackoverflow.com/questions/tagged/pyhf) with the `[pyhf]` and `[scikit-hep]` tags, which the `pyhf` dev team watches.
+
+<p align="center">
+<a href="https://stackoverflow.com/questions/tagged/pyhf">
+<img src="https://cdn.sstatic.net/Sites/stackoverflow/company/img/logos/so/so-logo.png" alt="Stack Overflow pyhf tag" width="50%"/>
+</a>
+</p>
+
+If you believe you have found a bug in `pyhf`, please report it in the [GitHub Issues](https://github.com/scikit-hep/pyhf/issues/new?template=Bug-Report.md&labels=bug&title=Bug+Report+:+Title+Here).
+
 ## Citation
 
 As noted in [Use and Citations](https://scikit-hep.org/pyhf/citations.html), the preferred BibTeX entry for citation of `pyhf` is

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ python -m pip uninstall pyhf
 
 ## Questions
 
-If you have a question about the use of `pyhf` not covered in [the documentation](https://scikit-hep.org/pyhf/), please ask a question on [Stack Overflow](https://stackoverflow.com/questions/tagged/pyhf) with the `[pyhf]` and `[scikit-hep]` tags, which the `pyhf` dev team watches.
+If you have a question about the use of `pyhf` not covered in [the documentation](https://scikit-hep.org/pyhf/), please ask a question on [Stack Overflow](https://stackoverflow.com/questions/tagged/pyhf) with the `[pyhf]` and `[scikit-hep]` tags, which the `pyhf` dev team [watches](https://stackoverflow.com/questions/tagged/pyhf?sort=Newest&filters=NoAcceptedAnswer&edited=true).
 
 <p align="center">
 <a href="https://stackoverflow.com/questions/tagged/pyhf">

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ python -m pip uninstall pyhf
 
 ## Questions
 
-If you have a question about the use of `pyhf` not covered in [the documentation](https://scikit-hep.org/pyhf/), please ask a question on [Stack Overflow](https://stackoverflow.com/questions/tagged/pyhf) with the `[pyhf]` and `[scikit-hep]` tags, which the `pyhf` dev team [watches](https://stackoverflow.com/questions/tagged/pyhf?sort=Newest&filters=NoAcceptedAnswer&edited=true).
+If you have a question about the use of `pyhf` not covered in [the documentation](https://scikit-hep.org/pyhf/), please ask a question on [Stack Overflow](https://stackoverflow.com/questions/tagged/pyhf) with the `[pyhf]` tag, which the `pyhf` dev team [watches](https://stackoverflow.com/questions/tagged/pyhf?sort=Newest&filters=NoAcceptedAnswer&edited=true).
 
 <p align="center">
 <a href="https://stackoverflow.com/questions/tagged/pyhf">

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -6,6 +6,20 @@ Frequently Asked Questions about :code:`pyhf` and its use.
 Questions
 ---------
 
+Where can I ask questions about ``pyhf`` use?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If you have a question about the use of ``pyhf`` not covered in the `documentation <https://scikit-hep.org/pyhf/>`__, please ask a question on `Stack Overflow <https://stackoverflow.com/questions/tagged/pyhf>`__ with the ``[pyhf]`` and ``[scikit-hep]`` tags, which the ``pyhf`` dev team watches.
+
+.. raw:: html
+
+  <p align="center">
+  <a href="https://stackoverflow.com/questions/tagged/pyhf">
+  <img src="https://cdn.sstatic.net/Sites/stackoverflow/company/img/logos/so/so-logo.png" alt="Stack Overflow pyhf tag" width="50%"/>
+  </a>
+  </p>
+
+If you believe you have found a bug in ``pyhf``, please report it in the `GitHub Issues <https://github.com/scikit-hep/pyhf/issues/new?template=Bug-Report.md&labels=bug&title=Bug+Report+:+Title+Here>`__.
+
 Is it possible to set the backend from the CLI?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -8,7 +8,7 @@ Questions
 
 Where can I ask questions about ``pyhf`` use?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If you have a question about the use of ``pyhf`` not covered in the `documentation <https://scikit-hep.org/pyhf/>`__, please ask a question on `Stack Overflow <https://stackoverflow.com/questions/tagged/pyhf>`__ with the ``[pyhf]`` and ``[scikit-hep]`` tags, which the ``pyhf`` dev team watches.
+If you have a question about the use of ``pyhf`` not covered in the `documentation <https://scikit-hep.org/pyhf/>`__, please ask a question on `Stack Overflow <https://stackoverflow.com/questions/tagged/pyhf>`__ with the ``[pyhf]`` and ``[scikit-hep]`` tags, which the ``pyhf`` dev team `watches <https://stackoverflow.com/questions/tagged/pyhf?sort=Newest&filters=NoAcceptedAnswer&edited=true>`__.
 
 .. raw:: html
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -8,7 +8,7 @@ Questions
 
 Where can I ask questions about ``pyhf`` use?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If you have a question about the use of ``pyhf`` not covered in the `documentation <https://scikit-hep.org/pyhf/>`__, please ask a question on `Stack Overflow <https://stackoverflow.com/questions/tagged/pyhf>`__ with the ``[pyhf]`` and ``[scikit-hep]`` tags, which the ``pyhf`` dev team `watches <https://stackoverflow.com/questions/tagged/pyhf?sort=Newest&filters=NoAcceptedAnswer&edited=true>`__.
+If you have a question about the use of ``pyhf`` not covered in the `documentation <https://scikit-hep.org/pyhf/>`__, please ask a question on `Stack Overflow <https://stackoverflow.com/questions/tagged/pyhf>`__ with the ``[pyhf]`` tag, which the ``pyhf`` dev team `watches <https://stackoverflow.com/questions/tagged/pyhf?sort=Newest&filters=NoAcceptedAnswer&edited=true>`__.
 
 .. raw:: html
 


### PR DESCRIPTION
# Description

Add a question section to direct users to the `pyhf` tag on Stack Overflow for user discussion. Additionally add this section to the FAQs.

A preview of this PR can be seen on RTD here: https://pyhf.readthedocs.io/en/docs-add-stack-overflow-tag/

**TODO:** 
- [x] Get Jim's help in making a `pyhf` Stack Overflow tag
   - Source of guidance for tag description: [`uproot`'s Stack Overflow tag](https://stackoverflow.com/tags/uproot/info)
- [x] Make a `pyhf` Stack Overflow question to be tagged
   - [Fit convergence failure in pyhf for small signal model](https://stackoverflow.com/questions/60089405/fit-convergence-failure-in-pyhf-for-small-signal-model/)
- [x] Wait for [`[pyhf]` Stack Overflow tag](https://stackoverflow.com/tags/pyhf/info) to be created and accepted

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add questions section for Stack Overflow [pyhf] tag to README and FAQs
```
