### PR TITLE
docs: Update keywords, classifiers, and URLs in setup.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: https://github.com/ambv/black
+-   repo: https://github.com/psf/black
     rev: stable
     hooks:
     - id: black

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,11 @@ setup(
     license='Apache',
     keywords='physics fitting numpy scipy tensorflow pytorch jax',
     classifiers=[
+        "Development Status :: 4 - Beta",
+        "License :: OSI Approved :: Apache Software License",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Physics",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -80,9 +80,9 @@ setup(
     long_description_content_type='text/x-rst',
     url='https://github.com/scikit-hep/pyhf',
     project_urls={
-        'Documentation': 'https://scikit-hep.org/pyhf/',
-        'Source': 'https://github.com/scikit-hep/pyhf',
-        'Tracker': 'https://github.com/scikit-hep/pyhf/issues',
+        "Documentation": "https://scikit-hep.org/pyhf/",
+        "Source": "https://github.com/scikit-hep/pyhf",
+        "Tracker": "https://github.com/scikit-hep/pyhf/issues",
     },
     author='Lukas Heinrich, Matthew Feickert, Giordon Stark',
     author_email='lukas.heinrich@cern.ch, matthew.feickert@cern.ch, gstark@cern.ch',

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     author='Lukas Heinrich, Matthew Feickert, Giordon Stark',
     author_email='lukas.heinrich@cern.ch, matthew.feickert@cern.ch, gstark@cern.ch',
     license='Apache',
-    keywords='physics fitting numpy scipy tensorflow pytorch',
+    keywords='physics fitting numpy scipy tensorflow pytorch jax',
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,11 @@ setup(
     long_description=long_description,
     long_description_content_type='text/x-rst',
     url='https://github.com/scikit-hep/pyhf',
+    project_urls={
+        'Documentation': 'https://scikit-hep.org/pyhf/',
+        'Source': 'https://github.com/scikit-hep/pyhf',
+        'Tracker': 'https://github.com/scikit-hep/pyhf/issues',
+    },
     author='Lukas Heinrich, Matthew Feickert, Giordon Stark',
     author_email='lukas.heinrich@cern.ch, matthew.feickert@cern.ch, gstark@cern.ch',
     license='Apache',


### PR DESCRIPTION
# Description

Resolves #861 

Add JAX to the [list of keywords in `setup.py`](https://github.com/scikit-hep/pyhf/blob/917bd5127c1da023b279c076bb41614fbb859487/setup.py#L85). Additionally, update the [classifies](https://packaging.python.org/guides/distributing-packages-using-setuptools/#classifiers) to include a `Development Status`, `License`, `Intended Audience`, and `Topic`. Also sneak in a URL update for Black in `.pre-commit-config.yaml`

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add JAX to keywords
* Update classifiers to include development status, license, intended audience, and topic
* Add project URLs
* Update Black URL in .pre-commit-config.yaml
```
