### PR TITLE
fix: Set checkout GHA persist-credentials to false for push to succeed

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -45,6 +45,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2.2.0
       with:
+        persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
         fetch-depth: 0
     - name: Set up git user
       run: |

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Push changes
       if: >-
         github.event.action == 'closed' && github.event.pull_request.merged
-      uses: ad-m/github-push-action@v0.5.0
+      uses: ad-m/github-push-action@v0.6.0
       with:
         github_token: ${{ secrets.GITHUB_PAT }}
     - name: Comment that something failed


### PR DESCRIPTION
# Description

Fix the Tag Creator workflow that [failed](https://github.com/scikit-hep/pyhf/runs/718450042?check_suite_focus=true) in PR #796 on the "Push changes" step with

```
Run ad-m/github-push-action@v0.5.0
  with:
    github_token: ***
    branch: master
    directory: .
  env:
    IS_MAJOR: false
    IS_MINOR: false
    IS_PATCH: true
    PR_NUMBER: 796
    PR_TITLE: build: Require minimum SciPy version of v1.4.0
    GITHUB_HEAD_REF: build/require-scipy-min-v-1.4.0
    BV_PART: patch
    pythonLocation: /opt/hostedtoolcache/Python/3.7.7/x64
    OLD_TAG: v0.4.1
    NEW_TAG: v0.4.2
    CHANGES: <there were a lot but they don't matter here>
    NUM_CHANGES: 48
/usr/bin/docker run --name be76db00e9f497df7b42a2802c9c7aa61823ab_e1ed51 --label be76db --workdir /github/workspace --rm -e IS_MAJOR -e IS_MINOR -e IS_PATCH -e PR_NUMBER -e PR_TITLE -e GITHUB_HEAD_REF -e BV_PART -e pythonLocation -e OLD_TAG -e NEW_TAG -e CHANGES -e NUM_CHANGES -e INPUT_GITHUB_TOKEN -e INPUT_REPOSITORY -e INPUT_BRANCH -e INPUT_FORCE -e INPUT_DIRECTORY -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/pyhf/pyhf":"/github/workspace" be76db:00e9f497df7b42a2802c9c7aa61823ab
Push to branch master
remote: error: GH006: Protected branch update failed for refs/heads/master.        
remote: error: 18 of 18 required status checks are expected. At least 2 approving reviews are required by reviewers with write access.        
To https://github.com/scikit-hep/pyhf.git
 * [new tag]         v0.4.2 -> v0.4.2
 ! [remote rejected] HEAD -> master (protected branch hook declined)
error: failed to push some refs to '***github.com/scikit-hep/pyhf.git'
```

by setting the [`checkout` GitHub Action's `persist-credentials` input](https://github.com/actions/checkout/tree/aabbfeb2ce60b5bd82389903509092c4648a9713#usage) to `false`. The motivations for this are covered in [`ad-m/github-push-action` Issue 44](https://github.com/ad-m/github-push-action/issues/44) and [`ad-m/github-push-action` PR 46](https://github.com/ad-m/github-push-action/pull/46).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update github-push-action to v0.6.0
* Use 'persist-credentials: false' to allow github-push-action to push to master with a personal access token
   - https://github.com/ad-m/github-push-action/issues/44
   - https://github.com/ad-m/github-push-action/pull/46
```
