### PR TITLE
docs: List the dev team as authors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,5 @@
+pyhf is openly developed by the core dev team consisting of:
+
+Lukas Heinrich
+Matthew Feickert
+Giordon Stark

--- a/README.rst
+++ b/README.rst
@@ -188,6 +188,9 @@ Authors
 Please check the `contribution statistics for a list of
 contributors <https://github.com/scikit-hep/pyhf/graphs/contributors>`__.
 
+Acknowledgements
+----------------
+
 Matthew Feickert has received support to work on ``pyhf`` provided by NSF
 cooperative agreement `OAC-1836650 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1836650>`__ (IRIS-HEP)
 and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377>`__ (DIANA/HEP).

--- a/README.rst
+++ b/README.rst
@@ -186,7 +186,7 @@ Authors
 ``pyhf`` is openly developed by Lukas Heinrich, Matthew Feickert, and Giordon Stark.
 
 Please check the `contribution statistics for a list of
-contributors <https://github.com/scikit-hep/pyhf/graphs/contributors>`__
+contributors <https://github.com/scikit-hep/pyhf/graphs/contributors>`__.
 
 Matthew Feickert has received support to work on ``pyhf`` provided by NSF
 cooperative agreement `OAC-1836650 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1836650>`__ (IRIS-HEP)

--- a/README.rst
+++ b/README.rst
@@ -188,6 +188,10 @@ Authors
 Please check the `contribution statistics for a list of
 contributors <https://github.com/scikit-hep/pyhf/graphs/contributors>`__
 
+Matthew Feickert has received support to work on ``pyhf`` provided by NSF
+cooperative agreement `OAC-1836650 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1836650>`__ (IRIS-HEP)
+and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377>`__ (DIANA/HEP).
+
 .. |GitHub Project| image:: https://img.shields.io/badge/GitHub--blue?style=social&logo=GitHub
    :target: https://github.com/scikit-hep/pyhf
 .. |DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1169739.svg

--- a/README.rst
+++ b/README.rst
@@ -183,6 +183,8 @@ BibTeX entry for citation of ``pyhf`` is
 Authors
 -------
 
+``pyhf`` is openly developed by Lukas Heinrich, Matthew Feickert, and Giordon Stark.
+
 Please check the `contribution statistics for a list of
 contributors <https://github.com/scikit-hep/pyhf/graphs/contributors>`__
 


### PR DESCRIPTION
# Description

As the dev team is listed as the authors in the citation it makes sense to also formally list them in the README. Additionally, an `AUTHORS` file is created with the dev team listed and an acknowledgements section is added and the [same NSF support statement that is used for `uproot`](https://github.com/scikit-hep/uproot#acknowledgements) is also attributed to @matthewfeickert.

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-add-authors/

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* List dev team as authors in README and AUTHORS
* Add acknowledgements section for NSF support statement
```
