### PR TITLE
docs: Add JAX to Python API docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -60,6 +60,7 @@ The computational backends that :code:`pyhf` provides interfacing for the vector
    numpy_backend.numpy_backend
    pytorch_backend.pytorch_backend
    tensorflow_backend.tensorflow_backend
+   jax_backend.jax_backend
 
 Optimizers
 ----------
@@ -74,6 +75,7 @@ Optimizers
    opt_pytorch.pytorch_optimizer
    opt_scipy.scipy_optimizer
    opt_tflow.tflow_optimizer
+   opt_jax.jax_optimizer
    opt_minuit.minuit_optimizer
 
 Modifiers

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,7 +112,13 @@ language = None
 #
 # today_fmt = '%B %d, %Y'
 
-autodoc_mock_imports = ['tensorflow', 'torch', 'iminuit', 'tensorflow_probability']
+autodoc_mock_imports = [
+    'tensorflow',
+    'torch',
+    'jax',
+    'iminuit',
+    'tensorflow_probability',
+]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -318,7 +324,7 @@ latex_documents = [
         master_doc,
         'pyhf.tex',
         u'pyhf Documentation',
-        u'Lukas Heinrich, Matthew Feickert',
+        u'Lukas Heinrich, Matthew Feickert, Giordon Stark',
         'manual',
     )
 ]

--- a/src/pyhf/__init__.py
+++ b/src/pyhf/__init__.py
@@ -45,7 +45,7 @@ def set_backend(backend, custom_optimizer=None):
         'numpy'
 
     Args:
-        backend (`str` or `pyhf.tensor` backend): One of the supported pyhf backends: NumPy, TensorFlow, and PyTorch
+        backend (`str` or `pyhf.tensor` backend): One of the supported pyhf backends: NumPy, TensorFlow, PyTorch, and JAX
         custom_optimizer (`pyhf.optimize` optimizer): Optional custom optimizer defined by the user
 
     Returns:

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -38,7 +38,7 @@ class _BasicNormal(object):
 
 
 class jax_backend(object):
-    """jax backend for pyhf"""
+    """JAX backend for pyhf"""
 
     def __init__(self, **kwargs):
         self.name = 'jax'

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -51,7 +51,7 @@ class jax_backend(object):
         Example:
 
             >>> import pyhf
-            >>> pyhf.set_backend(pyhf.tensor.jax_backend())
+            >>> pyhf.set_backend("jax")
             >>> a = pyhf.tensorlib.astensor([-2, -1, 0, 1, 2])
             >>> pyhf.tensorlib.clip(a, -1, 1)
             DeviceArray([-1., -1.,  0.,  1.,  1.], dtype=float64)
@@ -73,7 +73,7 @@ class jax_backend(object):
         Example:
 
             >>> import pyhf
-            >>> pyhf.set_backend(pyhf.tensor.jax_backend())
+            >>> pyhf.set_backend("jax")
             >>> a = pyhf.tensorlib.astensor([[1.0], [2.0]])
             >>> pyhf.tensorlib.tile(a, (1, 2))
             DeviceArray([[1., 1.],
@@ -95,7 +95,7 @@ class jax_backend(object):
         Example:
 
             >>> import pyhf
-            >>> pyhf.set_backend(pyhf.tensor.jax_backend())
+            >>> pyhf.set_backend("jax")
             >>> tensorlib = pyhf.tensorlib
             >>> a = tensorlib.astensor([4])
             >>> b = tensorlib.astensor([5])
@@ -215,7 +215,7 @@ class jax_backend(object):
         Example:
 
             >>> import pyhf
-            >>> pyhf.set_backend(pyhf.tensor.jax_backend())
+            >>> pyhf.set_backend("jax")
             >>> pyhf.tensorlib.simple_broadcast(
             ...   pyhf.tensorlib.astensor([1]),
             ...   pyhf.tensorlib.astensor([2, 3, 4]),
@@ -270,7 +270,7 @@ class jax_backend(object):
         Example:
 
             >>> import pyhf
-            >>> pyhf.set_backend(pyhf.tensor.jax_backend())
+            >>> pyhf.set_backend("jax")
             >>> pyhf.tensorlib.poisson(5., 6.)
             DeviceArray(0.16062314, dtype=float64)
             >>> values = pyhf.tensorlib.astensor([5., 9.])
@@ -313,7 +313,7 @@ class jax_backend(object):
         Example:
 
             >>> import pyhf
-            >>> pyhf.set_backend(pyhf.tensor.jax_backend())
+            >>> pyhf.set_backend("jax")
             >>> pyhf.tensorlib.normal(0.5, 0., 1.)
             DeviceArray(0.35206533, dtype=float64)
             >>> values = pyhf.tensorlib.astensor([0.5, 2.0])
@@ -339,7 +339,7 @@ class jax_backend(object):
         Example:
 
             >>> import pyhf
-            >>> pyhf.set_backend(pyhf.tensor.jax_backend())
+            >>> pyhf.set_backend("jax")
             >>> pyhf.tensorlib.normal_cdf(0.8)
             DeviceArray(0.7881446, dtype=float64)
             >>> values = pyhf.tensorlib.astensor([0.8, 2.0])
@@ -362,7 +362,7 @@ class jax_backend(object):
 
         Example:
             >>> import pyhf
-            >>> pyhf.set_backend(pyhf.tensor.jax_backend())
+            >>> pyhf.set_backend("jax")
             >>> rates = pyhf.tensorlib.astensor([5, 8])
             >>> values = pyhf.tensorlib.astensor([4, 9])
             >>> poissons = pyhf.tensorlib.poisson_dist(rates)
@@ -383,7 +383,7 @@ class jax_backend(object):
 
         Example:
             >>> import pyhf
-            >>> pyhf.set_backend(pyhf.tensor.jax_backend())
+            >>> pyhf.set_backend("jax")
             >>> means = pyhf.tensorlib.astensor([5, 8])
             >>> stds = pyhf.tensorlib.astensor([1, 0.5])
             >>> values = pyhf.tensorlib.astensor([4, 9])


### PR DESCRIPTION
# Description

Add JAX to the list of backends and optimizers in the Python API docs. We missed doing this in PR #377.

Build is at: https://pyhf.readthedocs.io/en/docs-add-jax-to-docs/

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add JAX to list of backends and optimizers in the Python API docs
   - Amends PR #377
* Use string alias to set JAX backend in examples
```
