### PR TITLE
docs: Add Les Houches 2019 New Physics Working Group Report citation

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,14 +1,13 @@
-@article{Heinrich:2018nip,
-      author         = "Heinrich, Lukas and Schulz, Holger and Turner, Jessica
-                        and Zhou, Ye-Ling",
-      title          = "{Constraining A₄ Leptonic Flavour Model Parameters at
-                        Colliders and Beyond}",
-      year           = "2018",
-      eprint         = "1810.05648",
+@inproceedings{Brooijmans:2020yij,
+      author         = "Brooijmans, G. and others",
+      title          = "{Les Houches 2019 Physics at TeV Colliders: New Physics
+                        Working Group Report}",
+      year           = "2020",
+      eprint         = "2002.12220",
+      booktitle      = "",
       archivePrefix  = "arXiv",
       primaryClass   = "hep-ph",
-      SLACcitation   = "%%CITATION = ARXIV:1810.05648;%%",
-      journal = ""
+      SLACcitation   = "%%CITATION = ARXIV:2002.12220;%%"
 }
 
 @booklet{ATL-PHYS-PUB-2019-029,
@@ -23,4 +22,17 @@
       year          = "2019",
       reportNumber  = "ATL-PHYS-PUB-2019-029",
       url           = "https://cds.cern.ch/record/2684863",
+}
+
+@article{Heinrich:2018nip,
+      author         = "Heinrich, Lukas and Schulz, Holger and Turner, Jessica
+                        and Zhou, Ye-Ling",
+      title          = "{Constraining A₄ Leptonic Flavour Model Parameters at
+                        Colliders and Beyond}",
+      year           = "2018",
+      eprint         = "1810.05648",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      SLACcitation   = "%%CITATION = ARXIV:1810.05648;%%",
+      journal = ""
 }


### PR DESCRIPTION
# Description

Add citation of pyhf in the [Les Houches 2019 Physics at TeV Colliders: New Physics Working Group Report](https://inspirehep.net/record/1782722). A blank "booktitle" entry is added to the citation entry from INSPIRE-HEP avoid an error during the Sphinx build. Additionally, reorder the BibTex file to be in _reverse_ chronological order for easier referencing (by humans) &mdash; this has no effect on the output.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add citation from Les Houches 2019 Physics at TeV Colliders: New Physics Working Group Report
* Use reverse chronological ordering in the use_citations BibTeX file
```
