### PR TITLE
docs: Add published HEPData likelihoods to Use and Citations page

### DIFF
--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -1,0 +1,26 @@
+@misc{ins1771533,
+    title = "{Search for chargino-neutralino production with mass splittings near the electroweak scale in three-lepton final states in $\sqrt{s}$ = 13 TeV $pp$ collisions with the ATLAS detector}",
+    doi = "10.17182/hepdata.91127",
+    url = "https://doi.org/10.17182/hepdata.91127",
+    year = "2019",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
+@misc{ins1765529,
+    title = "{Search for direct stau production in events with two hadronic $\tau$-leptons in $\sqrt{s} = 13$ TeV $pp$ collisions with the ATLAS detector}",
+    doi = "10.17182/hepdata.92006",
+    url = "https://doi.org/10.17182/hepdata.92006",
+    year = "2019",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
+@misc{ins1748602,
+    title = "{Search for bottom-squark pair production with the ATLAS detector in final states containing Higgs bosons, $b$-jets and missing transverse momentum}",
+    doi = "10.17182/hepdata.89408",
+    url = "https://doi.org/10.17182/hepdata.89408",
+    year = "2019",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}

--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -12,3 +12,13 @@ Updating list of citations and use cases of :code:`pyhf`:
    :list: bullet
    :all:
    :style: plain
+
+Published Likelihoods
+---------------------
+
+Updating list of HEPData entries for publications using ``HistFactory`` JSON likelihoods:
+
+.. bibliography:: bib/HEPData_likelihoods.bib
+   :list: bullet
+   :all:
+   :style: plain

--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -1,10 +1,16 @@
 Use and Citations
 =================
 
+Citation
+--------
+
 The preferred BibTeX entry for citation of ``pyhf`` is
 
 .. literalinclude:: bib/preferred.bib
    :language: bibtex
+
+Use in Publications
+-------------------
 
 Updating list of citations and use cases of :code:`pyhf`:
 


### PR DESCRIPTION
# Description

- Resolves #736 
- Resolves #780 

Add a listing of HEPData published likelihoods to the Use and Citations page. This PR adds the first three full likelihoods to ever be published by an LHC experiment (ATLAS):

- [Search for bottom-squark pair production with the ATLAS detector in final states containing Higgs bosons, _b_-jets and missing transverse momentum](https://www.hepdata.net/record/ins1748602)
- [Search for direct stau production in events with two hadronic τ-leptons in s√=13 TeV pp collisions with the ATLAS detector](https://www.hepdata.net/record/ins1765529)
- [Search for chargino-neutralino production with mass splittings near the electroweak scale in three-lepton final states in s√ = 13 TeV pp collisions with the ATLAS detector](https://www.hepdata.net/record/ins1771533)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add BibTeX file for HEPData publication entries with HistFactory likelihoods
* Add list of HEPData published likelihoods to Use and Citations page
```
