### PR TITLE
ci: Use checkout v2.2.0 fetch-depth option to unshallow all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,10 +88,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      # Get history and tags for versioning to work
-    - run: |
-        git fetch --prune --unshallow
-        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -15,10 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      # Get history and tags for dev versioning to work
-    - run: |
-        git fetch --prune --unshallow
-        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -44,9 +44,8 @@ jobs:
         fi
     - name: Checkout repository
       uses: actions/checkout@v2.2.0
-      # Get history for checkout master to work
-    - run: |
-        git fetch --prune --unshallow
+      with:
+        fetch-depth: 0
     - name: Set up git user
       run: |
         git config --local user.email "action@github.com"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -43,7 +43,7 @@ jobs:
           echo "::set-env name=BV_PART::patch"
         fi
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.2.0
       # Get history for checkout master to work
     - run: |
         git fetch --prune --unshallow


### PR DESCRIPTION
# Description

Use the `fetch-depth: 0` option introduced in [`v2.2.0` of the `checkout` action](https://github.com/actions/checkout/releases/tag/v2.2.0) to fetch all history for all tags and branches in a much cleaner fashion.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use checkout fetch-depth API to unshallow all branches and tags
   - Introduced in v2.2.0
   - c.f. https://github.com/actions/checkout/releases/tag/v2.2.0
* Explicitly set checkout version to v2.2.0 to avoid floating v2 release
   - c.f. https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#recommendations
```
