### PR TITLE
docs: Clarify role of return_fitted_val kwarg for fit and fixed_poi_fit

### DIFF
--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -24,7 +24,9 @@ def fit(data, pdf, init_pars=None, par_bounds=None, **kwargs):
 
     .. note::
 
-        :func:`twice_nll` is the objective function.
+        :func:`twice_nll` is the objective function given to the optimizer, and
+        is returned evaluated at the best fit model parameters when the kwarg
+        `return_fitted_val` is `True`.
 
     Example:
         >>> import pyhf

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -62,7 +62,9 @@ def fixed_poi_fit(poi_val, data, pdf, init_pars=None, par_bounds=None, **kwargs)
 
     .. note::
 
-        :func:`twice_nll` is the objective function.
+        :func:`twice_nll` is the objective function given to the optimizer and
+        is returned evaluated at the best fit model parameters when the optional
+        kwarg ``return_fitted_val`` is ``True``.
 
     Example:
         >>> import pyhf

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -24,9 +24,9 @@ def fit(data, pdf, init_pars=None, par_bounds=None, **kwargs):
 
     .. note::
 
-        :func:`twice_nll` is the objective function given to the optimizer, and
-        is returned evaluated at the best fit model parameters when the kwarg
-        `return_fitted_val` is `True`.
+        :func:`twice_nll` is the objective function given to the optimizer and
+        is returned evaluated at the best fit model parameters when the optional
+        kwarg ``return_fitted_val`` is ``True``.
 
     Example:
         >>> import pyhf

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -36,8 +36,13 @@ def fit(data, pdf, init_pars=None, par_bounds=None, **kwargs):
         ... )
         >>> observations = [51, 48]
         >>> data = pyhf.tensorlib.astensor(observations + model.config.auxdata)
-        >>> pyhf.infer.mle.fit(data, model, return_fitted_val=True)
-        (array([0.        , 1.0030512 , 0.96266961]), array([24.98393521]))
+        >>> bestfit_pars, twice_nll = pyhf.infer.mle.fit(data, model, return_fitted_val=True)
+        >>> bestfit_pars
+        array([0.        , 1.0030512 , 0.96266961])
+        >>> twice_nll
+        array([24.98393521])
+        >>> -2 * model.logpdf(bestfit_pars, data) == twice_nll
+        array([ True])
 
     Args:
         data (`tensor`): The data
@@ -75,8 +80,15 @@ def fixed_poi_fit(poi_val, data, pdf, init_pars=None, par_bounds=None, **kwargs)
         >>> observations = [51, 48]
         >>> data = pyhf.tensorlib.astensor(observations + model.config.auxdata)
         >>> test_poi = 1.0
-        >>> pyhf.infer.mle.fixed_poi_fit(test_poi, data, model, return_fitted_val=True)
-        (array([1.        , 0.97224597, 0.87553894]), array([28.92218013]))
+        >>> bestfit_pars, twice_nll = pyhf.infer.mle.fixed_poi_fit(
+        ...     test_poi, data, model, return_fitted_val=True
+        ... )
+        >>> bestfit_pars
+        array([1.        , 0.97224597, 0.87553894])
+        >>> twice_nll
+        array([28.92218013])
+        >>> -2 * model.logpdf(bestfit_pars, data) == twice_nll
+        array([ True])
 
     Args:
         data: The data


### PR DESCRIPTION
# Description

Following PR #960, add additional clarifying information to the note that in addition to being the objective function, `twice_nll` is given to the optimizer and is returned evaluated at the best fit model parameters when the optional kwarg `return_fitted_val=True`. Additionally, try to make this more clear by extending the docstring examples a bit.

Read the Docs build:
- https://pyhf.readthedocs.io/en/docs-clarify-objectiv-funciton-return/_generated/pyhf.infer.mle.fit.html
- https://pyhf.readthedocs.io/en/docs-clarify-objectiv-funciton-return/_generated/pyhf.infer.mle.fixed_poi_fit.html

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Clarify in note objective function returned evaluated at best fit model parameters for return_fitted_val
   - Amend PR #960
* Update docstring examples for mle.fit and mle.fixed_poi_fit to illiterate this
```
