### PR TITLE
fix: Sanitize double quotes for Tag Creator

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -120,6 +120,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
+              name: "bumpversion/${{ env['BV_PART'] }}"
             })
 
   always_job:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -88,11 +88,16 @@ jobs:
     - name: Comment on issue
       if: >-
         github.event.action == 'labeled'
-      uses: actions/github-script@0.3.0
+      uses: actions/github-script@v1.1.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          github.issues.createComment({...context.issue, body: "I've queued this up. When it gets merged, I'll create a ${{ env['BV_PART'] }} release from ${{ env['OLD_TAG'] }} → ${{ env['NEW_TAG'] }} which includes the following ${{ env['NUM_CHANGES'] }} change(s) [including this PR]:<br />${{ env['CHANGES'] }}<br />If you make any more changes, you probably want to re-trigger me again by removing the `bumpversion/${{ env['BV_PART'] }}` label and then adding it back again."})
+          github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "I've queued this up. When it gets merged, I'll create a ${{ env['BV_PART'] }} release from ${{ env['OLD_TAG'] }} → ${{ env['NEW_TAG'] }} which includes the following ${{ env['NUM_CHANGES'] }} change(s) [including this PR]:<br />${{ env['CHANGES'] }}<br />If you make any more changes, you probably want to re-trigger me again by removing the `bumpversion/${{ env['BV_PART'] }}` label and then adding it back again."
+            })
     - name: Push changes
       if: >-
         github.event.action == 'closed' && github.event.pull_request.merged
@@ -101,12 +106,21 @@ jobs:
         github_token: ${{ secrets.GITHUB_PAT }}
     - name: Comment that something failed
       if: failure()
-      uses: actions/github-script@0.3.0
+      uses: actions/github-script@v1.1.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          github.issues.createComment({...context.issue, body: ":cry: Something went wrong. I am not able to push. Check the [Actions pipeline](https://github.com/${{ github.repository }}/actions?query=workflow%3A%22Tag+Creator%22) to see what happened. If you make any more changes, you probably want to re-trigger me again by adding the `bumpversion/${{ env['BV_PART'] }}` label again."})
-          github.issues.removeLabel({...context.issue, labels: "bumpversion/${{ env['BV_PART'] }}" })
+          github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: ":cry: Something went wrong. I am not able to push. Check the [Actions pipeline](https://github.com/${{ github.repository }}/actions?query=workflow%3A%22Tag+Creator%22) to see what happened. If you make any more changes, you probably want to re-trigger me again by adding the `bumpversion/${{ env['BV_PART'] }}` label again."
+            })
+          github.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
 
   always_job:
     name: Always run job

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -79,7 +79,7 @@ jobs:
 
         CHANGES=$(git log --pretty=format:'%s' $OLD_TAG..HEAD -i -E --grep='^([a-z]*?):')
         CHANGES_NEWLINE="$(echo "${CHANGES}" | sed -e 's/^/  - /')"
-        SANITIZED_CHANGES=$(echo "${CHANGES}" | sed -e 's/^/<li>/' -e 's|$|</li>|' -e 's/(#[0-9]\+)//' )
+        SANITIZED_CHANGES=$(echo "${CHANGES}" | sed -e 's/^/<li>/' -e 's|$|</li>|' -e 's/(#[0-9]\+)//' -e 's/"/'"'"'/g')
         echo "::set-env name=CHANGES::${SANITIZED_CHANGES//$'\n'/}"
         NUM_CHANGES=$(echo -n "$CHANGES" | grep -c '^')
         echo "::set-env name=NUM_CHANGES::${NUM_CHANGES}"


### PR DESCRIPTION
# Description

Resolves #874 

Tag creator breaks due to

> feat: Add utility for computing object digests ("hashing")

as a result of the `"`s, so simply use `sed` to replace `"` with `'` in the sanitize stage.

```
sed -e 's/"/'"'"'/g'
```

This is not super elegant, but it works. Additionally, a `name` field is added to `github.issues.removeLabel` so that it actually removed the bumpversion label when the CI fails.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update to use github-script v1.1.0
* Replace double quotes with single quotes to avoid errors
* Add 'name' field to removeLabel to actually remove bumpversion label if tag creator fails
```
