### PR TITLE
revert: Rollback constraints on cloudpickle given TFP v0.10.1 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,7 @@
 from setuptools import setup
 
 extras_require = {
-    'tensorflow': [
-        'tensorflow~=2.0',
-        'tensorflow-probability~=0.8',
-        'cloudpickle!=1.5.0',  # TODO: Temp patch until tfp v0.11
-    ],
+    'tensorflow': ['tensorflow~=2.0', 'tensorflow-probability~=0.8',],
     'torch': ['torch~=1.2'],
     'jax': ['jax~=0.1,>0.1.51', 'jaxlib~=0.1,>0.1.33'],
     'xmlio': ['uproot'],

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 from setuptools import setup
 
 extras_require = {
-    'tensorflow': ['tensorflow~=2.0', 'tensorflow-probability~=0.8',],
+    'tensorflow': [
+        'tensorflow~=2.0',
+        'tensorflow-probability~=0.10',  # TODO: Temp patch until tfp v0.11
+    ],
     'torch': ['torch~=1.2'],
     'jax': ['jax~=0.1,>0.1.51', 'jaxlib~=0.1,>0.1.33'],
     'xmlio': ['uproot'],


### PR DESCRIPTION
# Description

Given the release of [TensorFlow Probability `v0.10.1`](https://github.com/tensorflow/probability/releases/tag/v0.10.1) which [decided to constraint `cloudpickle` to `v1.3.0`](https://github.com/tensorflow/probability/issues/991#issuecomment-654502970) remove the explicit constraints

https://github.com/scikit-hep/pyhf/blob/64dbce070156945f6bb524f79ee6e23d26b52f01/setup.py#L7

 in `setup.py`. Additionally, bump `TensorFlow Probability` to be in at least the `v0.10.X` range of releases.

This PR effectively reverts PR #915

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove constraints on cloudpickle version
   - cloudpickle version is constrained in TensorFlow Probability
   - Reverts PR #915
* Require TensorFlow Probability to at least in the v0.10 range
```
