### PR TITLE
chore: Use Debian based python:3.7-slim as base Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,5 +133,9 @@ jobs:
     - uses: actions/checkout@v1.2.0
     - name: Build Docker image
       run: |
-        docker build . --file docker/Dockerfile --tag pyhf/pyhf:$GITHUB_SHA
+        docker build . \
+          --file docker/Dockerfile \
+          --build-arg BASE_IMAGE=python:3.7-slim \
+          --tag pyhf/pyhf:$GITHUB_SHA \
+          --compress
         docker images

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,15 @@
-FROM matthewfeickert/python3-scipy-alpine:scipy-1.2.1 as base
+ARG BASE_IMAGE=python:3.7-slim
+FROM ${BASE_IMAGE} as base
 
 FROM base as builder
 COPY . /code
-RUN cd /code && \
-    apk add --no-cache git && \
-    rm -rf /var/cache/apk/* && \
+RUN apt-get -qq -y update && \
+    apt-get -qq -y install \
+        git && \
+    apt-get -y autoclean && \
+    apt-get -y autoremove && \
+    rm -rf /var/lib/apt-get/lists/* && \
+    cd /code && \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
     python -m pip install --no-cache-dir .[xmlio] && \
     python -m pip list

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,11 @@
 ARG BASE_IMAGE=python:3.7-slim
+# hadolint ignore=DL3006
 FROM ${BASE_IMAGE} as base
 
 FROM base as builder
 COPY . /code
 RUN apt-get -qq -y update && \
-    apt-get -qq -y install \
+    apt-get -qq -y install --no-install-recommends \
         git && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \


### PR DESCRIPTION
# Description

For less than 100MB more in size using [`python:3.7-slim`](https://hub.docker.com/layers/python/library/python/3.7-slim/images/sha256-e65d472af32c1f51cca9350de6bd63cf4ce440f2e68fb9301bcf12cdba1b0acd?context=explore) as 
a base image for the pyhf Docker images gets a much more common environment for reproduction and testing. For example, it can reproduce the failing error of the [Minimal pyhf example failing with 'Inequality constraints incompatible'](https://stackoverflow.com/questions/60514470/minimal-pyhf-example-failing-with-inequality-constraints-incompatible) Stack Overflow issue instantly rather then running for minutes and then failing on an iteration limit exceeded error as the Alpine based image does. It also allows for direct installation of SciPy and NumPy.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use python:3.7-slim as base image for Docker image builds
   - Allows for greater flexibility and easier reproducibility of user results and errors
```
