### PR TITLE
docs: Fix CLs wrapping and add shorter URL

### DIFF
--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -54,7 +54,8 @@ def cls(
 
     .. code-block:: shell
 
-        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/examples/json/2-bin_1-channel.json | pyhf cls
+    \b
+        $ curl -sL https://git.io/JJYDE | pyhf cls
         {
             "CLs_exp": [
                 0.07807427911686156,

--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -54,7 +54,7 @@ def cls(
 
     .. code-block:: shell
 
-    \b
+        \b
         $ curl -sL https://git.io/JJYDE | pyhf cls
         {
             "CLs_exp": [

--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -54,8 +54,9 @@ def cls(
 
     .. code-block:: shell
 
-        \b
         $ curl -sL https://git.io/JJYDE | pyhf cls
+
+        \b
         {
             "CLs_exp": [
                 0.07807427911686156,


### PR DESCRIPTION
# Pull Request Description

Resolves #940.

Read the Docs build: https://pyhf.readthedocs.io/en/docs-shorterurlforcls/cli.html#pyhf-cls

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Use shorter git.io url for pyhf cls --help docstring
* Fix wrapping of pyhf cls --help docstring using \b
```
