### PR TITLE
fix: Add key to workflow dictionary to make it valid JavaScript

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -103,7 +103,7 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           github.issues.createComment({...context.issue, body: ":cry: Something went wrong. I am not able to push. Check the [Actions pipeline](https://github.com/${{ github.repository }}/actions?query=workflow%3A%22Tag+Creator%22) to see what happened. If you make any more changes, you probably want to re-trigger me again by adding the `bumpversion/${{ env['BV_PART'] }}` label again."})
-          github.issues.removeLabel({...context.issue, "bumpversion/${{ env['BV_PART'] }}" })
+          github.issues.removeLabel({...context.issue, labels: "bumpversion/${{ env['BV_PART'] }}" })
 
   always_job:
     name: Always run job


### PR DESCRIPTION
# Pull Request Description

Following up PR #770, valid JavaScript doesn't allow a single string in a dictionary, assign a key to it fix it

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Valid JavaScript doesn't allow a single string in a dictionary, assign a key to it fix it
* Amends PR #770
```
