### PR TITLE
chore: Avoid mutable defaults

### DIFF
--- a/docs/exts/xref.py
+++ b/docs/exts/xref.py
@@ -5,8 +5,9 @@ from docutils import nodes
 from sphinx.util import caption_ref_re
 
 
-def xref(typ, rawtext, text, lineno, inliner, options={}, content=None):
+def xref(typ, rawtext, text, lineno, inliner, options=None, content=None):
     # avoid mutable defaults
+    options = {} if options is None else options
     content = [] if content is None else content
 
     title = target = text

--- a/docs/exts/xref.py
+++ b/docs/exts/xref.py
@@ -5,7 +5,9 @@ from docutils import nodes
 from sphinx.util import caption_ref_re
 
 
-def xref(typ, rawtext, text, lineno, inliner, options={}, content=[]):
+def xref(typ, rawtext, text, lineno, inliner, options={}, content=None):
+    # avoid mutable defaults
+    content = [] if content is None else content
 
     title = target = text
     # titleistarget = True

--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -133,17 +133,17 @@ def inspect(workspace, output_file, measurement):
     help='The location of the output json file. If not specified, prints to screen.',
     default=None,
 )
-@click.option('-c', '--channel', default=None, multiple=True, metavar='<CHANNEL>...')
-@click.option('-s', '--sample', default=None, multiple=True, metavar='<SAMPLE>...')
-@click.option('-m', '--modifier', default=None, multiple=True, metavar='<MODIFIER>...')
+@click.option('-c', '--channel', default=[], multiple=True, metavar='<CHANNEL>...')
+@click.option('-s', '--sample', default=[], multiple=True, metavar='<SAMPLE>...')
+@click.option('-m', '--modifier', default=[], multiple=True, metavar='<MODIFIER>...')
 @click.option(
     '-t',
     '--modifier-type',
-    default=None,
+    default=[],
     multiple=True,
     type=click.Choice(modifiers.uncombined.keys()),
 )
-@click.option('--measurement', default=None, multiple=True, metavar='<MEASUREMENT>...')
+@click.option('--measurement', default=[], multiple=True, metavar='<MEASUREMENT>...')
 def prune(
     workspace, output_file, channel, sample, modifier, modifier_type, measurement
 ):
@@ -154,13 +154,6 @@ def prune(
     """
     with click.open_file(workspace, 'r') as specstream:
         spec = json.load(specstream)
-
-    # avoid mutable defaults
-    channel = [] if channel is None else channel
-    sample = [] if sample is None else sample
-    modifier = [] if modifier is None else modifier
-    modifier_type = [] if modifier_type is None else modifier_type
-    measurement = [] if measurement is None else measurement
 
     ws = Workspace(spec)
     pruned_ws = ws.prune(
@@ -189,7 +182,7 @@ def prune(
 @click.option(
     '-c',
     '--channel',
-    default=None,
+    default=[],
     multiple=True,
     type=click.Tuple([str, str]),
     metavar='<PATTERN> <REPLACE>...',
@@ -197,7 +190,7 @@ def prune(
 @click.option(
     '-s',
     '--sample',
-    default=None,
+    default=[],
     multiple=True,
     type=click.Tuple([str, str]),
     metavar='<PATTERN> <REPLACE>...',
@@ -205,14 +198,14 @@ def prune(
 @click.option(
     '-m',
     '--modifier',
-    default=None,
+    default=[],
     multiple=True,
     type=click.Tuple([str, str]),
     metavar='<PATTERN> <REPLACE>...',
 )
 @click.option(
     '--measurement',
-    default=None,
+    default=[],
     multiple=True,
     type=click.Tuple([str, str]),
     metavar='<PATTERN> <REPLACE>...',
@@ -225,12 +218,6 @@ def rename(workspace, output_file, channel, sample, modifier, measurement):
     """
     with click.open_file(workspace, 'r') as specstream:
         spec = json.load(specstream)
-
-    # avoid mutable defaults
-    channel = [] if channel is None else channel
-    sample = [] if sample is None else sample
-    modifier = [] if modifier is None else modifier
-    measurement = [] if measurement is None else measurement
 
     ws = Workspace(spec)
     renamed_ws = ws.rename(

--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -133,17 +133,17 @@ def inspect(workspace, output_file, measurement):
     help='The location of the output json file. If not specified, prints to screen.',
     default=None,
 )
-@click.option('-c', '--channel', default=[], multiple=True, metavar='<CHANNEL>...')
-@click.option('-s', '--sample', default=[], multiple=True, metavar='<SAMPLE>...')
-@click.option('-m', '--modifier', default=[], multiple=True, metavar='<MODIFIER>...')
+@click.option('-c', '--channel', default=None, multiple=True, metavar='<CHANNEL>...')
+@click.option('-s', '--sample', default=None, multiple=True, metavar='<SAMPLE>...')
+@click.option('-m', '--modifier', default=None, multiple=True, metavar='<MODIFIER>...')
 @click.option(
     '-t',
     '--modifier-type',
-    default=[],
+    default=None,
     multiple=True,
     type=click.Choice(modifiers.uncombined.keys()),
 )
-@click.option('--measurement', default=[], multiple=True, metavar='<MEASUREMENT>...')
+@click.option('--measurement', default=None, multiple=True, metavar='<MEASUREMENT>...')
 def prune(
     workspace, output_file, channel, sample, modifier, modifier_type, measurement
 ):
@@ -154,6 +154,13 @@ def prune(
     """
     with click.open_file(workspace, 'r') as specstream:
         spec = json.load(specstream)
+
+    # avoid mutable defaults
+    channel = [] if channel is None else channel
+    sample = [] if sample is None else sample
+    modifier = [] if modifier is None else modifier
+    modifier_type = [] if modifier_type is None else modifier_type
+    measurement = [] if measurement is None else measurement
 
     ws = Workspace(spec)
     pruned_ws = ws.prune(
@@ -182,7 +189,7 @@ def prune(
 @click.option(
     '-c',
     '--channel',
-    default=[],
+    default=None,
     multiple=True,
     type=click.Tuple([str, str]),
     metavar='<PATTERN> <REPLACE>...',
@@ -190,7 +197,7 @@ def prune(
 @click.option(
     '-s',
     '--sample',
-    default=[],
+    default=None,
     multiple=True,
     type=click.Tuple([str, str]),
     metavar='<PATTERN> <REPLACE>...',
@@ -198,14 +205,14 @@ def prune(
 @click.option(
     '-m',
     '--modifier',
-    default=[],
+    default=None,
     multiple=True,
     type=click.Tuple([str, str]),
     metavar='<PATTERN> <REPLACE>...',
 )
 @click.option(
     '--measurement',
-    default=[],
+    default=None,
     multiple=True,
     type=click.Tuple([str, str]),
     metavar='<PATTERN> <REPLACE>...',
@@ -218,6 +225,12 @@ def rename(workspace, output_file, channel, sample, modifier, measurement):
     """
     with click.open_file(workspace, 'r') as specstream:
         spec = json.load(specstream)
+
+    # avoid mutable defaults
+    channel = [] if channel is None else channel
+    sample = [] if sample is None else sample
+    modifier = [] if modifier is None else modifier
+    measurement = [] if measurement is None else measurement
 
     ws = Workspace(spec)
     renamed_ws = ws.rename(

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -428,10 +428,10 @@ class Workspace(_ChannelSummaryMixin, dict):
         prune_samples=None,
         prune_channels=None,
         prune_measurements=None,
-        rename_modifiers={},
-        rename_samples={},
-        rename_channels={},
-        rename_measurements={},
+        rename_modifiers=None,
+        rename_samples=None,
+        rename_channels=None,
+        rename_measurements=None,
     ):
         """
         Return a new, pruned, renamed workspace specification. This will not modify the original workspace.
@@ -473,6 +473,10 @@ class Workspace(_ChannelSummaryMixin, dict):
         prune_samples = [] if prune_samples is None else prune_samples
         prune_channels = [] if prune_channels is None else prune_channels
         prune_measurements = [] if prune_measurements is None else prune_measurements
+        rename_modifiers = {} if rename_modifiers is None else rename_modifiers
+        rename_samples = {} if rename_samples is None else rename_samples
+        rename_channels = {} if rename_channels is None else rename_channels
+        rename_measurements = {} if rename_measurements is None else rename_measurements
 
         newspec = {
             'channels': [
@@ -576,7 +580,7 @@ class Workspace(_ChannelSummaryMixin, dict):
             prune_measurements=measurements,
         )
 
-    def rename(self, modifiers={}, samples={}, channels={}, measurements={}):
+    def rename(self, modifiers=None, samples=None, channels=None, measurements=None):
         """
         Return a new workspace specification with certain elements renamed.
 
@@ -593,6 +597,12 @@ class Workspace(_ChannelSummaryMixin, dict):
             ~pyhf.workspace.Workspace: A new workspace object with the specified components renamed
 
         """
+        # avoid mutable defaults
+        modifiers = {} if modifiers is None else modifiers
+        samples = {} if samples is None else samples
+        channels = {} if channels is None else channels
+        measurements = {} if measurements is None else measurements
+
         return self._prune_and_rename(
             rename_modifiers=modifiers,
             rename_samples=samples,

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -423,11 +423,11 @@ class Workspace(_ChannelSummaryMixin, dict):
 
     def _prune_and_rename(
         self,
-        prune_modifiers=[],
-        prune_modifier_types=[],
-        prune_samples=[],
-        prune_channels=[],
-        prune_measurements=[],
+        prune_modifiers=None,
+        prune_modifier_types=None,
+        prune_samples=None,
+        prune_channels=None,
+        prune_measurements=None,
         rename_modifiers={},
         rename_samples={},
         rename_channels={},
@@ -465,6 +465,15 @@ class Workspace(_ChannelSummaryMixin, dict):
             ~pyhf.workspace.Workspace: A new workspace object with the specified components removed or renamed
 
         """
+        # avoid mutable defaults
+        prune_modifiers = [] if prune_modifiers is None else prune_modifiers
+        prune_modifier_types = (
+            [] if prune_modifier_types is None else prune_modifier_types
+        )
+        prune_samples = [] if prune_samples is None else prune_samples
+        prune_channels = [] if prune_channels is None else prune_channels
+        prune_measurements = [] if prune_measurements is None else prune_measurements
+
         newspec = {
             'channels': [
                 {
@@ -529,7 +538,12 @@ class Workspace(_ChannelSummaryMixin, dict):
         return Workspace(newspec)
 
     def prune(
-        self, modifiers=[], modifier_types=[], samples=[], channels=[], measurements=[]
+        self,
+        modifiers=None,
+        modifier_types=None,
+        samples=None,
+        channels=None,
+        measurements=None,
     ):
         """
         Return a new, pruned workspace specification. This will not modify the original workspace.
@@ -547,6 +561,13 @@ class Workspace(_ChannelSummaryMixin, dict):
             ~pyhf.workspace.Workspace: A new workspace object with the specified components removed
 
         """
+        # avoid mutable defaults
+        modifiers = [] if modifiers is None else modifiers
+        modifier_types = [] if modifier_types is None else modifier_types
+        samples = [] if samples is None else samples
+        channels = [] if channels is None else channels
+        measurements = [] if measurements is None else measurements
+
         return self._prune_and_rename(
             prune_modifiers=modifiers,
             prune_modifier_types=modifier_types,


### PR DESCRIPTION
# Description

Given a Tweet by @jakevdp [about mutable defaults](https://twitter.com/jakevdp/status/1235271748867612673) that got me thinking along with a message with @mickypaganini, this PR makes all function defaults that are empty lists be `None` instead and follow the
```python
x = [] if x is None else x
```
pattern. However, this doesn't actually really do anything, as the design of the code so far is well thought through and any mutable defaults can't propagate through to [produce any of the usual errors](http://effbot.org/zone/default-values.htm). This PR exists to essentially future proof any changes and to try to mindless adopt 'best patterns' (if you will).

As can be seen by `git grep "=\[\]"`, `git grep "={}"`, (thank you [Black](https://github.com/psf/black)!) and 

```
$ git grep ".update" src/
src/pyhf/optimize/opt_minuit.py:            kwargs.update(**d)
src/pyhf/readxml.py:                        result['config']['parameters'][0].update(overall_param_obj)
src/pyhf/readxml.py:                        param_obj.update(overall_param_obj)
src/pyhf/tensor/jax_backend.py:        config.update('jax_enable_x64', True)
src/pyhf/writexml.py:            sample.attrib.update({'NormalizeByTheory': 'True'})
```

none of these changes will affect the current code. 

 this only affects `pyhf.workspace` and the `spec` CLI (hence why I mention above this change can't actually affect anything now). `setup.py` requires the `[]` and it is justified in the tests.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Avoid mutable defaults in all function definitions to follow 'best patterns'
   - c.f. https://twitter.com/jakevdp/status/1235271748867612673
```
