### PR TITLE
feat: Only allocate shapesys parameter if yield and uncrt are positive, nonzero

### DIFF
--- a/docs/likelihood.rst
+++ b/docs/likelihood.rst
@@ -132,7 +132,27 @@ shown below:
 
    { "name": "mod_name", "type": "shapesys", "data": [1.0, 1.5, 2.0] }
 
-An example of an uncorrelated shape modifier with three absolute uncertainty terms for a 3-bin channel.
+An example of an uncorrelated shape modifier with three absolute uncertainty
+terms for a 3-bin channel.
+
+.. warning::
+
+   Nuisance parameters will not be allocated for any bins where either
+
+     * the samples nominal expected rate is zero, or
+     * the absolute uncertainty is zero.
+
+   These values are, in the context of uncorrelated shape uncertainties,
+   unphysical. If this situation occurs, one needs to go back and understand
+   the inputs as this is undefined behavior in HistFactory.
+
+The previous example will allocate three nuisance parameters for ``mod_name``.
+The following example will allocate only two nuisance parameters for a 3-bin
+channel:
+
+.. code:: json
+
+   { "name": "mod_name", "type": "shapesys", "data": [1.0, 0.0, 2.0] }
 
 Correlated Shape (histosys)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -93,14 +93,14 @@ class shapesys_combined(object):
                     len(batch_access)
                 )
                 singular_sample_index = [
-                    i
-                    for i, x in enumerate(
+                    idx
+                    for idx, syst in enumerate(
                         default_backend.astensor(self._shapesys_mask)[s, :, 0]
                     )
-                    if any(x)
+                    if any(syst)
                 ][-1]
-                this_sample_mask = self._shapesys_mask[s][singular_sample_index][0]
-                access_field_for_syst_and_batch[this_sample_mask] = selection
+                sample_mask = self._shapesys_mask[s][singular_sample_index][0]
+                access_field_for_syst_and_batch[sample_mask] = selection
                 self._access_field[s, t] = access_field_for_syst_and_batch
 
     def _precompute(self):

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -78,7 +78,7 @@ class shapesys_combined(object):
             for t, batch_access in enumerate(syst_access):
                 selection = self.param_viewer.index_selection[s][t]
                 access_field_for_syst_and_batch = default_backend.astensor(
-                    [-1] * len(batch_access)
+                    [0] * len(batch_access)
                 )
                 singular_sample_index = [
                     i

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -73,6 +73,8 @@ class shapesys_combined(object):
         # now overwrite with right index in parameter
 
         for s, syst_access in enumerate(self._access_field):
+            if not pdfconfig.param_set(self._shapesys_mods[s]).n_parameters:
+                continue
             for t, batch_access in enumerate(syst_access):
                 selection = self.param_viewer.index_selection[s][t]
                 access_field_for_syst_and_batch = default_backend.astensor(
@@ -105,6 +107,8 @@ class shapesys_combined(object):
 
     def finalize(self, pdfconfig):
         for uncert_this_mod, pname in zip(self.__shapesys_uncrt, self._shapesys_mods):
+            if not pdfconfig.param_set(pname).n_parameters:
+                continue
             unc_nom = default_backend.astensor(
                 [x for x in uncert_this_mod[:, :, :] if any(x[0][x[0] > 0])]
             )

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -74,12 +74,12 @@ class shapesys_combined(object):
         # access field is shape (sys, batch, globalbin)
 
         # reindex it based on current masking
-        self._reindex_access_field()
+        self._reindex_access_field(pdfconfig)
 
         self._precompute()
         events.subscribe('tensorlib_changed')(self._precompute)
 
-    def _reindex_access_field(self):
+    def _reindex_access_field(self, pdfconfig):
         # access field maps to bin index, but needs to map to right index in
         # the parameter set
         for s, syst_access in enumerate(self._access_field):

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -121,7 +121,6 @@ class shapesys_combined(object):
 
             factors = numerator / denominator
             factors = factors[factors > 0]
-            self.factors = factors
             assert len(factors) == pdfconfig.param_set(pname).n_parameters
             pdfconfig.param_set(pname).factors = default_backend.tolist(factors)
             pdfconfig.param_set(pname).auxdata = default_backend.tolist(factors)

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -13,8 +13,8 @@ log = logging.getLogger(__name__)
 class shapesys(object):
     @classmethod
     def required_parset(cls, sample_data, modifier_data):
-        what = [(x > 0 and y > 0) for x, y in zip(modifier_data, sample_data)]
-        npars = sum(what)
+        valid_bins = [(x > 0 and y > 0) for x, y in zip(modifier_data, sample_data)]
+        npars = sum(valid_bins)
         return {
             'paramset_type': constrained_by_poisson,
             'n_parameters': npars,
@@ -75,13 +75,15 @@ class shapesys_combined(object):
         for s, syst_access in enumerate(self._access_field):
             for t, batch_access in enumerate(syst_access):
                 selection = self.param_viewer.index_selection[s][t]
-                what = default_backend.astensor([-1] * len(batch_access))
+                access_field_for_syst_and_batch = default_backend.astensor(
+                    [-1] * len(batch_access)
+                )
                 singular_sample_index = [
                     i for i, x in enumerate(self._shapesys_mask[s][0]) if any(x)
                 ][-1]
                 this_sample_mask = self._shapesys_mask[s][0][singular_sample_index]
-                what[this_sample_mask] = selection
-                self._access_field[s, t] = what
+                access_field_for_syst_and_batch[this_sample_mask] = selection
+                self._access_field[s, t] = access_field_for_syst_and_batch
         self._precompute()
         events.subscribe('tensorlib_changed')(self._precompute)
 

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -79,9 +79,10 @@ class shapesys_combined(object):
         self._precompute()
         events.subscribe('tensorlib_changed')(self._precompute)
 
-        for s, syst_access in enumerate(self._access_field):
-            if not pdfconfig.param_set(self._shapesys_mods[s]).n_parameters:
-                self._access_field[s] = 0
+    def _reindex_access_field(self, pdfconfig):
+        for syst_index, syst_access in enumerate(self._access_field):
+            if not pdfconfig.param_set(self._shapesys_mods[syst_index]).n_parameters:
+                self._access_field[syst_index] = 0
                 continue
             for batch_index, batch_access in enumerate(syst_access):
                 selection = self.param_viewer.index_selection[syst_index][batch_index]

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -77,13 +77,11 @@ class shapesys_combined(object):
         #here access field maps to bin index
         #now overwrite with right index in parameter
 
-        import numpy as np
-
         for s, syst_access in enumerate(self._access_field):
             for t, batch_access in enumerate(syst_access):
                 selection = self.param_viewer.index_selection[s][t]
                 what = default_backend.astensor([-1]*len(batch_access))
-                singular_sample_index = np.argsort(np.any(self._shapesys_mask[s][0],axis=1))[-1]
+                singular_sample_index = [i for i,x in enumerate(self._shapesys_mask[s][0]) if any(x)][-1]
                 this_sample_mask = self._shapesys_mask[s][0][singular_sample_index]
                 what[this_sample_mask] = selection
                 self._access_field[s,t] = what

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -79,13 +79,9 @@ class shapesys_combined(object):
         self._precompute()
         events.subscribe('tensorlib_changed')(self._precompute)
 
-    def _reindex_access_field(self, pdfconfig):
-        # access field maps to bin index, but needs to map to right index in
-        # the parameter set
-        for syst_index, syst_access in enumerate(self._access_field):
-            # if the associated shapesys modifier has no parameters (no valid
-            # bins), skip it
-            if not pdfconfig.param_set(self._shapesys_mods[syst_index]).n_parameters:
+        for s, syst_access in enumerate(self._access_field):
+            if not pdfconfig.param_set(self._shapesys_mods[s]).n_parameters:
+                self._access_field[s] = 0
                 continue
             for batch_index, batch_access in enumerate(syst_access):
                 selection = self.param_viewer.index_selection[syst_index][batch_index]
@@ -159,7 +155,6 @@ class shapesys_combined(object):
         else:
             flat_pars = tensorlib.reshape(pars, (-1,))
         shapefactors = tensorlib.gather(flat_pars, self.access_field)
-
         results_shapesys = tensorlib.einsum(
             'mab,s->msab', shapefactors, self.sample_ones
         )

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -82,26 +82,28 @@ class shapesys_combined(object):
     def _reindex_access_field(self, pdfconfig):
         # access field maps to bin index, but needs to map to right index in
         # the parameter set
-        for s, syst_access in enumerate(self._access_field):
+        for syst_index, syst_access in enumerate(self._access_field):
             # if the associated shapesys modifier has no parameters (no valid
             # bins), skip it
-            if not pdfconfig.param_set(self._shapesys_mods[s]).n_parameters:
+            if not pdfconfig.param_set(self._shapesys_mods[syst_index]).n_parameters:
                 continue
-            for t, batch_access in enumerate(syst_access):
-                selection = self.param_viewer.index_selection[s][t]
+            for batch_index, batch_access in enumerate(syst_access):
+                selection = self.param_viewer.index_selection[syst_index][batch_index]
                 access_field_for_syst_and_batch = default_backend.zeros(
                     len(batch_access)
                 )
                 singular_sample_index = [
                     idx
                     for idx, syst in enumerate(
-                        default_backend.astensor(self._shapesys_mask)[s, :, 0]
+                        default_backend.astensor(self._shapesys_mask)[syst_index, :, 0]
                     )
                     if any(syst)
                 ][-1]
-                sample_mask = self._shapesys_mask[s][singular_sample_index][0]
+                sample_mask = self._shapesys_mask[syst_index][singular_sample_index][0]
                 access_field_for_syst_and_batch[sample_mask] = selection
-                self._access_field[s, t] = access_field_for_syst_and_batch
+                self._access_field[
+                    syst_index, batch_index
+                ] = access_field_for_syst_and_batch
 
     def _precompute(self):
         tensorlib, _ = get_backend()

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -13,18 +13,20 @@ log = logging.getLogger(__name__)
 class shapesys(object):
     @classmethod
     def required_parset(cls, sample_data, modifier_data):
+
+        npars = sum([1 for x, y in zip(modifier_data, sample_data) if x > 0 and y > 0])
         return {
             'paramset_type': constrained_by_poisson,
-            'n_parameters': len(sample_data),
+            'n_parameters': npars,
             'modifier': cls.__name__,
             'is_constrained': cls.is_constrained,
             'is_shared': False,
-            'inits': (1.0,) * len(sample_data),
-            'bounds': ((1e-10, 10.0),) * len(sample_data),
+            'inits': (1.0,) * npars,
+            'bounds': ((1e-10, 10.0),) * npars,
             # nb: auxdata/factors set by finalize. Set to non-numeric to crash
             # if we fail to set auxdata/factors correctly
-            'auxdata': (None,) * len(sample_data),
-            'factors': (None,) * len(sample_data),
+            'auxdata': (None,) * npars,
+            'factors': (None,) * npars,
         }
 
 

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -13,20 +13,24 @@ log = logging.getLogger(__name__)
 class shapesys(object):
     @classmethod
     def required_parset(cls, sample_data, modifier_data):
-        valid_bins = [(x > 0 and y > 0) for x, y in zip(modifier_data, sample_data)]
-        npars = sum(valid_bins)
+        # count the number of bins with nonzero, positive yields
+        valid_bins = [
+            (sample_bin > 0 and modifier_bin > 0)
+            for sample_bin, modifier_bin in zip(modifier_data, sample_data)
+        ]
+        n_parameters = sum(valid_bins)
         return {
             'paramset_type': constrained_by_poisson,
-            'n_parameters': npars,
+            'n_parameters': n_parameters,
             'modifier': cls.__name__,
             'is_constrained': cls.is_constrained,
             'is_shared': False,
-            'inits': (1.0,) * npars,
-            'bounds': ((1e-10, 10.0),) * npars,
+            'inits': (1.0,) * n_parameters,
+            'bounds': ((1e-10, 10.0),) * n_parameters,
             # nb: auxdata/factors set by finalize. Set to non-numeric to crash
             # if we fail to set auxdata/factors correctly
-            'auxdata': (None,) * npars,
-            'factors': (None,) * npars,
+            'auxdata': (None,) * n_parameters,
+            'factors': (None,) * n_parameters,
         }
 
 

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -79,9 +79,13 @@ class shapesys_combined(object):
                     [-1] * len(batch_access)
                 )
                 singular_sample_index = [
-                    i for i, x in enumerate(self._shapesys_mask[s][0]) if any(x)
+                    i
+                    for i, x in enumerate(
+                        default_backend.astensor(self._shapesys_mask)[s, :, 0]
+                    )
+                    if any(x)
                 ][-1]
-                this_sample_mask = self._shapesys_mask[s][0][singular_sample_index]
+                this_sample_mask = self._shapesys_mask[s][singular_sample_index][0]
                 access_field_for_syst_and_batch[this_sample_mask] = selection
                 self._access_field[s, t] = access_field_for_syst_and_batch
         self._precompute()

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -43,10 +43,7 @@ class shapesys_combined(object):
         )
 
         self._shapesys_mask = [
-            [
-                [mega_mods[m][s]['data']['mask']
-            ] for s in pdfconfig.samples]
-            for m in keys
+            [[mega_mods[m][s]['data']['mask']] for s in pdfconfig.samples] for m in keys
         ]
         self.__shapesys_uncrt = default_backend.astensor(
             [
@@ -63,9 +60,7 @@ class shapesys_combined(object):
         self.finalize(pdfconfig)
 
         global_concatenated_bin_indices = [
-            [
-                [j for c in pdfconfig.channels for j in range(pdfconfig.channel_nbins[c])]
-            ]
+            [[j for c in pdfconfig.channels for j in range(pdfconfig.channel_nbins[c])]]
         ]
 
         self._access_field = default_backend.tile(
@@ -74,17 +69,19 @@ class shapesys_combined(object):
         )
         # access field is shape (sys, batch, globalbin)
 
-        #here access field maps to bin index
-        #now overwrite with right index in parameter
+        # here access field maps to bin index
+        # now overwrite with right index in parameter
 
         for s, syst_access in enumerate(self._access_field):
             for t, batch_access in enumerate(syst_access):
                 selection = self.param_viewer.index_selection[s][t]
-                what = default_backend.astensor([-1]*len(batch_access))
-                singular_sample_index = [i for i,x in enumerate(self._shapesys_mask[s][0]) if any(x)][-1]
+                what = default_backend.astensor([-1] * len(batch_access))
+                singular_sample_index = [
+                    i for i, x in enumerate(self._shapesys_mask[s][0]) if any(x)
+                ][-1]
                 this_sample_mask = self._shapesys_mask[s][0][singular_sample_index]
                 what[this_sample_mask] = selection
-                self._access_field[s,t] = what
+                self._access_field[s, t] = what
         self._precompute()
         events.subscribe('tensorlib_changed')(self._precompute)
 
@@ -145,7 +142,6 @@ class shapesys_combined(object):
         results_shapesys = tensorlib.einsum(
             'mab,s->msab', shapefactors, self.sample_ones
         )
-
 
         results_shapesys = tensorlib.where(
             self.shapesys_mask, results_shapesys, self.shapesys_default

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -188,7 +188,7 @@ def _nominal_and_modifiers_from_spec(config, spec):
                     )  # broadcasting
                 elif mtype in ['shapesys', 'staterror']:
                     uncrt = thismod['data'] if thismod else [0.0] * len(nom)
-                    maskval = [True if thismod else False] * len(nom)
+                    maskval = [(x > 0 and y > 0) for x, y in zip(uncrt, nom)]
                     mega_mods[key][s]['data']['mask'] += maskval
                     mega_mods[key][s]['data']['uncrt'] += uncrt
                     mega_mods[key][s]['data']['nom_data'] += nom

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -188,7 +188,10 @@ def _nominal_and_modifiers_from_spec(config, spec):
                     )  # broadcasting
                 elif mtype in ['shapesys', 'staterror']:
                     uncrt = thismod['data'] if thismod else [0.0] * len(nom)
-                    maskval = [(x > 0 and y > 0) for x, y in zip(uncrt, nom)]
+                    if mtype == 'shapesys':
+                        maskval = [(x > 0 and y > 0) for x, y in zip(uncrt, nom)]
+                    else:
+                        maskval = [True if thismod else False] * len(nom)
                     mega_mods[key][s]['data']['mask'] += maskval
                     mega_mods[key][s]['data']['uncrt'] += uncrt
                     mega_mods[key][s]['data']['nom_data'] += nom

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -229,7 +229,7 @@ def test_pdf_integration_shapesys_zeros(backend):
     assert pytest.approx(tensorlib.tolist(par_set_syst.factors)) == tensorlib.tolist(
         tensorlib.gather(factors, indices)
     )
-    assert getattr(par_set_syst_lowstats, 'factors', None) == None
+    assert getattr(par_set_syst_lowstats, 'factors', None) is None
 
 
 @pytest.mark.only_numpy

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -182,6 +182,56 @@ def test_pdf_integration_staterror(backend):
     )
 
 
+def test_pdf_integration_shapesys_zeros(backend):
+    spec = {
+        "channels": [
+            {
+                "name": "channel1",
+                "samples": [
+                    {
+                        "data": [20.0, 10.0, 5.0, 3.0, 2.0, 1.0],
+                        "modifiers": [
+                            {"data": None, "name": "mu", "type": "normfactor"}
+                        ],
+                        "name": "signal",
+                    },
+                    {
+                        "data": [100.0, 90, 0.0, 70, 0.1, 50],
+                        "modifiers": [
+                            {
+                                "data": [10, 9, 1, 0.0, 0.1, 5],
+                                "name": "syst",
+                                "type": "shapesys",
+                            },
+                            {
+                                "data": [0, 0, 0, 0, 0, 0],
+                                "name": "syst_lowstats",
+                                "type": "shapesys",
+                            },
+                        ],
+                        "name": "background1",
+                    },
+                ],
+            }
+        ]
+    }
+    pdf = pyhf.Model(spec)
+    par_set_syst = pdf.config.param_set('syst')
+    par_set_syst_lowstats = pdf.config.param_set('syst_lowstats')
+
+    assert par_set_syst.n_parameters == 4
+    assert par_set_syst_lowstats.n_parameters == 0
+    tensorlib, _ = backend
+    nominal_sq = tensorlib.power(tensorlib.astensor([100.0, 90, 0.0, 70, 0.1, 50]), 2)
+    uncerts_sq = tensorlib.power(tensorlib.astensor([10, 9, 1, 0.0, 0.1, 5]), 2)
+    factors = tensorlib.divide(nominal_sq, uncerts_sq)
+    indices = tensorlib.astensor([0, 1, 4, 5], dtype='int')
+    assert pytest.approx(tensorlib.tolist(par_set_syst.factors)) == tensorlib.tolist(
+        tensorlib.gather(factors, indices)
+    )
+    assert getattr(par_set_syst_lowstats, 'factors', None) == None
+
+
 @pytest.mark.only_numpy
 def test_pdf_integration_histosys(backend):
     source = json.load(open('validation/data/2bin_histosys_example2.json'))

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -918,7 +918,6 @@ def test_shapesys_nuisparfilter_validation():
     obs, exp = pyhf.infer.hypotest(1.0, d, m, return_expected_set=True)
     pyhf_results = {'CLs_obs': obs[0], 'CLs_exp': [e[0] for e in exp]}
 
-
     assert np.allclose(
         reference_root_results['CLs_obs'], pyhf_results['CLs_obs'], atol=1e-4, rtol=1e-5
     )

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -4,6 +4,7 @@ import pyhf.readxml
 import json
 import pytest
 import os
+import numpy as np
 
 
 @pytest.fixture(scope='module')
@@ -917,7 +918,6 @@ def test_shapesys_nuisparfilter_validation():
     obs, exp = pyhf.infer.hypotest(1.0, d, m, return_expected_set=True)
     pyhf_results = {'CLs_obs': obs[0], 'CLs_exp': [e[0] for e in exp]}
 
-    import numpy as np
 
     assert np.allclose(
         reference_root_results['CLs_obs'], pyhf_results['CLs_obs'], atol=1e-4, rtol=1e-5

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -847,34 +847,64 @@ def test_import_roundtrip(tmpdir, toplvl, basedir):
     for result, expected_result in zip(CLs_exp_set_after, CLs_exp_set_before):
         assert abs(result - expected_result) / expected_result < tolerance
 
+
 def test_shapesys_nuisparfilter_validation():
     reference_root_results = {
         "CLs_exp": [
-            2.702197937866914e-05, 
-            0.00037099917612576155, 
-            0.004360634386335687, 
-            0.03815031509701916, 
-            0.20203027564155074
-        ], 
-        "CLs_obs": 0.004360634405484502
-    }    
+            2.702197937866914e-05,
+            0.00037099917612576155,
+            0.004360634386335687,
+            0.03815031509701916,
+            0.20203027564155074,
+        ],
+        "CLs_obs": 0.004360634405484502,
+    }
     null = None
-    spec = {"channels":[
-        {
-            "name":"channel1",
-            "samples":[
-                {"data":[20,10],"modifiers":[{"data":null,"name":"SigXsecOverSM","type":"normfactor"}],"name":"signal"},
-                {"data":[100,10],"modifiers":[{"data":[10,0],"name":"syst","type":"shapesys"}],"name":"background1"}
-            ]
-        }],
-        "measurements":[
-            {"config":{
-                "parameters":[{"auxdata":[1],"bounds":[[0.5,1.5]],"inits":[1],"name":"lumi","sigmas":[0.1]}],
-                "poi":"SigXsecOverSM"},"name":"GaussExample"
+    spec = {
+        "channels": [
+            {
+                "name": "channel1",
+                "samples": [
+                    {
+                        "data": [20, 10],
+                        "modifiers": [
+                            {
+                                "data": null,
+                                "name": "SigXsecOverSM",
+                                "type": "normfactor",
+                            }
+                        ],
+                        "name": "signal",
+                    },
+                    {
+                        "data": [100, 10],
+                        "modifiers": [
+                            {"data": [10, 0], "name": "syst", "type": "shapesys"}
+                        ],
+                        "name": "background1",
+                    },
+                ],
             }
         ],
-        "observations":[{"data":[100,10],"name":"channel1"}],
-        "version":"1.0.0"
+        "measurements": [
+            {
+                "config": {
+                    "parameters": [
+                        {
+                            "auxdata": [1],
+                            "bounds": [[0.5, 1.5]],
+                            "inits": [1],
+                            "name": "lumi",
+                            "sigmas": [0.1],
+                        }
+                    ],
+                    "poi": "SigXsecOverSM",
+                },
+                "name": "GaussExample",
+            }
+        ],
+        "observations": [{"data": [100, 10], "name": "channel1"}],
+        "version": "1.0.0",
     }
     w = pyhf.Workspace(spec)
     m = w.model(
@@ -884,9 +914,14 @@ def test_shapesys_nuisparfilter_validation():
         },
     )
     d = w.data(m)
-    obs,exp = pyhf.infer.hypotest(1.0,d,m,return_expected_set = True)
+    obs, exp = pyhf.infer.hypotest(1.0, d, m, return_expected_set=True)
     pyhf_results = {'CLs_obs': obs[0], 'CLs_exp': [e[0] for e in exp]}
 
     import numpy as np
-    assert np.allclose(reference_root_results['CLs_obs'],pyhf_results['CLs_obs'],atol = 1e-4, rtol = 1e-5)
-    assert np.allclose(reference_root_results['CLs_exp'],pyhf_results['CLs_exp'],atol = 1e-4, rtol = 1e-5)
+
+    assert np.allclose(
+        reference_root_results['CLs_obs'], pyhf_results['CLs_obs'], atol=1e-4, rtol=1e-5
+    )
+    assert np.allclose(
+        reference_root_results['CLs_exp'], pyhf_results['CLs_exp'], atol=1e-4, rtol=1e-5
+    )


### PR DESCRIPTION
# Description

from discussions with @kratsg this fixes shapesys by only allocating nuisance parameters for bins in shapesys where the yield and the uncrt is > 0


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
- improve handling of shapesys by only allocating nuisance parameters for valid, physically meaningful bins (yield and uncertainty are nonzero and positive)
- add documentation about this particular "feature" of shapesys
```