### PR TITLE
docs: Add instructions for installing test releases from TestPyPI

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -47,11 +47,12 @@ TestPyPI
 
 ``pyhf`` tests packaging and distributing by publishing each commit to
 ``master`` to `TestPyPI <https://test.pypi.org/project/pyhf/>`__.
-In addition, installation of releases can be tested from TestPyPI with
+In addition, installation of the latest test release from TestPyPI can be tested
+with
 
 .. code-block:: bash
 
-  python -m pip install --extra-index-url https://test.pypi.org/simple/ pyhf
+  python -m pip install --extra-index-url https://test.pypi.org/simple/ --pre pyhf
 
 .. note::
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -61,7 +61,6 @@ with
   PyPI will still be the default package index ``pip`` will attempt to install
   from for all dependencies.
 
-
 Publishing
 ----------
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -47,11 +47,18 @@ TestPyPI
 
 ``pyhf`` tests packaging and distributing by publishing each commit to
 ``master`` to `TestPyPI <https://test.pypi.org/project/pyhf/>`__.
-In addition, you can test installation of releases from TestPyPI with
+In addition, installation of releases can be tested from TestPyPI with
 
 .. code-block:: bash
 
   python -m pip install --extra-index-url https://test.pypi.org/simple/ pyhf
+
+.. note::
+
+  This adds TestPyPI as `an additional package index to search <https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-extra-index-url>`__
+  when installing ``pyhf`` specifically.
+  PyPI will still be the default package index ``pip`` will attempt to install
+  from for all dependencies.
 
 
 Publishing

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -42,6 +42,18 @@ which will load the copy of ``text.txt`` in the temporary directory. This also
 works for parameterizations as this will effectively sandbox the file
 modifications made.
 
+TestPyPI
+~~~~~~~~
+
+``pyhf`` tests packaging and distributing by publishing each commit to
+``master`` to `TestPyPI <https://test.pypi.org/project/pyhf/>`__.
+In addition, you can test installation of releases from TestPyPI with
+
+.. code-block:: bash
+
+  python -m pip install --extra-index-url https://test.pypi.org/simple/ pyhf
+
+
 Publishing
 ----------
 


### PR DESCRIPTION
# Description

Resolves #858

Add instructions on how to install test releases from [TestPyPI](https://test.pypi.org/project/pyhf/) using the [`--extra-index-url`](https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-extra-index-url) and [`--pre`](https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-pre) options for `pip`.

```
python -m pip install --extra-index-url https://test.pypi.org/simple/ --pre pyhf
```

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-add-testpypi-install-example/development.html#testpypi

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add instructions on installing test releases from TestPyPI using --extra-index-url and --pre
```
