### PR TITLE
docs: Add 2020 ATLAS Induction Day and PyHEP 2020 tutorials

### DIFF
--- a/docs/bib/tutorials.bib
+++ b/docs/bib/tutorials.bib
@@ -1,6 +1,17 @@
 % NB: entries with same author-title-year are not picked up:
 %     https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/117
 
+@unpublished{Feickert20200716,
+  title  = {{pyhf: Accelerating analyses and preserving likelihoods}},
+  author = {Matthew Feickert},
+  year   = {2020},
+  month  = {Jul},
+  day    = {16},
+  note   = {PyHEP 2020 (virtual) Workshop (pyhf v0.4.4)},
+  organization = {HEP Software Foundation},
+  url    = {https://indico.cern.ch/event/882824/contributions/3931292/},
+}
+
 @unpublished{Heinrich20200716,
   title  = {{pyhf tutorial}},
   author = {Lukas Heinrich},

--- a/docs/bib/tutorials.bib
+++ b/docs/bib/tutorials.bib
@@ -7,7 +7,7 @@
   year   = {2020},
   month  = {Jul},
   day    = {16},
-  note   = {PyHEP 2020 (virtual) Workshop (pyhf v0.4.4)},
+  note   = {PyHEP 2020 Workshop (pyhf v0.4.4)},
   organization = {HEP Software Foundation},
   url    = {https://indico.cern.ch/event/882824/contributions/3931292/},
 }

--- a/docs/bib/tutorials.bib
+++ b/docs/bib/tutorials.bib
@@ -29,7 +29,7 @@
   year   = {2019},
   month  = {Oct},
   day    = {25},
-  note   = {(Internal) ATLAS Induction Day + Software Tutorial},
+  note   = {(Internal) ATLAS Induction Day + Software Tutorial (pyhf v0.1.2)},
   organization = {CERN},
   url    = {https://indico.cern.ch/event/831761/contributions/3484275/},
 }

--- a/docs/bib/tutorials.bib
+++ b/docs/bib/tutorials.bib
@@ -1,6 +1,17 @@
 % NB: entries with same author-title-year are not picked up:
 %     https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/117
 
+@unpublished{Heinrich20200716,
+  title  = {{pyhf tutorial}},
+  author = {Lukas Heinrich},
+  year   = {2020},
+  month  = {Jul},
+  day    = {16},
+  note   = {(Internal) ATLAS Induction Day + Software Tutorial (pyhf v0.4.4)},
+  organization = {CERN},
+  url    = {https://indico.cern.ch/event/892952/contributions/3853306/},
+}
+
 @unpublished{Heinrich20191025,
   title  = {{Introduction to pyhf}},
   author = {Lukas Heinrich},


### PR DESCRIPTION
# Description

This PR adds the tutorials that @lukasheinrich and @matthewfeickert gave on 2020-07-16 on `pyhf` `v0.4.4` at the [2020 ATLAS (internal) Induction Day + Software Tutorial](https://indico.cern.ch/event/892952/contributions/3853306/) and [PyHEP 2020](https://indico.cern.ch/event/882824/contributions/3931292/) respectively.

Read the Docs build: https://pyhf.readthedocs.io/en/docs-add-2020-tutorials/outreach.html#tutorials

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add Lukas's tutorial at the 2020 ATLAS Induction Day + Software Tutorial
* Add Matthew's tutorial at PyHEP 2020
* Add pyhf version numbers used to all tutorials
```
