### PR TITLE
feat: Update required_parset to pass in sample data and modifier data

### DIFF
--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -43,7 +43,7 @@ def inspect(workspace, output_file, measurement):
         (
             parname,
             modifiers.registry[result['modifiers'][parname]]
-            .required_parset(0)['paramset_type']
+            .required_parset([], [])['paramset_type']
             .__name__,
         )
         for parname in ws.parameters

--- a/src/pyhf/modifiers/__init__.py
+++ b/src/pyhf/modifiers/__init__.py
@@ -90,17 +90,17 @@ def modifier(*args, **kwargs):
     #   >>> @modifiers.modifier
     #   >>> ... class myCustomModifier(object):
     #   >>> ...   @classmethod
-    #   >>> ...   def required_parset(cls, npars): pass
+    #   >>> ...   def required_parset(cls, sample_data, modifier_data): pass
     #
     #   >>> @modifiers.modifier(name='myCustomNamer')
     #   >>> ... class myCustomModifier(object):
     #   >>> ...   @classmethod
-    #   >>> ...   def required_parset(cls, npars): pass
+    #   >>> ...   def required_parset(cls, sample_data, modifier_data): pass
     #
     #   >>> @modifiers.modifier(constrained=False)
     #   >>> ... class myUnconstrainedModifier(object):
     #   >>> ...   @classmethod
-    #   >>> ...   def required_parset(cls, npars): pass
+    #   >>> ...   def required_parset(cls, sample_data, modifier_data): pass
     #   >>> ...
     #   >>> myUnconstrainedModifier.pdf_type
     #   None
@@ -108,7 +108,7 @@ def modifier(*args, **kwargs):
     #   >>> @modifiers.modifier(constrained=True, pdf_type='poisson')
     #   >>> ... class myConstrainedCustomPoissonModifier(object):
     #   >>> ...   @classmethod
-    #   >>> ...   def required_parset(cls, npars): pass
+    #   >>> ...   def required_parset(cls, sample_data, modifier_data): pass
     #   >>> ...
     #   >>> myConstrainedCustomGaussianModifier.pdf_type
     #   'poisson'
@@ -116,12 +116,12 @@ def modifier(*args, **kwargs):
     #   >>> @modifiers.modifier(constrained=True)
     #   >>> ... class myCustomModifier(object):
     #   >>> ...   @classmethod
-    #   >>> ...   def required_parset(cls, npars): pass
+    #   >>> ...   def required_parset(cls, sample_data, modifier_data): pass
     #
     #   >>> @modifiers.modifier(op_code='multiplication')
     #   >>> ... class myMultiplierModifier(object):
     #   >>> ...   @classmethod
-    #   >>> ...   def required_parset(cls, npars): pass
+    #   >>> ...   def required_parset(cls, sample_data, modifier_data): pass
     #   >>> ...
     #   >>> myMultiplierModifier.op_code
     #   'multiplication'

--- a/src/pyhf/modifiers/histosys.py
+++ b/src/pyhf/modifiers/histosys.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 @modifier(name='histosys', constrained=True, op_code='addition')
 class histosys(object):
     @classmethod
-    def required_parset(cls, n_parameters):
+    def required_parset(cls, sample_data, modifier_data):
         return {
             'paramset_type': constrained_by_normal,
             'n_parameters': 1,

--- a/src/pyhf/modifiers/lumi.py
+++ b/src/pyhf/modifiers/lumi.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 @modifier(name='lumi', constrained=True, pdf_type='normal', op_code='multiplication')
 class lumi(object):
     @classmethod
-    def required_parset(cls, n_parameters):
+    def required_parset(cls, sample_data, modifier_data):
         return {
             'paramset_type': constrained_by_normal,
             'n_parameters': 1,

--- a/src/pyhf/modifiers/normfactor.py
+++ b/src/pyhf/modifiers/normfactor.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 @modifier(name='normfactor', op_code='multiplication')
 class normfactor(object):
     @classmethod
-    def required_parset(cls, n_parameters):
+    def required_parset(cls, sample_data, modifier_data):
         return {
             'paramset_type': unconstrained,
             'n_parameters': 1,

--- a/src/pyhf/modifiers/normsys.py
+++ b/src/pyhf/modifiers/normsys.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 @modifier(name='normsys', constrained=True, op_code='multiplication')
 class normsys(object):
     @classmethod
-    def required_parset(cls, n_parameters):
+    def required_parset(cls, sample_data, modifier_data):
         return {
             'paramset_type': constrained_by_normal,
             'n_parameters': 1,

--- a/src/pyhf/modifiers/shapefactor.py
+++ b/src/pyhf/modifiers/shapefactor.py
@@ -10,15 +10,15 @@ log = logging.getLogger(__name__)
 @modifier(name='shapefactor', op_code='multiplication')
 class shapefactor(object):
     @classmethod
-    def required_parset(cls, n_parameters):
+    def required_parset(cls, sample_data, modifier_data):
         return {
             'paramset_type': unconstrained,
-            'n_parameters': n_parameters,
+            'n_parameters': len(sample_data),
             'modifier': cls.__name__,
             'is_constrained': cls.is_constrained,
             'is_shared': True,
-            'inits': (1.0,) * n_parameters,
-            'bounds': ((0.0, 10.0),) * n_parameters,
+            'inits': (1.0,) * len(sample_data),
+            'bounds': ((0.0, 10.0),) * len(sample_data),
         }
 
 

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -12,19 +12,19 @@ log = logging.getLogger(__name__)
 )
 class shapesys(object):
     @classmethod
-    def required_parset(cls, n_parameters):
+    def required_parset(cls, sample_data, modifier_data):
         return {
             'paramset_type': constrained_by_poisson,
-            'n_parameters': n_parameters,
+            'n_parameters': len(sample_data),
             'modifier': cls.__name__,
             'is_constrained': cls.is_constrained,
             'is_shared': False,
-            'inits': (1.0,) * n_parameters,
-            'bounds': ((1e-10, 10.0),) * n_parameters,
+            'inits': (1.0,) * len(sample_data),
+            'bounds': ((1e-10, 10.0),) * len(sample_data),
             # nb: auxdata/factors set by finalize. Set to non-numeric to crash
             # if we fail to set auxdata/factors correctly
-            'auxdata': (None,) * n_parameters,
-            'factors': (None,) * n_parameters,
+            'auxdata': (None,) * len(sample_data),
+            'factors': (None,) * len(sample_data),
         }
 
 

--- a/src/pyhf/modifiers/staterror.py
+++ b/src/pyhf/modifiers/staterror.py
@@ -10,16 +10,16 @@ log = logging.getLogger(__name__)
 @modifier(name='staterror', constrained=True, op_code='multiplication')
 class staterror(object):
     @classmethod
-    def required_parset(cls, n_parameters):
+    def required_parset(cls, sample_data, modifier_data):
         return {
             'paramset_type': constrained_by_normal,
-            'n_parameters': n_parameters,
+            'n_parameters': len(sample_data),
             'modifier': cls.__name__,
             'is_constrained': cls.is_constrained,
             'is_shared': True,
-            'inits': (1.0,) * n_parameters,
-            'bounds': ((1e-10, 10.0),) * n_parameters,
-            'auxdata': (1.0,) * n_parameters,
+            'inits': (1.0,) * len(sample_data),
+            'bounds': ((1e-10, 10.0),) * len(sample_data),
+            'auxdata': (1.0,) * len(sample_data),
         }
 
 

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -39,7 +39,7 @@ def _paramset_requirements_from_channelspec(spec, channel_nbins):
                 try:
                     paramset_requirements = modifiers.registry[
                         modifier_def['type']
-                    ].required_parset(len(sample['data']))
+                    ].required_parset(sample['data'], modifier_def['data'])
                 except KeyError:
                     log.exception(
                         'Modifier not implemented yet (processing {0:s}). Available modifiers: {1}'.format(

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -36,7 +36,7 @@ def test_modifiers_structure():
     @modifier(name='myUnconstrainedModifier')
     class myCustomModifier(object):
         @classmethod
-        def required_parset(cls, n_parameters):
+        def required_parset(cls, sample_data, modifier_data):
             pass
 
     assert inspect.isclass(myCustomModifier)
@@ -48,7 +48,7 @@ def test_modifiers_structure():
     @modifier(name='myConstrainedModifier', constrained=True)
     class myCustomModifier(object):
         @classmethod
-        def required_parset(cls, n_parameters):
+        def required_parset(cls, sample_data, modifier_data):
             pass
 
     assert inspect.isclass(myCustomModifier)
@@ -65,7 +65,7 @@ def test_modifier_name_auto():
     @modifier
     class myCustomModifier(object):
         @classmethod
-        def required_parset(cls, n_parameters):
+        def required_parset(cls, sample_data, modifier_data):
             pass
 
     assert inspect.isclass(myCustomModifier)
@@ -81,7 +81,7 @@ def test_modifier_name_auto_withkwargs():
     @modifier(name=None, constrained=False)
     class myCustomModifier(object):
         @classmethod
-        def required_parset(cls, n_parameters):
+        def required_parset(cls, sample_data, modifier_data):
             pass
 
     assert inspect.isclass(myCustomModifier)
@@ -97,7 +97,7 @@ def test_modifier_name_custom():
     @modifier(name='myCustomName')
     class myCustomModifier(object):
         @classmethod
-        def required_parset(cls, n_parameters):
+        def required_parset(cls, sample_data, modifier_data):
             pass
 
     assert inspect.isclass(myCustomModifier)
@@ -144,7 +144,7 @@ def test_registry_name_clash():
 
         class myCustomModifier(object):
             @classmethod
-            def required_parset(cls, n_parameters):
+            def required_parset(cls, sample_data, modifier_data):
                 pass
 
         pyhf.modifiers.add_to_registry(myCustomModifier, 'histosys')


### PR DESCRIPTION
# Pull Request Description

This is related to a few issues on shapesys, but overall, we need to be able to hav ethe fine-control/fine-tuning to mask individual bins of a given parameter.

Resolves #773.

- Poisson(0) is undefined
- Poisson(1/0) is poorly defined
- we don't like 1/0 or similarly asymptotic values
- sometimes an analysis with n-bins in a channel defines a shapesys with data value = 0 somewhere -- maybe all bins -- maybe one bin
- and sometimes an analysis has a sample with 0 expected events (poor stats)
- shapesys sucks in this cases, and ROOT prunes out these cases, but we don't
- so we should
- the PR is the first step by expanding the api to pass around more information so we can handle it.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Modify required_parset API to allow sample data and modifier data to be passed through
```
