### PR TITLE
fix: Update infer.mle docstrings to match SciPy v1.5.0

### DIFF
--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -63,7 +63,7 @@ def fixed_poi_fit(poi_val, data, pdf, init_pars=None, par_bounds=None, **kwargs)
         >>> data = pyhf.tensorlib.astensor(observations + model.config.auxdata)
         >>> test_poi = 1.0
         >>> pyhf.infer.mle.fixed_poi_fit(test_poi, data, model, return_fitted_val=True)
-        (array([1.        , 0.97224597, 0.87553894]), 28.92218013492061)
+        (array([1.        , 0.97224597, 0.87553894]), array([28.92218013]))
 
     Args:
         data: The data

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -30,7 +30,7 @@ def fit(data, pdf, init_pars=None, par_bounds=None, **kwargs):
         >>> observations = [51, 48]
         >>> data = pyhf.tensorlib.astensor(observations + model.config.auxdata)
         >>> pyhf.infer.mle.fit(data, model, return_fitted_val=True)
-        (array([0.        , 1.0030512 , 0.96266961]), 24.98393521454011)
+        (array([0.        , 1.0030512 , 0.96266961]), array([24.98393521]))
 
     Args:
         data (`tensor`): The data


### PR DESCRIPTION
# Description

With [SciPy `v1.5.0`](https://github.com/scipy/scipy/releases/tag/v1.5.0) the return type for [`scipy.optimize.minimize`'s `res.fun`](https://docs.scipy.org/doc/scipy-1.5.0/reference/generated/scipy.optimize.minimize.html#scipy.optimize.minimize) is a NumPy array instead of a scalar. This PR updates the return type shown in examples of `pyhf.infer.mle` to pass the doctests in CI.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Show a NumPy array return type for the returned objective function (2*NLL) in the docs examples
```
