### PR TITLE
docs: Add FAQ on how to typeset "pyhf"

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -48,6 +48,23 @@ If you are unable to get a Python 3 runtime, versioned Docker images of ``pyhf``
 
 Once you have Python 3 installed, see the :ref:`installation` page to get started.
 
+How is ``pyhf`` typeset?
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+As you may have guessed from this page, ``pyhf`` is typeset in all lowercase.
+This is largely historical, as the core developers had just always typed it that way and it seemed a bit too short of a library name to write as ``PyHF``.
+When typesetting in LaTeX the developers recommend introducing the command
+
+    .. code-block:: latex
+
+        \newcommand{\pyhf}{\texttt{pyhf}}
+
+If the journal you are publishing in requires you to use ``textsc`` for software names it is okay to instead use
+
+    .. code-block:: latex
+
+        \newcommand{\pyhf}{\textsc{pyhf}}
+
 Troubleshooting
 ---------------
 


### PR DESCRIPTION
# Description

As a _very_ minor PR, this PR adds a FAQ on how to properly typeset the name `pyhf` [inspired by](https://twitter.com/HEPfeickert/status/1233416311541260290) the inclusion of `pyhf` in the [Les Houches 2019 Physics at TeV Colliders: New Physics Working Group Report](https://inspirehep.net/record/1782722).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add FAQ on how to typeset the name "pyhf" in journals
```
