### PR TITLE
fix: Get full history for Tag Creator workflow

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -43,7 +43,7 @@ jobs:
           echo "::set-env name=BV_PART::patch"
         fi
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v1.2.0
     - name: Set up git user
       run: |
         git config --local user.email "action@github.com"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -44,10 +44,9 @@ jobs:
         fi
     - name: Checkout repository
       uses: actions/checkout@v2
-      # Get history and tags for checkout master to work
+      # Get history for checkout master to work
     - run: |
         git fetch --prune --unshallow
-        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up git user
       run: |
         git config --local user.email "action@github.com"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -43,7 +43,7 @@ jobs:
           echo "::set-env name=BV_PART::patch"
         fi
     - name: Checkout repository
-      uses: actions/checkout@v1.2.0
+      uses: actions/checkout@v2
     - name: Set up git user
       run: |
         git config --local user.email "action@github.com"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -44,6 +44,10 @@ jobs:
         fi
     - name: Checkout repository
       uses: actions/checkout@v2
+      # Get history and tags for checkout master to work
+    - run: |
+        git fetch --prune --unshallow
+        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up git user
       run: |
         git config --local user.email "action@github.com"


### PR DESCRIPTION
# Description

In PR #826 all uses of `actions/checkout` were updated to `v2`. This was also done to the Tag Creator GitHub Action, which [resulted in a break](https://github.com/scikit-hep/pyhf/pull/796/checks?check_run_id=614484399#step:7:1). This change already caused trouble in PR #833 and PR #839, so the same patch that was applied to PR #833 is also applied here.

An example of the [patched workflow is done on this test branch here](https://github.com/scikit-hep/pyhf/runs/615811679?check_suite_focus=true#step:7:1).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Get all history for checkout master to work in Tag Creator
   - Amends PR #826
```
