### PR TITLE
fix: Protect against missing JAX imports

### DIFF
--- a/src/pyhf/tensor/__init__.py
+++ b/src/pyhf/tensor/__init__.py
@@ -11,12 +11,18 @@ class _BackendRetriever(object):
             self.numpy_backend = numpy_backend
             return numpy_backend
         elif name == 'jax_backend':
-            from .jax_backend import jax_backend
+            try:
+                from .jax_backend import jax_backend
 
-            assert jax_backend
-            # for autocomplete and dir() calls
-            self.jax_backend = jax_backend
-            return jax_backend
+                assert jax_backend
+                # for autocomplete and dir() calls
+                self.jax_backend = jax_backend
+                return jax_backend
+            except ImportError as e:
+                raise exceptions.ImportBackendError(
+                    "There was a problem importing JAX. The jax backend cannot be used.",
+                    e,
+                )
         elif name == 'pytorch_backend':
             try:
                 from .pytorch_backend import pytorch_backend

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -19,19 +19,26 @@ import pyhf
             "tensorflow_backend",
             pytest.raises(pyhf.exceptions.ImportBackendError),
         ],
+        [
+            "jax",
+            "jax_backend",
+            "jax_backend",
+            pytest.raises(pyhf.exceptions.ImportBackendError),
+        ],
     ],
-    ids=["numpy", "pytorch", "tensorflow"],
+    ids=["numpy", "pytorch", "tensorflow", "jax"],
 )
 def test_missing_backends(isolate_modules, param):
     backend_name, module_name, import_name, expectation = param
 
     # hide
     CACHE_BACKEND, sys.modules[backend_name] = sys.modules[backend_name], None
-    sys.modules.setdefault('pyhf.tensor.{}'.format(import_name), None)
-    CACHE_MODULE, sys.modules['pyhf.tensor.{}'.format(module_name)] = (
+    sys.modules.setdefault(f'pyhf.tensor.{import_name}', None)
+    CACHE_MODULE, sys.modules[f'pyhf.tensor.{module_name}'] = (
         sys.modules['pyhf.tensor.{}'.format(module_name)],
         None,
     )
+
     try:
         delattr(pyhf.tensor, module_name)
     except:
@@ -42,7 +49,7 @@ def test_missing_backends(isolate_modules, param):
 
     # put back
     CACHE_BACKEND, sys.modules[backend_name] = None, CACHE_BACKEND
-    CACHE_MODULE, sys.modules['pyhf.tensor.{}'.format(module_name)] = (
+    CACHE_MODULE, sys.modules[f'pyhf.tensor.{module_name}'] = (
         None,
         CACHE_MODULE,
     )


### PR DESCRIPTION
# Pull Request Description

Refactoring out #951. Add missing jax import protection.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Protect against missing JAX imports
* Add JAX to backends in test_init
```
