### PR TITLE
revert: Remove disk space regression hack fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,10 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Free disk space
+    - name: Check disk space
       # WARNING: Needed due to GitHub Actions disk space regression on Linux runners
       if: matrix.os == 'ubuntu-latest'
       run: |
-        sudo apt-get clean
         df -h
     - name: Install dependencies
       run: |
@@ -76,10 +75,9 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Free disk space
+    - name: Check disk space
       # WARNING: Needed due to GitHub Actions disk space regression on Linux runners
       run: |
-        sudo apt-get clean
         df -h
     - name: Install dependencies
       run: |
@@ -103,10 +101,9 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Free disk space
+    - name: Check disk space
       # WARNING: Needed due to GitHub Actions disk space regression on Linux runners
       run: |
-        sudo apt-get clean
         df -h
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Check disk space
-      # WARNING: Needed due to GitHub Actions disk space regression on Linux runners
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        df -h
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
@@ -75,10 +70,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Check disk space
-      # WARNING: Needed due to GitHub Actions disk space regression on Linux runners
-      run: |
-        df -h
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
@@ -101,10 +92,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Check disk space
-      # WARNING: Needed due to GitHub Actions disk space regression on Linux runners
-      run: |
-        df -h
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -22,11 +22,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Check disk space
-      # WARNING: Needed due to GitHub Actions disk space regression on Linux runners
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        df -h
     - name: Install from PyPI
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -22,11 +22,10 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Free disk space
+    - name: Check disk space
       # WARNING: Needed due to GitHub Actions disk space regression on Linux runners
       if: matrix.os == 'ubuntu-latest'
       run: |
-        sudo apt-get clean
         df -h
     - name: Install from PyPI
       run: |


### PR DESCRIPTION
# Description

The change on the VMs used for the Ubuntu builds that caused the disk space regression in PR #819 is getting rolled back (c.f. [`actions/virtual-environments` Issue 709](https://github.com/actions/virtual-environments/issues/709)). As a result, the temporary hack fix of running `apt-get clean` before installation on the `ubuntu-latest` jobs is no longer necessary and can be reverted.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Revert apt-get clean hack fix for disk space regression (now resolved)
   - c.f. https://github.com/actions/virtual-environments/issues/709
```
