### PR TITLE
docs: Add Zenodo metadata config file

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -10,3 +10,5 @@ tag = True
 [bumpversion:file:README.md]
 
 [bumpversion:file:docs/bib/preferred.bib]
+
+[bumpversion:file:.zenodo.json]

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,37 @@
+{
+    "description": "pure-Python implementation of HistFactory models with tensors and autograd",
+    "license": "Apache-2.0",
+    "title": "scikit-hep/pyhf: v0.4.0",
+    "version": "v0.4.0",
+    "upload_type": "software",
+    "creators": [
+        {
+            "affiliation": "CERN",
+            "name": "Lukas Heinrich",
+            "orcid": "0000-0002-4048-7584"
+        },
+        {
+            "affiliation": "University of Illinois at Urbana-Champaign",
+            "name": "Matthew Feickert",
+            "orcid": "0000-0003-4124-7862"
+        },
+        {
+            "affiliation": "SCIPP, University of California, Santa Cruz",
+            "name": "Giordon Stark",
+            "orcid": "0000-0001-6616-3433"
+        }
+    ],
+    "access_right": "open",
+    "related_identifiers": [
+        {
+            "scheme": "url",
+            "identifier": "https://github.com/scikit-hep/pyhf/tree/v0.4.0",
+            "relation": "isSupplementTo"
+        },
+        {
+            "scheme": "doi",
+            "identifier": "10.5281/zenodo.1169739",
+            "relation": "isVersionOf"
+        }
+    ]
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -22,6 +22,17 @@
         }
     ],
     "access_right": "open",
+    "keywords": [
+      "physics",
+      "statistics",
+      "fitting",
+      "scipy",
+      "numpy",
+      "tensorflow",
+      "pytorch",
+      "jax",
+      "auto-differentiation"
+    ],
     "related_identifiers": [
         {
             "scheme": "url",


### PR DESCRIPTION
# Description

Thanks to the helpful information from @lnielsen, I've learned that we can control the metadata for Zenodo releases through a `.zenodo.json` file, which this PR adds. Under the "Metadata" tab on the Zenodo releases for pyhf it mentions that

> JSON Export
> Zenodo automatically extracts metadata about your repository from GitHub APIs. For example, the authors are determined from the repository's contributor statistics. The automatic extraction is **solely a best guess**. Add a `.zenodo.json` file the root of your repository to explicit define the metadata. The format of file is the same as for our REST API (use e.g. below JSON to get started).

By copying and revising the metadata for [pyhf release `v0.4.0`](https://doi.org/10.5281/zenodo.3678702) and then taking some inspiration from the [`nipype` `.zenodo.json` file](https://github.com/nipy/nipype/blob/master/.zenodo.json) to add ORCIDs and keywords I've arrived at the following file. As the release number is part of the metadata the metadata file is now also governed by `bumpversion`. The only thing that I trimmed out of the auotgenerated one is the "publication_date" field as I'm not sure how to control that through `bumpversion` or something similar.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add .zenodo.json file to control Zenodo metadata
* Add .zenodo.json to bumpversion control
```