### PR TITLE
build: Require minimum SciPy version of v1.4.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ packages = find:
 include_package_data = True
 python_requires = >=3.6
 install_requires =
-    scipy  # requires numpy, which is required by pyhf and tensorflow
+    scipy>=1.4.0  # requires numpy, which is required by pyhf and tensorflow
     click>=6.0  # for console scripts,
     tqdm  # for readxml
     jsonschema>=3.2.0  # for utils


### PR DESCRIPTION
# Description

- Requires PR #795 to be resolved first

In [SciPy `v1.4.0`](https://github.com/scipy/scipy/blob/master/doc/release/1.4.0-notes.rst#scipy-optimize-improvements) the following fix is added in https://github.com/scipy/scipy/pull/10739

> SLSQP can run to singular BFGS updates, which it doesn't handle, and may exit with nan outputs and successful exit code. To avoid this, do the most trivial thing and just reset the matrix. This might not lead to convergence, but gets rid of false successful exits.
> ...
> The linalg changes are no-ops if there are no nans, and with nans generally give error exits. The BFGS update tweak is only triggered in cases where the code previously divided by zero. The SLSQP exit-on-too-many-resets check is also a corner case. So there should be no impact in non-problematic cases.

Adopting SciPy `v1.4.0` as the new minimum version will lead to faster fails and fewer 'Iteration limit exceeded' failures after multiple minutes. This change was discovered empirically in PR #795 and then hunted down by @kratsg for this PR.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Require SciPy v1.4.0 or newer
   - Avoids some 'Iteration limit exceeded' errors and false exits with nans
```
