### PR TITLE
chore: Clean up schemas and fix typos in docs about schemas 

### DIFF
--- a/src/pyhf/schemas/1.0.0/defs.json
+++ b/src/pyhf/schemas/1.0.0/defs.json
@@ -2,6 +2,26 @@
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "https://scikit-hep.org/pyhf/schemas/1.0.0/defs.json",
     "definitions": {
+        "workspace": {
+          "type": "object",
+          "properties": {
+              "channels": { "type": "array", "items": {"$ref": "#/definitions/channel"}, "minItems": 1 },
+              "measurements": { "type": "array", "items": {"$ref": "#/definitions/measurement"}, "minItems": 1 },
+              "observations": { "type": "array", "items": {"$ref": "#/definitions/observation" }, "minItems": 1 },
+              "version": { "const": "1.0.0" }
+          },
+          "additionalProperties": false,
+          "required": ["channels", "measurements", "observations", "version"]
+        },
+        "model": {
+          "type": "object",
+          "properties": {
+              "channels": { "type": "array", "items": {"$ref": "#/definitions/channel"}, "minItems": 1 },
+              "parameters": { "type": "array", "items": {"$ref": "#/definitions/parameter"} }
+          },
+          "additionalProperties": false,
+          "required": ["channels"]
+        },
         "observation": {
             "type": "object",
             "properties": {

--- a/src/pyhf/schemas/1.0.0/measurement.json
+++ b/src/pyhf/schemas/1.0.0/measurement.json
@@ -1,6 +1,5 @@
 {
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "https://scikit-hep.org/pyhf/schemas/1.0.0/measurement.json",
-    "type": "object",
     "$ref": "defs.json#/definitions/measurement"
 }

--- a/src/pyhf/schemas/1.0.0/model.json
+++ b/src/pyhf/schemas/1.0.0/model.json
@@ -1,11 +1,5 @@
 {
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "https://scikit-hep.org/pyhf/schemas/1.0.0/model.json",
-    "type": "object",
-    "properties": {
-        "channels": { "type": "array", "items": {"$ref": "defs.json#/definitions/channel"}, "minItems": 1 },
-        "parameters": { "type": "array", "items": {"$ref": "defs.json#/definitions/parameter"} }
-    },
-    "additionalProperties": false,
-    "required": ["channels"]
+    "$ref": "defs.json#/definitions/model"
 }

--- a/src/pyhf/schemas/1.0.0/workspace.json
+++ b/src/pyhf/schemas/1.0.0/workspace.json
@@ -1,13 +1,5 @@
 {
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "https://scikit-hep.org/pyhf/schemas/1.0.0/workspace.json",
-    "type": "object",
-    "properties": {
-        "channels": { "type": "array", "items": {"$ref": "defs.json#/definitions/channel"}, "minItems": 1 },
-        "measurements": { "type": "array", "items": {"$ref": "defs.json#/definitions/measurement"}, "minItems": 1 },
-        "observations": { "type": "array", "items": {"$ref": "defs.json#/definitions/observation" }, "minItems": 1 },
-        "version": { "const": "1.0.0" }
-    },
-    "additionalProperties": false,
-    "required": ["channels", "measurements", "observations", "version"]
+    "$ref": "defs.json#/definitions/workspace"
 }

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -88,7 +88,7 @@ def _join_channels(join, left_channels, right_channels):
         right_channels (`list`): The right channel specification.
 
     Returns:
-        :obj:`list`: A joined list of channels. Each channel follows the :obj:`defs.json#channel` `schema <https://scikit-hep.org/pyhf/likelihood.html#channel>`__
+        :obj:`list`: A joined list of channels. Each channel follows the :obj:`defs.json#/definitions/channel` `schema <https://scikit-hep.org/pyhf/likelihood.html#channel>`__
 
     """
 
@@ -129,7 +129,7 @@ def _join_observations(join, left_observations, right_observations):
         right_observations (`list`): The right observation specification.
 
     Returns:
-        :obj:`list`: A joined list of observations. Each observation follows the :obj:`defs.json#observation` `schema <https://scikit-hep.org/pyhf/likelihood.html#observations>`__
+        :obj:`list`: A joined list of observations. Each observation follows the :obj:`defs.json#/definitions/observation` `schema <https://scikit-hep.org/pyhf/likelihood.html#observations>`__
 
     """
     joined_observations = _join_items(join, left_observations, right_observations)
@@ -173,7 +173,7 @@ def _join_parameter_configs(measurement_name, left_parameters, right_parameters)
         right_parameters (`list`): The right parameter configuration specification.
 
     Returns:
-        :obj:`list`: A joined list of parameter configurations. Each parameter configuration follows the :obj:`defs.json#config` schema
+        :obj:`list`: A joined list of parameter configurations. Each parameter configuration follows the :obj:`defs.json#/definitions/config` schema
 
     """
     joined_parameter_configs = _join_items('outer', left_parameters, right_parameters)
@@ -203,7 +203,7 @@ def _join_measurements(join, left_measurements, right_measurements):
         right_measurements (`list`): The right measurement specification.
 
     Returns:
-        :obj:`list`: A joined list of measurements. Each measurement follows the :obj:`defs.json#measurement` `schema <https://scikit-hep.org/pyhf/likelihood.html#measurements>`__
+        :obj:`list`: A joined list of measurements. Each measurement follows the :obj:`defs.json#/definitions/measurement` `schema <https://scikit-hep.org/pyhf/likelihood.html#measurements>`__
 
     """
     joined_measurements = _join_items(join, left_measurements, right_measurements)


### PR DESCRIPTION
# Description

This cleans up the schemas a little bit and fixes typos in the documentation.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Clean up schemas by moving the bulk of the information into defs.json
* Fix up typos in documentation for the refs to the schema information
```