### PR TITLE
feat: Single precision setting for backends

### DIFF
--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -85,9 +85,9 @@ def cls(
 
     # set the backend if not NumPy
     if backend in ['pytorch', 'torch']:
-        set_backend(tensor.pytorch_backend(float='float64'))
+        set_backend(tensor.pytorch_backend(precision='64b'))
     elif backend in ['tensorflow', 'tf']:
-        set_backend(tensor.tensorflow_backend(float='float64'))
+        set_backend(tensor.tensorflow_backend(precision='64b'))
     elif backend in ['jax']:
         set_backend(tensor.jax_backend())
     tensorlib, _ = get_backend()

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -149,7 +149,7 @@ class jax_backend(object):
             `jax.interpreters.xla.DeviceArray`: A multi-dimensional, fixed-size homogenous array.
         """
         try:
-            dtype = dtypemap[dtype]
+            dtype = self.dtypemap[dtype]
         except KeyError:
             log.error('Invalid dtype: dtype must be float, int, or bool.')
             raise

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -42,8 +42,13 @@ class jax_backend(object):
 
     def __init__(self, **kwargs):
         self.name = 'jax'
-        self.precision = '64b'
-        config.update('jax_enable_x64', True)
+        self.precision = kwargs.get('precision', '64b')
+        self.dtypemap = {
+            'float': np.float64 if self.precision == '64b' else np.float32,
+            'int': np.int64 if self.precision == '64b' else np.int32,
+            'bool': np.bool_,
+        }
+        config.update('jax_enable_x64', self.precision == '64b')
 
     def clip(self, tensor_in, min_value, max_value):
         """
@@ -143,7 +148,6 @@ class jax_backend(object):
         Returns:
             `jax.interpreters.xla.DeviceArray`: A multi-dimensional, fixed-size homogenous array.
         """
-        dtypemap = {'float': np.float64, 'int': np.int64, 'bool': np.bool_}
         try:
             dtype = dtypemap[dtype]
         except KeyError:

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -42,8 +42,7 @@ class jax_backend(object):
 
     def __init__(self, **kwargs):
         self.name = 'jax'
-        self.float_precision = '64b'
-        self.int_precision = '64b'
+        self.precision = '64b'
         config.update('jax_enable_x64', True)
 
     def clip(self, tensor_in, min_value, max_value):

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -38,8 +38,7 @@ class numpy_backend(object):
 
     def __init__(self, **kwargs):
         self.name = 'numpy'
-        self.float_precision = '64b'
-        self.int_precision = '64b'
+        self.precision = '64b'
 
     def clip(self, tensor_in, min_value, max_value):
         """

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -38,7 +38,12 @@ class numpy_backend(object):
 
     def __init__(self, **kwargs):
         self.name = 'numpy'
-        self.precision = '64b'
+        self.precision = kwargs.get('precision', '64b')
+        self.dtypemap = {
+            'float': np.float64 if self.precision == '64b' else np.float32,
+            'int': np.int64 if self.precision == '64b' else np.int32,
+            'bool': np.bool_,
+        }
 
     def clip(self, tensor_in, min_value, max_value):
         """
@@ -138,9 +143,8 @@ class numpy_backend(object):
         Returns:
             `numpy.ndarray`: A multi-dimensional, fixed-size homogenous array.
         """
-        dtypemap = {'float': np.float64, 'int': np.int64, 'bool': np.bool_}
         try:
-            dtype = dtypemap[dtype]
+            dtype = self.dtypemap[dtype]
         except KeyError:
             log.error('Invalid dtype: dtype must be float, int, or bool.')
             raise

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -11,16 +11,13 @@ class pytorch_backend(object):
 
     def __init__(self, **kwargs):
         self.name = 'pytorch'
+        self.precision = kwargs.get('precision', '32b')
         self.dtypemap = {
-            'float': getattr(torch, kwargs.get('float', 'float32')),
-            'int': getattr(torch, kwargs.get('int', 'int32')),
+            'float': torch.float64 if self.precision == '64b' else torch.float32,
+            'int': torch.int64 if self.precision == '32b' else torch.int32,
             'bool': torch.bool,
         }
         torch.set_default_dtype(self.dtypemap["float"])
-        self.float_precision = (
-            '32b' if self.dtypemap['float'] == torch.float32 else '64b'
-        )
-        self.int_precision = '32b' if self.dtypemap['int'] == torch.int32 else '64b'
 
     def clip(self, tensor_in, min_value, max_value):
         """

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -14,7 +14,7 @@ class pytorch_backend(object):
         self.precision = kwargs.get('precision', '32b')
         self.dtypemap = {
             'float': torch.float64 if self.precision == '64b' else torch.float32,
-            'int': torch.int64 if self.precision == '32b' else torch.int32,
+            'int': torch.int64 if self.precision == '64b' else torch.int32,
             'bool': torch.bool,
         }
         torch.set_default_dtype(self.dtypemap["float"])

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -14,7 +14,7 @@ class tensorflow_backend(object):
         self.precision = kwargs.get('precision', '32b')
         self.dtypemap = {
             'float': tf.float64 if self.precision == '64b' else tf.float32,
-            'int': tf.int64 if self.precision == '32b' else tf.int32,
+            'int': tf.int64 if self.precision == '64b' else tf.int32,
             'bool': tf.bool,
         }
 

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -11,13 +11,12 @@ class tensorflow_backend(object):
 
     def __init__(self, **kwargs):
         self.name = 'tensorflow'
+        self.precision = kwargs.get('precision', '32b')
         self.dtypemap = {
-            'float': getattr(tf, kwargs.get('float', 'float32')),
-            'int': getattr(tf, kwargs.get('int', 'int32')),
+            'float': tf.float64 if self.precision == '64b' else tf.float32,
+            'int': tf.int64 if self.precision == '32b' else tf.int32,
             'bool': tf.bool,
         }
-        self.float_precision = '32b' if self.dtypemap['float'] == tf.float32 else '64b'
-        self.int_precision = '32b' if self.dtypemap['int'] == tf.int32 else '64b'
 
     def clip(self, tensor_in, min_value, max_value):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def reset_backend():
     params=[
         (pyhf.tensor.numpy_backend(), None),
         (pyhf.tensor.pytorch_backend(), None),
-        (pyhf.tensor.pytorch_backend(float='float64', int='int64'), None),
+        (pyhf.tensor.pytorch_backend(precision='64b'), None),
         (pyhf.tensor.tensorflow_backend(), None),
         (pyhf.tensor.jax_backend(), None),
         (

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -379,8 +379,15 @@ def test_tensor_precision(backend):
     assert tb.precision in ['32b', '64b']
 
 
-@pytest.mark.parametrize('tensorlib', ['pytorch_backend', 'tensorflow_backend'])
+@pytest.mark.parametrize(
+    'tensorlib',
+    ['numpy_backend', 'jax_backend', 'pytorch_backend', 'tensorflow_backend'],
+)
 @pytest.mark.parametrize('precision', ['64b', '32b'])
 def test_set_tensor_precision(tensorlib, precision):
     tb = getattr(pyhf.tensor, tensorlib)(precision=precision)
     assert tb.precision == precision
+    # check for float64/int64/float32/int32 in the dtypemap by looking at the class names
+    #   - may break if class names stop including this, but i doubt it
+    assert f'float{precision[:1]}' in str(tb.dtypemap['float'])
+    assert f'int{precision[:1]}' in str(tb.dtypemap['int'])

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -376,33 +376,11 @@ def test_pdf_eval_2(backend):
 
 def test_tensor_precision(backend):
     tb, _ = backend
-    assert tb.float_precision in ['32b', '64b']
-    assert tb.int_precision in ['32b', '64b']
+    assert tb.precision in ['32b', '64b']
 
 
-def test_set_tensor_precision():
-    tb = pyhf.tensor.pytorch_backend(float='float64', int='int64')
-    assert tb.float_precision == '64b'
-    assert tb.int_precision == '64b'
-    tb = pyhf.tensor.pytorch_backend(float='float32', int='int64')
-    assert tb.float_precision == '32b'
-    assert tb.int_precision == '64b'
-    tb = pyhf.tensor.pytorch_backend(float='float64', int='int32')
-    assert tb.float_precision == '64b'
-    assert tb.int_precision == '32b'
-    tb = pyhf.tensor.pytorch_backend()
-    assert tb.float_precision == '32b'
-    assert tb.int_precision == '32b'
-
-    tb = pyhf.tensor.tensorflow_backend(float='float64', int='int64')
-    assert tb.float_precision == '64b'
-    assert tb.int_precision == '64b'
-    tb = pyhf.tensor.tensorflow_backend(float='float32', int='int64')
-    assert tb.float_precision == '32b'
-    assert tb.int_precision == '64b'
-    tb = pyhf.tensor.tensorflow_backend(float='float64', int='int32')
-    assert tb.float_precision == '64b'
-    assert tb.int_precision == '32b'
-    tb = pyhf.tensor.tensorflow_backend()
-    assert tb.float_precision == '32b'
-    assert tb.int_precision == '32b'
+@pytest.mark.parametrize('tensorlib', ['pytorch_backend', 'tensorflow_backend'])
+@pytest.mark.parametrize('precision', ['64b', '32b'])
+def test_set_tensor_precision(tensorlib, precision):
+    tb = getattr(pyhf.tensor, tensorlib)(precision=precision)
+    assert tb.precision == precision


### PR DESCRIPTION
# Pull Request Description

- Resolves #911
- Resolves #912 

This will unify our backends further by allowing for precision configuration of ints and floats simultaneously, rather than configuring each one separately. Allowing a mix of precisions doesn't quite make sense and we should not encourage this behavior.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Unify setting precision for all tensorlib backends
* Provide 32/64 settings for all backends while keeping same defaults
```
