### PR TITLE
fix: Have release versioning work in docs build CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      # Get history and tags for versioning to work
+    - run: |
+        git fetch --prune --unshallow
+        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
# Description

Similar to PR #833, the docs build requires information on the version of pyhf is is reporting on to be able to properly display the version on the page. This PR unshallows the clone of pyhf used for the docs build and gets the tags as well.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Get all history and all tags for docs build to determine version of pyhf
   - Amends PR #826
```