### PR TITLE
fix: Remove unneeded directory slash in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,11 +2,11 @@
 **
 
 # Except the following
-!/.git/**
-!/docker/**
-!/src/**
-!/LICENSE
-!/pyproject.toml
-!/README.md
-!/setup.cfg
-!/setup.py
+!.git/**
+!docker/**
+!src/**
+!LICENSE
+!pyproject.toml
+!README.md
+!setup.cfg
+!setup.py


### PR DESCRIPTION
# Description

Resolves #787 

As [noted here](https://github.com/docker/hub-feedback/issues/511#issuecomment-504777737), unlike GitHub Actions (and all of our local versions of Docker), the automated builds that Docker Hub runs **will not** read the `.dockerignore` the same if there are directory slashes after a `!`.

So though 

```
!/setup.py
```

is valid, Docker Hub requires

```
!setup.py
```

The docs simply note that

> [Lines starting with ! (exclamation mark) can be used to make exceptions to exclusions](https://docs.docker.com/engine/reference/builder/#dockerignore-file)

This PR amends the [`.dockerignore`](https://github.com/scikit-hep/pyhf/blob/a3082bdc9ff34c538f24eba54edf4226de6d674d/.dockerignore) added in PR #748 to be compliant with Docker Hub's rules.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove unneeded directory slash to fix Docker Hub automated build
   - Amends PR #748
```
