### PR TITLE
ci: Use actions-gh-pages GitHub Action for deploy of docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,12 +122,13 @@ jobs:
         [ "$(ls -A docs/_build/html/schemas)" ]
     - name: Deploy docs to GitHub Pages
       if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
-      uses: crazy-max/ghaction-github-pages@v1.0.1
+      uses: peaceiris/actions-gh-pages@v3
       with:
-        target_branch: gh-pages
-        build_dir: docs/_build/html
-      env:
-        GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/_build/html
+        force_orphan: true
+        user_name: 'github-actions[bot]'
+        user_email: 'github-actions[bot]@users.noreply.github.com'
 
   docker:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
         force_orphan: true
         user_name: 'github-actions[bot]'
         user_email: 'github-actions[bot]@users.noreply.github.com'
+        commit_message: Deploy to GitHub pages
 
   docker:
 


### PR DESCRIPTION
# Description

Use the GitHub Action [`peaceiris/actions-gh-pages@v3`](https://github.com/peaceiris/actions-gh-pages) to deploy the docs to the `gh-pages` branch. The main advantage of [`peaceiris/actions-gh-pages`](https://github.com/peaceiris/actions-gh-pages) over [`crazy-max/ghaction-github-pages`](https://github.com/crazy-max/ghaction-github-pages) is that, in addition to being actively more developed, it allows for the use of an automatically created `GITHUB_TOKEN` instead of a user provided `GITHUB_PAT`.

For an example of this working see [PR 2 of `HEP-ML-LivingReview`](https://github.com/bnachman/HEP-ML-LivingReview/pull/2).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use peaceiris/actions-gh-pages@v3 to deploy docs to gh-pages branch
   - Allows use of GITHUB_TOKEN instead of GITHUB_PAT
```
