### PR TITLE
fix: Explicitly disallow Sphinx v3.1.0 in 'docs' extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ extras_require['test'] = sorted(
 extras_require['docs'] = sorted(
     set(
         [
-            'sphinx',
+            'sphinx!=3.1.0',
             'sphinxcontrib-bibtex',
             'sphinx-click',
             'sphinx_rtd_theme',


### PR DESCRIPTION
# Description

Resolves #894 

A [regression was introduced](https://github.com/sphinx-doc/sphinx/issues/7812) in [Sphinx `v3.1.0`](https://github.com/sphinx-doc/sphinx/releases/tag/v3.1.0) that breaks the docs, so simply don't allow v3.1.0 to be installed. This still allows for [`v3.0.4`](https://github.com/sphinx-doc/sphinx/releases/tag/v3.0.4) to be used and will attempt to use the next release of Sphinx after v3.1.0.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Disallow Sphinx v3.1.0 in 'docs' extra
   - c.f. https://github.com/sphinx-doc/sphinx/issues/7812
```
