### PR TITLE
fix: make pytorch_backend use configured dtypes

### DIFF
--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -13,7 +13,7 @@ class pytorch_backend(object):
         self.name = 'pytorch'
         self.dtypemap = {
             'float': getattr(torch, kwargs.get('float', 'float32')),
-            'int': getattr(torch, kwargs.get('float', 'int32')),
+            'int': getattr(torch, kwargs.get('int', 'int32')),
             'bool': torch.bool,
         }
 

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -16,6 +16,7 @@ class pytorch_backend(object):
             'int': getattr(torch, kwargs.get('int', 'int32')),
             'bool': torch.bool,
         }
+        torch.set_default_dtype(self.dtypemap["float"])
 
     def clip(self, tensor_in, min_value, max_value):
         """


### PR DESCRIPTION
# Description

This fixes a small typo in the constructor of `pytorch_backend`. The kwargs key for the int type was wrongly queried as "float".

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* typo in pytorch backend where one was unable to specify integer dtype
```