### PR TITLE
ci: Separate linting from testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,18 +27,6 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed -U -q --no-cache-dir -e .[test]
         python -m pip list
-    - name: Lint with Pyflakes
-      if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
-      run: |
-        python -m pyflakes .
-    - name: Lint with Black
-      if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
-      run: |
-        black --check --diff --verbose .
-    - name: Check MANIFEST
-      if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
-      run: |
-        check-manifest
     - name: Test with pytest
       run: |
         python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,6 @@
 name: Lint
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+
+    name: Lint Codebase
+    runs-on: ubuntu-latest
+    python-version: 3.8
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[lint]
+        python -m pip list
+    - name: Lint with Pyflakes
+      run: |
+        python -m pyflakes .
+    - name: Lint with Black
+      run: |
+        black --check --diff --verbose .
+    - name: Check MANIFEST
+      run: |
+        check-manifest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,14 +9,13 @@ jobs:
 
     name: Lint Codebase
     runs-on: ubuntu-latest
-    python-version: 3.8
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ python-version }}
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ python-version }}
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,3 @@ jobs:
     - name: Lint with Black
       run: |
         black --check --diff --verbose .
-    - name: Check MANIFEST
-      run: |
-        check-manifest

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -21,11 +21,14 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
-    - name: Install pep517 and twine
+    - name: Install pep517, check-manifest, and twine
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pep517 --user
-        python -m pip install twine
+        python -m pip install check-manifest twine
+    - name: Check MANIFEST
+      run: |
+        check-manifest
     - name: Build a binary wheel and a source tarball
       run: |
         python -m pep517.build --source --binary --out-dir dist/ .

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ extras_require['backends'] = sorted(
     )
 )
 extras_require['contrib'] = sorted(set(['matplotlib']))
+extras_require['lint'] = sorted(set(['pyflakes', 'black', 'check-manifest']))
 
 extras_require['test'] = sorted(
     set(
@@ -23,7 +24,6 @@ extras_require['test'] = sorted(
         + extras_require['xmlio']
         + extras_require['contrib']
         + [
-            'pyflakes',
             'pytest~=3.5',
             'pytest-cov>=2.5.1',
             'pytest-mock',
@@ -34,12 +34,10 @@ extras_require['test'] = sorted(
             'coverage>=4.0',  # coveralls
             'papermill~=2.0',
             'nteract-scrapbook~=0.2',
-            'check-manifest',
             'jupyter',
             'uproot~=3.3',
             'graphviz',
             'jsonpatch',
-            'black',
         ]
     )
 )
@@ -60,6 +58,7 @@ extras_require['docs'] = sorted(
 extras_require['develop'] = sorted(
     set(
         extras_require['docs']
+        + extras_require['lint']
         + extras_require['test']
         + ['nbdime', 'bumpversion', 'ipython', 'pre-commit', 'twine']
     )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras_require['backends'] = sorted(
     )
 )
 extras_require['contrib'] = sorted(set(['matplotlib']))
-extras_require['lint'] = sorted(set(['pyflakes', 'black', 'check-manifest']))
+extras_require['lint'] = sorted(set(['pyflakes', 'black']))
 
 extras_require['test'] = sorted(
     set(
@@ -60,7 +60,7 @@ extras_require['develop'] = sorted(
         extras_require['docs']
         + extras_require['lint']
         + extras_require['test']
-        + ['nbdime', 'bumpversion', 'ipython', 'pre-commit', 'twine']
+        + ['nbdime', 'bumpversion', 'ipython', 'pre-commit', 'check-manifest', 'twine']
     )
 )
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))


### PR DESCRIPTION
# Description

Create a separate `lint` extra that can be used to lint the codebase in a separate GitHub Actions workflow then the testing of the codebase. This should allow for faster testing overall, and it also allows for linting to not block development flow until a PR is finished.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add 'lint' extra to setup.py
* Move linting into a separate GitHub Actions workflow
   - Only run lint workflow on pull_request events
* Move MANIFEST check to publish-package workflow
   - Move check-manifest to 'develop' extra
```
