### PR TITLE
docs: Add hepdata_like model API to docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -46,6 +46,7 @@ Making Models from PDFs
    ~workspace.Workspace
    ~patchset.PatchSet
    ~patchset.Patch
+   simplemodels.hepdata_like
 
 Backends
 --------

--- a/src/pyhf/simplemodels.py
+++ b/src/pyhf/simplemodels.py
@@ -2,6 +2,38 @@ from . import Model
 
 
 def hepdata_like(signal_data, bkg_data, bkg_uncerts, batch_size=None):
+    """
+    Construct a simple single channel :class:`~pyhf.pdf.Model` with a
+    :class:`~pyhf.modifiers.shapesys` modifier representing an uncorrelated
+    background uncertainty.
+
+    Example:
+        >>> import pyhf
+        >>> pyhf.set_backend("numpy")
+        >>> model = pyhf.simplemodels.hepdata_like(
+        ...     signal_data=[12.0, 11.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0]
+        ... )
+        >>> model.schema
+        'model.json'
+        >>> model.config.channels
+        ['singlechannel']
+        >>> model.config.samples
+        ['background', 'signal']
+        >>> model.config.parameters
+        ['mu', 'uncorr_bkguncrt']
+        >>> model.expected_data(model.config.suggested_init())
+        array([ 62.        ,  63.        , 277.77777778,  55.18367347])
+
+    Args:
+        signal_data (`list`): The data in the signal sample
+        bkg_data (`list`): The data in the background sample
+        bkg_uncerts (`list`): The statistical uncertainty on the background sample counts
+        batch_size (`None` or `int`): Number of simultaneous (batched) Models to compute
+
+    Returns:
+        ~pyhf.pdf.Model: The statistical model adhering to the :obj:`model.json` schema
+
+    """
     spec = {
         'channels': [
             {


### PR DESCRIPTION
# Description

Resolves #928 

Add `pyhf.simplemodels.hepdata_like` to the docs as it is in the public API and used in many of the `pyhf` examples.

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-add-simplemodel-docs/_generated/pyhf.simplemodels.hepdata_like.html

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add docstring with examples to simplemodels.hepdata_like
* Add simplemodels.hepdata_like API to docs
```
