### PR TITLE
docs: Add TRExFitter babel translation

### DIFF
--- a/docs/babel.rst
+++ b/docs/babel.rst
@@ -65,3 +65,40 @@ These are all the files you need in order to use `pyhf xml2json <cli.html#pyhf-x
 which will read all of the XML files and load the histogram data from the histogram cache.
 
 The ``HistFactory`` workspace in ``results/`` contains all of the information necessary to rebuild the XML files again. For debugging purposes, the ``pyhf`` developers will often ask for your workspace file, which means ``results/3b_tag21.2.27-1_RW_ExpSyst_36100_multibin_bkg/Excl_combined_DefaultMeasurement.root``. If you want to generate the XML, you can open this file in ``ROOT`` and run ``DefaultMeasurement->PrintXML()`` which puts all of the XML files into the current directory you are in.
+
+
+TRExFitter
+----------
+
+.. note::
+
+    For more details on this section, please refer to the ATLAS-internal `TRExFitter documentation <https://trexfitter-docs.web.cern.ch/trexfitter-docs/advanced_topics/pyhf/>`_.
+
+In order to go from ``TRExFitter`` to ``pyhf``, the good news is that the RooWorkspace files (``XML`` and ``ROOT``) are already made for you. For a given configurastion which looks like
+
+.. code:: yaml
+
+    Job: "pyhf_example"
+    Label: "..."
+
+You can expect some files to be made like so:
+
+- ``pyhf_example/RooStats/pyhf_example.xml``
+- ``pyhf_example/RooStats/pyhf_example_Signal_region.xml``
+- ``pyhf_example/Histograms/pyhf_example_Signal_region_histos.root``
+
+These are all the files you need in order to use `pyhf xml2json <cli.html#pyhf-xml2json>`_. At this point, you could run
+
+.. code:: bash
+
+    pyhf xml2json pyhf_example/RooStats/pyhf_example.xml
+
+which will read all of the XML files and load the histogram data from the histogram cache.
+
+.. warning::
+
+    There are a few caveats one needs to be aware of with this conversion:
+
+    - Custom parameters cannot be held constant (e.g. lumi), see :pr:`846` and :issue:`739`.
+    - Uncorrelated shape systematics cannot be pruned, see :issue:`662`.
+    - Custom expressions for normalization factors cannot be used, see :issue:`850`.

--- a/docs/babel.rst
+++ b/docs/babel.rst
@@ -74,7 +74,7 @@ TRExFitter
 
     For more details on this section, please refer to the ATLAS-internal `TRExFitter documentation <https://trexfitter-docs.web.cern.ch/trexfitter-docs/advanced_topics/pyhf/>`_.
 
-In order to go from ``TRExFitter`` to ``pyhf``, the good news is that the RooWorkspace files (``XML`` and ``ROOT``) are already made for you. For a given configurastion which looks like
+In order to go from ``TRExFitter`` to ``pyhf``, the good news is that the RooWorkspace files (``XML`` and ``ROOT``) are already made for you. For a given configuration which looks like
 
 .. code:: yaml
 

--- a/docs/babel.rst
+++ b/docs/babel.rst
@@ -81,7 +81,7 @@ In order to go from ``TRExFitter`` to ``pyhf``, the good news is that the RooWor
     Job: "pyhf_example"
     Label: "..."
 
-You can expect some files to be made like so:
+You can expect some files to be made after the ``n``/``h`` and ``w`` steps:
 
 - ``pyhf_example/RooStats/pyhf_example.xml``
 - ``pyhf_example/RooStats/pyhf_example_Signal_region.xml``

--- a/docs/babel.rst
+++ b/docs/babel.rst
@@ -99,6 +99,6 @@ which will read all of the XML files and load the histogram data from the histog
 
     There are a few caveats one needs to be aware of with this conversion:
 
-    - Custom parameters cannot be held constant (e.g. lumi), see :pr:`846` and :issue:`739`.
-    - Uncorrelated shape systematics cannot be pruned, see :issue:`662`.
-    - Custom expressions for normalization factors cannot be used, see :issue:`850`.
+    - Custom parameters cannot be held constant (e.g. lumi), see PR :pr:`846` and Issue :issue:`739`.
+    - Uncorrelated shape systematics cannot be pruned, see Issue :issue:`662`.
+    - Custom expressions for normalization factors cannot be used, see Issue :issue:`850`.

--- a/docs/babel.rst
+++ b/docs/babel.rst
@@ -74,7 +74,7 @@ TRExFitter
 
     For more details on this section, please refer to the ATLAS-internal `TRExFitter documentation <https://trexfitter-docs.web.cern.ch/trexfitter-docs/advanced_topics/pyhf/>`_.
 
-In order to go from ``TRExFitter`` to ``pyhf``, the good news is that the RooWorkspace files (``XML`` and ``ROOT``) are already made for you. For a given configuration which looks like
+In order to go from ``TRExFitter`` to ``pyhf``, the good news is that the ``RooWorkspace`` files (``XML`` and ``ROOT``) are already made for you. For a given configuration which looks like
 
 .. code:: yaml
 


### PR DESCRIPTION
# Pull Request Description

This adds information about translating to pyhf from TRExFitter. See https://pyhf.readthedocs.io/en/docs-trexfitter-babel/babel.html#trexfitter for preview.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add documentation on translation from TRExFitter to pyhf
```
