### PR TITLE
ci: Run Docker test on tag pushes to avoid breaking CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build Docker image
-      if: "!(startsWith(github.ref, 'refs/tags/'))"
       uses: docker/build-push-action@v1
       with:
         repository: pyhf/pyhf
@@ -144,7 +143,6 @@ jobs:
     - name: List built images
       run: docker images
     - name: Run CLI API check
-      if: "!(startsWith(github.ref, 'refs/tags/'))"
       run: |
         printf "\npyhf\n"
         docker run --rm pyhf/pyhf:test
@@ -153,7 +151,6 @@ jobs:
         printf "\npyhf --help\n"
         docker run --rm pyhf/pyhf:test --help
     - name: Check for curl and tar
-      if: "!(startsWith(github.ref, 'refs/tags/'))"
       run: >-
         docker run --rm
         --entrypoint /bin/bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
     - name: List built images
       run: docker images
     - name: Run CLI API check
+      if: "!(startsWith(github.ref, 'refs/tags/'))"
       run: |
         printf "\npyhf\n"
         docker run --rm pyhf/pyhf:test
@@ -152,6 +153,7 @@ jobs:
         printf "\npyhf --help\n"
         docker run --rm pyhf/pyhf:test --help
     - name: Check for curl and tar
+      if: "!(startsWith(github.ref, 'refs/tags/'))"
       run: >-
         docker run --rm
         --entrypoint /bin/bash


### PR DESCRIPTION
# Description

In the release of `v0.4.4` through the merge of PR #915 we saw that the deployment CI worked perfectly :tada: but that the [CI still failed on the **push of the tag**](https://github.com/scikit-hep/pyhf/runs/831652135) because the Docker image build test currently doesn't run the _build_ on tag events but we don't have a check for the following parts if it is tagged or not.

https://github.com/scikit-hep/pyhf/blob/6ac0f6280c56111c32f46ec9aaad0286d05d36e7/.github/workflows/ci.yml#L134-L147

These parts aren't skipped automatically, and so the CI fails.

Instead of trying to check every step, this PR just lets this CI step run even on tag events and avoid this problem alltogether.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Run the Docker build check on all events, even if it is from a push of a tag
```
