### PR TITLE
feat: Add percentile function to tensorlib

### DIFF
--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -300,19 +300,19 @@ class jax_backend:
 
                 - \\'linear\\': ``i + (j - i) * fraction``, where ``fraction`` is the fractional part of the index surrounded by ``i`` and ``j``
 
-                - \\'lower\\': Not yet implemented in JAX
+                - \\'lower\\': ``i``
 
-                - \\'higher\\': Not yet implemented in JAX
+                - \\'higher\\': ``j``
 
-                - \\'midpoint\\': Not yet implemented in JAX
+                - \\'midpoint\\': ``(i + j) / 2``
 
-                - \\'nearest\\': Not yet implemented in JAX
+                - \\'nearest\\': ``i`` or ``j``, whichever is nearest
 
         Returns:
             JAX ndarray: The value of the :math:`q`-th percentile of the tensor along the specified axis.
 
         """
-        return np.percentile(tensor_in, q, axis=axis, interpolation=interpolation)
+        return jnp.percentile(tensor_in, q, axis=axis, interpolation=interpolation)
 
     def stack(self, sequence, axis=0):
         return jnp.stack(sequence, axis=axis)

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -312,7 +312,6 @@ class jax_backend:
             JAX ndarray: The value of the :math:`q`-th percentile of the tensor along the specified axis.
 
         """
-        # TODO: https://github.com/google/jax/issues/2607
         return np.percentile(tensor_in, q, axis=axis, interpolation=interpolation)
 
     def stack(self, sequence, axis=0):

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -312,6 +312,7 @@ class jax_backend:
             JAX ndarray: The value of the :math:`q`-th percentile of the tensor along the specified axis.
 
         """
+        # TODO: https://github.com/google/jax/issues/2607
         return np.percentile(tensor_in, q, axis=axis, interpolation=interpolation)
 
     def stack(self, sequence, axis=0):

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -277,7 +277,7 @@ class jax_backend:
     def exp(self, tensor_in):
         return jnp.exp(tensor_in)
 
-    def percentile(self, tensor_in, percentile, axis=None, interpolation="linear"):
+    def percentile(self, tensor_in, q, axis=None, interpolation="linear"):
         r"""
         Compute the :math:`q`-th percentile of the tensor along the specified axis.
 
@@ -293,7 +293,7 @@ class jax_backend:
 
         Args:
             tensor_in (`tensor`): The tensor containing the data
-            percentile (`float` or `tensor`): The :math:`q`-th percentile to compute
+            q (`float` or `tensor`): The :math:`q`-th percentile to compute
             axis (`number` or `tensor`): The dimensions along which to compute
             interpolation (`str`): The interpolation method to use when the desired
                 percentile lies between two data points ``i < j``:
@@ -312,9 +312,7 @@ class jax_backend:
             JAX ndarray: The value of the :math:`q`-th percentile of the tensor along the specified axis.
 
         """
-        return np.percentile(
-            tensor_in, percentile, axis=axis, interpolation=interpolation
-        )
+        return np.percentile(tensor_in, q, axis=axis, interpolation=interpolation)
 
     def stack(self, sequence, axis=0):
         return jnp.stack(sequence, axis=axis)

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -296,8 +296,17 @@ class jax_backend:
             percentile (`float` or `tensor`): The :math:`q`-th percentile to compute
             axis (`number` or `tensor`): The dimensions along which to compute
             interpolation (`str`): The interpolation method to use when the desired
-                                   percentile lies between two data points:
-                                   {‘linear’, ‘lower’, ‘higher’, ‘midpoint’, ‘nearest’}
+                percentile lies between two data points ``i < j``:
+
+                - \\'linear\\': ``i + (j - i) * fraction``, where ``fraction`` is the fractional part of the index surrounded by ``i`` and ``j``
+
+                - \\'lower\\': Not yet implemented in JAX
+
+                - \\'higher\\': Not yet implemented in JAX
+
+                - \\'midpoint\\': Not yet implemented in JAX
+
+                - \\'nearest\\': Not yet implemented in JAX
 
         Returns:
             JAX ndarray: The value of the :math:`q`-th percentile of the tensor along the specified axis.

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -277,6 +277,36 @@ class jax_backend:
     def exp(self, tensor_in):
         return jnp.exp(tensor_in)
 
+    def percentile(self, tensor_in, percentile, axis=None, interpolation="linear"):
+        r"""
+        Compute the :math:`q`-th percentile of the tensor along the specified axis.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("jax")
+            >>> a = pyhf.tensorlib.astensor([[10, 7, 4], [3, 2, 1]])
+            >>> pyhf.tensorlib.percentile(a, 50)
+            DeviceArray(3.5, dtype=float64)
+            >>> pyhf.tensorlib.percentile(a, 50, axis=1)
+            DeviceArray([7., 2.], dtype=float64)
+
+        Args:
+            tensor_in (`tensor`): The tensor containing the data
+            percentile (`float` or `tensor`): The :math:`q`-th percentile to compute
+            axis (`number` or `tensor`): The dimensions along which to compute
+            interpolation (`str`): The interpolation method to use when the desired
+                                   percentile lies between two data points:
+                                   {‘linear’, ‘lower’, ‘higher’, ‘midpoint’, ‘nearest’}
+
+        Returns:
+            JAX ndarray: The value of the :math:`q`-th percentile of the tensor along the specified axis.
+
+        """
+        return np.percentile(
+            tensor_in, percentile, axis=axis, interpolation=interpolation
+        )
+
     def stack(self, sequence, axis=0):
         return jnp.stack(sequence, axis=axis)
 

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -314,7 +314,7 @@ class jax_backend:
             JAX ndarray: The value of the :math:`q`-th percentile of the tensor along the specified axis.
 
         """
-        # TODO: Monitor future JAX releases for percentile dtype changes
+        # TODO: Monitor future JAX releases for changes to percentile dtype promotion
         # c.f. https://github.com/google/jax/issues/8513
         return jnp.percentile(tensor_in, q, axis=axis, interpolation=interpolation)
 

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -287,7 +287,7 @@ class jax_backend:
             >>> pyhf.set_backend("jax")
             >>> a = pyhf.tensorlib.astensor([[10, 7, 4], [3, 2, 1]])
             >>> pyhf.tensorlib.percentile(a, 50)
-            DeviceArray(3.5, dtype=float64)
+            DeviceArray(3.499999..., dtype=float64)
             >>> pyhf.tensorlib.percentile(a, 50, axis=1)
             DeviceArray([7., 2.], dtype=float64)
 

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -293,20 +293,21 @@ class jax_backend:
 
         Args:
             tensor_in (`tensor`): The tensor containing the data
-            q (`float` or `tensor`): The :math:`q`-th percentile to compute
+            q (:obj:`float` or `tensor`): The :math:`q`-th percentile to compute
             axis (`number` or `tensor`): The dimensions along which to compute
-            interpolation (`str`): The interpolation method to use when the desired
-                percentile lies between two data points ``i < j``:
+            interpolation (:obj:`str`): The interpolation method to use when the
+             desired percentile lies between two data points ``i < j``:
 
-                - \\'linear\\': ``i + (j - i) * fraction``, where ``fraction`` is the fractional part of the index surrounded by ``i`` and ``j``
+                - ``'linear'``: ``i + (j - i) * fraction``, where ``fraction`` is the
+                  fractional part of the index surrounded by ``i`` and ``j``.
 
-                - \\'lower\\': ``i``
+                - ``'lower'``: ``i``.
 
-                - \\'higher\\': ``j``
+                - ``'higher'``: ``j``.
 
-                - \\'midpoint\\': ``(i + j) / 2``
+                - ``'midpoint'``: ``(i + j) / 2``.
 
-                - \\'nearest\\': ``i`` or ``j``, whichever is nearest
+                - ``'nearest'``: ``i`` or ``j``, whichever is nearest.
 
         Returns:
             JAX ndarray: The value of the :math:`q`-th percentile of the tensor along the specified axis.

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -284,10 +284,11 @@ class jax_backend:
         Example:
 
             >>> import pyhf
+            >>> import jax.numpy as jnp
             >>> pyhf.set_backend("jax")
             >>> a = pyhf.tensorlib.astensor([[10, 7, 4], [3, 2, 1]])
-            >>> pyhf.tensorlib.percentile(a, 50)
-            DeviceArray(3.499999..., dtype=float64)
+            >>> pyhf.tensorlib.percentile(a, jnp.float64(50))
+            DeviceArray(3.5, dtype=float64)
             >>> pyhf.tensorlib.percentile(a, 50, axis=1)
             DeviceArray([7., 2.], dtype=float64)
 
@@ -313,6 +314,8 @@ class jax_backend:
             JAX ndarray: The value of the :math:`q`-th percentile of the tensor along the specified axis.
 
         """
+        # TODO: Monitor future JAX releases for percentile dtype changes
+        # c.f. https://github.com/google/jax/issues/8513
         return jnp.percentile(tensor_in, q, axis=axis, interpolation=interpolation)
 
     def stack(self, sequence, axis=0):

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -261,7 +261,7 @@ class numpy_backend:
     def exp(self, tensor_in):
         return np.exp(tensor_in)
 
-    def percentile(self, tensor_in, percentile, axis=None, interpolation="linear"):
+    def percentile(self, tensor_in, q, axis=None, interpolation="linear"):
         r"""
         Compute the :math:`q`-th percentile of the tensor along the specified axis.
 
@@ -277,7 +277,7 @@ class numpy_backend:
 
         Args:
             tensor_in (`tensor`): The tensor containing the data
-            percentile (`float` or `tensor`): The :math:`q`-th percentile to compute
+            q (`float` or `tensor`): The :math:`q`-th percentile to compute
             axis (`number` or `tensor`): The dimensions along which to compute
             interpolation (`str`): The interpolation method to use when the desired
                 percentile lies between two data points ``i < j``:
@@ -296,9 +296,7 @@ class numpy_backend:
             NumPy ndarray: The value of the :math:`q`-th percentile of the tensor along the specified axis.
 
         """
-        return np.percentile(
-            tensor_in, percentile, axis=axis, interpolation=interpolation
-        )
+        return np.percentile(tensor_in, q, axis=axis, interpolation=interpolation)
 
     def stack(self, sequence, axis=0):
         return np.stack(sequence, axis=axis)

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -280,8 +280,17 @@ class numpy_backend:
             percentile (`float` or `tensor`): The :math:`q`-th percentile to compute
             axis (`number` or `tensor`): The dimensions along which to compute
             interpolation (`str`): The interpolation method to use when the desired
-                                   percentile lies between two data points:
-                                   {‘linear’, ‘lower’, ‘higher’, ‘midpoint’, ‘nearest’}
+                percentile lies between two data points ``i < j``:
+
+                - \\'linear\\': ``i + (j - i) * fraction``, where ``fraction`` is the fractional part of the index surrounded by ``i`` and ``j``
+
+                - \\'lower\\': ``i``
+
+                - \\'higher\\': ``j``
+
+                - \\'midpoint\\': ``(i + j) / 2``
+
+                - \\'nearest\\': ``i`` or ``j``, whichever is nearest
 
         Returns:
             NumPy ndarray: The value of the :math:`q`-th percentile of the tensor along the specified axis.

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -261,6 +261,36 @@ class numpy_backend:
     def exp(self, tensor_in):
         return np.exp(tensor_in)
 
+    def percentile(self, tensor_in, percentile, axis=None, interpolation="linear"):
+        r"""
+        Compute the :math:`q`-th percentile of the tensor along the specified axis.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("numpy")
+            >>> a = pyhf.tensorlib.astensor([[10, 7, 4], [3, 2, 1]])
+            >>> pyhf.tensorlib.percentile(a, 50)
+            3.5
+            >>> pyhf.tensorlib.percentile(a, 50, axis=1)
+            array([7., 2.])
+
+        Args:
+            tensor_in (`tensor`): The tensor containing the data
+            percentile (`float` or `tensor`): The :math:`q`-th percentile to compute
+            axis (`number` or `tensor`): The dimensions along which to compute
+            interpolation (`str`): The interpolation method to use when the desired
+                                   percentile lies between two data points:
+                                   {‘linear’, ‘lower’, ‘higher’, ‘midpoint’, ‘nearest’}
+
+        Returns:
+            NumPy ndarray: The value of the :math:`q`-th percentile of the tensor along the specified axis.
+
+        """
+        return np.percentile(
+            tensor_in, percentile, axis=axis, interpolation=interpolation
+        )
+
     def stack(self, sequence, axis=0):
         return np.stack(sequence, axis=axis)
 

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -277,20 +277,21 @@ class numpy_backend:
 
         Args:
             tensor_in (`tensor`): The tensor containing the data
-            q (`float` or `tensor`): The :math:`q`-th percentile to compute
+            q (:obj:`float` or `tensor`): The :math:`q`-th percentile to compute
             axis (`number` or `tensor`): The dimensions along which to compute
-            interpolation (`str`): The interpolation method to use when the desired
-                percentile lies between two data points ``i < j``:
+            interpolation (:obj:`str`): The interpolation method to use when the
+             desired percentile lies between two data points ``i < j``:
 
-                - \\'linear\\': ``i + (j - i) * fraction``, where ``fraction`` is the fractional part of the index surrounded by ``i`` and ``j``
+                - ``'linear'``: ``i + (j - i) * fraction``, where ``fraction`` is the
+                  fractional part of the index surrounded by ``i`` and ``j``.
 
-                - \\'lower\\': ``i``
+                - ``'lower'``: ``i``.
 
-                - \\'higher\\': ``j``
+                - ``'higher'``: ``j``.
 
-                - \\'midpoint\\': ``(i + j) / 2``
+                - ``'midpoint'``: ``(i + j) / 2``.
 
-                - \\'nearest\\': ``i`` or ``j``, whichever is nearest
+                - ``'nearest'``: ``i`` or ``j``, whichever is nearest.
 
         Returns:
             NumPy ndarray: The value of the :math:`q`-th percentile of the tensor along the specified axis.

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -294,7 +294,7 @@ class pytorch_backend:
             >>> pyhf.set_backend("pytorch")
             >>> a = pyhf.tensorlib.astensor([[10, 7, 4], [3, 2, 1]])
             >>> pyhf.tensorlib.percentile(a, 50)
-            tensor([3.5000])
+            tensor(3.5000)
             >>> pyhf.tensorlib.percentile(a, 50, axis=1)
             tensor([7., 2.])
 

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -320,6 +320,7 @@ class pytorch_backend:
 
         """
         # TODO: Adopt PyTorch native implimentation when available
+        # c.f. https://github.com/pytorch/pytorch/issues/35977
         import numpy as np
 
         np_result = np.percentile(

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -303,8 +303,17 @@ class pytorch_backend:
             percentile (`float` or `tensor`): The :math:`q`-th percentile to compute
             axis (`number` or `tensor`): The dimensions along which to compute
             interpolation (`str`): The interpolation method to use when the desired
-                                   percentile lies between two data points:
-                                   {‘linear’, ‘lower’, ‘higher’, ‘midpoint’, ‘nearest’}
+                percentile lies between two data points ``i < j``:
+
+                - \\'linear\\': ``i + (j - i) * fraction``, where ``fraction`` is the fractional part of the index surrounded by ``i`` and ``j``
+
+                - \\'lower\\': ``i``
+
+                - \\'higher\\': ``j``
+
+                - \\'midpoint\\': ``(i + j) / 2``
+
+                - \\'nearest\\': ``i`` or ``j``, whichever is nearest
 
         Returns:
             PyTorch tensor: The value of the :math:`q`-th percentile of the tensor along the specified axis.

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -316,7 +316,15 @@ class pytorch_backend:
         np_result = np.percentile(
             tensor_in.data.numpy(), percentile, axis=axis, interpolation=interpolation
         )
-        return self.astensor(np_result)
+        # Ensure consistent return structure as other backends
+        # Only needed given #TODO above
+        result_tensor = self.astensor(np_result)
+        result = (
+            result_tensor[0]
+            if result_tensor.shape == torch.Size([1])
+            else result_tensor
+        )
+        return result
 
     def stack(self, sequence, axis=0):
         return torch.stack(sequence, dim=axis)

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -313,9 +313,8 @@ class pytorch_backend:
         # TODO: Adopt PyTorch native implimentation when available
         import numpy as np
 
-        ndarray = tensor_in.data.numpy()
         np_result = np.percentile(
-            ndarray, percentile, axis=axis, interpolation=interpolation
+            tensor_in.data.numpy(), percentile, axis=axis, interpolation=interpolation
         )
         return self.astensor(np_result)
 

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -310,9 +310,7 @@ class pytorch_backend:
             PyTorch tensor: The value of the :math:`q`-th percentile of the tensor along the specified axis.
 
         """
-        # k = 1 + round(0.01 * float(percentile) * (tensor_in.numel() - 1))
-        # # return tensor_in.view(-1).kthvalue(k, dim=axis).values.item()
-        # return tensor_in.view(-1).kthvalue(k).values.item()
+        # TODO: Adopt PyTorch native implimentation when available
         import numpy as np
 
         ndarray = tensor_in.data.numpy()

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -307,34 +307,20 @@ class pytorch_backend:
 
                 - \\'linear\\': ``i + (j - i) * fraction``, where ``fraction`` is the fractional part of the index surrounded by ``i`` and ``j``
 
-                - \\'lower\\': ``i``
+                - \\'lower\\': Not yet implemented in PyTorch
 
-                - \\'higher\\': ``j``
+                - \\'higher\\': Not yet implemented in PyTorch
 
-                - \\'midpoint\\': ``(i + j) / 2``
+                - \\'midpoint\\': Not yet implemented in PyTorch
 
-                - \\'nearest\\': ``i`` or ``j``, whichever is nearest
+                - \\'nearest\\': Not yet implemented in PyTorch
 
         Returns:
             PyTorch tensor: The value of the :math:`q`-th percentile of the tensor along the specified axis.
 
         """
-        # TODO: Adopt PyTorch native implimentation when available
-        # c.f. https://github.com/pytorch/pytorch/issues/35977
-        import numpy as np
-
-        np_result = np.percentile(
-            tensor_in.data.numpy(), q, axis=axis, interpolation=interpolation
-        )
-        # Ensure consistent return structure as other backends
-        # Only needed given #TODO above
-        result_tensor = self.astensor(np_result)
-        result = (
-            result_tensor[0]
-            if result_tensor.shape == torch.Size([1])
-            else result_tensor
-        )
-        return result
+        # Interpolation options not yet supported
+        return torch.quantile(tensor_in, q / 100, dim=axis)
 
     def stack(self, sequence, axis=0):
         return torch.stack(sequence, dim=axis)

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -310,11 +310,16 @@ class pytorch_backend:
             PyTorch tensor: The value of the :math:`q`-th percentile of the tensor along the specified axis.
 
         """
-        dim = tensor_in.shape[-1] if axis is None else axis
-        k = 1 + round(0.01 * float(percentile) * (tensor_in.numel() - 1))
-        # return tensor_in.view(-1).kthvalue(k, dim=axis).values.item()
-        return tensor_in.view(-1).kthvalue(k).values.item()
-        # return dist.icdf(tensor_in, percentile, axis=axis, interpolation=interpolation)
+        # k = 1 + round(0.01 * float(percentile) * (tensor_in.numel() - 1))
+        # # return tensor_in.view(-1).kthvalue(k, dim=axis).values.item()
+        # return tensor_in.view(-1).kthvalue(k).values.item()
+        import numpy as np
+
+        ndarray = tensor_in.data.numpy()
+        np_result = np.percentile(
+            ndarray, percentile, axis=axis, interpolation=interpolation
+        )
+        return self.astensor(np_result)
 
     def stack(self, sequence, axis=0):
         return torch.stack(sequence, dim=axis)

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -320,6 +320,7 @@ class pytorch_backend:
 
         """
         # Interpolation options not yet supported
+        # c.f. https://github.com/pytorch/pytorch/issues/38349
         return torch.quantile(tensor_in, q / 100, dim=axis)
 
     def stack(self, sequence, axis=0):

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -294,9 +294,9 @@ class pytorch_backend:
             >>> pyhf.set_backend("pytorch")
             >>> a = pyhf.tensorlib.astensor([[10, 7, 4], [3, 2, 1]])
             >>> pyhf.tensorlib.percentile(a, 50)
-            3.5
+            tensor([3.5000])
             >>> pyhf.tensorlib.percentile(a, 50, axis=1)
-            array([7., 2.])
+            tensor([7., 2.])
 
         Args:
             tensor_in (`tensor`): The tensor containing the data

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -284,6 +284,38 @@ class pytorch_backend:
     def exp(self, tensor_in):
         return torch.exp(tensor_in)
 
+    def percentile(self, tensor_in, percentile, axis=None, interpolation="linear"):
+        r"""
+        Compute the :math:`q`-th percentile of the tensor along the specified axis.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("pytorch")
+            >>> a = pyhf.tensorlib.astensor([[10, 7, 4], [3, 2, 1]])
+            >>> pyhf.tensorlib.percentile(a, 50)
+            3.5
+            >>> pyhf.tensorlib.percentile(a, 50, axis=1)
+            array([7., 2.])
+
+        Args:
+            tensor_in (`tensor`): The tensor containing the data
+            percentile (`float` or `tensor`): The :math:`q`-th percentile to compute
+            axis (`number` or `tensor`): The dimensions along which to compute
+            interpolation (`str`): The interpolation method to use when the desired
+                                   percentile lies between two data points:
+                                   {‘linear’, ‘lower’, ‘higher’, ‘midpoint’, ‘nearest’}
+
+        Returns:
+            PyTorch tensor: The value of the :math:`q`-th percentile of the tensor along the specified axis.
+
+        """
+        dim = tensor_in.shape[-1] if axis is None else axis
+        k = 1 + round(0.01 * float(percentile) * (tensor_in.numel() - 1))
+        # return tensor_in.view(-1).kthvalue(k, dim=axis).values.item()
+        return tensor_in.view(-1).kthvalue(k).values.item()
+        # return dist.icdf(tensor_in, percentile, axis=axis, interpolation=interpolation)
+
     def stack(self, sequence, axis=0):
         return torch.stack(sequence, dim=axis)
 

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -284,7 +284,7 @@ class pytorch_backend:
     def exp(self, tensor_in):
         return torch.exp(tensor_in)
 
-    def percentile(self, tensor_in, percentile, axis=None, interpolation="linear"):
+    def percentile(self, tensor_in, q, axis=None, interpolation="linear"):
         r"""
         Compute the :math:`q`-th percentile of the tensor along the specified axis.
 
@@ -300,7 +300,7 @@ class pytorch_backend:
 
         Args:
             tensor_in (`tensor`): The tensor containing the data
-            percentile (`float` or `tensor`): The :math:`q`-th percentile to compute
+            q (`float` or `tensor`): The :math:`q`-th percentile to compute
             axis (`number` or `tensor`): The dimensions along which to compute
             interpolation (`str`): The interpolation method to use when the desired
                 percentile lies between two data points ``i < j``:
@@ -323,7 +323,7 @@ class pytorch_backend:
         import numpy as np
 
         np_result = np.percentile(
-            tensor_in.data.numpy(), percentile, axis=axis, interpolation=interpolation
+            tensor_in.data.numpy(), q, axis=axis, interpolation=interpolation
         )
         # Ensure consistent return structure as other backends
         # Only needed given #TODO above

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -320,7 +320,8 @@ class pytorch_backend:
 
         """
         # Interpolation options not yet supported
-        # c.f. https://github.com/pytorch/pytorch/issues/38349
+        # c.f. https://github.com/pytorch/pytorch/pull/49267
+        # c.f. https://github.com/pytorch/pytorch/pull/59397
         return torch.quantile(tensor_in, q / 100, dim=axis)
 
     def stack(self, sequence, axis=0):

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -300,20 +300,21 @@ class pytorch_backend:
 
         Args:
             tensor_in (`tensor`): The tensor containing the data
-            q (`float` or `tensor`): The :math:`q`-th percentile to compute
+            q (:obj:`float` or `tensor`): The :math:`q`-th percentile to compute
             axis (`number` or `tensor`): The dimensions along which to compute
-            interpolation (`str`): The interpolation method to use when the desired
-                percentile lies between two data points ``i < j``:
+            interpolation (:obj:`str`): The interpolation method to use when the
+             desired percentile lies between two data points ``i < j``:
 
-                - \\'linear\\': ``i + (j - i) * fraction``, where ``fraction`` is the fractional part of the index surrounded by ``i`` and ``j``
+                - ``'linear'``: ``i + (j - i) * fraction``, where ``fraction`` is the
+                  fractional part of the index surrounded by ``i`` and ``j``.
 
-                - \\'lower\\': Not yet implemented in PyTorch
+                - ``'lower'``: Not yet implemented in PyTorch.
 
-                - \\'higher\\': Not yet implemented in PyTorch
+                - ``'higher'``: Not yet implemented in PyTorch.
 
-                - \\'midpoint\\': Not yet implemented in PyTorch
+                - ``'midpoint'``: Not yet implemented in PyTorch.
 
-                - \\'nearest\\': Not yet implemented in PyTorch
+                - ``'nearest'``: Not yet implemented in PyTorch.
 
         Returns:
             PyTorch tensor: The value of the :math:`q`-th percentile of the tensor along the specified axis.

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -303,7 +303,7 @@ class tensorflow_backend:
     def exp(self, tensor_in):
         return tf.exp(tensor_in)
 
-    def percentile(self, tensor_in, percentile, axis=None, interpolation="linear"):
+    def percentile(self, tensor_in, q, axis=None, interpolation="linear"):
         r"""
         Compute the :math:`q`-th percentile of the tensor along the specified axis.
 
@@ -321,7 +321,7 @@ class tensorflow_backend:
 
         Args:
             tensor_in (`tensor`): The tensor containing the data
-            percentile (`float` or `tensor`): The :math:`q`-th percentile to compute
+            q (`float` or `tensor`): The :math:`q`-th percentile to compute
             axis (`number` or `tensor`): The dimensions along which to compute
             interpolation (`str`): The interpolation method to use when the desired
                 percentile lies between two data points ``i < j``:
@@ -341,7 +341,7 @@ class tensorflow_backend:
 
         """
         return tfp.stats.percentile(
-            tensor_in, percentile, axis=axis, interpolation=interpolation
+            tensor_in, q, axis=axis, interpolation=interpolation
         )
 
     def stack(self, sequence, axis=0):

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -340,6 +340,7 @@ class tensorflow_backend:
             TensorFlow Tensor: The value of the :math:`q`-th percentile of the tensor along the specified axis.
 
         """
+        # TODO: https://github.com/tensorflow/probability/issues/864
         return tfp.stats.percentile(
             tensor_in, q, axis=axis, interpolation=interpolation
         )

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -303,6 +303,38 @@ class tensorflow_backend:
     def exp(self, tensor_in):
         return tf.exp(tensor_in)
 
+    def percentile(self, tensor_in, percentile, axis=None, interpolation="linear"):
+        r"""
+        Compute the :math:`q`-th percentile of the tensor along the specified axis.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("tensorflow")
+            >>> a = pyhf.tensorlib.astensor([[10, 7, 4], [3, 2, 1]])
+            >>> t = pyhf.tensorlib.percentile(a, 50)
+            >>> print(t)
+            tf.Tensor(3.5, shape=(), dtype=float32)
+            >>> t = pyhf.tensorlib.percentile(a, 50, axis=1)
+            >>> print(t)
+            tf.Tensor([7. 2.], shape=(2,), dtype=float32)
+
+        Args:
+            tensor_in (`tensor`): The tensor containing the data
+            percentile (`float` or `tensor`): The :math:`q`-th percentile to compute
+            axis (`number` or `tensor`): The dimensions along which to compute
+            interpolation (`str`): The interpolation method to use when the desired
+                                   percentile lies between two data points:
+                                   {‘linear’, ‘lower’, ‘higher’, ‘midpoint’, ‘nearest’}
+
+        Returns:
+            TensorFlow Tensor: The value of the :math:`q`-th percentile of the tensor along the specified axis.
+
+        """
+        return tfp.stats.percentile(
+            tensor_in, percentile, axis=axis, interpolation=interpolation
+        )
+
     def stack(self, sequence, axis=0):
         return tf.stack(sequence, axis=axis)
 

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -324,8 +324,17 @@ class tensorflow_backend:
             percentile (`float` or `tensor`): The :math:`q`-th percentile to compute
             axis (`number` or `tensor`): The dimensions along which to compute
             interpolation (`str`): The interpolation method to use when the desired
-                                   percentile lies between two data points:
-                                   {‘linear’, ‘lower’, ‘higher’, ‘midpoint’, ‘nearest’}
+                percentile lies between two data points ``i < j``:
+
+                - \\'linear\\': ``i + (j - i) * fraction``, where ``fraction`` is the fractional part of the index surrounded by ``i`` and ``j``
+
+                - \\'lower\\': ``i``
+
+                - \\'higher\\': ``j``
+
+                - \\'midpoint\\': ``(i + j) / 2``
+
+                - \\'nearest\\': ``i`` or ``j``, whichever is nearest
 
         Returns:
             TensorFlow Tensor: The value of the :math:`q`-th percentile of the tensor along the specified axis.

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -340,7 +340,6 @@ class tensorflow_backend:
             TensorFlow Tensor: The value of the :math:`q`-th percentile of the tensor along the specified axis.
 
         """
-        # TODO: https://github.com/tensorflow/probability/issues/864
         return tfp.stats.percentile(
             tensor_in, q, axis=axis, interpolation=interpolation
         )

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -321,20 +321,21 @@ class tensorflow_backend:
 
         Args:
             tensor_in (`tensor`): The tensor containing the data
-            q (`float` or `tensor`): The :math:`q`-th percentile to compute
+            q (:obj:`float` or `tensor`): The :math:`q`-th percentile to compute
             axis (`number` or `tensor`): The dimensions along which to compute
-            interpolation (`str`): The interpolation method to use when the desired
-                percentile lies between two data points ``i < j``:
+            interpolation (:obj:`str`): The interpolation method to use when the
+             desired percentile lies between two data points ``i < j``:
 
-                - \\'linear\\': ``i + (j - i) * fraction``, where ``fraction`` is the fractional part of the index surrounded by ``i`` and ``j``
+                - ``'linear'``: ``i + (j - i) * fraction``, where ``fraction`` is the
+                  fractional part of the index surrounded by ``i`` and ``j``.
 
-                - \\'lower\\': ``i``
+                - ``'lower'``: ``i``.
 
-                - \\'higher\\': ``j``
+                - ``'higher'``: ``j``.
 
-                - \\'midpoint\\': ``(i + j) / 2``
+                - ``'midpoint'``: ``(i + j) / 2``.
 
-                - \\'nearest\\': ``i`` or ``j``, whichever is nearest
+                - ``'nearest'``: ``i`` or ``j``, whichever is nearest.
 
         Returns:
             TensorFlow Tensor: The value of the :math:`q`-th percentile of the tensor along the specified axis.

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -314,10 +314,10 @@ class tensorflow_backend:
             >>> a = pyhf.tensorlib.astensor([[10, 7, 4], [3, 2, 1]])
             >>> t = pyhf.tensorlib.percentile(a, 50)
             >>> print(t)
-            tf.Tensor(3.5, shape=(), dtype=float32)
+            tf.Tensor(3.5, shape=(), dtype=float64)
             >>> t = pyhf.tensorlib.percentile(a, 50, axis=1)
             >>> print(t)
-            tf.Tensor([7. 2.], shape=(2,), dtype=float32)
+            tf.Tensor([7. 2.], shape=(2,), dtype=float64)
 
         Args:
             tensor_in (`tensor`): The tensor containing the data

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -379,7 +379,7 @@ def test_percentile(backend):
     assert tb.tolist(tb.percentile(a, 50, axis=1)) == [7.0, 2.0]
 
 
-# JAX doesn't yet support "nearest" as an interpolation scheme
+# PyTorch doesn't yet support interpolation schemes other than "linear"
 def test_percentile_interpolation(backend):
     tb = pyhf.tensorlib
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -380,17 +380,12 @@ def test_percentile(backend):
 
 
 # JAX doesn't yet support "nearest" as an interpolation scheme
-# TensorFlow Probability uses a descending ordering causing nearest error
 def test_percentile_interpolation(backend):
     tb = pyhf.tensorlib
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])
 
     assert tb.tolist(tb.percentile(a, 50, interpolation="linear")) == 3.5
-    # TODO: Unify this with NumPy through TFP team fixing difference
-    if tb.name == "tensorflow":
-        assert tb.tolist(tb.percentile(a, 50, interpolation="nearest")) == 4.0
-    else:
-        assert tb.tolist(tb.percentile(a, 50, interpolation="nearest")) == 3.0
+    assert tb.tolist(tb.percentile(a, 50, interpolation="nearest")) == 3.0
     assert tb.tolist(tb.percentile(a, 50, interpolation="lower")) == 3.0
     assert tb.tolist(tb.percentile(a, 50, interpolation="midpoint")) == 3.5
     assert tb.tolist(tb.percentile(a, 50, interpolation="higher")) == 4.0

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -375,7 +375,6 @@ def test_percentile(backend):
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])
     assert tb.tolist(tb.percentile(a, 50)) == 3.5
     assert tb.tolist(tb.percentile(a, 50, axis=1)) == [7.0, 2.0]
-    assert tb.tolist(tb.percentile(a, 50, interpolation="linear")) == 3.5
 
 
 # JAX doesn't yet support "nearest" as an interpolation scheme
@@ -385,6 +384,12 @@ def test_percentile_interpolation(backend):
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])
     assert tb.tolist(tb.percentile(a, 50, interpolation="linear")) == 3.5
     assert tb.tolist(tb.percentile(a, 50, interpolation="nearest")) == 3.0
+    assert tb.tolist(tb.percentile(a, 50, interpolation="lower")) == 3.0
+    assert tb.tolist(tb.percentile(a, 50, interpolation="midpoint")) == 3.5
+    assert tb.tolist(tb.percentile(a, 50, interpolation="higher")) == 4.0
+
+    assert tb.tolist(tb.percentile(a, 30, interpolation="linear")) == 2.5
+    assert tb.tolist(tb.percentile(a, 30, interpolation="nearest")) == 3.0
 
 
 def test_tensor_tile(backend):

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -384,26 +384,16 @@ def test_percentile(backend):
 def test_percentile_interpolation(backend):
     tb = pyhf.tensorlib
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])
+
     assert tb.tolist(tb.percentile(a, 50, interpolation="linear")) == 3.5
     # TODO: Unify this with NumPy through TFP team fixing difference
     if tb.name == "tensorflow":
         assert tb.tolist(tb.percentile(a, 50, interpolation="nearest")) == 4.0
-    # TODO: Unify this with NumPy thorugh JAX team implimenting
-    elif tb.name == "jax":
-        with pytest.raises(NotImplementedError):
-            assert tb.tolist(tb.percentile(a, 50, interpolation="nearest")) == 3.0
     else:
         assert tb.tolist(tb.percentile(a, 50, interpolation="nearest")) == 3.0
-    # TODO: Unify this with NumPy thorugh JAX team implimenting
-    if tb.name == "jax":
-        with pytest.raises(NotImplementedError):
-            assert tb.tolist(tb.percentile(a, 50, interpolation="lower")) == 3.0
-            assert tb.tolist(tb.percentile(a, 50, interpolation="midpoint")) == 3.5
-            assert tb.tolist(tb.percentile(a, 50, interpolation="higher")) == 4.0
-    else:
-        assert tb.tolist(tb.percentile(a, 50, interpolation="lower")) == 3.0
-        assert tb.tolist(tb.percentile(a, 50, interpolation="midpoint")) == 3.5
-        assert tb.tolist(tb.percentile(a, 50, interpolation="higher")) == 4.0
+    assert tb.tolist(tb.percentile(a, 50, interpolation="lower")) == 3.0
+    assert tb.tolist(tb.percentile(a, 50, interpolation="midpoint")) == 3.5
+    assert tb.tolist(tb.percentile(a, 50, interpolation="higher")) == 4.0
 
 
 def test_tensor_tile(backend):

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -378,7 +378,9 @@ def test_percentile(backend):
 
 
 # JAX doesn't yet support "nearest" as an interpolation scheme
+# TensorFlow Probability uses a descending ordering causing nearest error
 @pytest.mark.fail_jax
+@pytest.mark.fail_tensorflow
 def test_percentile_interpolation(backend):
     tb = pyhf.tensorlib
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -370,6 +370,23 @@ def test_boolean_mask(backend):
     )
 
 
+def test_percentile(backend):
+    tb = pyhf.tensorlib
+    a = tb.astensor([[10, 7, 4], [3, 2, 1]])
+    assert tb.tolist(tb.percentile(a, 50)) == 3.5
+    assert tb.tolist(tb.percentile(a, 50, axis=1)) == [7.0, 2.0]
+    assert tb.tolist(tb.percentile(a, 50, interpolation="linear")) == 3.5
+
+
+# JAX doesn't yet support "nearest" as an interpolation scheme
+@pytest.mark.fail_jax
+def test_percentile_interpolation(backend):
+    tb = pyhf.tensorlib
+    a = tb.astensor([[10, 7, 4], [3, 2, 1]])
+    assert tb.tolist(tb.percentile(a, 50, interpolation="linear")) == 3.5
+    assert tb.tolist(tb.percentile(a, 50, interpolation="nearest")) == 3.0
+
+
 def test_tensor_tile(backend):
     a = [[1], [2], [3]]
     tb = pyhf.tensorlib

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -381,19 +381,29 @@ def test_percentile(backend):
 
 # JAX doesn't yet support "nearest" as an interpolation scheme
 # TensorFlow Probability uses a descending ordering causing nearest error
-@pytest.mark.fail_jax
-@pytest.mark.fail_tensorflow
 def test_percentile_interpolation(backend):
     tb = pyhf.tensorlib
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])
     assert tb.tolist(tb.percentile(a, 50, interpolation="linear")) == 3.5
-    assert tb.tolist(tb.percentile(a, 50, interpolation="nearest")) == 3.0
-    assert tb.tolist(tb.percentile(a, 50, interpolation="lower")) == 3.0
-    assert tb.tolist(tb.percentile(a, 50, interpolation="midpoint")) == 3.5
-    assert tb.tolist(tb.percentile(a, 50, interpolation="higher")) == 4.0
-
-    assert tb.tolist(tb.percentile(a, 30, interpolation="linear")) == 2.5
-    assert tb.tolist(tb.percentile(a, 30, interpolation="nearest")) == 3.0
+    # TODO: Unify this with NumPy through TFP team fixing difference
+    if tb.name == "tensorflow":
+        assert tb.tolist(tb.percentile(a, 50, interpolation="nearest")) == 4.0
+    # TODO: Unify this with NumPy thorugh JAX team implimenting
+    elif tb.name == "jax":
+        with pytest.raises(NotImplementedError):
+            assert tb.tolist(tb.percentile(a, 50, interpolation="nearest")) == 3.0
+    else:
+        assert tb.tolist(tb.percentile(a, 50, interpolation="nearest")) == 3.0
+    # TODO: Unify this with NumPy thorugh JAX team implimenting
+    if tb.name == "jax":
+        with pytest.raises(NotImplementedError):
+            assert tb.tolist(tb.percentile(a, 50, interpolation="lower")) == 3.0
+            assert tb.tolist(tb.percentile(a, 50, interpolation="midpoint")) == 3.5
+            assert tb.tolist(tb.percentile(a, 50, interpolation="higher")) == 4.0
+    else:
+        assert tb.tolist(tb.percentile(a, 50, interpolation="lower")) == 3.0
+        assert tb.tolist(tb.percentile(a, 50, interpolation="midpoint")) == 3.5
+        assert tb.tolist(tb.percentile(a, 50, interpolation="higher")) == 4.0
 
 
 def test_tensor_tile(backend):

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -373,7 +373,9 @@ def test_boolean_mask(backend):
 def test_percentile(backend):
     tb = pyhf.tensorlib
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])
+    assert tb.tolist(tb.percentile(a, 0)) == 1
     assert tb.tolist(tb.percentile(a, 50)) == 3.5
+    assert tb.tolist(tb.percentile(a, 100)) == 10
     assert tb.tolist(tb.percentile(a, 50, axis=1)) == [7.0, 2.0]
 
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -383,6 +383,7 @@ def test_percentile(backend):
 
 # FIXME: PyTorch doesn't yet support interpolation schemes other than "linear"
 # c.f. https://github.com/pytorch/pytorch/pull/59397
+# c.f. https://github.com/scikit-hep/pyhf/issues/1693
 @pytest.mark.skip_pytorch
 @pytest.mark.skip_pytorch64
 @pytest.mark.skip_jax
@@ -404,7 +405,7 @@ def test_percentile_jax(backend):
     assert tb.tolist(tb.percentile(a, 0)) == 1
 
     # TODO: Monitor future JAX releases for changes to percentile dtype promotion
-    # c.f. https://github.com/google/jax/issues/8513
+    # c.f. https://github.com/scikit-hep/pyhf/issues/1693
     assert tb.tolist(tb.percentile(a, np.float64(50))) == 3.5
     assert tb.tolist(tb.percentile(a, np.float64(100))) == 10
     assert tb.tolist(tb.percentile(a, 50, axis=1)) == [7.0, 2.0]
@@ -416,7 +417,7 @@ def test_percentile_interpolation_jax(backend):
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])
 
     # TODO: Monitor future JAX releases for changes to percentile dtype promotion
-    # c.f. https://github.com/google/jax/issues/8513
+    # c.f. https://github.com/scikit-hep/pyhf/issues/1693
     assert tb.tolist(tb.percentile(a, np.float64(50), interpolation="linear")) == 3.5
     assert tb.tolist(tb.percentile(a, 50, interpolation="nearest")) == 3.0
     assert tb.tolist(tb.percentile(a, 50, interpolation="lower")) == 3.0

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -381,7 +381,10 @@ def test_percentile(backend):
     assert tb.tolist(tb.percentile(a, 50, axis=1)) == [7.0, 2.0]
 
 
-# PyTorch doesn't yet support interpolation schemes other than "linear"
+# FIXME: PyTorch doesn't yet support interpolation schemes other than "linear"
+# c.f. https://github.com/pytorch/pytorch/pull/59397
+@pytest.mark.skip_pytorch
+@pytest.mark.skip_pytorch64
 def test_percentile_interpolation(backend):
     tb = pyhf.tensorlib
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -403,9 +403,10 @@ def test_percentile_jax(backend):
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])
     assert tb.tolist(tb.percentile(a, 0)) == 1
 
-    # FIXME: JAX has floating point issues with "linear" interpolation method
-    assert pytest.approx(tb.tolist(tb.percentile(a, 50)), rel=1e-6) == 3.5
-    assert pytest.approx(tb.tolist(tb.percentile(a, 100)), rel=1e-6) == 10
+    # TODO: Monitor future JAX releases for changes to percentile dtype promotion
+    # c.f. https://github.com/google/jax/issues/8513
+    assert tb.tolist(tb.percentile(a, np.float64(50))) == 3.5
+    assert tb.tolist(tb.percentile(a, np.float64(100))) == 10
     assert tb.tolist(tb.percentile(a, 50, axis=1)) == [7.0, 2.0]
 
 
@@ -414,11 +415,9 @@ def test_percentile_interpolation_jax(backend):
     tb = pyhf.tensorlib
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])
 
-    # FIXME: JAX has floating point issues with "linear" interpolation method
-    assert (
-        pytest.approx(tb.tolist(tb.percentile(a, 50, interpolation="linear")), rel=1e-6)
-        == 3.5
-    )
+    # TODO: Monitor future JAX releases for changes to percentile dtype promotion
+    # c.f. https://github.com/google/jax/issues/8513
+    assert tb.tolist(tb.percentile(a, np.float64(50), interpolation="linear")) == 3.5
     assert tb.tolist(tb.percentile(a, 50, interpolation="nearest")) == 3.0
     assert tb.tolist(tb.percentile(a, 50, interpolation="lower")) == 3.0
     assert tb.tolist(tb.percentile(a, 50, interpolation="midpoint")) == 3.5

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -374,8 +374,10 @@ def test_percentile(backend):
     tb = pyhf.tensorlib
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])
     assert tb.tolist(tb.percentile(a, 0)) == 1
-    assert tb.tolist(tb.percentile(a, 50)) == 3.5
-    assert tb.tolist(tb.percentile(a, 100)) == 10
+
+    # FIXME: (Only) JAX has floating point issues here
+    assert pytest.approx(tb.tolist(tb.percentile(a, 50)), rel=1e-6) == 3.5
+    assert pytest.approx(tb.tolist(tb.percentile(a, 100)), rel=1e-6) == 10
     assert tb.tolist(tb.percentile(a, 50, axis=1)) == [7.0, 2.0]
 
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -403,7 +403,7 @@ def test_percentile_jax(backend):
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])
     assert tb.tolist(tb.percentile(a, 0)) == 1
 
-    # FIXME: (Only) JAX has floating point issues here
+    # FIXME: JAX has floating point issues with "linear" interpolation method
     assert pytest.approx(tb.tolist(tb.percentile(a, 50)), rel=1e-6) == 3.5
     assert pytest.approx(tb.tolist(tb.percentile(a, 100)), rel=1e-6) == 10
     assert tb.tolist(tb.percentile(a, 50, axis=1)) == [7.0, 2.0]
@@ -414,7 +414,7 @@ def test_percentile_interpolation_jax(backend):
     tb = pyhf.tensorlib
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])
 
-    # FIXME: (Only) JAX has floating point issues here
+    # FIXME: JAX has floating point issues with "linear" interpolation method
     assert (
         pytest.approx(tb.tolist(tb.percentile(a, 50, interpolation="linear")), rel=1e-6)
         == 3.5


### PR DESCRIPTION
# Description

* ~~Partially addresses Issue #815~~
* Resolves #815
* Resolves #1573

Add a `percentile` function to the tensor backends that adheres to [NumPy's `numpy.percentile`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.percentile.html) API.

~~To get quotation marks to look okay for the interpolation method section of the docstrings I used `\\` to escape them given [this Stack Overflow question](https://stackoverflow.com/questions/17965655/how-to-escape-single-quotes-in-restructuredtext-when-converting-to-html-using-sp). There may be a better way.~~

Docs build at: https://pyhf--817.org.readthedocs.build/en/817/api.html#backends

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add percentile function to the tensor backends
* Add tests for percentile and its interpolation methods
   - JAX requires additional dtype support with the 'linear' interpolation method
     c.f. https://github.com/google/jax/issues/8513
   - PyTorch has yet to implement interpolation method options
   - c.f. https://github.com/scikit-hep/pyhf/issues/1693
```
