### PR TITLE
ci: Add Python 3.8 to tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7]
 
     steps:
     - uses: actions/checkout@v2
@@ -56,6 +56,32 @@ jobs:
       if: github.event_name == 'schedule' && matrix.python-version == 3.7
       run: |
         python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/test_benchmark.py
+
+  test_python38_linux:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v1.2.0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[test]
+        python -m pip list
+    - name: Test with pytest
+      run: |
+        python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+    - name: Test Contrib module with pytest
+      run: |
+        python -m pytest -r sx tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
 
   notebooks:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         python-version: [3.8]
 
     steps:
-    - uses: actions/checkout@v1.2.0
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -56,32 +56,6 @@ jobs:
       if: github.event_name == 'schedule' && matrix.python-version == 3.7
       run: |
         python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/test_benchmark.py
-
-  test_python38_linux:
-
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[test]
-        python -m pip list
-    - name: Test with pytest
-      run: |
-        python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
-    - name: Test Contrib module with pytest
-      run: |
-        python -m pytest -r sx tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
 
   notebooks:
 

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     package_dir={'': 'src'},
     packages=find_packages(where='src'),


### PR DESCRIPTION
# Description

Resolves #633

Add Python 3.8 to the collection of Python runtimes tested, and reflect this in the PyPI classifiers list. Python 3.8 is tested both in the normal CI tests and in the PyPI release tests.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add Python 3.8 to runtimes tested in CI tests
* Add Python 3.8 to PyPI classifiers
```
