### PR TITLE
feat: Update jsonschema to non-alpha release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
         'scipy',  # requires numpy, which is required by pyhf and tensorflow
         'click>=6.0',  # for console scripts,
         'tqdm',  # for readxml
-        'jsonschema>=v3.0.0a2',  # for utils, alpha-release for draft 6
+        'jsonschema>=v3.2.0',  # for utils
         'jsonpatch',
         'pyyaml',  # for parsing CLI equal-delimited options
     ],

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
         'scipy',  # requires numpy, which is required by pyhf and tensorflow
         'click>=6.0',  # for console scripts,
         'tqdm',  # for readxml
-        'jsonschema>=v3.2.0',  # for utils
+        'jsonschema>=3.2.0',  # for utils
         'jsonpatch',
         'pyyaml',  # for parsing CLI equal-delimited options
     ],


### PR DESCRIPTION
# Description

Resolves #800 

Updates to [`jsonschema` `v3.2.0`](https://github.com/Julian/jsonschema/releases/tag/v3.2.0) which is a stable release that uses [JSON Schema draft-06](https://json-schema.org/draft-06/json-schema-release-notes.html).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR


```
* Update jsonschema to v3.2.0 to move off alpha release
   - Moves to JSON Schema draft-06 (https://json-schema.org/draft-06/json-schema-release-notes.html)
```
