### PR TITLE
fix: Avoid warning of 'app.add_stylesheet() is deprecated'

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ sys.path.insert(1, str(Path('./exts').resolve()))
 
 
 def setup(app):
-    app.add_stylesheet(
+    app.add_css_file(
         'https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.2/gh-fork-ribbon.min.css'
     )
 


### PR DESCRIPTION
# Description

Avoid warning in building the docs of

```
/home/runner/work/pyhf/pyhf/docs/conf.py:29: RemovedInSphinx40Warning: The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
  'https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.2/gh-fork-ribbon.min.css'
```

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-fix-inline-interpreted-parsing-error

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use app.add_css_file over deprecated app.add_stylesheet
   - Deprecated since Sphinx v1.8.0
   - https://github.com/sphinx-doc/sphinx/blob/800dcf0f0a8040ae84c4aaa7053f62201170c47d/CHANGES#L1510
```
