### PR TITLE
ci: Use Python 3.8 in all steps of publishing distributions

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -69,6 +69,6 @@ jobs:
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == 'scikit-hep/pyhf'
-      uses: pypa/gh-action-pypi-publish@v1.1.0
+      uses: pypa/gh-action-pypi-publish@v1.2.2
       with:
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master
       if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pyhf'
-      uses: pypa/gh-action-pypi-publish@v1.1.0
+      uses: pypa/gh-action-pypi-publish@v1.2.2
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -17,10 +17,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install pep517 and twine
       run: |
         python -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
# Description

Update the publishing CI to use release [`v1.2.2`](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.2.2) of the [PyPA's `gh-action-pypi-publish` action](https://github.com/pypa/gh-action-pypi-publish). As of [`v1.2.1`](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.2.1) the action uses Python 3.8 inside of the Docker environment. Additionally, use Python 3.8 for 

Thank you again for such an awesome GitHub action, @webknjaz! :rocket: 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use Python 3.8 for building wheel and source distributions
* Update gh-action-pypi-publish GitHub action to v1.2.2
   - Use Python 3.8 in the action's Docker environment as of v1.2.1
```
