### PR TITLE
docs: Add citation from Run 2 Reinterpretation of LHC Results paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,17 @@
+@article{Abdallah:2020pec,
+      author         = "Abdallah, Waleed and others",
+      title          = "{Reinterpretation of LHC Results for New Physics: Status
+                        and Recommendations after Run 2}",
+      collaboration  = "LHC Reinterpretation Forum",
+      year           = "2020",
+      eprint         = "2003.07868",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      reportNumber   = "CERN-LPCC-2020-001, FERMILAB-FN-1098-CMS-T,
+                        Imperial/HEP/2020/RIF/01",
+      SLACcitation   = "%%CITATION = ARXIV:2003.07868;%%"
+}
+
 @inproceedings{Brooijmans:2020yij,
       author         = "Brooijmans, G. and others",
       title          = "{Les Houches 2019 Physics at TeV Colliders: New Physics

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -9,7 +9,8 @@
       primaryClass   = "hep-ph",
       reportNumber   = "CERN-LPCC-2020-001, FERMILAB-FN-1098-CMS-T,
                         Imperial/HEP/2020/RIF/01",
-      SLACcitation   = "%%CITATION = ARXIV:2003.07868;%%"
+      SLACcitation   = "%%CITATION = ARXIV:2003.07868;%%",
+      journal        = ""
 }
 
 @inproceedings{Brooijmans:2020yij,


### PR DESCRIPTION
# Description

Add use citation from [_Reinterpretation of LHC Results for New Physics: Status and Recommendations after Run 2_](https://inspirehep.net/record/1785921)

PR #808 should go in first.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from Reinterpretation of LHC Results for New Physics: Status and Recommendations after Run 2
   - c.f. https://inspirehep.net/record/1785921
```