### PR TITLE
refactor: Use AsymptoticTestStatDistribution.expected_value API in hypotest for better integration

### DIFF
--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -114,9 +114,12 @@ def hypotest(
     if kwargs.get('return_expected_set'):
         CLs_exp = []
         for n_sigma in [2, 1, 0, -1, -2]:
+
+            expected_bonly_teststat = b_only_distribution.expected_value(n_sigma)
+
             CLs = sig_plus_bkg_distribution.pvalue(
-                n_sigma
-            ) / b_only_distribution.pvalue(n_sigma)
+                expected_bonly_teststat
+            ) / b_only_distribution.pvalue(expected_bonly_teststat)
             CLs_exp.append(tensorlib.reshape(CLs, (1,)))
         CLs_exp = tensorlib.astensor(CLs_exp)
         if kwargs.get('return_expected'):
@@ -124,9 +127,9 @@ def hypotest(
         _returns.append(CLs_exp)
     elif kwargs.get('return_expected'):
         n_sigma = 0
-        CLs = sig_plus_bkg_distribution.pvalue(n_sigma) / b_only_distribution.pvalue(
-            n_sigma
-        )
+        CLs = sig_plus_bkg_distribution.pvalue(
+            expected_bonly_teststat
+        ) / b_only_distribution.pvalue(expected_bonly_teststat)
         _returns.append(tensorlib.reshape(CLs, (1,)))
     # Enforce a consistent return type of the observed CLs
     return tuple(_returns) if len(_returns) > 1 else _returns[0]

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -127,6 +127,8 @@ def hypotest(
         _returns.append(CLs_exp)
     elif kwargs.get('return_expected'):
         n_sigma = 0
+        expected_bonly_teststat = b_only_distribution.expected_value(n_sigma)
+
         CLs = sig_plus_bkg_distribution.pvalue(
             expected_bonly_teststat
         ) / b_only_distribution.pvalue(expected_bonly_teststat)

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -84,7 +84,7 @@ class AsymptoticTestStatDistribution(object):
         Returns:
             Float: The expected value of the test statistic.
         """
-        return nsigma
+        return self.shift + nsigma
 
 
 class AsymptoticCalculator(object):


### PR DESCRIPTION
# Description

This changes hypotest to make better use of the teststat distribution API (which we overlooked before - making the hypotest code more principled.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR


```
* Use AsymptoticTestStatDistribution.expected_value for a more principled and clear calculation of the CLs
* Apply the displacement of the test statistic distribution shift to the AsymptoticTestStatDistribution.expected_value
```
