### PR TITLE
fix: Add AUTHORS to MANIFEST ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,4 +30,5 @@ ignore = [
     'codecov.yml',
     'CODE_OF_CONDUCT.md',
     'CONTRIBUTING.md',
+    'AUTHORS',
 ]


### PR DESCRIPTION
# Description

Add `AUTHORS` to `MANIFEST` ignore list in `pyproject.toml`. This was missed in PR #844 and is being caught now by a [logic change in `check-manifest` `v0.42`](https://github.com/mgedmin/check-manifest/blob/master/CHANGES.rst#042-2020-05-03).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add AUTHORS file to MANIFEST ignore list
   - Amends PR #844
```
