### PR TITLE
chore: Update gh-action-pypi-publish to non-alpha release

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -57,12 +57,12 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master
       if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pyhf'
-      uses: pypa/gh-action-pypi-publish@v1.0.0a0
+      uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == 'scikit-hep/pyhf'
-      uses: pypa/gh-action-pypi-publish@v1.0.0a0
+      uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
# Description

The [`gh-action-pypi-publish` action](https://github.com/pypa/gh-action-pypi-publish) release currently being used is [`v1.0.0a0`](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.0.0a0) which is an alpha release. This PR moves it to the first stable release: [`v1.1.0`](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.1.0).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update gh-action-pypi-publish to a stable non-alpha release (v1.1.0)
```
