### PR TITLE
ci: Use official Docker GitHub Action for publication to Docker Hub

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -2,10 +2,10 @@ name: Publish Docker Images
 
 on:
   push:
-    # branches:
-    # - master
-    # tags:
-    # - v*
+    branches:
+    - master
+    tags:
+    - v*
 
 jobs:
   build-and-publish:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,35 @@
+name: Publish Docker Images
+
+on:
+  push:
+    # branches:
+    # - master
+    # tags:
+    # - v*
+
+jobs:
+  build-and-publish:
+    name: Build and publish Docker images to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Build and Publish to Registry
+      if: "! ${{ startsWith(github.ref, 'refs/tags/') }}"
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: pyhf/pyhf
+        dockerfile: docker/Dockerfile
+        tags: latest
+    - name: Build and Publish to Registry with Release Tag
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: pyhf/pyhf
+        dockerfile: docker/Dockerfile
+        tags: latest,latest-stable
+        tag_with_ref: true


### PR DESCRIPTION
# Description

Resolves #716

Use the [official Docker GitHub Action](https://github.com/docker/build-push-action) (released today) to publish to the Docker image to Docker Hub.

Using the `tag_with_ref` option, tag the image with the version release number and `latest-stable` when the push is a tag release.

c.f. [`pyhf/pyhf-validation` PR 11](https://github.com/pyhf/pyhf-validation/pull/11) for an example of this working.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use official Docker GitHub Action to publish to Docker Hub
   - Tag image with version release and 'latest-stable' tags if the push is a tag release
```