### PR TITLE
docs: Add MadMiner citation

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -24,6 +24,23 @@
       url           = "https://cds.cern.ch/record/2684863",
 }
 
+@article{Brehmer:2019xox,
+      author         = "Brehmer, Johann and Kling, Felix and Espejo, Irina and
+                        Cranmer, Kyle",
+      title          = "{MadMiner: Machine learning-based inference for particle
+                        physics}",
+      journal        = "Comput. Softw. Big Sci.",
+      volume         = "4",
+      year           = "2020",
+      number         = "1",
+      pages          = "3",
+      doi            = "10.1007/s41781-020-0035-2",
+      eprint         = "1907.10621",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      SLACcitation   = "%%CITATION = ARXIV:1907.10621;%%"
+}
+
 @article{Heinrich:2018nip,
       author         = "Heinrich, Lukas and Schulz, Holger and Turner, Jessica
                         and Zhou, Ye-Ling",


### PR DESCRIPTION
# Description

Add citation by [MadMiner: Machine learning-based inference for particle physics](https://inspirehep.net/record/1746275) in 2019 to the citations docs page.

Thanks @johannbrehmer, @irinaespejo, @KlingFelix, and @cranmer! :)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add citation by MadMiner paper
```
