### PR TITLE
fix: Get full history and all tags for TestPyPI and PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -30,16 +30,28 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: |
         python -m pep517.build --source --binary --out-dir dist/ .
-    - name: Verify versioning is working
-      if: github.event_name == 'push' && "!(startsWith(github.ref, 'refs/tags/'))" && github.repository == 'scikit-hep/pyhf'
+    - name: Verify untagged commits have dev versions
+      if: "!(startsWith(github.ref, 'refs/tags/'))" && github.repository == 'scikit-hep/pyhf'
       run: |
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
-        echo "pep517.build named built distribution: ${wheel_name}"
-        if [[ "${wheel_name}" == *"pyhf-0.1.dev"* ]]; then
+        if [[ "${wheel_name}" == *"pyhf-0.1.dev"* || "${wheel_name}" != *"dev"* ]]; then
+          echo "pep517.build incorrectly named built distribution: ${wheel_name}"
           echo "pep517 is lacking the history and tags required to determine version number"
           echo "intentionally erroring with 'return 1' now"
           return 1
         fi
+        echo "pep517.build named built distribution: ${wheel_name}"
+    - name: Verify tagged commits don't have dev versions
+      if: startsWith(github.ref, 'refs/tags') && github.repository == 'scikit-hep/pyhf'
+      run: |
+        wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
+        if [[ "${wheel_name}" == *"dev"* ]]; then
+          echo "pep517.build incorrectly named built distribution: ${wheel_name}"
+          echo "this is incorrrectly being treated as a dev release"
+          echo "intentionally erroring with 'return 1' now"
+          return 1
+        fi
+        echo "pep517.build named built distribution: ${wheel_name}"
     - name: Verify the distribution
       run: twine check dist/*
     - name: Publish distribution 📦 to Test PyPI

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    # Fetch all tags
+    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    # Fetch all tags
-    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      # Get full history and all tags for dev versioning to work
-      with:
-        fetch-depth: 0
-    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      # Get history and tags for dev versioning to work
+    - run: |
+        git fetch --prune --unshallow
+        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
@@ -30,6 +30,15 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: |
         python -m pep517.build --source --binary --out-dir dist/ .
+    - name: Verify versioning is working
+      run: |
+        wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
+        echo "pep517.build named built distribution: ${wheel_name}"
+        if [[ "${wheel_name}" == *"pyhf-0.1.dev"* ]]; then
+          echo "pep517 is lacking the history and tags required to determine version number"
+          echo "intentionally erroring with 'return 1' now"
+          return 1
+        fi
     - name: Verify the distribution
       run: twine check dist/*
     - name: Publish distribution 📦 to Test PyPI

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,10 +1,10 @@
 name: publish distributions
 on:
   push:
-    # branches:
-    # - master
-    # tags:
-    # - v*
+    branches:
+    - master
+    tags:
+    - v*
   pull_request:
     branches:
     - master

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -31,6 +31,7 @@ jobs:
       run: |
         python -m pep517.build --source --binary --out-dir dist/ .
     - name: Verify versioning is working
+      if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags') && github.repository == 'scikit-hep/pyhf'
       run: |
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
         echo "pep517.build named built distribution: ${wheel_name}"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -17,6 +17,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    # Fetch all tags
+    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      # Get full history and all tags for dev versioning to work
       with:
         fetch-depth: 0
-    # Fetch all tags
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python 3.7
       uses: actions/setup-python@v1

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,10 +1,10 @@
 name: publish distributions
 on:
   push:
-    branches:
-    - master
-    tags:
-    - v*
+    # branches:
+    # - master
+    # tags:
+    # - v*
   pull_request:
     branches:
     - master

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         python -m pep517.build --source --binary --out-dir dist/ .
     - name: Verify versioning is working
-      if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags') && github.repository == 'scikit-hep/pyhf'
+      if: github.event_name == 'push' && "!(startsWith(github.ref, 'refs/tags/'))" && github.repository == 'scikit-hep/pyhf'
       run: |
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
         echo "pep517.build named built distribution: ${wheel_name}"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         python -m pep517.build --source --binary --out-dir dist/ .
     - name: Verify untagged commits have dev versions
-      if: "!(startsWith(github.ref, 'refs/tags/'))" && github.repository == 'scikit-hep/pyhf'
+      if: "!startsWith(github.ref, 'refs/tags/')"
       run: |
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
         if [[ "${wheel_name}" == *"pyhf-0.1.dev"* || "${wheel_name}" != *"dev"* ]]; then
@@ -42,7 +42,7 @@ jobs:
         fi
         echo "pep517.build named built distribution: ${wheel_name}"
     - name: Verify tagged commits don't have dev versions
-      if: startsWith(github.ref, 'refs/tags') && github.repository == 'scikit-hep/pyhf'
+      if: startsWith(github.ref, 'refs/tags')
       run: |
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
         if [[ "${wheel_name}" == *"dev"* ]]; then


### PR DESCRIPTION
# Description

Resolves #832 

Have [`actions/checkout@v2`](https://github.com/actions/checkout/releases/tag/v2) unshallow the history and get all of the tags. This allows `pep517` to be able to use the repo information to assign the version number of the build properly.

Here are examples of the verification check:
- [Failing properly (as expected)](https://github.com/scikit-hep/pyhf/runs/606545321?check_suite_focus=true#step:7:13)
- [Succeeding](https://github.com/scikit-hep/pyhf/runs/606768192?check_suite_focus=true#step:8:13)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Get all history and all tags for pep517 to determine version of the built distribution
   - Amends PR #826
* Add versioning verification check
```
