### PR TITLE
docs: remove misplaced equal sign

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -91,7 +91,7 @@ equally.  For constrained modifiers, the implied constraint term is given as
 well as the necessary input data required to construct it.  :math:`\sigma_b`
 corresponds to the relative uncertainty of the event rate, whereas
 :math:`\delta_b` is the event rate uncertainty of the sample relative to the
-total event rate :math:`\nu_b = \sum_s = \nu^0_{sb}`.
+total event rate :math:`\nu_b = \sum_s \nu^0_{sb}`.
 
 Modifiers implementing uncertainties are paired with
 a corresponding default constraint term on the parameter limiting the


### PR DESCRIPTION
# Description

Fix of minor typo in documentation: Remove misplaced equal sign in equation for total background.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
- [ ] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR
