### PR TITLE
fix: Set backend global states correctly

### DIFF
--- a/src/pyhf/__init__.py
+++ b/src/pyhf/__init__.py
@@ -77,7 +77,9 @@ def set_backend(backend, custom_optimizer=None):
             )
 
     # need to determine if the tensorlib changed or the optimizer changed for events
-    tensorlib_changed = bool(backend.name != tensorlib.name)
+    tensorlib_changed = bool(
+        (backend.name != tensorlib.name) | (backend.precision != tensorlib.precision)
+    )
     optimizer_changed = False
 
     if backend.name == 'tensorflow':

--- a/src/pyhf/__init__.py
+++ b/src/pyhf/__init__.py
@@ -108,6 +108,8 @@ def set_backend(backend, custom_optimizer=None):
         events.trigger("tensorlib_changed")()
     if optimizer_changed:
         events.trigger("optimizer_changed")()
+    # set up any other globals for backend
+    tensorlib._setup()
 
 
 from .pdf import Model

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -48,6 +48,11 @@ class jax_backend(object):
             'int': np.int64 if self.precision == '64b' else np.int32,
             'bool': np.bool_,
         }
+
+    def _setup(self):
+        """
+        Run any global setups for the jax lib.
+        """
         config.update('jax_enable_x64', self.precision == '64b')
 
     def clip(self, tensor_in, min_value, max_value):

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -1,5 +1,7 @@
 import jax.numpy as np
 from jax.config import config
+
+config.update('jax_enable_x64', True)
 from jax.scipy.special import gammaln
 from jax.scipy.stats import norm, poisson
 import numpy as onp
@@ -53,7 +55,6 @@ class jax_backend(object):
         """
         Run any global setups for the jax lib.
         """
-        config.update('jax_enable_x64', self.precision == '64b')
 
     def clip(self, tensor_in, min_value, max_value):
         """

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -1,7 +1,8 @@
-import jax.numpy as np
 from jax.config import config
 
 config.update('jax_enable_x64', True)
+
+import jax.numpy as np
 from jax.scipy.special import gammaln
 from jax.scipy.stats import norm, poisson
 import numpy as onp

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -49,7 +49,6 @@ class numpy_backend(object):
         """
         Run any global setups for the numpy lib.
         """
-        pass
 
     def clip(self, tensor_in, min_value, max_value):
         """

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -45,6 +45,12 @@ class numpy_backend(object):
             'bool': np.bool_,
         }
 
+    def _setup(self):
+        """
+        Run any global setups for the numpy lib.
+        """
+        pass
+
     def clip(self, tensor_in, min_value, max_value):
         """
         Clips (limits) the tensor values to be within a specified min and max.

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -17,6 +17,11 @@ class pytorch_backend(object):
             'int': torch.int64 if self.precision == '64b' else torch.int32,
             'bool': torch.bool,
         }
+
+    def _setup(self):
+        """
+        Run any global setups for the pytorch lib.
+        """
         torch.set_default_dtype(self.dtypemap["float"])
 
     def clip(self, tensor_in, min_value, max_value):

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -18,6 +18,12 @@ class tensorflow_backend(object):
             'bool': tf.bool,
         }
 
+    def _setup(self):
+        """
+        Run any global setups for the tensorflow lib.
+        """
+        pass
+
     def clip(self, tensor_in, min_value, max_value):
         """
         Clips (limits) the tensor values to be within a specified min and max.

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -22,7 +22,6 @@ class tensorflow_backend(object):
         """
         Run any global setups for the tensorflow lib.
         """
-        pass
 
     def clip(self, tensor_in, min_value, max_value):
         """

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -44,6 +44,9 @@ def test_custom_backend_name_supported():
             self.name = "pytorch"
             self.precision = '64b'
 
+        def _setup(self):
+            pass
+
     with pytest.raises(AttributeError):
         pyhf.set_backend(custom_backend())
 
@@ -53,6 +56,9 @@ def test_custom_backend_name_notsupported():
         def __init__(self, **kwargs):
             self.name = "notsupported"
             self.precision = '64b'
+
+        def _setup(self):
+            pass
 
     backend = custom_backend()
     assert pyhf.tensorlib.name != backend.name

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -42,6 +42,7 @@ def test_custom_backend_name_supported():
     class custom_backend(object):
         def __init__(self, **kwargs):
             self.name = "pytorch"
+            self.precision = '64b'
 
     with pytest.raises(AttributeError):
         pyhf.set_backend(custom_backend())
@@ -51,6 +52,7 @@ def test_custom_backend_name_notsupported():
     class custom_backend(object):
         def __init__(self, **kwargs):
             self.name = "notsupported"
+            self.precision = '64b'
 
     backend = custom_backend()
     assert pyhf.tensorlib.name != backend.name

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -391,3 +391,45 @@ def test_set_tensor_precision(tensorlib, precision):
     #   - may break if class names stop including this, but i doubt it
     assert f'float{precision[:1]}' in str(tb.dtypemap['float'])
     assert f'int{precision[:1]}' in str(tb.dtypemap['int'])
+
+
+def test_trigger_tensorlib_changed_name(mocker):
+    numpy_64 = pyhf.tensor.numpy_backend(precision='64b')
+    jax_64 = pyhf.tensor.jax_backend(precision='64b')
+
+    pyhf.set_backend(numpy_64)
+
+    evt = mocker.Mock()
+    pyhf.events.subscribe('tensorlib_changed')(evt)
+
+    assert evt.call_count == 0
+    pyhf.set_backend(jax_64)
+    assert evt.call_count == 1
+
+
+def test_trigger_tensorlib_changed_precision(mocker):
+    jax_64 = pyhf.tensor.jax_backend(precision='64b')
+    jax_32 = pyhf.tensor.jax_backend(precision='32b')
+
+    pyhf.set_backend(jax_64)
+
+    evt = mocker.Mock()
+    pyhf.events.subscribe('tensorlib_changed')(evt)
+
+    assert evt.call_count == 0
+    pyhf.set_backend(jax_32)
+    assert evt.call_count == 1
+
+
+@pytest.mark.parametrize(
+    'tensorlib',
+    ['numpy_backend', 'jax_backend', 'pytorch_backend', 'tensorflow_backend'],
+)
+@pytest.mark.parametrize('precision', ['64b', '32b'])
+def test_tensorlib_setup(tensorlib, precision, mocker):
+    tb = getattr(pyhf.tensor, tensorlib)(precision=precision)
+
+    m = mocker.patch(f'pyhf.tensor.{tensorlib}._setup')
+    assert m.call_count == 0
+    pyhf.set_backend(tb)
+    assert m.call_count == 1

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -399,12 +399,12 @@ def test_trigger_tensorlib_changed_name(mocker):
 
     pyhf.set_backend(numpy_64)
 
-    evt = mocker.Mock()
-    pyhf.events.subscribe('tensorlib_changed')(evt)
+    func = mocker.Mock()
+    pyhf.events.subscribe('tensorlib_changed')(func)
 
-    assert evt.call_count == 0
+    assert func.call_count == 0
     pyhf.set_backend(jax_64)
-    assert evt.call_count == 1
+    assert func.call_count == 1
 
 
 def test_trigger_tensorlib_changed_precision(mocker):
@@ -413,12 +413,12 @@ def test_trigger_tensorlib_changed_precision(mocker):
 
     pyhf.set_backend(jax_64)
 
-    evt = mocker.Mock()
-    pyhf.events.subscribe('tensorlib_changed')(evt)
+    func = mocker.Mock()
+    pyhf.events.subscribe('tensorlib_changed')(func)
 
-    assert evt.call_count == 0
+    assert func.call_count == 0
     pyhf.set_backend(jax_32)
-    assert evt.call_count == 1
+    assert func.call_count == 1
 
 
 @pytest.mark.parametrize(
@@ -429,7 +429,7 @@ def test_trigger_tensorlib_changed_precision(mocker):
 def test_tensorlib_setup(tensorlib, precision, mocker):
     tb = getattr(pyhf.tensor, tensorlib)(precision=precision)
 
-    m = mocker.patch(f'pyhf.tensor.{tensorlib}._setup')
-    assert m.call_count == 0
+    func = mocker.patch(f'pyhf.tensor.{tensorlib}._setup')
+    assert func.call_count == 0
     pyhf.set_backend(tb)
-    assert m.call_count == 1
+    assert func.call_count == 1


### PR DESCRIPTION
# Pull Request Description

This resolves #921 by providing an internal `_setup()` method to all tensorlib backends allowing us to call it when we `set_backend()` in `pyhf`. This allows us to update the global settings when needed.

Additionally, there's a regression introduced via #910 in which we don't trigger `tensorlib_changed` if the precision of the tensorlib changes &mdash; this is fixed as well.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* set_backend() will trigger global state changes for tensorlib
* Tensorlib precision changes will now trigger tensorlib_changed events
```
