### PR TITLE
fix: Remove dead OVH Binder build endpoint and add GESIS and Turing endpoints

### DIFF
--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -13,5 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Trigger Binder build
       run: |
-        # Use Binder build API to trigger repo2docker to build image on GKE Binder Federation clusters
+        # Use Binder build API to trigger repo2docker to build image on Google Cloud, GESIS Notebooks, and Turing Institute Binder Federation clusters
         bash binder/trigger_binder.sh https://gke.mybinder.org/build/gh/scikit-hep/pyhf/master
+        bash binder/trigger_binder.sh https://gesis.mybinder.org/build/gh/scikit-hep/pyhf/master
+        bash binder/trigger_binder.sh https://turing.mybinder.org/build/gh/scikit-hep/pyhf/master

--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -13,6 +13,5 @@ jobs:
     - uses: actions/checkout@v2
     - name: Trigger Binder build
       run: |
-        # Use Binder build API to trigger repo2docker to build image on GKE and OVH Binder Federation clusters
+        # Use Binder build API to trigger repo2docker to build image on GKE Binder Federation clusters
         bash binder/trigger_binder.sh https://gke.mybinder.org/build/gh/scikit-hep/pyhf/master
-        bash binder/trigger_binder.sh https://ovh.mybinder.org/build/gh/scikit-hep/pyhf/master


### PR DESCRIPTION
# Description

Resolves #854 

The OVH Cloud [Binder Federation](https://discourse.jupyter.org/t/the-binder-federation/1286) cluster build API endpoint seems to be dead and is causing errors of

```
curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to ovh.mybinder.org:443 
```
Given this remove the endpoint from the Merged PR CI. However, as the Binder Federation now includes [GESIS Notebooks](https://blog.jupyter.org/gesis-joins-the-binder-federation-8603d878ff77) and the [Turing Institute](https://www.turing.ac.uk/) these endpoints are added.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove dead OVH Binder build endpoint from Merged PR workflow
* Add GESIS Notebooks and Turing Institute Binder build endpoints
```
