### PR TITLE
fix: Disallow cloudpickle v1.5.0 in 'tensorflow' extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,11 @@
 from setuptools import setup
 
 extras_require = {
-    'tensorflow': ['tensorflow~=2.0', 'tensorflow-probability~=0.8'],
+    'tensorflow': [
+        'tensorflow~=2.0',
+        'tensorflow-probability~=0.8',
+        'cloudpickle!=1.5.0',
+    ],
     'torch': ['torch~=1.2'],
     'jax': ['jax~=0.1,>0.1.51', 'jaxlib~=0.1,>0.1.33'],
     'xmlio': ['uproot'],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ extras_require = {
     'tensorflow': [
         'tensorflow~=2.0',
         'tensorflow-probability~=0.8',
-        'cloudpickle!=1.5.0',
+        'cloudpickle!=1.5.0',  # TODO: Temp patch until tfp v0.11
     ],
     'torch': ['torch~=1.2'],
     'jax': ['jax~=0.1,>0.1.51', 'jaxlib~=0.1,>0.1.33'],


### PR DESCRIPTION
# Description

Resolves #913 

This is a temporary fix to Issue #913, as the actual fix in [TensorFlow Probability PR 993](https://github.com/tensorflow/probability/pull/993) won't be available in a PyPI release until TensorFlow Probability `v0.11.0`. By explicitly disallowing `cloudpickle` `v1.5.0` this patch unblocks development.

# Checklist Before Requesting Reviewer

- [x] Tests are passing (Current release tests are incapable of passing on this PR)
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Explicitly disallow cloudpickle v1.5.0 to avoid breaking TensorFlow Probability 
   - This is a temporary solution to unblock development, but should be removed once TensorFlow Probability v0.11 has been released
   - https://github.com/tensorflow/probability/issues/991
   - https://github.com/cloudpipe/cloudpickle/issues/390
```