### PR TITLE
test: Add test of independence of pyhf.infer from pyhf details

### DIFF
--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -85,3 +85,53 @@ def test_hypotest_return_expected_set(tmpdir, hypotest_args):
     assert isinstance(result[2], type(tb.astensor(result[2])))
     assert len(result[3]) == 5
     assert check_uniform_type(result[3])
+
+def test_inferapi_pyhf_independence():
+    '''
+    pyhf.infer should eventually be factored out so it should be
+    infependent from pyhf internals. This is testing that
+    a much simpler model still can run through pyhf.infer.hypotest
+    '''
+    from pyhf import get_backend
+    class _NonPyhfConfig(object):
+        def __init__(self):
+            self.poi_index = 0
+            self.npars = 2
+        def suggested_init(self):
+            return [1.0,1.0]
+        def suggested_bounds(self):
+            return [[0.,10.],[0.,10.]]
+
+    class NonPyhfModel(object):
+        def __init__(self,spec):
+            self.sig,self.nominal,self.uncert = spec 
+            self.factor = (self.nominal/self.uncert)**2
+            self.aux = 1.0*self.factor
+            self.config = _NonPyhfConfig()
+        
+        def _make_main_pdf(self,pars):
+            mu,gamma = pars
+            expected_main = gamma*self.nominal + mu*self.sig
+            return pyhf.probability.Poisson(expected_main)
+
+        def _make_constraint_pdf(self,pars):
+            mu,gamma = pars
+            return pyhf.probability.Poisson(gamma*self.factor)        
+
+        def expected_data(self,pars,include_auxdata = True):
+            tensorlib,_ = get_backend()
+            expected_main = tensorlib.astensor([self._make_main_pdf(pars).expected_data()])
+            aux_data      = tensorlib.astensor([self._make_constraint_pdf(pars).expected_data()])
+            if not include_auxdata:
+                return expected_main
+            return tensorlib.concatenate([expected_main,aux_data])
+
+        def logpdf(self,pars,data):
+            tensorlib,_ = get_backend()
+            maindata, auxdata = data
+            main =  self._make_main_pdf(pars).log_prob(maindata)
+            constraint = self._make_constraint_pdf(pars).log_prob(auxdata)
+            return tensorlib.astensor([main + constraint])
+
+    m = NonPyhfModel([5,50,7])
+    print(pyhf.infer.hypotest(1.0,m.expected_data(m.config.suggested_init()),m))

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -86,6 +86,7 @@ def test_hypotest_return_expected_set(tmpdir, hypotest_args):
     assert len(result[3]) == 5
     assert check_uniform_type(result[3])
 
+
 def test_inferapi_pyhf_independence():
     '''
     pyhf.infer should eventually be factored out so it should be
@@ -93,45 +94,52 @@ def test_inferapi_pyhf_independence():
     a much simpler model still can run through pyhf.infer.hypotest
     '''
     from pyhf import get_backend
+
     class _NonPyhfConfig(object):
         def __init__(self):
             self.poi_index = 0
             self.npars = 2
+
         def suggested_init(self):
-            return [1.0,1.0]
+            return [1.0, 1.0]
+
         def suggested_bounds(self):
-            return [[0.,10.],[0.,10.]]
+            return [[0.0, 10.0], [0.0, 10.0]]
 
     class NonPyhfModel(object):
-        def __init__(self,spec):
-            self.sig,self.nominal,self.uncert = spec 
-            self.factor = (self.nominal/self.uncert)**2
-            self.aux = 1.0*self.factor
+        def __init__(self, spec):
+            self.sig, self.nominal, self.uncert = spec
+            self.factor = (self.nominal / self.uncert) ** 2
+            self.aux = 1.0 * self.factor
             self.config = _NonPyhfConfig()
-        
-        def _make_main_pdf(self,pars):
-            mu,gamma = pars
-            expected_main = gamma*self.nominal + mu*self.sig
+
+        def _make_main_pdf(self, pars):
+            mu, gamma = pars
+            expected_main = gamma * self.nominal + mu * self.sig
             return pyhf.probability.Poisson(expected_main)
 
-        def _make_constraint_pdf(self,pars):
-            mu,gamma = pars
-            return pyhf.probability.Poisson(gamma*self.factor)        
+        def _make_constraint_pdf(self, pars):
+            mu, gamma = pars
+            return pyhf.probability.Poisson(gamma * self.factor)
 
-        def expected_data(self,pars,include_auxdata = True):
-            tensorlib,_ = get_backend()
-            expected_main = tensorlib.astensor([self._make_main_pdf(pars).expected_data()])
-            aux_data      = tensorlib.astensor([self._make_constraint_pdf(pars).expected_data()])
+        def expected_data(self, pars, include_auxdata=True):
+            tensorlib, _ = get_backend()
+            expected_main = tensorlib.astensor(
+                [self._make_main_pdf(pars).expected_data()]
+            )
+            aux_data = tensorlib.astensor(
+                [self._make_constraint_pdf(pars).expected_data()]
+            )
             if not include_auxdata:
                 return expected_main
-            return tensorlib.concatenate([expected_main,aux_data])
+            return tensorlib.concatenate([expected_main, aux_data])
 
-        def logpdf(self,pars,data):
-            tensorlib,_ = get_backend()
+        def logpdf(self, pars, data):
+            tensorlib, _ = get_backend()
             maindata, auxdata = data
-            main =  self._make_main_pdf(pars).log_prob(maindata)
+            main = self._make_main_pdf(pars).log_prob(maindata)
             constraint = self._make_constraint_pdf(pars).log_prob(auxdata)
             return tensorlib.astensor([main + constraint])
 
-    m = NonPyhfModel([5,50,7])
-    print(pyhf.infer.hypotest(1.0,m.expected_data(m.config.suggested_init()),m))
+    m = NonPyhfModel([5, 50, 7])
+    print(pyhf.infer.hypotest(1.0, m.expected_data(m.config.suggested_init()), m))

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -142,4 +142,5 @@ def test_inferapi_pyhf_independence():
             return tensorlib.astensor([main + constraint])
 
     model = NonPyhfModel([5, 50, 7])
-    print(pyhf.infer.hypotest(1.0, model.expected_data(model.config.suggested_init()), model))
+    cls = pyhf.infer.hypotest(1.0, model.expected_data(model.config.suggested_init()), model)
+    assert np.isclose(cls[0],0.61564114)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -141,5 +141,5 @@ def test_inferapi_pyhf_independence():
             constraint = self._make_constraint_pdf(pars).log_prob(auxdata)
             return tensorlib.astensor([main + constraint])
 
-    m = NonPyhfModel([5, 50, 7])
-    print(pyhf.infer.hypotest(1.0, m.expected_data(m.config.suggested_init()), m))
+    model = NonPyhfModel([5, 50, 7])
+    print(pyhf.infer.hypotest(1.0, model.expected_data(model.config.suggested_init()), model))

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1,6 +1,6 @@
 import pytest
 import pyhf
-
+import numpy as np
 
 @pytest.fixture(scope='module')
 def hypotest_args():
@@ -143,4 +143,5 @@ def test_inferapi_pyhf_independence():
 
     model = NonPyhfModel([5, 50, 7])
     cls = pyhf.infer.hypotest(1.0, model.expected_data(model.config.suggested_init()), model)
-    assert np.isclose(cls[0],0.61564114)
+    
+    assert np.isclose(cls[0],0.7267836451638846)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -2,6 +2,7 @@ import pytest
 import pyhf
 import numpy as np
 
+
 @pytest.fixture(scope='module')
 def hypotest_args():
     pdf = pyhf.simplemodels.hepdata_like(
@@ -142,6 +143,8 @@ def test_inferapi_pyhf_independence():
             return tensorlib.astensor([main + constraint])
 
     model = NonPyhfModel([5, 50, 7])
-    cls = pyhf.infer.hypotest(1.0, model.expected_data(model.config.suggested_init()), model)
-    
-    assert np.isclose(cls[0],0.7267836451638846)
+    cls = pyhf.infer.hypotest(
+        1.0, model.expected_data(model.config.suggested_init()), model
+    )
+
+    assert np.isclose(cls[0], 0.7267836451638846)


### PR DESCRIPTION
# Description

this is a test that pyhf.infer.hypotest is really independent of pyhf. This is basically preparing a out-sourcing of the inference package

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add test that pyhf.infer.hypotest is independent of pyhf to ensure that inference is decoupled
```