### PR TITLE
chore: Migrate metadata and setup options to setup.cfg

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ current_version = 0.4.1
 commit = True
 tag = True
 
-[bumpversion:file:setup.py]
+[bumpversion:file:setup.cfg]
 
 [bumpversion:file:src/pyhf/version.py]
 
@@ -12,4 +12,3 @@ tag = True
 [bumpversion:file:docs/bib/preferred.bib]
 
 [bumpversion:file:.zenodo.json]
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = pyhf
 version = 0.4.1
 description = (partial) pure Python HistFactory implementation
-long_description = file:README.rst
+long_description = file: README.rst
 long_description_content_type = text/x-rst
 url = https://github.com/scikit-hep/pyhf
 author = Lukas Heinrich, Matthew Feickert, Giordon Stark

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,30 @@
+[metadata]
+name = pyhf
+version = 0.4.1
+description = (partial) pure Python HistFactory implementation
+long_description = file:README.rst
+long_description_content_type = text/x-rst
+url = https://github.com/scikit-hep/pyhf
+author = Lukas Heinrich, Matthew Feickert, Giordon Stark
+author_email = lukas.heinrich@cern.ch, matthew.feickert@cern.ch, gstark@cern.ch
+license = Apache
+license_file = LICENSE
+keywords = physics fitting numpy scipy tensorflow pytorch jax
+project_urls =
+    Documentation = https://scikit-hep.org/pyhf/
+    Source = https://github.com/scikit-hep/pyhf
+    Tracker = https://github.com/scikit-hep/pyhf/issues
+classifiers =
+    Development Status :: 4 - Beta
+    License :: OSI Approved :: Apache Software License
+    Intended Audience :: Science/Research
+    Topic :: Scientific/Engineering
+    Topic :: Scientific/Engineering :: Physics
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
 [bdist_wheel]
 universal = 1
 
@@ -31,30 +58,3 @@ source-dir = docs
 build-dir = docs/_build
 all-files = 1
 warning-is-error = 1
-
-[metadata]
-name = pyhf
-version = 0.4.1
-description = (partial) pure Python HistFactory implementation
-long_description = file:README.rst
-long_description_content_type = text/x-rst
-url = https://github.com/scikit-hep/pyhf
-author = Lukas Heinrich, Matthew Feickert, Giordon Stark
-author_email = lukas.heinrich@cern.ch, matthew.feickert@cern.ch, gstark@cern.ch
-license = Apache
-license_file = LICENSE
-keywords = physics fitting numpy scipy tensorflow pytorch jax
-project_urls =
-    Documentation = https://scikit-hep.org/pyhf/
-    Source = https://github.com/scikit-hep/pyhf
-    Tracker = https://github.com/scikit-hep/pyhf/issues
-classifiers =
-    Development Status :: 4 - Beta
-    License :: OSI Approved :: Apache Software License
-    Intended Audience :: Science/Research
-    Topic :: Scientific/Engineering
-    Topic :: Scientific/Engineering :: Physics
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [bdist_wheel]
 universal = 1
 
-[metadata]
-license_file = LICENSE
-
 [options]
 setup_requires =
     setuptools_scm>=1.15.0
@@ -15,3 +12,30 @@ source-dir = docs
 build-dir = docs/_build
 all-files = 1
 warning-is-error = 1
+
+[metadata]
+name = pyhf
+version = 0.4.1
+description = (partial) pure Python HistFactory implementation
+long_description = file:README.rst
+long_description_content_type = text/x-rst
+url = https://github.com/scikit-hep/pyhf
+author = Lukas Heinrich, Matthew Feickert, Giordon Stark
+author_email = lukas.heinrich@cern.ch, matthew.feickert@cern.ch, gstark@cern.ch
+license = Apache
+license_file = LICENSE
+keywords = physics fitting numpy scipy tensorflow pytorch jax
+project_urls =
+    Documentation = https://scikit-hep.org/pyhf/
+    Source = https://github.com/scikit-hep/pyhf
+    Tracker = https://github.com/scikit-hep/pyhf/issues
+classifiers =
+    Development Status :: 4 - Beta
+    License :: OSI Approved :: Apache Software License
+    Intended Audience :: Science/Research
+    Topic :: Scientific/Engineering
+    Topic :: Scientific/Engineering :: Physics
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,25 @@ universal = 1
 setup_requires =
     setuptools_scm>=1.15.0
     setuptools_scm_git_archive>=1.0
+package_dir =
+    = src
+packages = find:
+include_package_data = True
+python_requires = >=3.6
+install_requires =
+    scipy  # requires numpy, which is required by pyhf and tensorflow
+    click>=6.0  # for console scripts,
+    tqdm  # for readxml
+    jsonschema>=3.2.0  # for utils
+    jsonpatch
+    pyyaml  # for parsing CLI equal-delimited options
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+console_scripts =
+    pyhf = pyhf.cli:cli
 
 [build_sphinx]
 project = pyhf

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,4 @@
 from setuptools import setup, find_packages
-from pathlib import Path
-
-this_directory = Path(__file__).parent.resolve()
-with open(Path(this_directory).joinpath('README.rst'), encoding='utf-8') as readme_rst:
-    long_description = readme_rst.read()
 
 extras_require = {
     'tensorflow': ['tensorflow~=2.0', 'tensorflow-probability~=0.8'],

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 extras_require = {
     'tensorflow': ['tensorflow~=2.0', 'tensorflow-probability~=0.8'],

--- a/setup.py
+++ b/setup.py
@@ -73,32 +73,6 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 
 setup(
-    name='pyhf',
-    version='0.4.1',
-    description='(partial) pure python histfactory implementation',
-    long_description=long_description,
-    long_description_content_type='text/x-rst',
-    url='https://github.com/scikit-hep/pyhf',
-    project_urls={
-        "Documentation": "https://scikit-hep.org/pyhf/",
-        "Source": "https://github.com/scikit-hep/pyhf",
-        "Tracker": "https://github.com/scikit-hep/pyhf/issues",
-    },
-    author='Lukas Heinrich, Matthew Feickert, Giordon Stark',
-    author_email='lukas.heinrich@cern.ch, matthew.feickert@cern.ch, gstark@cern.ch',
-    license='Apache',
-    keywords='physics fitting numpy scipy tensorflow pytorch jax',
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "License :: OSI Approved :: Apache Software License",
-        "Intended Audience :: Science/Research",
-        "Topic :: Scientific/Engineering",
-        "Topic :: Scientific/Engineering :: Physics",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-    ],
     package_dir={'': 'src'},
     packages=find_packages(where='src'),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -68,20 +68,7 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 
 setup(
-    package_dir={'': 'src'},
-    packages=find_packages(where='src'),
-    include_package_data=True,
-    python_requires=">=3.6",
-    install_requires=[
-        'scipy',  # requires numpy, which is required by pyhf and tensorflow
-        'click>=6.0',  # for console scripts,
-        'tqdm',  # for readxml
-        'jsonschema>=3.2.0',  # for utils
-        'jsonpatch',
-        'pyyaml',  # for parsing CLI equal-delimited options
-    ],
     extras_require=extras_require,
-    entry_points={'console_scripts': ['pyhf=pyhf.cli:cli']},
     dependency_links=[],
     use_scm_version=lambda: {'local_scheme': lambda version: ''},
 )

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,5 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(
     extras_require=extras_require,
-    dependency_links=[],
     use_scm_version=lambda: {'local_scheme': lambda version: ''},
 )


### PR DESCRIPTION
# Description

Resolves #872 

Use `setup.cfg` as the main source of configuration and install information by migrating metadata and setup options from `setup.py` to `setup.cfg`. This is done mainly by following @henryiii's examples on the [Scikit-HEP packaging information page](https://scikit-hep.org/developer/packaging#setup-configuration-medium-priority) and by looking at the [gwcelery `setup.cfg` file](https://git.ligo.org/emfollow/gwcelery/-/blob/46374fad07099fcc38cc6e620c6c7fc7afc736b2/setup.cfg) and `setuptools` docs on [Configuring `setup()` using `setup.cfg` files](https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files).

The basic argument for doing this is `setup.py` is for logic as it is Python, and `setup.cfg` is for static configuration options.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Move PyPI metadata from setup.py to setup.cfg
* Move setup options from setup.py to setup.cfg
* Remove now unused pathlib.Path and setuptools.find_packages imports
* Remove dependency_links as there are none
```
