### PR TITLE
chore: Update setup-python action to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+        architecture: 'x86'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
@@ -70,6 +71,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+        architecture: 'x86'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
@@ -96,6 +98,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+        architecture: 'x86'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -67,7 +67,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -93,7 +93,7 @@ jobs:
         git fetch --prune --unshallow
         git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: 'x86'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
@@ -71,7 +70,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: 'x86'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
@@ -98,7 +96,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: 'x86'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -23,7 +23,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-        architecture: 'x86'
     - name: Install pep517 and twine
       run: |
         python -m pip install pep517 --user

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -23,6 +23,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
+        architecture: 'x86'
     - name: Install pep517 and twine
       run: |
         python -m pip install pep517 --user

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -20,7 +20,7 @@ jobs:
         git fetch --prune --unshallow
         git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Install pep517 and twine

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install from PyPI

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -22,7 +22,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: 'x86'
     - name: Install from PyPI
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -22,6 +22,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+        architecture: 'x86'
     - name: Install from PyPI
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -62,7 +62,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-        architecture: 'x86'
     - name: Install bumpversion
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -62,6 +62,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
+        architecture: 'x86'
     - name: Install bumpversion
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -59,7 +59,7 @@ jobs:
         git merge --squash "origin/${GITHUB_HEAD_REF}"
         git commit -m "${PR_TITLE} (#${PR_NUMBER})"
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Install bumpversion


### PR DESCRIPTION
# Description

[`v2` of the `setup-python` GitHub Action](https://github.com/actions/setup-python/releases/tag/v2) has been released. This PR updates all GitHub Action workflows to use the new stable release.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use v2 of the setup-python GitHub Action in all GitHub Action workflows
```