### PR TITLE
fix: Keep Sphinx at v3.0.X releases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ extras_require['test'] = sorted(
 extras_require['docs'] = sorted(
     set(
         [
-            'sphinx~=3.0.0',  # Sphinx v3.1 series bugs break docs
+            'sphinx~=3.0.0',  # Sphinx v3.1.X regressions break docs
             'sphinxcontrib-bibtex',
             'sphinx-click',
             'sphinx_rtd_theme',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ extras_require['test'] = sorted(
 extras_require['docs'] = sorted(
     set(
         [
-            'sphinx!=3.1.0',
+            'sphinx~=3.0.0',  # Sphinx v3.1 series bugs break docs
             'sphinxcontrib-bibtex',
             'sphinx-click',
             'sphinx_rtd_theme',


### PR DESCRIPTION
# Description

This PR is in response to Issue #897, but does not fix it. [Sphinx Issue 7844](https://github.com/sphinx-doc/sphinx/issues/7844) is needed for it to actually resolved.

Temporarily keep Sphinx below `v3.1.0` as `v3.1.0` and `v3.1.1` have regressions that break the docs. 

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-fix-autosummary-bug

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Confine Sphinx to be in the v3.0.X series of releases
   - Avoid regressions introduced in v3.1.0 and v3.1.1
```
