### PR TITLE
ci: Verify build backend is compliant with PEP 517 in publishing workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Check MANIFEST
       run: |
         check-manifest
-    - name: Build a binary wheel and a source tarball
+    - name: Build a wheel and a sdist
       run: |
         python -m pep517.build --source --binary --out-dir dist/ .
     - name: Verify untagged commits have dev versions

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -29,6 +29,9 @@ jobs:
     - name: Check MANIFEST
       run: |
         check-manifest
+    - name: Test the build backend is compliant with PEP517
+      run: |
+        python -m pep517.check .
     - name: Build a wheel and a sdist
       run: |
         python -m pep517.build --source --binary --out-dir dist/ .


### PR DESCRIPTION
# Description

Resolves #908 

Use [`pep517.check`](https://github.com/pypa/pep517/tree/82a303d0cdb5de1e48f30b90ee299a8e0cbfad3b) to verify that the build backend is compliant with [PEP 517](https://www.python.org/dev/peps/pep-0517/) before attempting to build the distributions in the publishing workflow. Additionally, based off of the discussion with @henryiii in Issue #908, use more honest/clear wording RE: the wheels produced in the publishing workflow.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Test the build backend is compliant with PEP 517 with pep517.check
* Use more clear language with regards to wheels
```
