### PR TITLE
docs: Add simple examples for inspect, cls, and digest CLI

### DIFF
--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -47,7 +47,25 @@ def cls(
     optimizer,
     optconf,
 ):
-    """Compute CLs value(s) for a given pyhf workspace."""
+    """
+    Compute CLs value(s) for a given pyhf workspace.
+
+    Example:
+
+    .. code-block:: shell
+
+        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/examples/json/2-bin_1-channel.json | pyhf cls
+        {
+            "CLs_exp": [
+                0.07807427911686156,
+                0.17472571775474618,
+                0.35998495263681285,
+                0.6343568235898907,
+                0.8809947004472013
+            ],
+            "CLs_obs": 0.3599845631401915
+        }
+    """
     with click.open_file(workspace, 'r') as specstream:
         spec = json.load(specstream)
 

--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -328,6 +328,13 @@ def digest(workspace, algorithm, output_json):
 
     Returns:
         digests (:obj:`dict`): A mapping of the hashing algorithms used to the computed digest for the workspace.
+
+    Example:
+
+    .. code-block:: shell
+
+        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/examples/json/2-bin_1-channel.json | pyhf digest
+        sha256:dad8822af55205d60152cbe4303929042dbd9d4839012e055e7c6b6459d68d73
     """
     with click.open_file(workspace, 'r') as specstream:
         spec = json.load(specstream)

--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -25,7 +25,40 @@ def cli():
 )
 @click.option('--measurement', default=None)
 def inspect(workspace, output_file, measurement):
-    """Inspect a pyhf JSON document."""
+    """
+    Inspect a pyhf JSON document.
+
+    Example:
+
+    .. code-block:: shell
+
+        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/examples/json/2-bin_1-channel.json | pyhf inspect
+                  Summary
+            ------------------
+               channels  1
+                samples  2
+             parameters  2
+              modifiers  2
+
+               channels  nbins
+             ----------  -----
+          singlechannel    2
+
+                samples
+             ----------
+             background
+                 signal
+
+             parameters  constraint              modifiers
+             ----------  ----------              ----------
+                     mu  unconstrained           normfactor
+        uncorr_bkguncrt  constrained_by_poisson  shapesys
+
+            measurement           poi            parameters
+             ----------        ----------        ----------
+        (*) Measurement            mu            (none)
+
+    """
     with click.open_file(workspace, 'r') as specstream:
         spec = json.load(specstream)
 


### PR DESCRIPTION
# Description

Add some simple examples on how to use the `pyhf` CLI for `inspect`, `cls` and `digest`. This is not comprehensive, but just an in passing through PR.

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-add-inspect-example/cli.html

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add simple example for pyhf inspect, pyhf cls, and pyhf digest CLI
```
