### PR TITLE
docs: Extend infer docstrings with mathematical examples

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -120,7 +120,6 @@ Inference
 .. autosummary::
    :toctree: _generated/
 
-   hypotest
    test_statistics.qmu
    test_statistics.qmu_tilde
    test_statistics.tmu
@@ -128,6 +127,7 @@ Inference
    mle.twice_nll
    mle.fit
    mle.fixed_poi_fit
+   hypotest
    calculators.generate_asimov_data
    calculators.AsymptoticTestStatDistribution
    calculators.AsymptoticCalculator

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -30,11 +30,13 @@ def hypotest(
 
     Args:
         poi_test (Number or Tensor): The value of the parameter of interest (POI)
-        data (Number or Tensor): The root of the calculated test statistic given the Asimov data, :math:`\sqrt{q_{\mu,A}}`
-        pdf (~pyhf.pdf.Model): The HistFactory statistical model
+        data (Number or Tensor): The data considered
+        pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``
         init_pars (Array or Tensor): The initial parameter values to be used for minimization
         par_bounds (Array or Tensor): The parameter value bounds to be used for minimization
-        qtilde (Bool): When ``True`` perform the calculation using the alternative test statistic, :math:`\tilde{q}`, as defined in Equation (62) of :xref:`arXiv:1007.1727`
+        qtilde (Bool): When ``True`` perform the calculation using the alternative
+         test statistic, :math:`\tilde{q}`, as defined under the Wald
+         approximation in Equation (62) of :xref:`arXiv:1007.1727`.
 
     Keyword Args:
         return_tail_probs (bool): Bool for returning :math:`\mathrm{CL}_{s+b}` and :math:`\mathrm{CL}_{b}`

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -67,6 +67,7 @@ def hypotest(
                 \mathrm{CL}_{s+b} = p_{s+b}
                 = p\left(q \geq q_{\mathrm{obs}}\middle|s+b\right)
                 = \int\limits_{q_{\mathrm{obs}}}^{\infty} f\left(q\,\middle|s+b\right)\,dq
+                = 1 - F\left(q_{\mathrm{obs}}\,\middle|\mu'\right)
                 = 1 - \Phi\left(\frac{q_{\mathrm{obs}} + 1/\sigma_{s+b}^{2}}{2/\sigma_{s+b}}\right)
 
             .. math::
@@ -74,8 +75,12 @@ def hypotest(
                 \mathrm{CL}_{b} = 1- p_{b}
                 = p\left(q \geq q_{\mathrm{obs}}\middle|b\right)
                 = 1 - \int\limits_{-\infty}^{q_{\mathrm{obs}}} f\left(q\,\middle|b\right)\,dq
+                = 1 - F\left(q_{\mathrm{obs}}\,\middle|0\right)
                 = 1 - \Phi\left(\frac{q_{\mathrm{obs}} - 1/\sigma_{b}^{2}}{2/\sigma_{b}}\right)
 
+            where the cumulative density functions
+            :math:`F\left(q\,\middle|\mu'\right)`
+            are given by Equations (57) and (65)
             with Equations (73) and (74) for the mean
 
             .. math::

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -37,30 +37,30 @@ def hypotest(
         qtilde (Bool): When ``True`` perform the calculation using the alternative test statistic, :math:`\tilde{q}`, as defined in Equation (62) of :xref:`arXiv:1007.1727`
 
     Keyword Args:
-        return_tail_probs (bool): Bool for returning :math:`\textrm{CL}_{s+b}` and :math:`\textrm{CL}_{b}`
-        return_expected (bool): Bool for returning :math:`\textrm{CL}_{\textrm{exp}}`
-        return_expected_set (bool): Bool for returning the :math:`(-2,-1,0,1,2)\sigma` :math:`\textrm{CL}_{\textrm{exp}}` --- the "Brazil band"
+        return_tail_probs (bool): Bool for returning :math:`\mathrm{CL}_{s+b}` and :math:`\mathrm{CL}_{b}`
+        return_expected (bool): Bool for returning :math:`\mathrm{CL}_{\mathrm{exp}}`
+        return_expected_set (bool): Bool for returning the :math:`(-2,-1,0,1,2)\sigma` :math:`\mathrm{CL}_{\mathrm{exp}}` --- the "Brazil band"
 
     Returns:
         Tuple of Floats and lists of Floats:
 
-            - :math:`\textrm{CL}_{s}`: The :math:`p`-value compared to the given threshold :math:`\alpha`, typically taken to be :math:`0.05`, defined in :xref:`arXiv:1007.1727` as
+            - :math:`\mathrm{CL}_{s}`: The :math:`p`-value compared to the given threshold :math:`\alpha`, typically taken to be :math:`0.05`, defined in :xref:`arXiv:1007.1727` as
 
             .. math::
 
-                \textrm{CL}_{s} = \frac{\textrm{CL}_{s+b}}{\textrm{CL}_{b}} = \frac{p_{s+b}}{1-p_{b}}
+                \mathrm{CL}_{s} = \frac{\mathrm{CL}_{s+b}}{\mathrm{CL}_{b}} = \frac{p_{s+b}}{1-p_{b}}
 
-            to protect against excluding signal models in which there is little sensitivity. In the case that :math:`\textrm{CL}_{s} \leq \alpha` the given signal model is excluded.
+            to protect against excluding signal models in which there is little sensitivity. In the case that :math:`\mathrm{CL}_{s} \leq \alpha` the given signal model is excluded.
 
-            - :math:`\left[\textrm{CL}_{s+b}, \textrm{CL}_{b}\right]`: The signal + background :math:`p`-value and 1 minus the background only :math:`p`-value as defined in Equations (75) and (76) of :xref:`arXiv:1007.1727`
-
-            .. math::
-
-                \textrm{CL}_{s+b} = p_{s+b} = \int\limits_{q_{\textrm{obs}}}^{\infty} f\left(q\,\middle|s+b\right)\,dq = 1 - \Phi\left(\frac{q_{\textrm{obs}} + 1/\sigma_{s+b}^{2}}{2/\sigma_{s+b}}\right)
+            - :math:`\left[\mathrm{CL}_{s+b}, \mathrm{CL}_{b}\right]`: The signal + background :math:`p`-value and 1 minus the background only :math:`p`-value as defined in Equations (75) and (76) of :xref:`arXiv:1007.1727`
 
             .. math::
 
-                \textrm{CL}_{b} = 1- p_{b} = 1 - \int\limits_{-\infty}^{q_{\textrm{obs}}} f\left(q\,\middle|b\right)\,dq = 1 - \Phi\left(\frac{q_{\textrm{obs}} - 1/\sigma_{b}^{2}}{2/\sigma_{b}}\right)
+                \mathrm{CL}_{s+b} = p_{s+b} = \int\limits_{q_{\mathrm{obs}}}^{\infty} f\left(q\,\middle|s+b\right)\,dq = 1 - \Phi\left(\frac{q_{\mathrm{obs}} + 1/\sigma_{s+b}^{2}}{2/\sigma_{s+b}}\right)
+
+            .. math::
+
+                \mathrm{CL}_{b} = 1- p_{b} = 1 - \int\limits_{-\infty}^{q_{\mathrm{obs}}} f\left(q\,\middle|b\right)\,dq = 1 - \Phi\left(\frac{q_{\mathrm{obs}} - 1/\sigma_{b}^{2}}{2/\sigma_{b}}\right)
 
             with Equations (73) and (74) for the mean
 
@@ -76,13 +76,13 @@ def hypotest(
 
             of the test statistic :math:`q` under the background only and and signal + background hypotheses. Only returned when ``return_tail_probs`` is ``True``.
 
-            - :math:`\textrm{CL}_{s,\textrm{exp}}`: The expected :math:`\textrm{CL}_{s}` value corresponding to the test statistic under the background only hypothesis :math:`\left(\mu=0\right)`. Only returned when ``return_expected`` is ``True``.
+            - :math:`\mathrm{CL}_{s,\mathrm{exp}}`: The expected :math:`\mathrm{CL}_{s}` value corresponding to the test statistic under the background only hypothesis :math:`\left(\mu=0\right)`. Only returned when ``return_expected`` is ``True``.
 
-            - :math:`\textrm{CL}_{s,\textrm{exp}}` band: The set of expected :math:`\textrm{CL}_{s}` values corresponding to the median significance of variations of the signal strength from the background only hypothesis :math:`\left(\mu=0\right)` at :math:`(-2,-1,0,1,2)\sigma`. That is, the :math:`p`-values that satisfy Equation (89) of :xref:`arXiv:1007.1727`
+            - :math:`\mathrm{CL}_{s,\mathrm{exp}}` band: The set of expected :math:`\mathrm{CL}_{s}` values corresponding to the median significance of variations of the signal strength from the background only hypothesis :math:`\left(\mu=0\right)` at :math:`(-2,-1,0,1,2)\sigma`. That is, the :math:`p`-values that satisfy Equation (89) of :xref:`arXiv:1007.1727`
 
             .. math::
 
-                \textrm{band}_{N\sigma} = \mu' + \sigma\,\Phi^{-1}\left(1-\alpha\right) \pm N\sigma
+                \mathrm{band}_{N\sigma} = \mu' + \sigma\,\Phi^{-1}\left(1-\alpha\right) \pm N\sigma
 
             for :math:`\mu'=0` and :math:`N \in \left\{-2, -1, 0, 1, 2\right\}`. These values define the boundaries of an uncertainty band sometimes referred to as the "Brazil band". Only returned when ``return_expected_set`` is ``True``.
 

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -84,6 +84,15 @@ def hypotest(
             statistic :math:`q \in \{q_{\mu}, \tilde{q}_{\mu}\}`.
             Only returned when ``return_tail_probs`` is ``True``.
 
+            .. note::
+
+                The definitions of the :math:`\mathrm{CL}_{s+b}` and
+                :math:`\mathrm{CL}_{b}` used are based on profile likelihood
+                ratio test statistics.
+                This procedure is common in the LHC-era, but differs from
+                procedures used in the LEP and Tevatron eras, as briefly
+                discussed in :math:`\S` 3.8 of of :xref:`arXiv:1007.1727`.
+
             - :math:`\mathrm{CL}_{s,\mathrm{exp}}`: The expected :math:`\mathrm{CL}_{s}`
               value corresponding to the test statistic under the background
               only hypothesis :math:`\left(\mu=0\right)`.

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -75,6 +75,7 @@ def hypotest(
                 = 1 - \int\limits_{-\infty}^{q_{\mathrm{obs}}} f\left(q\,\middle|b\right)\,dq
                 = 1 - F\left(q_{\mathrm{obs}}\,\middle|\mu'=0\right)
 
+            for signal strength :math:`\mu` and Asimov strength :math:`\mu'`,
             where the cumulative density functions
             :math:`F\left(q\,\middle|\mu'\right)`
             are given by Equations (57) and (65) of :xref:`arXiv:1007.1727`

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -66,7 +66,7 @@ def hypotest(
                 \mathrm{CL}_{s+b} = p_{s+b}
                 = p\left(q \geq q_{\mathrm{obs}}\middle|s+b\right)
                 = \int\limits_{q_{\mathrm{obs}}}^{\infty} f\left(q\,\middle|s+b\right)\,dq
-                = 1 - F\left(q_{\mathrm{obs}}\,\middle|\mu'\right)
+                = 1 - F\left(q_{\mathrm{obs}}(\mu)\,\middle|\mu'\right)
 
             and 1 minus the background only model hypothesis :math:`p`-value
 
@@ -75,14 +75,13 @@ def hypotest(
                 \mathrm{CL}_{b} = 1- p_{b}
                 = p\left(q \geq q_{\mathrm{obs}}\middle|b\right)
                 = 1 - \int\limits_{-\infty}^{q_{\mathrm{obs}}} f\left(q\,\middle|b\right)\,dq
-                = 1 - F\left(q_{\mathrm{obs}}\,\middle|0\right)
+                = 1 - F\left(q_{\mathrm{obs}}(\mu)\,\middle|0\right)
 
-            for signal strength :math:`\mu` and Asimov strength :math:`\mu'`,
-            where the cumulative density functions
-            :math:`F\left(q\,\middle|\mu'\right)`
-            are given by Equations (57) and (65) of :xref:`arXiv:1007.1727`
-            for upper-limit-like test statistic
-            :math:`q \in \{q_{\mu}, \tilde{q}_{\mu}\}`.
+            for signal strength :math:`\mu` and model hypothesis signal strength
+            :math:`\mu'`, where the cumulative density functions
+            :math:`F\left(q(\mu)\,\middle|\mu'\right)` are given by Equations (57)
+            and (65) of :xref:`arXiv:1007.1727` for upper-limit-like test
+            statistic :math:`q \in \{q_{\mu}, \tilde{q}_{\mu}\}`.
             Only returned when ``return_tail_probs`` is ``True``.
 
             - :math:`\mathrm{CL}_{s,\mathrm{exp}}`: The expected :math:`\mathrm{CL}_{s}`

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -73,7 +73,7 @@ def hypotest(
                 \mathrm{CL}_{b} = 1- p_{b}
                 = p\left(q \geq q_{\mathrm{obs}}\middle|b\right)
                 = 1 - \int\limits_{-\infty}^{q_{\mathrm{obs}}} f\left(q\,\middle|b\right)\,dq
-                = 1 - F\left(q_{\mathrm{obs}}\,\middle|\mu'=0\right)
+                = 1 - F\left(q_{\mathrm{obs}}\,\middle|0\right)
 
             for signal strength :math:`\mu` and Asimov strength :math:`\mu'`,
             where the cumulative density functions

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -35,7 +35,7 @@ def hypotest(
         init_pars (Array or Tensor): The initial parameter values to be used for minimization
         par_bounds (Array or Tensor): The parameter value bounds to be used for minimization
         qtilde (Bool): When ``True`` perform the calculation using the alternative
-         test statistic, :math:`\tilde{q}`, as defined under the Wald
+         test statistic, :math:`\tilde{q}_{\mu}`, as defined under the Wald
          approximation in Equation (62) of :xref:`arXiv:1007.1727`.
 
     Keyword Args:

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -44,15 +44,22 @@ def hypotest(
     Returns:
         Tuple of Floats and lists of Floats:
 
-            - :math:`\mathrm{CL}_{s}`: The :math:`p`-value compared to the given threshold :math:`\alpha`, typically taken to be :math:`0.05`, defined in :xref:`arXiv:1007.1727` as
+            - :math:`\mathrm{CL}_{s}`: The modified :math:`p`-value compared to
+              the given threshold :math:`\alpha`, typically taken to be :math:`0.05`,
+              defined in :xref:`arXiv:1007.1727` as
 
             .. math::
 
                 \mathrm{CL}_{s} = \frac{\mathrm{CL}_{s+b}}{\mathrm{CL}_{b}} = \frac{p_{s+b}}{1-p_{b}}
 
-            to protect against excluding signal models in which there is little sensitivity. In the case that :math:`\mathrm{CL}_{s} \leq \alpha` the given signal model is excluded.
+            to protect against excluding signal models in which there is little
+            sensitivity. In the case that :math:`\mathrm{CL}_{s} \leq \alpha`
+            the given signal model is excluded.
 
-            - :math:`\left[\mathrm{CL}_{s+b}, \mathrm{CL}_{b}\right]`: The signal + background :math:`p`-value and 1 minus the background only :math:`p`-value as defined in Equations (75) and (76) of :xref:`arXiv:1007.1727`
+            - :math:`\left[\mathrm{CL}_{s+b}, \mathrm{CL}_{b}\right]`: The
+              signal + background :math:`p`-value and 1 minus the background only
+              :math:`p`-value as defined in Equations (75) and (76) of
+              :xref:`arXiv:1007.1727`
 
             .. math::
 
@@ -74,17 +81,31 @@ def hypotest(
 
                 V\left[q\right] = \frac{4}{\sigma^{2}}
 
-            of the test statistic :math:`q` under the background only and and signal + background hypotheses. Only returned when ``return_tail_probs`` is ``True``.
+            of the test statistic :math:`q` under the background only and and
+            signal + background hypotheses.
+            Only returned when ``return_tail_probs`` is ``True``.
 
-            - :math:`\mathrm{CL}_{s,\mathrm{exp}}`: The expected :math:`\mathrm{CL}_{s}` value corresponding to the test statistic under the background only hypothesis :math:`\left(\mu=0\right)`. Only returned when ``return_expected`` is ``True``.
+            - :math:`\mathrm{CL}_{s,\mathrm{exp}}`: The expected :math:`\mathrm{CL}_{s}`
+              value corresponding to the test statistic under the background
+              only hypothesis :math:`\left(\mu=0\right)`.
+              Only returned when ``return_expected`` is ``True``.
 
-            - :math:`\mathrm{CL}_{s,\mathrm{exp}}` band: The set of expected :math:`\mathrm{CL}_{s}` values corresponding to the median significance of variations of the signal strength from the background only hypothesis :math:`\left(\mu=0\right)` at :math:`(-2,-1,0,1,2)\sigma`. That is, the :math:`p`-values that satisfy Equation (89) of :xref:`arXiv:1007.1727`
+            - :math:`\mathrm{CL}_{s,\mathrm{exp}}` band: The set of expected
+              :math:`\mathrm{CL}_{s}` values corresponding to the median
+              significance of variations of the signal strength from the
+              background only hypothesis :math:`\left(\mu=0\right)` at
+              :math:`(-2,-1,0,1,2)\sigma`.
+              That is, the :math:`p`-values that satisfy Equation (89) of
+              :xref:`arXiv:1007.1727`
 
             .. math::
 
                 \mathrm{band}_{N\sigma} = \mu' + \sigma\,\Phi^{-1}\left(1-\alpha\right) \pm N\sigma
 
-            for :math:`\mu'=0` and :math:`N \in \left\{-2, -1, 0, 1, 2\right\}`. These values define the boundaries of an uncertainty band sometimes referred to as the "Brazil band". Only returned when ``return_expected_set`` is ``True``.
+            for :math:`\mu'=0` and :math:`N \in \left\{-2, -1, 0, 1, 2\right\}`.
+            These values define the boundaries of an uncertainty band sometimes
+            referred to as the "Brazil band".
+            Only returned when ``return_expected_set`` is ``True``.
 
     """
     init_pars = init_pars or pdf.config.suggested_init()

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -59,15 +59,22 @@ def hypotest(
             - :math:`\left[\mathrm{CL}_{s+b}, \mathrm{CL}_{b}\right]`: The
               signal + background :math:`p`-value and 1 minus the background only
               :math:`p`-value as defined in Equations (75) and (76) of
-              :xref:`arXiv:1007.1727`
+              :xref:`arXiv:1007.1727` for upper-limit-like test statistic
+              :math:`q \in \{q_{\mu}, \tilde{q}_{\mu}\}`
 
             .. math::
 
-                \mathrm{CL}_{s+b} = p_{s+b} = \int\limits_{q_{\mathrm{obs}}}^{\infty} f\left(q\,\middle|s+b\right)\,dq = 1 - \Phi\left(\frac{q_{\mathrm{obs}} + 1/\sigma_{s+b}^{2}}{2/\sigma_{s+b}}\right)
+                \mathrm{CL}_{s+b} = p_{s+b}
+                = p\left(q \geq q_{\mathrm{obs}}\middle|s+b\right)
+                = \int\limits_{q_{\mathrm{obs}}}^{\infty} f\left(q\,\middle|s+b\right)\,dq
+                = 1 - \Phi\left(\frac{q_{\mathrm{obs}} + 1/\sigma_{s+b}^{2}}{2/\sigma_{s+b}}\right)
 
             .. math::
 
-                \mathrm{CL}_{b} = 1- p_{b} = 1 - \int\limits_{-\infty}^{q_{\mathrm{obs}}} f\left(q\,\middle|b\right)\,dq = 1 - \Phi\left(\frac{q_{\mathrm{obs}} - 1/\sigma_{b}^{2}}{2/\sigma_{b}}\right)
+                \mathrm{CL}_{b} = 1- p_{b}
+                = p\left(q \geq q_{\mathrm{obs}}\middle|b\right)
+                = 1 - \int\limits_{-\infty}^{q_{\mathrm{obs}}} f\left(q\,\middle|b\right)\,dq
+                = 1 - \Phi\left(\frac{q_{\mathrm{obs}} - 1/\sigma_{b}^{2}}{2/\sigma_{b}}\right)
 
             with Equations (73) and (74) for the mean
 

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -91,7 +91,7 @@ def hypotest(
                 ratio test statistics.
                 This procedure is common in the LHC-era, but differs from
                 procedures used in the LEP and Tevatron eras, as briefly
-                discussed in :math:`\S` 3.8 of of :xref:`arXiv:1007.1727`.
+                discussed in :math:`\S` 3.8 of :xref:`arXiv:1007.1727`.
 
             - :math:`\mathrm{CL}_{s,\mathrm{exp}}`: The expected :math:`\mathrm{CL}_{s}`
               value corresponding to the test statistic under the background

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -57,10 +57,7 @@ def hypotest(
             the given signal model is excluded.
 
             - :math:`\left[\mathrm{CL}_{s+b}, \mathrm{CL}_{b}\right]`: The
-              signal + background :math:`p`-value and 1 minus the background only
-              :math:`p`-value as defined in Equations (75) and (76) of
-              :xref:`arXiv:1007.1727` for upper-limit-like test statistic
-              :math:`q \in \{q_{\mu}, \tilde{q}_{\mu}\}`
+              signal + background model hypothesis :math:`p`-value
 
             .. math::
 
@@ -68,33 +65,21 @@ def hypotest(
                 = p\left(q \geq q_{\mathrm{obs}}\middle|s+b\right)
                 = \int\limits_{q_{\mathrm{obs}}}^{\infty} f\left(q\,\middle|s+b\right)\,dq
                 = 1 - F\left(q_{\mathrm{obs}}\,\middle|\mu'\right)
-                = 1 - \Phi\left(\frac{q_{\mathrm{obs}} + 1/\sigma_{s+b}^{2}}{2/\sigma_{s+b}}\right)
+
+            and 1 minus the background only model hypothesis :math:`p`-value
 
             .. math::
 
                 \mathrm{CL}_{b} = 1- p_{b}
                 = p\left(q \geq q_{\mathrm{obs}}\middle|b\right)
                 = 1 - \int\limits_{-\infty}^{q_{\mathrm{obs}}} f\left(q\,\middle|b\right)\,dq
-                = 1 - F\left(q_{\mathrm{obs}}\,\middle|0\right)
-                = 1 - \Phi\left(\frac{q_{\mathrm{obs}} - 1/\sigma_{b}^{2}}{2/\sigma_{b}}\right)
+                = 1 - F\left(q_{\mathrm{obs}}\,\middle|\mu'=0\right)
 
             where the cumulative density functions
             :math:`F\left(q\,\middle|\mu'\right)`
-            are given by Equations (57) and (65)
-            with Equations (73) and (74) for the mean
-
-            .. math::
-
-                E\left[q\right] = \frac{1 - 2\mu}{\sigma^{2}}
-
-            and variance
-
-            .. math::
-
-                V\left[q\right] = \frac{4}{\sigma^{2}}
-
-            of the test statistic :math:`q` under the background only and and
-            signal + background hypotheses.
+            are given by Equations (57) and (65) of :xref:`arXiv:1007.1727`
+            for upper-limit-like test statistic
+            :math:`q \in \{q_{\mu}, \tilde{q}_{\mu}\}`.
             Only returned when ``return_tail_probs`` is ``True``.
 
             - :math:`\mathrm{CL}_{s,\mathrm{exp}}`: The expected :math:`\mathrm{CL}_{s}`

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -75,8 +75,9 @@ class AsymptoticTestStatDistribution(object):
 
     def pvalue(self, value):
         r"""
-        The :math:`p`-value for a given value of the test statistic.
-        The :math:`p`-values for signal strength :math:`\mu` and Asimov strength :math:`\mu'` as defined in Equations (59) and (57) of :xref:`arXiv:1007.1727`
+        The :math:`p`-value for a given value of the test statistic corresponding
+        to signal strength :math:`\mu` and Asimov strength :math:`\mu'` as
+        defined in Equations (59) and (57) of :xref:`arXiv:1007.1727`
 
         .. math::
 

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -74,8 +74,21 @@ class AsymptoticTestStatDistribution(object):
         return tensorlib.normal_cdf((value - self.shift))
 
     def pvalue(self, value):
-        """
-        Compute the :math:`p`-value for a given value of the test statistic.
+        r"""
+        The :math:`p`-value for a given value of the test statistic.
+        The :math:`p`-values for signal strength :math:`\mu` and Asimov strength :math:`\mu'` as defined in Equations (59) and (57) of :xref:`arXiv:1007.1727`
+
+        .. math::
+
+            p_{\mu} = 1-F\left(q_{\mu}\middle|\mu'\right) = 1- \Phi\left(\sqrt{q_{\mu}} - \frac{\left(\mu-\mu'\right)}{\sigma}\right)
+
+        with Equation (29)
+
+        .. math::
+
+            \frac{(\mu-\mu')}{\sigma} = \sqrt{\Lambda}= \sqrt{q_{\mu,A}}
+
+        given the observed test statistics :math:`q_{\mu}` and :math:`q_{\mu,A}`.
 
         Args:
             value (`float`): The test statistic value.

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -18,8 +18,8 @@ def twice_nll(pars, data, pdf):
 
        \lambda\left(\mu\right) = \frac{L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}\right)}{L\left(\hat{\mu}, \hat{\boldsymbol{\theta}}\right)}
 
-    It serves as the objective function to minimize in ~pyhf.infer.mle.fit and
-    ~pyhf.infer.mle.fixed_poi_fit.
+    It serves as the objective function to minimize in :func:`~pyhf.infer.mle.fit`
+    and :func:`~pyhf.infer.mle.fixed_poi_fit`.
 
     Example:
         >>> import pyhf

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -50,7 +50,7 @@ def twice_nll(pars, data, pdf):
 def fit(data, pdf, init_pars=None, par_bounds=None, **kwargs):
     r"""
     Run a unconstrained maximum likelihood fit.
-    This is done by minimizing the objective function of twice the negative log-likelihood
+    This is done by minimizing the objective function :func:`~pyhf.infer.mle.twice_nll`
     of the model parameters given the observed data.
     This is used to produce the maximal likelihood :math:`L\left(\hat{\mu}, \hat{\boldsymbol{\theta}}\right)`
     in the profile likelihood ratio in Equation (7) in :xref:`arXiv:1007.1727`
@@ -102,7 +102,7 @@ def fit(data, pdf, init_pars=None, par_bounds=None, **kwargs):
 def fixed_poi_fit(poi_val, data, pdf, init_pars=None, par_bounds=None, **kwargs):
     r"""
     Run a maximum likelihood fit with the POI value fixed.
-    This is done by minimizing the objective function of twice the negative log-likelihood
+    This is done by minimizing the objective function of :func:`~pyhf.infer.mle.twice_nll`
     of the model parameters given the observed data, for a given fixed value of :math:`\mu`.
     This is used to produce the constrained maximal likelihood for the given :math:`\mu`
     :math:`L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}\right)` in the profile

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -4,16 +4,32 @@ from ..exceptions import UnspecifiedPOI
 
 
 def twice_nll(pars, data, pdf):
-    """
-    Twice the negative Log-Likelihood.
+    r"""
+    Two times the negative log-likelihood of the model parameters, :math:`\left(\mu, \boldsymbol{\theta}\right)`, given the observed data
+
+    .. math::
+
+        -2\ln L\left(\mu, \boldsymbol{\theta}\right)
+
+    It is used in the calculation of the test statistic, :math:`t_{\mu}`, as defiend in Equation (8) in :xref:`arXiv:1007.1727`
+
+    .. math::
+
+       t_{\mu} = -2\ln\lambda\left(\mu\right)
+
+    where :math:`\lambda\left(\mu\right)` is the profile likelihood ratio as defined in Equation (7)
+
+    .. math::
+
+       \lambda\left(\mu\right) = \frac{L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}\right)}{L\left(\hat{\mu}, \hat{\boldsymbol{\theta}}\right)}
 
     Args:
-        data (`tensor`): The data
+        pars (`tensor`): The parameters of the HistFactory model
+        data (`tensor`): The data to be considered
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
 
     Returns:
-        Twice the negative log likelihood.
-
+        Float: Two times the negative log-likelihood, :math:`-2\ln L\left(\mu, \boldsymbol{\theta}\right)`
     """
     return -2 * pdf.logpdf(pars, data)
 

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -48,8 +48,17 @@ def twice_nll(pars, data, pdf):
 
 
 def fit(data, pdf, init_pars=None, par_bounds=None, **kwargs):
-    """
+    r"""
     Run a unconstrained maximum likelihood fit.
+    This is done by minimizing the objective function of twice the negative log-likelihood
+    of the model parameters given the observed data.
+    This is used to produce the maximal likelihood :math:`L\left(\hat{\mu}, \hat{\boldsymbol{\theta}}\right)`
+    in the profile likelihood ratio in Equation (7) in :xref:`arXiv:1007.1727`
+
+    .. math::
+
+       \lambda\left(\mu\right) = \frac{L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}\right)}{L\left(\hat{\mu}, \hat{\boldsymbol{\theta}}\right)}
+
 
     .. note::
 
@@ -91,8 +100,17 @@ def fit(data, pdf, init_pars=None, par_bounds=None, **kwargs):
 
 
 def fixed_poi_fit(poi_val, data, pdf, init_pars=None, par_bounds=None, **kwargs):
-    """
+    r"""
     Run a maximum likelihood fit with the POI value fixed.
+    This is done by minimizing the objective function of twice the negative log-likelihood
+    of the model parameters given the observed data, for a given fixed value of :math:`\mu`.
+    This is used to produce the constrained maximal likelihood for the given :math:`\mu`
+    :math:`L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}\right)` in the profile
+    likelihood ratio in Equation (7) in :xref:`arXiv:1007.1727`
+
+    .. math::
+
+       \lambda\left(\mu\right) = \frac{L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}\right)}{L\left(\hat{\mu}, \hat{\boldsymbol{\theta}}\right)}
 
     .. note::
 

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -5,12 +5,7 @@ from ..exceptions import UnspecifiedPOI
 
 def twice_nll(pars, data, pdf):
     r"""
-    Two times the negative log-likelihood of the model parameters, :math:`\left(\mu, \boldsymbol{\theta}\right)`, given the observed data
-
-    .. math::
-
-        -2\ln L\left(\mu, \boldsymbol{\theta}\right)
-
+    Two times the negative log-likelihood of the model parameters, :math:`\left(\mu, \boldsymbol{\theta}\right)`, given the observed data.
     It is used in the calculation of the test statistic, :math:`t_{\mu}`, as defiend in Equation (8) in :xref:`arXiv:1007.1727`
 
     .. math::
@@ -22,6 +17,9 @@ def twice_nll(pars, data, pdf):
     .. math::
 
        \lambda\left(\mu\right) = \frac{L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}\right)}{L\left(\hat{\mu}, \hat{\boldsymbol{\theta}}\right)}
+
+    It serves as the objective function to minimize in ~pyhf.infer.mle.fit and
+    ~pyhf.infer.mle.fixed_poi_fit.
 
     Args:
         pars (`tensor`): The parameters of the HistFactory model

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -16,7 +16,7 @@ def twice_nll(pars, data, pdf):
 
     .. math::
 
-       \lambda\left(\mu\right) = \frac{L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}\right)}{L\left(\hat{\mu}, \hat{\boldsymbol{\theta}}\right)}
+       \lambda\left(\mu\right) = \frac{L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}\right)}{L\left(\hat{\mu}, \hat{\boldsymbol{\theta}}\right)}\,.
 
     It serves as the objective function to minimize in :func:`~pyhf.infer.mle.fit`
     and :func:`~pyhf.infer.mle.fixed_poi_fit`.

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -21,13 +21,28 @@ def twice_nll(pars, data, pdf):
     It serves as the objective function to minimize in ~pyhf.infer.mle.fit and
     ~pyhf.infer.mle.fixed_poi_fit.
 
+    Example:
+        >>> import pyhf
+        >>> pyhf.set_backend("numpy")
+        >>> model = pyhf.simplemodels.hepdata_like(
+        ...     signal_data=[12.0, 11.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0]
+        ... )
+        >>> observations = [51, 48]
+        >>> data = pyhf.tensorlib.astensor(observations + model.config.auxdata)
+        >>> parameters = model.config.suggested_init()  # nominal parameters
+        >>> twice_nll = pyhf.infer.mle.twice_nll(parameters, data, model)
+        >>> twice_nll
+        array([30.77525435])
+        >>> -2 * model.logpdf(parameters, data) == twice_nll
+        array([ True])
+
     Args:
         pars (`tensor`): The parameters of the HistFactory model
         data (`tensor`): The data to be considered
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
 
     Returns:
-        Float: Two times the negative log-likelihood, :math:`-2\ln L\left(\mu, \boldsymbol{\theta}\right)`
+        Tensor: Two times the negative log-likelihood, :math:`-2\ln L\left(\mu, \boldsymbol{\theta}\right)`
     """
     return -2 * pdf.logpdf(pars, data)
 

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -52,7 +52,7 @@ def qmu(mu, data, pdf, init_pars, par_bounds):
     r"""
     The test statistic, :math:`q_{\mu}`, for establishing an upper
     limit on the strength parameter, :math:`\mu`, as defiend in
-    Equation (14) in :xref:`arXiv:1007.1727`.
+    Equation (14) in :xref:`arXiv:1007.1727`
 
     .. math::
        :nowrap:
@@ -63,6 +63,12 @@ def qmu(mu, data, pdf, init_pars, par_bounds):
           0, & \hat{\mu} > \mu
           \end{array}\right.
         \end{equation}
+
+    where :math:`\lambda\left(\mu\right)` is the profile likelihood ratio as defined in Equation (7)
+
+    .. math::
+
+       \lambda\left(\mu\right) = \frac{L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}\right)}{L\left(\hat{\mu}, \hat{\boldsymbol{\theta}}\right)}\,.
 
     Example:
         >>> import pyhf
@@ -105,7 +111,29 @@ def qmu_tilde(mu, data, pdf, init_pars, par_bounds):
     r"""
     The test statistic, :math:`\tilde{q}_{\mu}`, for establishing an upper
     limit on the strength parameter, :math:`\mu`, for models with
-    bounded POI, as defiend in Equation (16) in :xref:`arXiv:1007.1727`.
+    bounded POI, as defiend in Equation (16) in :xref:`arXiv:1007.1727`
+
+    .. math::
+       :nowrap:
+
+       \begin{equation}
+          \tilde{q}_{\mu} = \left\{\begin{array}{ll}
+          -2\ln\tilde{\lambda}\left(\mu\right), &\hat{\mu} < \mu,\\
+          0, & \hat{\mu} > \mu
+          \end{array}\right.
+        \end{equation}
+
+    where :math:`\tilde{\lambda}\left(\mu\right)` is the constrained profile likelihood ratio as defined in Equation (10)
+
+    .. math::
+       :nowrap:
+
+       \begin{equation}
+          \tilde{\lambda}\left(\mu\right) = \left\{\begin{array}{ll}
+          \frac{L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}(\mu)\right)}{L\left(\hat{\mu}, \hat{\hat{\boldsymbol{\theta}}}(0)\right)}, &\hat{\mu} < 0,\\
+          \frac{L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}(\mu)\right)}{L\left(\hat{\mu}, \hat{\boldsymbol{\theta}}\right)}, &\hat{\mu} \geq 0.
+          \end{array}\right.
+        \end{equation}
 
     Example:
         >>> import pyhf

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -146,8 +146,18 @@ def qmu_tilde(mu, data, pdf, init_pars, par_bounds):
 def tmu(mu, data, pdf, init_pars, par_bounds):
     r"""
     The test statistic, :math:`t_{\mu}`, for establishing a two-sided
-    interval on the strength parameter, :math:`\mu`, as defiend in Equation (10)
-    in :xref:`arXiv:1007.1727`.
+    interval on the strength parameter, :math:`\mu`, as defiend in Equation (8)
+    in :xref:`arXiv:1007.1727`
+
+    .. math::
+
+       t_{\mu} = -2\ln\lambda\left(\mu\right)
+
+    where :math:`\lambda\left(\mu\right)` is the profile likelihood ratio as defined in Equation (7)
+
+    .. math::
+
+       \lambda\left(\mu\right) = \frac{L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}\right)}{L\left(\hat{\mu}, \hat{\boldsymbol{\theta}}\right)}\,.
 
     Example:
         >>> import pyhf
@@ -188,9 +198,25 @@ def tmu(mu, data, pdf, init_pars, par_bounds):
 
 def tmu_tilde(mu, data, pdf, init_pars, par_bounds):
     r"""
-    The test statistic, :math:`t_{\mu}`, for establishing a two-sided
+    The test statistic, :math:`\tilde{t}_{\mu}`, for establishing a two-sided
     interval on the strength parameter, :math:`\mu`, for models with
-    bounded POI, as defiend in Equation (11) in :xref:`arXiv:1007.1727`.
+    bounded POI, as defiend in Equation (11) in :xref:`arXiv:1007.1727`
+
+    .. math::
+
+       \tilde{t}_{\mu} = -2\ln\tilde{\lambda}\left(\mu\right)
+
+    where :math:`\tilde{\lambda}\left(\mu\right)` is the constrained profile likelihood ratio as defined in Equation (10)
+
+    .. math::
+       :nowrap:
+
+       \begin{equation}
+          \tilde{\lambda}\left(\mu\right) = \left\{\begin{array}{ll}
+          \frac{L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}(\mu)\right)}{L\left(\hat{\mu}, \hat{\hat{\boldsymbol{\theta}}}(0)\right)}, &\hat{\mu} < 0,\\
+          \frac{L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}(\mu)\right)}{L\left(\hat{\mu}, \hat{\boldsymbol{\theta}}\right)}, &\hat{\mu} \geq 0.
+          \end{array}\right.
+        \end{equation}
 
     Example:
         >>> import pyhf


### PR DESCRIPTION
# Description

Resolves #601 

Add mathematical examples/foundations of the use of the infer API in [arXiv:1007.1727](https://arxiv.org/abs/1007.1727) as well as provide additional API examples. This is mainly a port of work started on [`docs/add-docstrings-to-utils`](https://github.com/scikit-hep/pyhf/compare/docs/add-docstrings-to-utils), which was incomplete and had errors.

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-update-maths-in-infer-docstrings/api.html#inference

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add maths examples to the infer API docstrings
   - Based on relation to equations in https://arxiv.org/abs/1007.1727
* Correct hypotest docstring to use the profile likelihood ratio test statistic
* Add API example to twice_nll docstring
```
