### PR TITLE
refactor: Use _TensorViewer in ParamViewer

### DIFF
--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -47,7 +47,6 @@ class ParamViewer(object):
     """
 
     def __init__(self, shape, par_map, selection):
-        db = default_backend
         self.shape = shape
         self.selection = selection
 

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -70,7 +70,7 @@ class ParamViewer(object):
 
     def __init__(self, shape, par_map, selection):
 
-        sbatch = shape[0] if len(shape) > 1 else None
+        batch = shape[0] if len(shape) > 1 else None
 
         fullsize = default_backend.product(default_backend.astensor(shape))
         flat_indices = default_backend.astensor(range(int(fullsize)), dtype='int')

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -1,5 +1,5 @@
 from .. import get_backend, default_backend, events
-from ..tensor.common import _TensorViewer
+from ..tensor.common import _TensorViewer, _tensorviewer_from_slices
 
 
 def _tensorviewer_from_parmap(par_map, batch_size):
@@ -22,23 +22,6 @@ def _tensorviewer_from_parmap(par_map, batch_size):
         )
     )
     return _TensorViewer(indices, names=names, batch_size=batch_size)
-
-
-def _tensorviewer_from_slices(slices, names, batch_size):
-    target_slices = []
-    start = 0
-    for sl in slices:
-        stop = start + (sl.stop - sl.start)
-        target_slices.append(slice(start, stop))
-        start = stop
-
-    db = default_backend
-    ranges = []
-    for sl in target_slices:
-        ranges.append(db.astensor(range(sl.start, sl.stop)))
-    if not ranges:
-        return None
-    return _TensorViewer(ranges, names=names, batch_size=batch_size)
 
 
 def extract_index_access(

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -26,14 +26,18 @@ class ParamViewer(object):
 
         # prepares names and per-parset ranges
         # in the order or the parameters
-        names, indices = list(
+        names, indices, starts = list(
             zip(
                 *sorted(
                     [
-                        (k, db.astensor(range(v['slice'].start, v['slice'].stop)))
+                        (
+                            k,
+                            db.astensor(range(v['slice'].start, v['slice'].stop)),
+                            v['slice'].start,
+                        )
                         for k, v in par_map.items()
                     ],
-                    key=lambda x: x[1][0],
+                    key=lambda x: x[2],
                 )
             )
         )

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -6,13 +6,13 @@ def _tensorviewer_from_parmap(par_map, batch_size):
     db = default_backend
     # prepares names and per-parset ranges
     # in the order of the parameters
-    names, indices, _ = list(
+    names, slices, _ = list(
         zip(
             *sorted(
                 [
                     (
                         k,
-                        db.astensor(range(v['slice'].start, v['slice'].stop)),
+                        v['slice'],
                         v['slice'].start,
                     )
                     for k, v in par_map.items()
@@ -21,7 +21,7 @@ def _tensorviewer_from_parmap(par_map, batch_size):
             )
         )
     )
-    return _TensorViewer(indices, names=names, batch_size=batch_size)
+    return _tensorviewer_from_slices(slices, names=names, batch_size=batch_size)
 
 
 def extract_index_access(

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -24,10 +24,10 @@ def _tensorviewer_from_parmap(par_map, batch_size):
     return _TensorViewer(indices, names=names, batch_size=batch_size)
 
 
-def _tensorviewer_from_slices(start_slices, batch_size):
+def _tensorviewer_from_slices(slices, batch_size):
     target_slices = []
     start = 0
-    for sl in start_slices:
+    for sl in slices:
         stop = start + (sl.stop - sl.start)
         target_slices.append(slice(start, stop))
         start = stop
@@ -56,15 +56,9 @@ class ParamViewer(object):
         # a tensor viewer that can split and stitch parameters
         self.allpar_viewer = _tensorviewer_from_parmap(par_map, self.batch)
 
-        # to combine the selected
-        # parameters into a overall tensor
-        # we need to prep some ranges
-
-        start_slices = [par_map[s]['slice'] for s in selection]
-
         # a tensor viewer that can split and stitch the selected parameters
         self.slices, self.selected_viewer = _tensorviewer_from_slices(
-            start_slices, self.batch
+            [par_map[s]['slice'] for s in selection] , self.batch
         )
 
         self._precompute()

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -51,7 +51,7 @@ class ParamViewer(object):
     Helper class to extract parameter data from possibly batched input
     """
 
-    def __init__(self, shape, par_map, selection):
+    def __init__(self, shape, par_map, par_selection):
 
         batch = shape[0] if len(shape) > 1 else None
 
@@ -64,7 +64,7 @@ class ParamViewer(object):
 
         # a tensor viewer that can split and stitch the selected parameters
         self.selected_viewer = _tensorviewer_from_slices(
-            [par_map[s]['slice'] for s in selection], selection, batch
+            [par_map[s]['slice'] for s in par_selection], par_selection, batch
         )
 
         self._precompute()

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -73,7 +73,7 @@ class ParamViewer(object):
         self.selected = self.allpar_viewer.split(all_indices, selection=self.selection)
 
         # LH: just self.selected but as python lists
-        self.index_selection =  self.selected
+        self.index_selection = self.selected
         # [
         #     tensorlib.tolist(tensorlib.astensor(x, dtype='int')) for x in self.selected
         # ]

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -69,20 +69,19 @@ class ParamViewer(object):
     """
 
     def __init__(self, shape, par_map, selection):
-        self.selection = selection
 
-        self.batch = shape[0] if len(shape) > 1 else None
+        sbatch = shape[0] if len(shape) > 1 else None
 
         fullsize = default_backend.product(default_backend.astensor(shape))
         flat_indices = default_backend.astensor(range(int(fullsize)), dtype='int')
         self._all_indices = default_backend.reshape(flat_indices, shape)
 
         # a tensor viewer that can split and stitch parameters
-        self.allpar_viewer = _tensorviewer_from_parmap(par_map, self.batch)
+        self.allpar_viewer = _tensorviewer_from_parmap(par_map, batch)
 
         # a tensor viewer that can split and stitch the selected parameters
         self.selected_viewer = _tensorviewer_from_slices(
-            [par_map[s]['slice'] for s in self.selection], self.selection, self.batch
+            [par_map[s]['slice'] for s in selection], selection, batch
         )
 
         self._precompute()

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -53,7 +53,7 @@ def extract_index_access(
         index_selection = baseviewer.split(indices, selection=subviewer.names)
         stitched = subviewer.stitch(index_selection)
 
-        # LH: the transpose is here so that modifier code doesn't have to do it
+        # the transpose is here so that modifier code doesn't have to do it
         indices_concatenated = tensorlib.astensor(
             tensorlib.einsum('ij->ji', stitched)
             if len(tensorlib.shape(stitched)) > 1

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -37,8 +37,8 @@ def _tensorviewer_from_slices(slices, batch_size):
     for sl in target_slices:
         ranges.append(db.astensor(range(sl.start, sl.stop)))
     if not ranges:
-        return (target_slices, None)
-    return target_slices, _TensorViewer(ranges, batch_size=batch_size)
+        return None
+    return _TensorViewer(ranges, batch_size=batch_size)
 
 
 class ParamViewer(object):
@@ -57,7 +57,7 @@ class ParamViewer(object):
         self.allpar_viewer = _tensorviewer_from_parmap(par_map, self.batch)
 
         # a tensor viewer that can split and stitch the selected parameters
-        self.slices, self.selected_viewer = _tensorviewer_from_slices(
+        self.selected_viewer = _tensorviewer_from_slices(
             [par_map[s]['slice'] for s in selection], self.batch
         )
 

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -70,16 +70,12 @@ class ParamViewer(object):
         flat_indices = tensorlib.astensor(list(range(int(fullsize))), dtype='int')
         all_indices = tensorlib.reshape(flat_indices, self.shape)
 
-        self.selected = self.allpar_viewer.split(all_indices, selection=self.selection)
-
-        # LH: just self.selected but as python lists
-        self.index_selection = self.selected
-        # [
-        #     tensorlib.tolist(tensorlib.astensor(x, dtype='int')) for x in self.selected
-        # ]
+        self.index_selection = self.allpar_viewer.split(
+            all_indices, selection=self.selection
+        )
 
         if self.selection:
-            stitched = self.selected_viewer.stitch(self.selected)
+            stitched = self.selected_viewer.stitch(self.index_selection)
 
             # LH: the transpose is here so that modifier code doesn't have to do it
             self.indices_concatenated = tensorlib.astensor(

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -57,7 +57,7 @@ class ParamViewer(object):
 
         # a tensor viewer that can split and stitch the selected parameters
         self.selected_viewer = _tensorviewer_from_slices(
-            [par_map[s]['slice'] for s in selection], self.batch
+            [par_map[s]['slice'] for s in self.selection], self.batch
         )
 
         self._precompute()

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -1,17 +1,27 @@
 from .. import get_backend, default_backend, events
-from ..tensor.common import _tensorviewer_from_slices
+from ..tensor.common import _TensorViewer, _tensorviewer_from_slices
 
 
 def _tensorviewer_from_parmap(par_map, batch_size):
-    names, slices, _ = list(
+    db = default_backend
+    # prepares names and per-parset ranges
+    # in the order of the parameters
+    names, indices, _ = list(
         zip(
             *sorted(
-                [(k, v['slice'], v['slice'].start,) for k, v in par_map.items()],
+                [
+                    (
+                        k,
+                        list(range(v['slice'].start,v['slice'].stop)),
+                        v['slice'].start,
+                    )
+                    for k, v in par_map.items()
+                ],
                 key=lambda x: x[2],
             )
         )
     )
-    return _tensorviewer_from_slices(slices, names=names, batch_size=batch_size)
+    return _TensorViewer(indices, names=names, batch_size=batch_size)
 
 
 def extract_index_access(

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -1,15 +1,11 @@
 from .. import get_backend, default_backend, events
 from ..tensor.common import (
-    _TensorViewer,
     _tensorviewer_from_slices,
     _tensorviewer_from_sizes,
 )
 
 
 def _tensorviewer_from_parmap(par_map, batch_size):
-    db = default_backend
-    # prepares names and per-parset ranges
-    # in the order of the parameters
     names, slices, _ = list(
         zip(
             *sorted(

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -9,14 +9,7 @@ def _tensorviewer_from_parmap(par_map, batch_size):
     names, slices, _ = list(
         zip(
             *sorted(
-                [
-                    (
-                        k,
-                        v['slice'],
-                        v['slice'].start,
-                    )
-                    for k, v in par_map.items()
-                ],
+                [(k, v['slice'], v['slice'].start,) for k, v in par_map.items()],
                 key=lambda x: x[2],
             )
         )

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -73,9 +73,10 @@ class ParamViewer(object):
     def _precompute(self):
         tensorlib, _ = get_backend()
 
-        theshape = tensorlib.product(tensorlib.astensor(self.shape, dtype='int'))
-        flat_indices = tensorlib.astensor(list(range(int(theshape))), dtype='int')
+        fullsize = tensorlib.product(tensorlib.astensor(self.shape, dtype='int'))
+        flat_indices = tensorlib.astensor(list(range(int(fullsize))), dtype='int')
         all_indices = tensorlib.reshape(flat_indices, self.shape)
+
         self.selected = self.allpar_viewer.split(all_indices, selection=self.selection)
 
         # LH: just self.selected but as python lists

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -1,11 +1,8 @@
 from .. import get_backend, default_backend, events
-from ..tensor.common import _TensorViewer, _tensorviewer_from_slices
+from ..tensor.common import _tensorviewer_from_slices
 
 
 def _tensorviewer_from_parmap(par_map, batch_size):
-    db = default_backend
-    # prepares names and per-parset ranges
-    # in the order of the parameters
     names, slices, _ = list(
         zip(
             *sorted(

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -58,7 +58,7 @@ class ParamViewer(object):
 
         # a tensor viewer that can split and stitch the selected parameters
         self.slices, self.selected_viewer = _tensorviewer_from_slices(
-            [par_map[s]['slice'] for s in selection] , self.batch
+            [par_map[s]['slice'] for s in selection], self.batch
         )
 
         self._precompute()

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -5,8 +5,8 @@ from ..tensor.common import _TensorViewer, _tensorviewer_from_slices
 def _tensorviewer_from_parmap(par_map, batch_size):
     db = default_backend
     # prepares names and per-parset ranges
-    # in the order or the parameters
-    names, indices, starts = list(
+    # in the order of the parameters
+    names, indices, _ = list(
         zip(
             *sorted(
                 [

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -73,9 +73,10 @@ class ParamViewer(object):
         self.selected = self.allpar_viewer.split(all_indices, selection=self.selection)
 
         # LH: just self.selected but as python lists
-        self.index_selection = [
-            tensorlib.tolist(tensorlib.astensor(x, dtype='int')) for x in self.selected
-        ]
+        self.index_selection =  self.selected
+        # [
+        #     tensorlib.tolist(tensorlib.astensor(x, dtype='int')) for x in self.selected
+        # ]
 
         if self.selection:
             stitched = self.selected_viewer.stitch(self.selected)

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -53,18 +53,18 @@ class ParamViewer(object):
 
     def __init__(self, shape, par_map, par_selection):
 
-        batch = shape[0] if len(shape) > 1 else None
+        batch_size = shape[0] if len(shape) > 1 else None
 
         fullsize = default_backend.product(default_backend.astensor(shape))
         flat_indices = default_backend.astensor(range(int(fullsize)), dtype='int')
         self._all_indices = default_backend.reshape(flat_indices, shape)
 
         # a tensor viewer that can split and stitch parameters
-        self.allpar_viewer = _tensorviewer_from_parmap(par_map, batch)
+        self.allpar_viewer = _tensorviewer_from_parmap(par_map, batch_size)
 
         # a tensor viewer that can split and stitch the selected parameters
         self.selected_viewer = _tensorviewer_from_slices(
-            [par_map[s]['slice'] for s in par_selection], par_selection, batch
+            [par_map[s]['slice'] for s in par_selection], par_selection, batch_size
         )
 
         self._precompute()

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -75,11 +75,13 @@ class ParamViewer(object):
         )
 
         if self.selection:
-            stitched = self.selected_viewer.stitch(self.index_selection)
+            self.stitched = self.selected_viewer.stitch(self.index_selection)
 
             # LH: the transpose is here so that modifier code doesn't have to do it
             self.indices_concatenated = tensorlib.astensor(
-                tensorlib.einsum('ij->ji', stitched) if self.batch else stitched,
+                tensorlib.einsum('ij->ji', self.stitched)
+                if self.batch
+                else self.stitched,
                 dtype='int',
             )
 

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -317,23 +317,6 @@ class _ConstraintModel(object):
         if self.has_pdf():
             self.constraints_tv = _TensorViewer(indices, self.batch_size)
 
-    def expected_data(self, pars):
-        tensorlib, _ = get_backend()
-        auxdata = None
-        if not self.viewer_aux.index_selection:
-            return None
-        slice_data = self.viewer_aux.get(pars)
-        for parname, sl in zip(self.config.auxdata_order, self.viewer_aux.slices):
-            # order matters! because we generated auxdata in a certain order
-            thisaux = self.config.param_set(parname).expected_data(
-                tensorlib.einsum('ij->ji', slice_data[sl])
-            )
-            tocat = [thisaux] if auxdata is None else [auxdata, thisaux]
-            auxdata = tensorlib.concatenate(tocat, axis=1)
-        if self.batch_size is None:
-            return auxdata[0]
-        return auxdata
-
     def has_pdf(self):
         """
         Indicate whether this model has a constraint.

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -11,7 +11,7 @@ from . import events
 from . import probability as prob
 from .constraints import gaussian_constraint_combined, poisson_constraint_combined
 from .parameters import reduce_paramsets_requirements, ParamViewer
-from .tensor.common import _TensorViewer, _tensorviewer_from_slices
+from .tensor.common import _TensorViewer, _tensorviewer_from_sizes
 from .mixins import _ChannelSummaryMixin
 
 log = logging.getLogger(__name__)
@@ -550,14 +550,13 @@ class Model(object):
             config=self.config, batch_size=self.batch_size
         )
 
-        slices = []
-        total_size = self.config.nmaindata + self.config.nauxdata
+        sizes = []
         if self.main_model.has_pdf():
-            slices.append(slice(0, self.config.nmaindata))
+            sizes.append(self.config.nmaindata)
         if self.constraint_model.has_pdf():
-            slices.append(slice(self.config.nmaindata, total_size))
-        self.fullpdf_tv = _tensorviewer_from_slices(
-            slices, ['main', 'aux'], self.batch_size
+            sizes.append(self.config.nauxdata)
+        self.fullpdf_tv = _tensorviewer_from_sizes(
+            sizes, ['main', 'aux'], self.batch_size
         )
 
     def expected_auxdata(self, pars):

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -11,7 +11,7 @@ from . import events
 from . import probability as prob
 from .constraints import gaussian_constraint_combined, poisson_constraint_combined
 from .parameters import reduce_paramsets_requirements, ParamViewer
-from .tensor.common import _TensorViewer
+from .tensor.common import _TensorViewer, _tensorviewer_from_slices
 from .mixins import _ChannelSummaryMixin
 
 log = logging.getLogger(__name__)
@@ -550,15 +550,15 @@ class Model(object):
             config=self.config, batch_size=self.batch_size
         )
 
-        cut = self.nominal_rates.shape[-1]
-        total_size = cut + len(self.config.auxdata)
-        position = list(range(total_size))
-        indices = []
+        slices = []
+        total_size = self.config.nmaindata + self.config.nauxdata
         if self.main_model.has_pdf():
-            indices.append(position[:cut])
+            slices.append(slice(0, self.config.nmaindata))
         if self.constraint_model.has_pdf():
-            indices.append(position[cut:])
-        self.fullpdf_tv = _TensorViewer(indices, self.batch_size)
+            slices.append(slice(self.config.nmaindata, total_size))
+        self.fullpdf_tv = _tensorviewer_from_slices(
+            slices, ['main', 'aux'], self.batch_size
+        )
 
     def expected_auxdata(self, pars):
         """

--- a/src/pyhf/tensor/common.py
+++ b/src/pyhf/tensor/common.py
@@ -64,6 +64,18 @@ class _TensorViewer(object):
 
 
 def _tensorviewer_from_slices(slices, names, batch_size):
+    '''
+    Creates a _Tensorviewer based on slice sizes.
+
+    (the actual slice start and stops are not relevant)
+
+    the TV will be able to stitch together data with
+    matching sizes (e.g. extracted using the slices)
+
+    tv.stitch([foo[slice1],foo[slice2],foo[slice3])
+
+    and split them again accordingly.
+    '''
     target_slices = []
     start = 0
     for sl in slices:

--- a/src/pyhf/tensor/common.py
+++ b/src/pyhf/tensor/common.py
@@ -61,3 +61,20 @@ class _TensorViewer(object):
             tensorlib.einsum('j...->...j', tensorlib.gather(data, idx))
             for idx in indices
         ]
+
+
+def _tensorviewer_from_slices(slices, names, batch_size):
+    target_slices = []
+    start = 0
+    for sl in slices:
+        stop = start + (sl.stop - sl.start)
+        target_slices.append(slice(start, stop))
+        start = stop
+
+    db = default_backend
+    ranges = []
+    for sl in target_slices:
+        ranges.append(db.astensor(range(sl.start, sl.stop)))
+    if not ranges:
+        return None
+    return _TensorViewer(ranges, names=names, batch_size=batch_size)

--- a/src/pyhf/tensor/common.py
+++ b/src/pyhf/tensor/common.py
@@ -3,7 +3,7 @@ from .. import events
 
 
 class _TensorViewer(object):
-    def __init__(self, indices, batch_size=None):
+    def __init__(self, indices, batch_size=None, names=None):
         # self.partition_indices has the "target" indices
         # of the stitched vector. In order to  .gather()
         # an concatennation of source arrays into the
@@ -15,7 +15,7 @@ class _TensorViewer(object):
         # array([6, 8, 9, 7])
 
         self.batch_size = batch_size
-
+        self.names = names
         self._partition_indices = indices
         _concat_indices = default_backend.astensor(
             default_backend.concatenate(self._partition_indices), dtype='int'
@@ -31,6 +31,8 @@ class _TensorViewer(object):
         self.partition_indices = [
             tensorlib.astensor(idx, dtype='int') for idx in self._partition_indices
         ]
+        if self.names:
+            self.name_map = dict(zip(self.names, self.partition_indices))
 
     def stitch(self, data):
         tensorlib, _ = get_backend()
@@ -45,12 +47,17 @@ class _TensorViewer(object):
             stitched = tensorlib.einsum('j...->...j', stitched)
         return stitched
 
-    def split(self, data):
+    def split(self, data, selection=None):
         tensorlib, _ = get_backend()
+        indices = (
+            self.partition_indices
+            if selection is None
+            else [self.name_map[n] for n in selection]
+        )
         if len(tensorlib.shape(data)) == 1:
-            return [tensorlib.gather(data, idx) for idx in self.partition_indices]
+            return [tensorlib.gather(data, idx) for idx in indices]
         data = tensorlib.einsum('...j->j...', tensorlib.astensor(data))
         return [
             tensorlib.einsum('j...->...j', tensorlib.gather(data, idx))
-            for idx in self.partition_indices
+            for idx in indices
         ]

--- a/src/pyhf/tensor/common.py
+++ b/src/pyhf/tensor/common.py
@@ -63,11 +63,19 @@ class _TensorViewer(object):
         ]
 
 
-def _tensorviewer_from_slices(slices, names, batch_size):
-    '''
-    Creates a _Tensorviewer based on slice sizes.
+def _tensorviewer_from_slices(target_slices, names, batch_size):
+    db = default_backend
+    ranges = []
+    for sl in target_slices:
+        ranges.append(db.astensor(range(sl.start, sl.stop)))
+    if not target_slices:
+        return None
+    return _TensorViewer(ranges, names=names, batch_size=batch_size)
 
-    (the actual slice start and stops are not relevant)
+
+def _tensorviewer_from_sizes(sizes, names, batch_size):
+    '''
+    Creates a _Tensorviewer based on tensor sizes.
 
     the TV will be able to stitch together data with
     matching sizes (e.g. extracted using the slices)
@@ -78,15 +86,9 @@ def _tensorviewer_from_slices(slices, names, batch_size):
     '''
     target_slices = []
     start = 0
-    for sl in slices:
-        stop = start + (sl.stop - sl.start)
+    for sz in sizes:
+        stop = start + sz
         target_slices.append(slice(start, stop))
         start = stop
 
-    db = default_backend
-    ranges = []
-    for sl in target_slices:
-        ranges.append(db.astensor(range(sl.start, sl.stop)))
-    if not ranges:
-        return None
-    return _TensorViewer(ranges, names=names, batch_size=batch_size)
+    return _tensorviewer_from_slices(target_slices, names, batch_size)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,41 @@
 import pytest
 import pyhf
 import sys
+import requests
+import hashlib
+import tarfile
+import json
+import os
+
+@pytest.fixture(scope='module')
+def sbottom_likelihoods_download():
+    """Download the sbottom likelihoods tarball from HEPData"""
+    sbottom_HEPData_URL = "https://doi.org/10.17182/hepdata.89408.v1/r2"
+    targz_filename = "sbottom_workspaces.tar.gz"
+    response = requests.get(sbottom_HEPData_URL, stream=True)
+    assert response.status_code == 200
+    with open(targz_filename, "wb") as file:
+        file.write(response.content)
+    assert (
+        hashlib.sha256(open(targz_filename, "rb").read()).hexdigest()
+        == "9089b0e5fabba335bea4c94545ccca8ddd21289feeab2f85e5bcc8bada37be70"
+    )
+    # Open as a tarfile
+    yield tarfile.open(targz_filename, "r:gz")
+    os.remove(targz_filename)
 
 
+# Factory as fixture pattern
+@pytest.fixture
+def get_json_from_tarfile():
+    def _get_json_from_tarfile(tarfile, json_name):
+        json_file = (
+            tarfile.extractfile(tarfile.getmember(json_name)).read().decode("utf8")
+        )
+        return json.loads(json_file)
+
+    return _get_json_from_tarfile
+    
 @pytest.fixture(scope='function')
 def isolate_modules():
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import tarfile
 import json
 import os
 
+
 @pytest.fixture(scope='module')
 def sbottom_likelihoods_download():
     """Download the sbottom likelihoods tarball from HEPData"""
@@ -35,7 +36,8 @@ def get_json_from_tarfile():
         return json.loads(json_file)
 
     return _get_json_from_tarfile
-    
+
+
 @pytest.fixture(scope='function')
 def isolate_modules():
     """

--- a/tests/test_paramviewer.py
+++ b/tests/test_paramviewer.py
@@ -1,6 +1,5 @@
 import pyhf
 from pyhf.parameters import ParamViewer
-from .test_regression import sbottom_likelihoods_download, get_json_from_tarfile
 
 
 def test_paramviewer_simple_nonbatched(backend):

--- a/tests/test_paramviewer.py
+++ b/tests/test_paramviewer.py
@@ -1,5 +1,6 @@
 import pyhf
 from pyhf.parameters import ParamViewer
+from .test_regression import sbottom_likelihoods_download, get_json_from_tarfile
 
 
 def test_paramviewer_simple_nonbatched(backend):
@@ -18,6 +19,18 @@ def test_paramviewer_simple_nonbatched(backend):
     assert pyhf.tensorlib.tolist(par_slice[slice(0, 2)]) == [6, 7]
 
     assert pyhf.tensorlib.tolist(par_slice) == [6, 7, 1, 2]
+
+
+def test_paramviewer_order(sbottom_likelihoods_download, get_json_from_tarfile):
+    lhood = get_json_from_tarfile(sbottom_likelihoods_download, "RegionA/BkgOnly.json")
+    patch = get_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionA/patch.sbottom_1300_205_60.json"
+    )
+    workspace = pyhf.workspace.Workspace(lhood)
+    model = workspace.model(patches=[patch])
+
+    pv = ParamViewer((model.config.npars,), model.config.par_map, [])
+    assert list(pv.allpar_viewer.names) == model.config.par_order
 
 
 def test_paramviewer_simple_batched(backend):

--- a/tests/test_paramviewer.py
+++ b/tests/test_paramviewer.py
@@ -10,14 +10,14 @@ def test_paramviewer_simple_nonbatched(backend):
     view = ParamViewer(
         parshape,
         {'hello': {'slice': slice(0, 2)}, 'world': {'slice': slice(5, 7)}},
-        ['hello', 'world'],
+        ['world', 'hello'],
     )
     par_slice = view.get(pars)
-    assert pyhf.tensorlib.tolist(par_slice[view.slices[0]]) == [1, 2]
+    assert pyhf.tensorlib.tolist(par_slice[slice(2, 4)]) == [1, 2]
 
-    assert pyhf.tensorlib.tolist(par_slice[view.slices[1]]) == [6, 7]
+    assert pyhf.tensorlib.tolist(par_slice[slice(0, 2)]) == [6, 7]
 
-    assert pyhf.tensorlib.tolist(par_slice) == [1, 2, 6, 7]
+    assert pyhf.tensorlib.tolist(par_slice) == [6, 7, 1, 2]
 
 
 def test_paramviewer_simple_batched(backend):
@@ -28,7 +28,7 @@ def test_paramviewer_simple_batched(backend):
     view = ParamViewer(
         parshape,
         {'hello': {'slice': slice(0, 2)}, 'world': {'slice': slice(3, 4)}},
-        ['hello', 'world'],
+        ['world', 'hello'],
     )
     par_slice = view.get(pars)
 
@@ -38,7 +38,7 @@ def test_paramviewer_simple_batched(backend):
     )  # first dimension is batch dim
 
     assert pyhf.tensorlib.shape(par_slice) == (3, 3)
-    assert pyhf.tensorlib.tolist(par_slice[view.slices[0]]) == [[1, 5, 9], [2, 6, 10]]
-    assert pyhf.tensorlib.tolist(par_slice[view.slices[1]]) == [[4, 8, 12]]
+    assert pyhf.tensorlib.tolist(par_slice[slice(1, 3)]) == [[1, 5, 9], [2, 6, 10]]
+    assert pyhf.tensorlib.tolist(par_slice[slice(0, 1)]) == [[4, 8, 12]]
 
-    assert pyhf.tensorlib.tolist(par_slice) == [[1, 5, 9], [2, 6, 10], [4, 8, 12]]
+    assert pyhf.tensorlib.tolist(par_slice) == [[4, 8, 12], [1, 5, 9], [2, 6, 10]]

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -2,6 +2,7 @@ import pytest
 import pyhf
 import numpy as np
 
+
 def calculate_CLs(bkgonly_json, signal_patch_json):
     """
     Calculate the observed CLs and the expected CLs band from a background only

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,42 +1,6 @@
 import pytest
-import requests
-import hashlib
-import tarfile
-import json
-import os
 import pyhf
 import numpy as np
-
-
-@pytest.fixture(scope='module')
-def sbottom_likelihoods_download():
-    """Download the sbottom likelihoods tarball from HEPData"""
-    sbottom_HEPData_URL = "https://doi.org/10.17182/hepdata.89408.v1/r2"
-    targz_filename = "sbottom_workspaces.tar.gz"
-    response = requests.get(sbottom_HEPData_URL, stream=True)
-    assert response.status_code == 200
-    with open(targz_filename, "wb") as file:
-        file.write(response.content)
-    assert (
-        hashlib.sha256(open(targz_filename, "rb").read()).hexdigest()
-        == "9089b0e5fabba335bea4c94545ccca8ddd21289feeab2f85e5bcc8bada37be70"
-    )
-    # Open as a tarfile
-    yield tarfile.open(targz_filename, "r:gz")
-    os.remove(targz_filename)
-
-
-# Factory as fixture pattern
-@pytest.fixture
-def get_json_from_tarfile():
-    def _get_json_from_tarfile(tarfile, json_name):
-        json_file = (
-            tarfile.extractfile(tarfile.getmember(json_name)).read().decode("utf8")
-        )
-        return json.loads(json_file)
-
-    return _get_json_from_tarfile
-
 
 def calculate_CLs(bkgonly_json, signal_patch_json):
     """

--- a/tests/test_tensorviewer.py
+++ b/tests/test_tensorviewer.py
@@ -1,0 +1,54 @@
+import pyhf
+from pyhf.tensor.common import _TensorViewer
+from pyhf.parameters import ParamViewer
+from pyhf import default_backend, get_backend
+from pyhf import events
+
+def test_tensorviewer(backend):
+    tb,_ = backend
+    tv = _TensorViewer(
+        [
+            tb.astensor([0, 4, 5]),
+            tb.astensor([1, 2, 3]),
+            tb.astensor([6]),
+        ],
+        names=['zzz', 'aaa','x']
+    )
+
+    data = tb.astensor(tb.astensor(list(range(7))) * 10, dtype = 'int')
+
+    a = [tb.tolist(x) for x in tv.split(data, selection=['aaa'])]
+    assert a == [[10, 20, 30]]
+
+    a = [tb.tolist(x) for x in tv.split(data, selection=['aaa','zzz'])]
+    assert a == [[10, 20, 30],[0,40,50]]
+
+    a = [tb.tolist(x) for x in tv.split(data, selection=['zzz','aaa'])]
+    assert a == [[0,40,50],[10, 20, 30]]
+
+    a = [tb.tolist(x) for x in tv.split(data, selection=['x','aaa'])]
+    assert a == [[60],[10,20,30]]
+
+    a = [tb.tolist(x) for x in tv.split(data, selection=[])]
+    assert a == []
+
+    a = [tb.tolist(x) for x in tv.split(data)]
+    assert a == [[0,40,50],[10,20,30],[60]]
+
+    subviewer = _TensorViewer(
+        [
+            tb.astensor([0]),
+            tb.astensor([1, 2, 3]),
+        ],
+        names=['x', 'aaa']
+    )
+    assert tb.tolist(subviewer.stitch(tv.split(data,['x','aaa']))) == [60,10,20,30]
+
+    subviewer = _TensorViewer(
+        [
+            tb.astensor([0, 1, 2]),
+            tb.astensor([3]),
+        ],
+        names=['aaa','x']
+    )
+    assert tb.tolist(subviewer.stitch(tv.split(data,['aaa','x']))) == [10,20,30,60]

--- a/tests/test_tensorviewer.py
+++ b/tests/test_tensorviewer.py
@@ -4,51 +4,40 @@ from pyhf.parameters import ParamViewer
 from pyhf import default_backend, get_backend
 from pyhf import events
 
+
 def test_tensorviewer(backend):
-    tb,_ = backend
+    tb, _ = backend
     tv = _TensorViewer(
-        [
-            tb.astensor([0, 4, 5]),
-            tb.astensor([1, 2, 3]),
-            tb.astensor([6]),
-        ],
-        names=['zzz', 'aaa','x']
+        [tb.astensor([0, 4, 5]), tb.astensor([1, 2, 3]), tb.astensor([6]),],
+        names=['zzz', 'aaa', 'x'],
     )
 
-    data = tb.astensor(tb.astensor(list(range(7))) * 10, dtype = 'int')
+    data = tb.astensor(tb.astensor(list(range(7))) * 10, dtype='int')
 
     a = [tb.tolist(x) for x in tv.split(data, selection=['aaa'])]
     assert a == [[10, 20, 30]]
 
-    a = [tb.tolist(x) for x in tv.split(data, selection=['aaa','zzz'])]
-    assert a == [[10, 20, 30],[0,40,50]]
+    a = [tb.tolist(x) for x in tv.split(data, selection=['aaa', 'zzz'])]
+    assert a == [[10, 20, 30], [0, 40, 50]]
 
-    a = [tb.tolist(x) for x in tv.split(data, selection=['zzz','aaa'])]
-    assert a == [[0,40,50],[10, 20, 30]]
+    a = [tb.tolist(x) for x in tv.split(data, selection=['zzz', 'aaa'])]
+    assert a == [[0, 40, 50], [10, 20, 30]]
 
-    a = [tb.tolist(x) for x in tv.split(data, selection=['x','aaa'])]
-    assert a == [[60],[10,20,30]]
+    a = [tb.tolist(x) for x in tv.split(data, selection=['x', 'aaa'])]
+    assert a == [[60], [10, 20, 30]]
 
     a = [tb.tolist(x) for x in tv.split(data, selection=[])]
     assert a == []
 
     a = [tb.tolist(x) for x in tv.split(data)]
-    assert a == [[0,40,50],[10,20,30],[60]]
+    assert a == [[0, 40, 50], [10, 20, 30], [60]]
 
     subviewer = _TensorViewer(
-        [
-            tb.astensor([0]),
-            tb.astensor([1, 2, 3]),
-        ],
-        names=['x', 'aaa']
+        [tb.astensor([0]), tb.astensor([1, 2, 3]),], names=['x', 'aaa']
     )
-    assert tb.tolist(subviewer.stitch(tv.split(data,['x','aaa']))) == [60,10,20,30]
+    assert tb.tolist(subviewer.stitch(tv.split(data, ['x', 'aaa']))) == [60, 10, 20, 30]
 
     subviewer = _TensorViewer(
-        [
-            tb.astensor([0, 1, 2]),
-            tb.astensor([3]),
-        ],
-        names=['aaa','x']
+        [tb.astensor([0, 1, 2]), tb.astensor([3]),], names=['aaa', 'x']
     )
-    assert tb.tolist(subviewer.stitch(tv.split(data,['aaa','x']))) == [10,20,30,60]
+    assert tb.tolist(subviewer.stitch(tv.split(data, ['aaa', 'x']))) == [10, 20, 30, 60]

--- a/tests/test_tensorviewer.py
+++ b/tests/test_tensorviewer.py
@@ -1,8 +1,4 @@
-import pyhf
 from pyhf.tensor.common import _TensorViewer
-from pyhf.parameters import ParamViewer
-from pyhf import default_backend, get_backend
-from pyhf import events
 
 
 def test_tensorviewer(backend):


### PR DESCRIPTION
# Description

moves `ParamViewer` to use `_TensorViewer` so that we re-use that logic instead of repeating ourselves

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove unused constraint_model.expected_data method (used some details in ParamViewer that were removed
* Refactor ParamViewer to use TensorViewer remove .slices attribute
* Add ability in TensorViewer to attach names to subspaces and return only subset of tensors when splitting
* Add tensorviewer tests
* Modify paramviewer tests to test more interesting cases
* simpify _TensorViewer construction for full pdf using new helper methods
```
