### PR TITLE
customizable metrics in hypotest

### DIFF
--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -5,6 +5,26 @@ from .. import get_backend
 from .calculators import AsymptoticCalculator
 
 
+def _assemble_metrics(CLsb, CLb, metrics):
+    tensorlib, _ = get_backend()
+    CLs = CLsb / CLb
+    CLsb, CLb, CLs = (
+        tensorlib.reshape(CLsb, (1,)),
+        tensorlib.reshape(CLb, (1,)),
+        tensorlib.reshape(CLs, (1,)),
+    )
+
+    returns = []
+    for m in metrics:
+        if m == 'CLs':
+            returns.append(CLs)
+        if m == 'CLsb':
+            returns.append(CLsb)
+        if m == 'CLb':
+            returns.append(CLb)
+    return returns
+
+
 def hypotest(
     poi_test, data, pdf, init_pars=None, par_bounds=None, qtilde=False, **kwargs
 ):
@@ -101,33 +121,27 @@ def hypotest(
 
     CLsb = sig_plus_bkg_distribution.pvalue(teststat)
     CLb = b_only_distribution.pvalue(teststat)
-    CLs = CLsb / CLb
-    CLsb, CLb, CLs = (
-        tensorlib.reshape(CLsb, (1,)),
-        tensorlib.reshape(CLb, (1,)),
-        tensorlib.reshape(CLs, (1,)),
-    )
 
-    _returns = [CLs]
-    if kwargs.get('return_tail_probs'):
-        _returns.append([CLsb, CLb])
+    _returns = []
+
+    metrics = kwargs.get('metrics', ['CLs'])
+
+    _returns += _assemble_metrics(CLsb, CLb, metrics)
+
     if kwargs.get('return_expected_set'):
         CLs_exp = []
         for n_sigma in [2, 1, 0, -1, -2]:
-            CLs = sig_plus_bkg_distribution.pvalue(
-                n_sigma
-            ) / b_only_distribution.pvalue(n_sigma)
-            CLs_exp.append(tensorlib.reshape(CLs, (1,)))
-        CLs_exp = tensorlib.astensor(CLs_exp)
-        if kwargs.get('return_expected'):
-            _returns.append(CLs_exp[2])
+            CLsb = sig_plus_bkg_distribution.pvalue(n_sigma)
+            CLb = b_only_distribution.pvalue(n_sigma)
+            this_nsigma = _assemble_metrics(CLsb, CLb, metrics)
+            CLs_exp.append(this_nsigma)
         _returns.append(CLs_exp)
     elif kwargs.get('return_expected'):
         n_sigma = 0
-        CLs = sig_plus_bkg_distribution.pvalue(n_sigma) / b_only_distribution.pvalue(
-            n_sigma
-        )
-        _returns.append(tensorlib.reshape(CLs, (1,)))
+        CLsb = sig_plus_bkg_distribution.pvalue(n_sigma)
+        CLb = b_only_distribution.pvalue(n_sigma)
+        this_nsigma = _assemble_metrics(CLsb, CLb, metrics)
+        _returns += this_nsigma
     # Enforce a consistent return type of the observed CLs
     return tuple(_returns) if len(_returns) > 1 else _returns[0]
 


### PR DESCRIPTION
# Description

From a discussion with @cranmer. This allows specifying which metrics to return from a hypotest. Defaults to `['CLs']` but can be used to get e.g. obs and exp bands for CLsb only or all metrics together:

<img width="1034" alt="screenshot" src="https://user-images.githubusercontent.com/2318083/87946761-bd707d00-caa2-11ea-8625-11e73442dfdf.png">

If the API is fine w/ people I can updated docs etc.


# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
- [ ] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR
