### PR TITLE
fix: Removes invalid property in .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -38,11 +38,6 @@
             "scheme": "url",
             "identifier": "https://github.com/scikit-hep/pyhf/tree/v0.4.1",
             "relation": "isSupplementTo"
-        },
-        {
-            "scheme": "doi",
-            "identifier": "10.5281/zenodo.1169739",
-            "relation": "isVersionOf"
         }
     ]
 }


### PR DESCRIPTION
# Description

Fixes the `.zenodo.json` file added in PR #779. This problem with the `.zenodo.json` file is there is an error in the autogenerated metadata that was copied and pasted form Zenodo in PR #779.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Removes invalid content in .zenodo.json (schema-related)
   - Amends PR #779
```