### PR TITLE
docs: Unrestrict Sphinx from v3.0.X releases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extras_require['test'] = sorted(
 extras_require['docs'] = sorted(
     set(
         [
-            'sphinx~=3.0.0',  # Sphinx v3.1.X regressions break docs
+            'sphinx~=3.1',  # Sphinx v3.1.X regressions break docs
             'sphinxcontrib-bibtex',
             'sphinx-click',
             'sphinx_rtd_theme',

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extras_require['test'] = sorted(
 extras_require['docs'] = sorted(
     set(
         [
-            'sphinx~=3.1,>3.1.1',  # Sphinx v3.1.1 regression (PR #some number)
+            'sphinx>3.1.1',
             'sphinxcontrib-bibtex',
             'sphinx-click',
             'sphinx_rtd_theme',

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extras_require['test'] = sorted(
 extras_require['docs'] = sorted(
     set(
         [
-            'sphinx~=3.1',  # Sphinx v3.1.X regressions break docs
+            'sphinx~=3.1,>3.1.1',  # Sphinx v3.1.1 regression (PR #some number)
             'sphinxcontrib-bibtex',
             'sphinx-click',
             'sphinx_rtd_theme',

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extras_require['test'] = sorted(
 extras_require['docs'] = sorted(
     set(
         [
-            'sphinx>3.1.1',
+            'sphinx>=3.1.2',
             'sphinxcontrib-bibtex',
             'sphinx-click',
             'sphinx_rtd_theme',


### PR DESCRIPTION
# Description

Resolves #897

Avoid the regressions caused by Sphinx `v3.1.0` and `v3.1.1` by requiring [Sphinx `v3.1.2`](https://github.com/sphinx-doc/sphinx/releases/tag/v3.1.2) or later.

Huge thanks goes out to @tk0miya :bow: who did some amazing work to make sure that Sphinx would still support libraries that are using `pyhf`'s style of syntax (c.f. [Sphinx Issue 7844](https://github.com/sphinx-doc/sphinx/issues/7844)).

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-unrestrict-sphinx

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Require Sphinx release v3.1.2 or later
   - Avoid regressions in Sphinx v3.1.0 and v3.1.1
```
