### PR TITLE
chore: Future proof release against uproot4 API changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ extras_require = {
     ],
     'torch': ['torch~=1.2'],
     'jax': ['jax~=0.1,>0.1.51', 'jaxlib~=0.1,>0.1.33'],
-    'xmlio': ['uproot'],
+    'xmlio': ['uproot<4.0'],  # Future proof against uproot4 API changes
     'minuit': ['iminuit'],
 }
 extras_require['backends'] = sorted(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ extras_require = {
     ],
     'torch': ['torch~=1.2'],
     'jax': ['jax~=0.1,>0.1.51', 'jaxlib~=0.1,>0.1.33'],
-    'xmlio': ['uproot<4.0'],  # Future proof against uproot4 API changes
+    'xmlio': ['uproot~=3.6'],  # Future proof against uproot4 API changes
     'minuit': ['iminuit'],
 }
 extras_require['backends'] = sorted(


### PR DESCRIPTION
# Description

As @jpivarski mentioned that `uproot4` is going to have some API changes from the `uproot` `v3` releases, require that the version of `uproot` that is included in the releases until `uproot4` is released for broad use is using the `uproot` `v3` API.

Once `uproot4` is released and stable this can get changed to using

```python
'xmlio': ['uproot~=4.0']
```

to ensure that all future releases of `pyhf` get the `uproot4` API.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Ensure that the next release series of pyhf isn't broken in the future by API changes in uproot4
```