### PR TITLE
fix: Change p-value calculation from 1-cdf(x) to cdf(-x)

### DIFF
--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -71,6 +71,7 @@ class AsymptoticTestStatDistribution(object):
 
         """
         tensorlib, _ = get_backend()
+        # computing cdf(-x) instead of 1-cdf(x) for right-tail p-value for improved numerical stability
         return tensorlib.normal_cdf(-(value - self.shift))
 
     def expected_value(self, nsigma):

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -71,7 +71,7 @@ class AsymptoticTestStatDistribution(object):
 
         """
         tensorlib, _ = get_backend()
-        return 1 - tensorlib.normal_cdf(value - self.shift)
+        return tensorlib.normal_cdf(-(value - self.shift))
 
     def expected_value(self, nsigma):
         """

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -335,7 +335,10 @@ class pytorch_backend(object):
         # we get a more numerically stable variant for low p-values/high significances using erfc(x) := 1 - erf(x)
         # since erf(-x) = -erf(x) we can replace
         # 1 + erf(x) = 1 - erf(-x) = 1 - (1 - erfc(-x)) = erfc(-x)
-        mu, sigma = broadcast_all(mu, sigma)
+        mu, sigma = [
+            torch.as_tensor(_par, dtype=self.dtypemap["float"])
+            for _par in broadcast_all(mu, sigma)
+        ]
         return 0.5 * torch.erfc(-((x - mu) * sigma.reciprocal() / math.sqrt(2)))
 
     def poisson_dist(self, rate):

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -324,8 +324,11 @@ class pytorch_backend(object):
         Returns:
             PyTorch FloatTensor: The CDF
         """
-        # the following variant is numerically more stable for low p-values
-        # than the default version that uses torch.erf
+        # the implementation of torch.Normal.cdf uses torch.erf:
+        # 0.5 * (1 + torch.erf((value - self.loc) * self.scale.reciprocal() / math.sqrt(2)))
+        # (see https://github.com/pytorch/pytorch/blob/3bbedb34b9b316729a27e793d94488b574e1577a/torch/distributions/normal.py#L78-L81)
+        # we get a more numerically stable variant for low p-values/high significances
+        # by replacing erf with (1 - erfc) since by definition
         # erfc(x) = 1 - erf(x)
         mu, sigma = broadcast_all(mu, sigma)
         return 0.5 * torch.erfc(-((x - mu) * sigma.reciprocal() / math.sqrt(2)))

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -1,7 +1,9 @@
 """PyTorch Tensor Library Module."""
 import torch
 import torch.autograd
+from torch.distributions.utils import broadcast_all
 import logging
+import math
 
 log = logging.getLogger(__name__)
 
@@ -322,8 +324,11 @@ class pytorch_backend(object):
         Returns:
             PyTorch FloatTensor: The CDF
         """
-        normal = torch.distributions.Normal(mu, sigma)
-        return normal.cdf(x)
+        # the following variant is numerically more stable for low p-values
+        # than the default version that uses torch.erf
+        # erfc(x) = 1 - erf(x)
+        mu, sigma = broadcast_all(mu, sigma)
+        return 0.5 * torch.erfc(-((x - mu) * sigma.reciprocal() / math.sqrt(2)))
 
     def poisson_dist(self, rate):
         r"""

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -337,10 +337,7 @@ class pytorch_backend(object):
         # we get a more numerically stable variant for low p-values/high significances using erfc(x) := 1 - erf(x)
         # since erf(-x) = -erf(x) we can replace
         # 1 + erf(x) = 1 - erf(-x) = 1 - (1 - erfc(-x)) = erfc(-x)
-        mu, sigma = [
-            torch.as_tensor(_par, dtype=self.dtypemap["float"])
-            for _par in broadcast_all(mu, sigma)
-        ]
+        mu, sigma = broadcast_all(mu, sigma)
         return 0.5 * torch.erfc(-((x - mu) * sigma.reciprocal() / math.sqrt(2)))
 
     def poisson_dist(self, rate):

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -327,9 +327,9 @@ class pytorch_backend(object):
         # the implementation of torch.Normal.cdf uses torch.erf:
         # 0.5 * (1 + torch.erf((value - self.loc) * self.scale.reciprocal() / math.sqrt(2)))
         # (see https://github.com/pytorch/pytorch/blob/3bbedb34b9b316729a27e793d94488b574e1577a/torch/distributions/normal.py#L78-L81)
-        # we get a more numerically stable variant for low p-values/high significances
-        # by replacing erf with (1 - erfc) since by definition
-        # erfc(x) = 1 - erf(x)
+        # we get a more numerically stable variant for low p-values/high significances using erfc(x) := 1 - erf(x)
+        # since erf(-x) = -erf(x) we can replace
+        # 1 + erf(x) = 1 - erf(-x) = 1 - (1 - erfc(-x)) = erfc(-x)
         mu, sigma = broadcast_all(mu, sigma)
         return 0.5 * torch.erfc(-((x - mu) * sigma.reciprocal() / math.sqrt(2)))
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -176,7 +176,7 @@ def test_calculator_distributions_without_teststatistic(qtilde):
 )
 def test_asymptotic_dist_low_pvalues(backend, nsigma, expected_pval):
     rtol = 1e-8
-    if backend[0].float_precision != '64b':
+    if backend[0].precision != '64b':
         rtol = 1e-5
     dist = pyhf.infer.calculators.AsymptoticTestStatDistribution(0)
     assert np.isclose(np.array(dist.pvalue(nsigma)), expected_pval, rtol=rtol, atol=0)
@@ -184,7 +184,7 @@ def test_asymptotic_dist_low_pvalues(backend, nsigma, expected_pval):
 
 def test_significance_to_pvalue_roundtrip(backend):
     rtol = 1e-15
-    if backend[0].float_precision != '64b':
+    if backend[0].precision != '64b':
         rtol = 1e-6
     sigma = np.arange(0, 10, 0.1)
     dist = pyhf.infer.calculators.AsymptoticTestStatDistribution(0)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -176,10 +176,7 @@ def test_calculator_distributions_without_teststatistic(qtilde):
 )
 def test_asymptotic_dist_low_pvalues(backend, nsigma, expected_pval):
     rtol = 1e-8
-    if hasattr(backend[0], "dtypemap") and (
-        backend[0].dtypemap["float"] == torch.float32
-        or backend[0].dtypemap["float"] == tf.float32
-    ):
+    if backend[0].float_precision != '64b':
         rtol = 1e-5
     dist = pyhf.infer.calculators.AsymptoticTestStatDistribution(0)
     assert np.isclose(np.array(dist.pvalue(nsigma)), expected_pval, rtol=rtol, atol=0)
@@ -187,10 +184,7 @@ def test_asymptotic_dist_low_pvalues(backend, nsigma, expected_pval):
 
 def test_significance_to_pvalue_roundtrip(backend):
     rtol = 1e-15
-    if hasattr(backend[0], "dtypemap") and (
-        backend[0].dtypemap["float"] == torch.float32
-        or backend[0].dtypemap["float"] == tf.float32
-    ):
+    if backend[0].float_precision != '64b':
         rtol = 1e-6
     sigma = np.arange(0, 10, 0.1)
     dist = pyhf.infer.calculators.AsymptoticTestStatDistribution(0)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -172,6 +172,7 @@ def test_calculator_distributions_without_teststatistic(qtilde):
     "nsigma,expected_pval",
     [
         # values tabulated using ROOT.RooStats.SignificanceToPValue
+        # they are consistent with relative difference < 1e-14 with scipy.stats.norm.sf
         (5, 2.866515718791945e-07),
         (6, 9.865876450377018e-10),
         (7, 1.279812543885835e-12),

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -157,3 +157,15 @@ def test_calculator_distributions_without_teststatistic(qtilde):
     )
     with pytest.raises(RuntimeError):
         calc.distributions(1.0)
+
+
+def test_asymptotic_dist_low_pvalues():
+    rtol = 1e-6
+    atol = 0
+    dist = pyhf.infer.calculators.AsymptoticTestStatDistribution(0)
+    # values tabulated using ROOT.RooStats.SignificanceToPValue
+    assert np.isclose(dist.pvalue(5), 2.866515718791945e-07, rtol=rtol, atol=atol)
+    assert np.isclose(dist.pvalue(6), 9.865876450377018e-10, rtol=rtol, atol=atol)
+    assert np.isclose(dist.pvalue(7), 1.279812543885835e-12, rtol=rtol, atol=atol)
+    assert np.isclose(dist.pvalue(8), 6.220960574271829e-16, rtol=rtol, atol=atol)
+    assert np.isclose(dist.pvalue(9), 1.1285884059538408e-19, rtol=rtol, atol=atol)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -2,8 +2,6 @@ import pytest
 import pyhf
 import numpy as np
 import scipy.stats
-import torch
-import tensorflow as tf
 
 
 @pytest.fixture(scope='module')

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -161,15 +161,6 @@ def test_calculator_distributions_without_teststatistic(qtilde):
 
 
 @pytest.mark.parametrize(
-    "backend_rtol",
-    [
-        (pyhf.tensor.numpy_backend(), 1e-8),
-        (pyhf.tensor.tensorflow_backend(), 1e-5),
-        (pyhf.tensor.pytorch_backend(), 1e-5),
-        (pyhf.tensor.jax_backend(), 1e-8),
-    ],
-)
-@pytest.mark.parametrize(
     "nsigma,expected_pval",
     [
         # values tabulated using ROOT.RooStats.SignificanceToPValue
@@ -181,8 +172,16 @@ def test_calculator_distributions_without_teststatistic(qtilde):
         (9, 1.1285884059538408e-19),
     ],
 )
-def test_asymptotic_dist_low_pvalues(backend_rtol, nsigma, expected_pval):
-    backend, rtol = backend_rtol
+@pytest.mark.parametrize(
+    "backend,rtol",
+    [
+        (pyhf.tensor.numpy_backend(), 1e-8),
+        (pyhf.tensor.tensorflow_backend(), 1e-5),
+        (pyhf.tensor.pytorch_backend(), 1e-5),
+        (pyhf.tensor.jax_backend(), 1e-8),
+    ],
+)
+def test_asymptotic_dist_low_pvalues(backend, rtol, nsigma, expected_pval):
     atol = 0
     pyhf.set_backend(backend)
     dist = pyhf.infer.calculators.AsymptoticTestStatDistribution(0)
@@ -192,7 +191,7 @@ def test_asymptotic_dist_low_pvalues(backend_rtol, nsigma, expected_pval):
 
 
 @pytest.mark.parametrize(
-    "backend_rtol",
+    "backend,rtol",
     [
         (pyhf.tensor.numpy_backend(), 1e-15),
         (pyhf.tensor.tensorflow_backend(), 1e-6),
@@ -200,8 +199,7 @@ def test_asymptotic_dist_low_pvalues(backend_rtol, nsigma, expected_pval):
         (pyhf.tensor.jax_backend(), 1e-15),
     ],
 )
-def test_significance_to_pvalue_roundtrip(backend_rtol):
-    backend, rtol = backend_rtol
+def test_significance_to_pvalue_roundtrip(backend, rtol):
     pyhf.set_backend(backend)
     sigma = np.arange(0, 10, 0.1)
     dist = pyhf.infer.calculators.AsymptoticTestStatDistribution(0)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -711,7 +711,7 @@ def validate_hypotest(pdf, data, mu_test, expected_result, tolerance=1e-6):
     [
         (setup_1bin_shapesys(), 1e-6),
         (setup_1bin_lumi(), 4e-6),
-        (setup_1bin_normsys(), 1e-6),
+        (setup_1bin_normsys(), 2e-6),
         (setup_2bin_histosys(), 8e-5),
         (setup_2bin_2channel(), 1e-6),
         (setup_2bin_2channel_couplednorm(), 1e-6),

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -189,7 +189,7 @@ def expected_result_1bin_normsys(mu=1.0):
     if mu == 1:
         expected_result = {
             "exp": [
-                7.471684419037561e-10,
+                7.47169462e-10,
                 5.7411551509088054e-08,
                 3.6898088062731205e-06,
                 0.00016965731538267896,
@@ -711,7 +711,7 @@ def validate_hypotest(pdf, data, mu_test, expected_result, tolerance=1e-6):
     [
         (setup_1bin_shapesys(), 1e-6),
         (setup_1bin_lumi(), 4e-6),
-        (setup_1bin_normsys(), 2e-6),
+        (setup_1bin_normsys(), 2e-9),
         (setup_2bin_histosys(), 8e-5),
         (setup_2bin_2channel(), 1e-6),
         (setup_2bin_2channel_couplednorm(), 1e-6),


### PR DESCRIPTION
# Description

Resolves #901 

By looking at the [implementation of `scipy.stats.norm.sf`](https://github.com/scipy/scipy/blob/0a7bc723d105288f4b728305733ed8cb3c8feeb5/scipy/stats/_continuous_distns.py#L262)  I noticed we can fix #901 by changing from `1-cdf(x)` to `cdf(-x)` which gives a more numerically stable result for most backends except pytorch. The pytorch function uses `erf`, but i changed that to using `erfc` (see https://en.wikipedia.org/wiki/Q-function#Definition_and_basic_properties) and after that it also seems to produce better results. I wrote it analogous to the [implementation of `torch.Normal.cdf`](
https://github.com/pytorch/pytorch/blob/3bbedb34b9b316729a27e793d94488b574e1577a/torch/distributions/normal.py#L78-L81)

Now, as a side effect it seems one of the validation tests does not pass anymore since the relative difference now is `1.3651304883824116e-06` instead of the required `1e-6`. What to do about that? In theory the values should be calculated more accurately now, so it could be the better match was accidentally?

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use Normal cdf(-x) to compute p-value for improved numerical stability
* Add tests for extremely small p-values
```