### PR TITLE
fix: Check if HEAD of origin/master is accessible from latest tag

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -23,6 +23,7 @@ jobs:
         python-version: 3.7
     - name: Install pep517 and twine
       run: |
+        python -m pip install --upgrade pip setuptools wheel
         python -m pip install pep517 --user
         python -m pip install twine
     - name: Build a binary wheel and a source tarball

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -32,12 +32,19 @@ jobs:
     - name: Verify untagged commits have dev versions
       if: "!startsWith(github.ref, 'refs/tags/')"
       run: |
+        latest_tag=$(git describe --tags)
+        latest_tag_revlist_SHA=$(git rev-list -n 1 ${latest_tag})
+        master_SHA="$(git rev-parse --verify origin/master)"
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
-        if [[ "${wheel_name}" == *"pyhf-0.1.dev"* || "${wheel_name}" != *"dev"* ]]; then
-          echo "pep517.build incorrectly named built distribution: ${wheel_name}"
-          echo "pep517 is lacking the history and tags required to determine version number"
-          echo "intentionally erroring with 'return 1' now"
-          return 1
+        if [[ "${latest_tag_revlist_SHA}" != "${master_SHA}" ]]; then # don't check branch push events from tags
+          if [[ "${wheel_name}" == *"pyhf-0.1.dev"* || "${wheel_name}" != *"dev"* ]]; then
+            echo "pep517.build incorrectly named built distribution: ${wheel_name}"
+            echo "pep517 is lacking the history and tags required to determine version number"
+            echo "intentionally erroring with 'return 1' now"
+            return 1
+          fi
+        else
+          echo "Push event to origin/master was triggered by push of tag ${latest_tag}"
         fi
         echo "pep517.build named built distribution: ${wheel_name}"
     - name: Verify tagged commits don't have dev versions

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -36,7 +36,7 @@ jobs:
         latest_tag_revlist_SHA=$(git rev-list -n 1 ${latest_tag})
         master_SHA="$(git rev-parse --verify origin/master)"
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
-        if [[ "${latest_tag_revlist_SHA}" != "${master_SHA}" ]]; then # don't check branch push events from tags
+        if [[ "${latest_tag_revlist_SHA}" != "${master_SHA}" ]]; then # don't check master push events coming from tags
           if [[ "${wheel_name}" == *"pyhf-0.1.dev"* || "${wheel_name}" != *"dev"* ]]; then
             echo "pep517.build incorrectly named built distribution: ${wheel_name}"
             echo "pep517 is lacking the history and tags required to determine version number"


### PR DESCRIPTION
# Description

Resolves #887 

We can get the name of the latest tag that has been created (the tag that was just pushed) with

```
latest_tag=$(git describe --tags)
```

and then with that get the latest commit on the tag's `rev-list`

```
latest_tag_revlist_SHA=$(git rev-list -n 1 ${latest_tag})
```

As `git rev-list ${latest_tag}` will give the list of commits accessible _from_ the `${latest tag}`, then `${latest_tag_revlist_SHA}` will point to the most recent commit accessible &mdash; the last commit on `origin/master` which is the one `bumpversion` created when making `${latest tag}`. Note that we have to do it this way, as the actual SHA (from `git rev-parse --verfiy`) for the `${latest tag}` and `origin/master` will be _different_. Then we can simply get the SHA from `origin/master`

```
master_SHA="$(git rev-parse --verify origin/master)"
```

and check if they're **different**

```bash
[[ "${latest_tag_revlist_SHA}" != "${master_SHA}" ]]
```

If they are, then the HEAD of `origin/master` is **not** accessible from `${latest tag}` (it has advanced further ahead in the commit history), so the commit on the `push` event is coming from a commit on a PR and so should be checked if it is a dev version. **If they're the same**, then that's only possible if a tag was created by `bumpversion` and pushed to `master` on the push event that triggered the distribution so the check should be skipped and the distribution should be published to TestPyPI.

The important thing to remember is that the `publish-package` workflow gets run **3** times for each release PR that gets merged in:
1. First, when the PR gets merged to `master` this causes a `push` event on `master` which runs.
2. When Tag Creator pushes the **commit** from `bumpversion` to `origin` this causes a `push` event on `master` which runs.
3. When Tag Creator pushes the **tag** from `bumpversion` to `origin` this causes a `tag` event which runs.

2 and 3 happen simultaneously from the same push. This PR disentangles type 1 events from type 3 events.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Fix wheel version check on push events to origin/master on releases
   - Needed to work with Tag Creator workflow (c.f. PR #884)
   - Fixes deployment of releases to TestPyPI as well
   - Amends PR #884
```
