### PR TITLE
feat: Add precision information to tensorlib backends

### DIFF
--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -42,7 +42,8 @@ class jax_backend(object):
 
     def __init__(self, **kwargs):
         self.name = 'jax'
-        self.precision = '64b'
+        self.float_precision = '64b'
+        self.int_precision = '64b'
         config.update('jax_enable_x64', True)
 
     def clip(self, tensor_in, min_value, max_value):

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -42,6 +42,7 @@ class jax_backend(object):
 
     def __init__(self, **kwargs):
         self.name = 'jax'
+        self.precision = '64b'
         config.update('jax_enable_x64', True)
 
     def clip(self, tensor_in, min_value, max_value):

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -38,6 +38,7 @@ class numpy_backend(object):
 
     def __init__(self, **kwargs):
         self.name = 'numpy'
+        self.precision = '64b'
 
     def clip(self, tensor_in, min_value, max_value):
         """

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -38,7 +38,8 @@ class numpy_backend(object):
 
     def __init__(self, **kwargs):
         self.name = 'numpy'
-        self.precision = '64b'
+        self.float_precision = '64b'
+        self.int_precision = '64b'
 
     def clip(self, tensor_in, min_value, max_value):
         """

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -17,6 +17,7 @@ class pytorch_backend(object):
             'bool': torch.bool,
         }
         torch.set_default_dtype(self.dtypemap["float"])
+        self.precision = '32b' if self.dtypemap['float'] == torch.float32 else '64b'
 
     def clip(self, tensor_in, min_value, max_value):
         """

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -17,7 +17,10 @@ class pytorch_backend(object):
             'bool': torch.bool,
         }
         torch.set_default_dtype(self.dtypemap["float"])
-        self.precision = '32b' if self.dtypemap['float'] == torch.float32 else '64b'
+        self.float_precision = (
+            '32b' if self.dtypemap['float'] == torch.float32 else '64b'
+        )
+        self.int_precision = '32b' if self.dtypemap['int'] == torch.int32 else '64b'
 
     def clip(self, tensor_in, min_value, max_value):
         """

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -16,6 +16,7 @@ class tensorflow_backend(object):
             'int': getattr(tf, kwargs.get('int', 'int32')),
             'bool': tf.bool,
         }
+        self.precision = '32b' if self.dtypemap['float'] == tf.float32 else '64b'
 
     def clip(self, tensor_in, min_value, max_value):
         """

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -16,7 +16,8 @@ class tensorflow_backend(object):
             'int': getattr(tf, kwargs.get('int', 'int32')),
             'bool': tf.bool,
         }
-        self.precision = '32b' if self.dtypemap['float'] == tf.float32 else '64b'
+        self.float_precision = '32b' if self.dtypemap['float'] == tf.float32 else '64b'
+        self.int_precision = '32b' if self.dtypemap['int'] == tf.int32 else '64b'
 
     def clip(self, tensor_in, min_value, max_value):
         """

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -379,7 +379,6 @@ def test_tensor_precision(backend):
     assert tb.precision in ['32b', '64b']
 
 
-
 def test_set_tensor_precision():
     tb = pyhf.tensor.pytorch_backend(float='float64', int='int64')
     assert tb.precision == '64b'

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -376,16 +376,32 @@ def test_pdf_eval_2(backend):
 
 def test_tensor_precision(backend):
     tb, _ = backend
-    assert tb.precision in ['32b', '64b']
-
+    assert tb.float_precision in ['32b', '64b']
+    assert tb.int_precision in ['32b', '64b']
 
 def test_set_tensor_precision():
     tb = pyhf.tensor.pytorch_backend(float='float64', int='int64')
-    assert tb.precision == '64b'
+    assert tb.float_precision == '64b'
+    assert tb.int_precision == '64b'
+    tb = pyhf.tensor.pytorch_backend(float='float32', int='int64')
+    assert tb.float_precision == '32b'
+    assert tb.int_precision == '64b'
+    tb = pyhf.tensor.pytorch_backend(float='float64', int='int32')
+    assert tb.float_precision == '64b'
+    assert tb.int_precision == '32b'
     tb = pyhf.tensor.pytorch_backend()
-    assert tb.precision == '32b'
+    assert tb.float_precision == '32b'
+    assert tb.int_precision == '32b'
 
     tb = pyhf.tensor.tensorflow_backend(float='float64', int='int64')
-    assert tb.precision == '64b'
+    assert tb.float_precision == '64b'
+    assert tb.int_precision == '64b'
+    tb = pyhf.tensor.tensorflow_backend(float='float32', int='int64')
+    assert tb.float_precision == '32b'
+    assert tb.int_precision == '64b'
+    tb = pyhf.tensor.tensorflow_backend(float='float64', int='int32')
+    assert tb.float_precision == '64b'
+    assert tb.int_precision == '32b'
     tb = pyhf.tensor.tensorflow_backend()
-    assert tb.precision == '32b'
+    assert tb.float_precision == '32b'
+    assert tb.int_precision == '32b'

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -379,6 +379,7 @@ def test_tensor_precision(backend):
     assert tb.float_precision in ['32b', '64b']
     assert tb.int_precision in ['32b', '64b']
 
+
 def test_set_tensor_precision():
     tb = pyhf.tensor.pytorch_backend(float='float64', int='int64')
     assert tb.float_precision == '64b'

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -372,3 +372,21 @@ def test_pdf_eval_2(backend):
     assert pytest.approx([-23.579605171119738], rel=5e-5) == pyhf.tensorlib.tolist(
         pdf.logpdf(pdf.config.suggested_init(), data)
     )
+
+
+def test_tensor_precision(backend):
+    tb, _ = backend
+    assert tb.precision in ['32b', '64b']
+
+
+
+def test_set_tensor_precision():
+    tb = pyhf.tensor.pytorch_backend(float='float64', int='int64')
+    assert tb.precision == '64b'
+    tb = pyhf.tensor.pytorch_backend()
+    assert tb.precision == '32b'
+
+    tb = pyhf.tensor.tensorflow_backend(float='float64', int='int64')
+    assert tb.precision == '64b'
+    tb = pyhf.tensor.tensorflow_backend()
+    assert tb.precision == '32b'


### PR DESCRIPTION
# Description

This provides an API for `tb.xxxx_precision` to report the precision of the `float`/`int`. (I don't think we should mix and match precision for ints/floats so we should revisit how we set them).

This resolves #907.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Provide API for tensorlib precision of ints and floats
```