### PR TITLE
docs: Add list of media publications and make 'outreach' page

### DIFF
--- a/docs/bib/media.bib
+++ b/docs/bib/media.bib
@@ -1,0 +1,19 @@
+@article{CERN_News_2019,
+  title   = {{New open release allows theorists to explore LHC data in a new way}},
+  author  = {Katarina Anthony},
+  journal = {CERN News},
+  year    = {2020},
+  month   = {January},
+  day     = {9},
+  url     = {https://home.cern/news/news/knowledge-sharing/new-open-release-allows-theorists-explore-lhc-data-new-way},
+}
+
+@article{ATLAS_News_2019,
+  title   = {{New open release streamlines interactions with theoretical physicists}},
+  author  = {Katarina Anthony},
+  journal = {ATLAS News},
+  year    = {2019},
+  month   = {December},
+  day     = {12},
+  url     = {https://atlas.cern/updates/atlas-news/new-open-likelihoods},
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@
    likelihood
    learn
    examples
-   talks
+   outreach
    installation
    development
    faq

--- a/docs/outreach.rst
+++ b/docs/outreach.rst
@@ -1,5 +1,5 @@
-Talks
-=====
+Outreach
+========
 
 We are always interested in talking about :code:`pyhf`. See the abstract and a list of previously given presentations and feel free to invite us to your next conference/workshop/meeting!
 

--- a/docs/outreach.rst
+++ b/docs/outreach.rst
@@ -66,8 +66,8 @@ This list will be updated with posters presented on :code:`pyhf`:
    :all:
    :style: plain
 
-In the News
------------
+In the Media
+------------
 
 This list will be updated with media publications featuring :code:`pyhf`:
 

--- a/docs/talks.rst
+++ b/docs/talks.rst
@@ -65,3 +65,13 @@ This list will be updated with posters presented on :code:`pyhf`:
    :list: bullet
    :all:
    :style: plain
+
+In the News
+-----------
+
+This list will be updated with media publications featuring :code:`pyhf`:
+
+.. bibliography:: bib/media.bib
+   :list: bullet
+   :all:
+   :style: plain


### PR DESCRIPTION
# Description

Partially addresses Issue #736.

Adds a listing of media publications related to pyhf. This listing is added to the renamed (from "Talks") "Outreach" page.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Rename "talks" page to "outreach"
* Add listing of media publications related to pyhf to outreach page
```
