### PR TITLE
chore: Use GitHub Actions checkout action v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: [3.6, 3.7]
 
     steps:
-    - uses: actions/checkout@v1.2.0
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -71,7 +71,7 @@ jobs:
         python-version: [3.7]
 
     steps:
-    - uses: actions/checkout@v1.2.0
+    - uses: actions/checkout@v2
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
@@ -98,7 +98,7 @@ jobs:
         python-version: [3.7]
 
     steps:
-    - uses: actions/checkout@v1.2.0
+    - uses: actions/checkout@v2
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged
     steps:
-    - uses: actions/checkout@v1.2.0
+    - uses: actions/checkout@v2
     - name: Trigger Binder build
       run: |
         # Use Binder build API to trigger repo2docker to build image on GKE and OVH Binder Federation clusters

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Build and Publish to Registry
       if: "!(startsWith(github.ref, 'refs/tags/'))"
       uses: docker/build-push-action@v1

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build and publish Python distro to (Test)PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1.2.0
+    - uses: actions/checkout@v2
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: [3.7]
 
     steps:
-    - uses: actions/checkout@v1.2.0
+    - uses: actions/checkout@v2
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -43,7 +43,7 @@ jobs:
           echo "::set-env name=BV_PART::patch"
         fi
     - name: Checkout repository
-      uses: actions/checkout@v1.2.0
+      uses: actions/checkout@v2
     - name: Set up git user
       run: |
         git config --local user.email "action@github.com"


### PR DESCRIPTION
# Description

Update the [`checkout` GitHub Action](https://github.com/actions/checkout) to use stable release `v2`.

Requires PR #825 to go in first.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update checkout action to v2 (stable major release v2.0.0)
```
