### PR TITLE
revert: Allow 0-dimensional shape tensors

### DIFF
--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -40,7 +40,7 @@ def fit(data, pdf, init_pars=None, par_bounds=None, **kwargs):
         >>> bestfit_pars
         array([0.        , 1.0030512 , 0.96266961])
         >>> twice_nll
-        array([24.98393521])
+        24.98393521454011
         >>> -2 * model.logpdf(bestfit_pars, data) == twice_nll
         array([ True])
 
@@ -86,7 +86,7 @@ def fixed_poi_fit(poi_val, data, pdf, init_pars=None, par_bounds=None, **kwargs)
         >>> bestfit_pars
         array([1.        , 0.97224597, 0.87553894])
         >>> twice_nll
-        array([28.92218013])
+        28.92218013492061
         >>> -2 * model.logpdf(bestfit_pars, data) == twice_nll
         array([ True])
 

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -40,7 +40,7 @@ def fit(data, pdf, init_pars=None, par_bounds=None, **kwargs):
         >>> bestfit_pars
         array([0.        , 1.0030512 , 0.96266961])
         >>> twice_nll
-        24.98393521454011
+        array(24.98393521)
         >>> -2 * model.logpdf(bestfit_pars, data) == twice_nll
         array([ True])
 
@@ -86,7 +86,7 @@ def fixed_poi_fit(poi_val, data, pdf, init_pars=None, par_bounds=None, **kwargs)
         >>> bestfit_pars
         array([1.        , 0.97224597, 0.87553894])
         >>> twice_nll
-        28.92218013492061
+        array(28.92218013)
         >>> -2 * model.logpdf(bestfit_pars, data) == twice_nll
         array([ True])
 

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -58,5 +58,5 @@ def qmu(mu, data, pdf, init_pars, par_bounds):
     qmu = fixed_poi_fit_lhood_val - unconstrained_fit_lhood_val
     qmu = tensorlib.where(
         muhatbhat[pdf.config.poi_index] > mu, tensorlib.astensor(0.0), qmu
-    )[0]
+    )
     return tensorlib.clip(qmu, 0, max_value=None)

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -56,7 +56,7 @@ def qmu(mu, data, pdf, init_pars, par_bounds):
         data, pdf, init_pars, par_bounds, return_fitted_val=True
     )
     qmu = fixed_poi_fit_lhood_val - unconstrained_fit_lhood_val
-    # Required for backend uniformity (JAX differs from others)
+    # atleast_1d required for backend uniformity (JAX differs from others)
     qmu = tensorlib.atleast_1d(
         tensorlib.where(
             muhatbhat[pdf.config.poi_index] > mu, tensorlib.astensor(0.0), qmu

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -58,5 +58,5 @@ def qmu(mu, data, pdf, init_pars, par_bounds):
     qmu = fixed_poi_fit_lhood_val - unconstrained_fit_lhood_val
     qmu = tensorlib.where(
         muhatbhat[pdf.config.poi_index] > mu, tensorlib.astensor(0.0), qmu
-    )
+    )[0]
     return tensorlib.clip(qmu, 0, max_value=None)

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -56,10 +56,7 @@ def qmu(mu, data, pdf, init_pars, par_bounds):
         data, pdf, init_pars, par_bounds, return_fitted_val=True
     )
     qmu = fixed_poi_fit_lhood_val - unconstrained_fit_lhood_val
-    # atleast_1d required for backend uniformity (JAX differs from others)
-    qmu = tensorlib.atleast_1d(
-        tensorlib.where(
-            muhatbhat[pdf.config.poi_index] > mu, tensorlib.astensor(0.0), qmu
-        )
-    )[0]
+    qmu = tensorlib.where(
+        muhatbhat[pdf.config.poi_index] > mu, tensorlib.astensor(0.0), qmu
+    )
     return tensorlib.clip(qmu, 0, max_value=None)

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -56,7 +56,10 @@ def qmu(mu, data, pdf, init_pars, par_bounds):
         data, pdf, init_pars, par_bounds, return_fitted_val=True
     )
     qmu = fixed_poi_fit_lhood_val - unconstrained_fit_lhood_val
-    qmu = tensorlib.where(
-        muhatbhat[pdf.config.poi_index] > mu, tensorlib.astensor(0.0), qmu
+    # Required for backend uniformity (JAX differs from others)
+    qmu = tensorlib.atleast_1d(
+        tensorlib.where(
+            muhatbhat[pdf.config.poi_index] > mu, tensorlib.astensor(0.0), qmu
+        )
     )[0]
     return tensorlib.clip(qmu, 0, max_value=None)

--- a/src/pyhf/optimize/opt_numpy.py
+++ b/src/pyhf/optimize/opt_numpy.py
@@ -27,6 +27,6 @@ def wrap_objective(objective, data, pdf, stitch_pars, do_grad=False, jit_pieces=
     def func(pars):
         pars = tensorlib.astensor(pars)
         constrained_pars = stitch_pars(pars)
-        return objective(constrained_pars, data, pdf)
+        return objective(constrained_pars, data, pdf)[0]
 
     return func

--- a/src/pyhf/optimize/opt_pytorch.py
+++ b/src/pyhf/optimize/opt_pytorch.py
@@ -29,7 +29,7 @@ def wrap_objective(objective, data, pdf, stitch_pars, do_grad=False, jit_pieces=
             constrained_pars = stitch_pars(pars)
             constr_nll = objective(constrained_pars, data, pdf)
             grad = torch.autograd.grad(constr_nll, pars)[0]
-            return constr_nll.detach().numpy(), grad
+            return constr_nll.detach().numpy()[0], grad
 
     else:
 
@@ -37,6 +37,6 @@ def wrap_objective(objective, data, pdf, stitch_pars, do_grad=False, jit_pieces=
             pars = tensorlib.astensor(pars)
             constrained_pars = stitch_pars(pars)
             constr_nll = objective(constrained_pars, data, pdf)
-            return constr_nll
+            return constr_nll[0]
 
     return func

--- a/src/pyhf/optimize/opt_tflow.py
+++ b/src/pyhf/optimize/opt_tflow.py
@@ -31,13 +31,13 @@ def wrap_objective(objective, data, pdf, stitch_pars, do_grad=False, jit_pieces=
             # when tf.gather is used and this needs to be converted back to a
             # tensor to be usable as a value
             grad = tape.gradient(constr_nll, pars)
-            return constr_nll.numpy(), tf.convert_to_tensor(grad)
+            return constr_nll.numpy()[0], tf.convert_to_tensor(grad)
 
     else:
 
         def func(pars):
             pars = tensorlib.astensor(pars)
             constrained_pars = stitch_pars(pars)
-            return objective(constrained_pars, data, pdf)
+            return objective(constrained_pars, data, pdf)[0]
 
     return func

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -163,13 +163,8 @@ class jax_backend(object):
         except KeyError:
             log.error('Invalid dtype: dtype must be float, int, or bool.')
             raise
-        tensor = np.asarray(tensor_in, dtype=dtype)
-        # Ensure non-empty tensor shape for consistency
-        try:
-            tensor.shape[0]
-        except IndexError:
-            tensor = np.reshape(tensor, [1])
-        return np.asarray(tensor, dtype=dtype)
+
+        return np.asarray(tensor_in, dtype=dtype)
 
     def sum(self, tensor_in, axis=None):
         return np.sum(tensor_in, axis=axis)

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -75,7 +75,7 @@ class jax_backend(object):
             args (Array of Tensors): Sequence of tensors
 
         Returns:
-            JAX ndarray: A tensor, or list of tensors, each with `ndim >= 1`
+            JAX ndarray: A tensor, or list of tensors, each with ``ndim >= 1``
 
         """
         return np.atleast_1d(*args)

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -60,28 +60,6 @@ class jax_backend(object):
         Run any global setups for the jax lib.
         """
 
-    def atleast_1d(self, *args):
-        """
-        Convert inputs to tensors with at least one dimension.
-
-        Example:
-
-            >>> import pyhf
-            >>> pyhf.set_backend("jax")
-            >>> pyhf.tensorlib.atleast_1d(1.)
-            DeviceArray([1.], dtype=float64)
-            >>> pyhf.tensorlib.atleast_1d(1., [3., 4.])
-            [DeviceArray([1.], dtype=float64), DeviceArray([3., 4.], dtype=float64)]
-
-        Args:
-            args (Array of Tensors): Sequence of tensors
-
-        Returns:
-            JAX ndarray: A tensor, or list of tensors, each with ``ndim >= 1``
-
-        """
-        return np.atleast_1d(*args)
-
     def clip(self, tensor_in, min_value, max_value):
         """
         Clips (limits) the tensor values to be within a specified min and max.

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -68,6 +68,8 @@ class jax_backend(object):
 
             >>> import pyhf
             >>> pyhf.set_backend("jax")
+            >>> pyhf.tensorlib.atleast_1d(1.)
+            DeviceArray([1.], dtype=float64)
             >>> pyhf.tensorlib.atleast_1d(1., [3., 4.])
             [DeviceArray([1.], dtype=float64), DeviceArray([3., 4.], dtype=float64)]
 

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -68,7 +68,7 @@ class jax_backend(object):
 
             >>> import pyhf
             >>> pyhf.set_backend("jax")
-            >>> pyhf.tensorlib.atleast_1d(1., [3., 4.]))
+            >>> pyhf.tensorlib.atleast_1d(1., [3., 4.])
             [DeviceArray([1.], dtype=float64), DeviceArray([3., 4.], dtype=float64)]
 
         Args:

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -60,6 +60,26 @@ class jax_backend(object):
         Run any global setups for the jax lib.
         """
 
+    def atleast_1d(self, *args):
+        """
+        Convert inputs to tensors with at least one dimension.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("jax")
+            >>> pyhf.tensorlib.atleast_1d(1., [3., 4.]))
+            [DeviceArray([1.], dtype=float64), DeviceArray([3., 4.], dtype=float64)]
+
+        Args:
+            args (Array of Tensors): Sequence of tensors
+
+        Returns:
+            JAX ndarray: A tensor, or list of tensors, each with `ndim >= 1`
+
+        """
+        return np.atleast_1d(*args)
+
     def clip(self, tensor_in, min_value, max_value):
         """
         Clips (limits) the tensor values to be within a specified min and max.

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -152,6 +152,17 @@ class jax_backend(object):
         """
         Convert to a JAX ndarray.
 
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("jax")
+            >>> tensor = pyhf.tensorlib.astensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+            >>> tensor
+            DeviceArray([[1., 2., 3.],
+                         [4., 5., 6.]], dtype=float64)
+            >>> type(tensor)
+            <class 'jax.interpreters.xla.DeviceArray'>
+
         Args:
             tensor_in (Number or Tensor): Tensor object
 

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -61,6 +61,8 @@ class numpy_backend(object):
 
             >>> import pyhf
             >>> pyhf.set_backend("numpy")
+            >>> pyhf.tensorlib.atleast_1d(1.)
+            array([1.])
             >>> pyhf.tensorlib.atleast_1d(1., [3., 4.])
             [array([1.]), array([3., 4.])]
 

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -68,7 +68,7 @@ class numpy_backend(object):
             args (Array of Tensors): Sequence of arrays
 
         Returns:
-            NumPy ndarray: An array, or list of arrays, each with `ndim >= 1`
+            NumPy ndarray: An array, or list of arrays, each with ``ndim >= 1``
 
         """
         return np.atleast_1d(*args)

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -145,6 +145,17 @@ class numpy_backend(object):
         """
         Convert to a NumPy array.
 
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("numpy")
+            >>> tensor = pyhf.tensorlib.astensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+            >>> tensor
+            array([[1., 2., 3.],
+                   [4., 5., 6.]])
+            >>> type(tensor)
+            <class 'numpy.ndarray'>
+
         Args:
             tensor_in (Number or Tensor): Tensor object
 

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -157,13 +157,7 @@ class numpy_backend(object):
             log.error('Invalid dtype: dtype must be float, int, or bool.')
             raise
 
-        tensor = np.asarray(tensor_in, dtype=dtype)
-        # Ensure non-empty tensor shape for consistency
-        try:
-            tensor.shape[0]
-        except IndexError:
-            tensor = tensor.reshape(1)
-        return tensor
+        return np.asarray(tensor_in, dtype=dtype)
 
     def sum(self, tensor_in, axis=None):
         return np.sum(tensor_in, axis=axis)

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -61,7 +61,7 @@ class numpy_backend(object):
 
             >>> import pyhf
             >>> pyhf.set_backend("numpy")
-            >>> pyhf.tensorlib.atleast_1d(1., [3., 4.]))
+            >>> pyhf.tensorlib.atleast_1d(1., [3., 4.])
             [array([1.]), array([3., 4.])]
 
         Args:

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -53,6 +53,26 @@ class numpy_backend(object):
         Run any global setups for the numpy lib.
         """
 
+    def atleast_1d(self, *args):
+        """
+        Convert inputs to tensors with at least one dimension.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("numpy")
+            >>> pyhf.tensorlib.atleast_1d(1., [3., 4.]))
+            [array([1.]), array([3., 4.])]
+
+        Args:
+            args (Array of Tensors): Sequence of arrays
+
+        Returns:
+            NumPy ndarray: An array, or list of arrays, each with `ndim >= 1`
+
+        """
+        return np.atleast_1d(*args)
+
     def clip(self, tensor_in, min_value, max_value):
         """
         Clips (limits) the tensor values to be within a specified min and max.

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -53,28 +53,6 @@ class numpy_backend(object):
         Run any global setups for the numpy lib.
         """
 
-    def atleast_1d(self, *args):
-        """
-        Convert inputs to tensors with at least one dimension.
-
-        Example:
-
-            >>> import pyhf
-            >>> pyhf.set_backend("numpy")
-            >>> pyhf.tensorlib.atleast_1d(1.)
-            array([1.])
-            >>> pyhf.tensorlib.atleast_1d(1., [3., 4.])
-            [array([1.]), array([3., 4.])]
-
-        Args:
-            args (Array of Tensors): Sequence of arrays
-
-        Returns:
-            NumPy ndarray: An array, or list of arrays, each with ``ndim >= 1``
-
-        """
-        return np.atleast_1d(*args)
-
     def clip(self, tensor_in, min_value, max_value):
         """
         Clips (limits) the tensor values to be within a specified min and max.

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -227,7 +227,7 @@ class pytorch_backend(object):
             list of Tensors: The sequence broadcast together.
         """
 
-        args = [arg if arg.size() != torch.Size([]) else arg.view(1) for arg in args]
+        args = [arg.view(1) if not self.shape(arg) else arg for arg in args]
         max_dim = max(map(len, args))
         try:
             assert not [arg for arg in args if 1 < len(arg) < max_dim]

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -112,6 +112,17 @@ class pytorch_backend(object):
         """
         Convert to a PyTorch Tensor.
 
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("pytorch")
+            >>> tensor = pyhf.tensorlib.astensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+            >>> tensor
+            tensor([[1., 2., 3.],
+                    [4., 5., 6.]])
+            >>> type(tensor)
+            <class 'torch.Tensor'>
+
         Args:
             tensor_in (Number or Tensor): Tensor object
 

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -44,7 +44,7 @@ class pytorch_backend(object):
             args (Array of Tensors): Sequence of tensors
 
         Returns:
-            PyTorch tensor: A tensor, or list of tensors, each with `ndim >= 1`
+            PyTorch tensor: A tensor, or list of tensors, each with ``ndim >= 1``
 
         """
         # TODO: Use torch.atleast_1d API when available

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -29,6 +29,36 @@ class pytorch_backend(object):
         """
         torch.set_default_dtype(self.dtypemap["float"])
 
+    def atleast_1d(self, *args):
+        """
+        Convert inputs to tensors with at least one dimension.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("pytorch")
+            >>> pyhf.tensorlib.atleast_1d(1., [3., 4.]))
+            [tensor([1.]), tensor([3., 4.])]
+
+        Args:
+            args (Array of Tensors): Sequence of tensors
+
+        Returns:
+            PyTorch tensor: A tensor, or list of tensors, each with `ndim >= 1`
+
+        """
+        # TODO: Use torch.atleast_1d API when available
+        arg_map = map(self.astensor, args)
+        tensor_list = []
+        for arg in arg_map:
+            try:
+                arg.shape[0]
+            except IndexError:
+                arg = arg.view(1)
+            tensor_list.append(arg)
+
+        return tensor_list
+
     def clip(self, tensor_in, min_value, max_value):
         """
         Clips (limits) the tensor values to be within a specified min and max.

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -37,6 +37,8 @@ class pytorch_backend(object):
 
             >>> import pyhf
             >>> pyhf.set_backend("pytorch")
+            >>> pyhf.tensorlib.atleast_1d(1.)
+            tensor([1.])
             >>> pyhf.tensorlib.atleast_1d(1., [3., 4.])
             [tensor([1.]), tensor([3., 4.])]
 

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -37,7 +37,7 @@ class pytorch_backend(object):
 
             >>> import pyhf
             >>> pyhf.set_backend("pytorch")
-            >>> pyhf.tensorlib.atleast_1d(1., [3., 4.]))
+            >>> pyhf.tensorlib.atleast_1d(1., [3., 4.])
             [tensor([1.]), tensor([3., 4.])]
 
         Args:

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -49,7 +49,10 @@ class pytorch_backend(object):
         """
         # TODO: Use torch.atleast_1d API when available
         arg_map = map(self.astensor, args)
-        return [arg.view(1) if not self.shape(arg) else arg for arg in arg_map]
+        tensor_list = [arg.view(1) if not self.shape(arg) else arg for arg in arg_map]
+        if len(tensor_list) == 1:
+            tensor_list = tensor_list[0]
+        return tensor_list
 
     def clip(self, tensor_in, min_value, max_value):
         """

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -29,33 +29,6 @@ class pytorch_backend(object):
         """
         torch.set_default_dtype(self.dtypemap["float"])
 
-    def atleast_1d(self, *args):
-        """
-        Convert inputs to tensors with at least one dimension.
-
-        Example:
-
-            >>> import pyhf
-            >>> pyhf.set_backend("pytorch")
-            >>> pyhf.tensorlib.atleast_1d(1.)
-            tensor([1.])
-            >>> pyhf.tensorlib.atleast_1d(1., [3., 4.])
-            [tensor([1.]), tensor([3., 4.])]
-
-        Args:
-            args (Array of Tensors): Sequence of tensors
-
-        Returns:
-            PyTorch tensor: A tensor, or list of tensors, each with ``ndim >= 1``
-
-        """
-        # TODO: Use torch.atleast_1d API when available
-        arg_map = map(self.astensor, args)
-        tensor_list = [arg.view(1) if not self.shape(arg) else arg for arg in arg_map]
-        if len(tensor_list) == 1:
-            tensor_list = tensor_list[0]
-        return tensor_list
-
     def clip(self, tensor_in, min_value, max_value):
         """
         Clips (limits) the tensor values to be within a specified min and max.

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -227,6 +227,9 @@ class pytorch_backend(object):
             list of Tensors: The sequence broadcast together.
         """
 
+        args = [
+            arg if arg.size() != torch.Size([]) else arg.unsqueeze(0) for arg in args
+        ]
         max_dim = max(map(len, args))
         try:
             assert not [arg for arg in args if 1 < len(arg) < max_dim]

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -124,13 +124,7 @@ class pytorch_backend(object):
             log.error('Invalid dtype: dtype must be float, int, or bool.')
             raise
 
-        tensor = torch.as_tensor(tensor_in, dtype=dtype)
-        # Ensure non-empty tensor shape for consistency
-        try:
-            tensor.shape[0]
-        except IndexError:
-            tensor = tensor.expand(1)
-        return tensor
+        return torch.as_tensor(tensor_in, dtype=dtype)
 
     def gather(self, tensor, indices):
         return tensor[indices.type(torch.LongTensor)]

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -49,15 +49,7 @@ class pytorch_backend(object):
         """
         # TODO: Use torch.atleast_1d API when available
         arg_map = map(self.astensor, args)
-        tensor_list = []
-        for arg in arg_map:
-            try:
-                arg.shape[0]
-            except IndexError:
-                arg = arg.view(1)
-            tensor_list.append(arg)
-
-        return tensor_list
+        return [arg.view(1) if not self.shape(arg) else arg for arg in arg_map]
 
     def clip(self, tensor_in, min_value, max_value):
         """

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -227,9 +227,7 @@ class pytorch_backend(object):
             list of Tensors: The sequence broadcast together.
         """
 
-        args = [
-            arg if arg.size() != torch.Size([]) else arg.unsqueeze(0) for arg in args
-        ]
+        args = [arg if arg.size() != torch.Size([]) else arg.view(1) for arg in args]
         max_dim = max(map(len, args))
         try:
             assert not [arg for arg in args if 1 < len(arg) < max_dim]

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -26,38 +26,6 @@ class tensorflow_backend(object):
         Run any global setups for the tensorflow lib.
         """
 
-    def atleast_1d(self, *args):
-        """
-        Convert inputs to tensors with at least one dimension.
-
-        Example:
-
-            >>> import pyhf
-            >>> pyhf.set_backend("tensorflow")
-            >>> tensor = pyhf.tensorlib.atleast_1d(1.)
-            >>> print(tensor)
-            tf.Tensor([1.], shape=(1,), dtype=float32)
-            >>> tensor_list = pyhf.tensorlib.atleast_1d(1., [3., 4.])
-            >>> print([str(t) for t in tensor_list]) # doctest: +NORMALIZE_WHITESPACE
-            ['tf.Tensor([1.], shape=(1,), dtype=float32)',
-             'tf.Tensor([3. 4.], shape=(2,), dtype=float32)']
-
-        Args:
-            args (Array of Tensors): Sequence of tensors
-
-        Returns:
-            TensorFlow Tensor: A tensor, or list of tensors, each with ``ndim >= 1``
-
-        """
-        # TODO: Use tf.experimental.numpy.atleast_1d API when available
-        arg_map = map(self.astensor, args)
-        tensor_list = [
-            tf.reshape(arg, [1]) if not self.shape(arg) else arg for arg in arg_map
-        ]
-        if len(tensor_list) == 1:
-            tensor_list = tensor_list[0]
-        return tensor_list
-
     def clip(self, tensor_in, min_value, max_value):
         """
         Clips (limits) the tensor values to be within a specified min and max.

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -48,7 +48,12 @@ class tensorflow_backend(object):
         """
         # TODO: Use tf.experimental.numpy.atleast_1d API when available
         arg_map = map(self.astensor, args)
-        return [tf.reshape(arg, [1]) if not self.shape(arg) else arg for arg in arg_map]
+        tensor_list = [
+            tf.reshape(arg, [1]) if not self.shape(arg) else arg for arg in arg_map
+        ]
+        if len(tensor_list) == 1:
+            tensor_list = tensor_list[0]
+        return tensor_list
 
     def clip(self, tensor_in, min_value, max_value):
         """

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -136,6 +136,18 @@ class tensorflow_backend(object):
         """
         Convert to a TensorFlow Tensor.
 
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("tensorflow")
+            >>> tensor = pyhf.tensorlib.astensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+            >>> tensor
+            <tf.Tensor: shape=(2, 3), dtype=float32, numpy=
+            array([[1., 2., 3.],
+                   [4., 5., 6.]], dtype=float32)>
+            >>> type(tensor)
+            <class 'tensorflow.python.framework.ops.EagerTensor'>
+
         Args:
             tensor_in (Number or Tensor): Tensor object
 

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -284,42 +284,15 @@ class tensorflow_backend(object):
 
         """
 
-        # How does NumPy do this?
-        # def generic_len(a):
-        #     try:
-        #         return len(a)
-        #     except TypeError:
-        #         if len(a.shape) < 1:
-        #             return 0
-        #         else:
-        #             return a.shape[0]
-        def generic_len(a):
-            try:
-                return a.shape[0]
-            except IndexError:
-                return 0
-
-        # [self.astensor([arg]) for arg in args if arg.shape[0] errror]
-
-        max_dim = max(map(generic_len, args))
+        max_dim = max(map(tf.size, args))
         try:
-            assert not [arg for arg in args if 1 < generic_len(arg) < max_dim]
+            assert not [arg for arg in args if 1 < tf.size(arg) < max_dim]
         except AssertionError as error:
             log.error(
                 'ERROR: The arguments must be of compatible size: 1 or %i', max_dim
             )
             raise error
-
-        print([arg for arg in args])
-        print([generic_len(arg) for arg in args])
-        print("spacer")
-        broadcast = [
-            arg
-            if generic_len(arg) > 1
-            else tf.tile(tf.slice(arg, [0], [1]), tf.stack([max_dim]))
-            for arg in args
-        ]
-        return broadcast
+        return [tf.broadcast_to(arg, (max_dim,)) for arg in args]
 
     def einsum(self, subscripts, *operands):
         """

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -26,6 +26,38 @@ class tensorflow_backend(object):
         Run any global setups for the tensorflow lib.
         """
 
+    def atleast_1d(self, *args):
+        """
+        Convert inputs to tensors with at least one dimension.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("tensorflow")
+            >>> tensor_list = pyhf.tensorlib.atleast_1d(1., [3., 4.]))
+            >>> print([str(t) for t in tensor_list]) # doctest: +NORMALIZE_WHITESPACE
+            ['tf.Tensor([1.], shape=(1,), dtype=float32)',
+             'tf.Tensor([3. 4.], shape=(2,), dtype=float32)']
+
+        Args:
+            args (Array of Tensors): Sequence of tensors
+
+        Returns:
+            TensorFlow Tensor: A tensor, or list of tensors, each with `ndim >= 1`
+
+        """
+        # TODO: Use tf.experimental.numpy.atleast_1d API when available
+        arg_map = map(self.astensor, args)
+        tensor_list = []
+        for arg in arg_map:
+            try:
+                arg.shape[0]
+            except IndexError:
+                arg = tf.reshape(arg, [1])
+            tensor_list.append(arg)
+
+        return tensor_list
+
     def clip(self, tensor_in, min_value, max_value):
         """
         Clips (limits) the tensor values to be within a specified min and max.

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -43,7 +43,7 @@ class tensorflow_backend(object):
             args (Array of Tensors): Sequence of tensors
 
         Returns:
-            TensorFlow Tensor: A tensor, or list of tensors, each with `ndim >= 1`
+            TensorFlow Tensor: A tensor, or list of tensors, each with ``ndim >= 1``
 
         """
         # TODO: Use tf.experimental.numpy.atleast_1d API when available

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -34,7 +34,7 @@ class tensorflow_backend(object):
 
             >>> import pyhf
             >>> pyhf.set_backend("tensorflow")
-            >>> tensor_list = pyhf.tensorlib.atleast_1d(1., [3., 4.]))
+            >>> tensor_list = pyhf.tensorlib.atleast_1d(1., [3., 4.])
             >>> print([str(t) for t in tensor_list]) # doctest: +NORMALIZE_WHITESPACE
             ['tf.Tensor([1.], shape=(1,), dtype=float32)',
              'tf.Tensor([3. 4.], shape=(2,), dtype=float32)']

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -48,15 +48,7 @@ class tensorflow_backend(object):
         """
         # TODO: Use tf.experimental.numpy.atleast_1d API when available
         arg_map = map(self.astensor, args)
-        tensor_list = []
-        for arg in arg_map:
-            try:
-                arg.shape[0]
-            except IndexError:
-                arg = tf.reshape(arg, [1])
-            tensor_list.append(arg)
-
-        return tensor_list
+        return [tf.reshape(arg, [1]) if not self.shape(arg) else arg for arg in arg_map]
 
     def clip(self, tensor_in, min_value, max_value):
         """

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -156,11 +156,6 @@ class tensorflow_backend(object):
             tensor.device
         except AttributeError:
             tensor = tf.convert_to_tensor(tensor_in)
-            # Ensure non-empty tensor shape for consistency
-            try:
-                tensor.shape[0]
-            except IndexError:
-                tensor = tf.reshape(tensor, [1])
         if tensor.dtype is not dtype:
             tensor = tf.cast(tensor, dtype)
         return tensor

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -34,6 +34,9 @@ class tensorflow_backend(object):
 
             >>> import pyhf
             >>> pyhf.set_backend("tensorflow")
+            >>> tensor = pyhf.tensorlib.atleast_1d(1.)
+            >>> print(tensor)
+            tf.Tensor([1.], shape=(1,), dtype=float32)
             >>> tensor_list = pyhf.tensorlib.atleast_1d(1., [3., 4.])
             >>> print([str(t) for t in tensor_list]) # doctest: +NORMALIZE_WHITESPACE
             ['tf.Tensor([1.], shape=(1,), dtype=float32)',

--- a/tests/test_backend_consistency.py
+++ b/tests/test_backend_consistency.py
@@ -117,7 +117,7 @@ def test_hypotest_q_mu(
         q_mu = pyhf.infer.test_statistics.qmu(
             1.0, data, pdf, pdf.config.suggested_init(), pdf.config.suggested_bounds(),
         )
-        test_statistic.append(pyhf.tensorlib.tolist(q_mu))
+        test_statistic.append(q_mu)
 
     # compare to NumPy/SciPy
     test_statistic = np.array(test_statistic)

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -187,7 +187,7 @@ def test_batched_constraints(backend):
         )
     )
     assert np.isclose(
-        result[0],
+        result,
         sum(
             [
                 default_backend.poisson_logpdf(data, rate)
@@ -195,7 +195,7 @@ def test_batched_constraints(backend):
             ]
         ),
     )
-    assert result.shape == (1,)
+    assert result.shape == ()
 
     suggested_pars = [1.1] * 3 + [0.0] * 5  # 2 pois 5 norm
     constraint = poisson_constraint_combined(config)
@@ -208,7 +208,7 @@ def test_batched_constraints(backend):
         )
     )
     assert np.isclose(
-        result[0],
+        result,
         sum(
             [
                 default_backend.poisson_logpdf(data, rate)
@@ -216,7 +216,7 @@ def test_batched_constraints(backend):
             ]
         ),
     )
-    assert result.shape == (1,)
+    assert result.shape == ()
 
     constraint = poisson_constraint_combined(config, batch_size=10)
     result = constraint.logpdf(

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -20,6 +20,36 @@ def check_uniform_type(in_list):
     )
 
 
+def test_mle_fit_default(tmpdir, hypotest_args):
+    """
+    Check that the default return structure of pyhf.infer.mle.fit is as expected
+    """
+    tb = pyhf.tensorlib
+
+    _, data, model = hypotest_args
+    kwargs = {}
+    result = pyhf.infer.mle.fit(data, model, **kwargs)
+    # bestfit_pars
+    assert isinstance(result, type(tb.astensor(result)))
+    assert pyhf.tensorlib.shape(result) == (model.config.npars,)
+
+
+def test_mle_fit_return_fitted_val(tmpdir, hypotest_args):
+    """
+    Check that the return structure of pyhf.infer.mle.fit with the
+    return_fitted_val keyword arg is as expected
+    """
+    tb = pyhf.tensorlib
+
+    _, data, model = hypotest_args
+    kwargs = {"return_fitted_val": True}
+    result = pyhf.infer.mle.fit(data, model, **kwargs)
+    # bestfit_pars, twice_nll
+    assert pyhf.tensorlib.shape(result[0]) == (model.config.npars,)
+    assert isinstance(result[0], type(tb.astensor(result[0])))
+    assert pyhf.tensorlib.shape(result[1]) == ()
+
+
 def test_hypotest_default(tmpdir, hypotest_args):
     """
     Check that the default return structure of pyhf.infer.hypotest is as expected

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -318,7 +318,7 @@ def test_optim_with_value(backend, source, spec, mu):
         return_fitted_val=True,
     )
     assert pyhf.tensorlib.tolist(result)
-    assert pyhf.tensorlib.shape(fitted_val) == (1,)
+    assert pyhf.tensorlib.shape(fitted_val) == ()
 
 
 @pytest.mark.parametrize('mu', [1.0], ids=['mu=1'])

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -86,16 +86,6 @@ def test_complex_tensor_ops(backend):
     ) == [1, 2, 1]
 
 
-def test_atleast_1d(backend):
-    tb = pyhf.tensorlib
-    assert tb.tolist(tb.atleast_1d(1)) == [1]
-    # FIXME for PyTorch
-    # assert np.all(
-    #     np.array(tb.atleast_1d(1, [2, 3])).all()
-    #     == np.array([tb.astensor([1]), tb.astensor([2, 3])]).all()
-    # )
-
-
 def test_ones(backend):
     tb = pyhf.tensorlib
     assert tb.tolist(tb.ones((2, 3))) == [[1, 1, 1], [1, 1, 1]]

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -86,6 +86,16 @@ def test_complex_tensor_ops(backend):
     ) == [1, 2, 1]
 
 
+def test_atleast_1d(backend):
+    tb = pyhf.tensorlib
+    assert tb.tolist(tb.atleast_1d(1)) == [1]
+    # FIXME for PyTorch
+    # assert np.all(
+    #     np.array(tb.atleast_1d(1, [2, 3])).all()
+    #     == np.array([tb.astensor([1]), tb.astensor([2, 3])]).all()
+    # )
+
+
 def test_ones(backend):
     tb = pyhf.tensorlib
     assert tb.tolist(tb.ones((2, 3))) == [[1, 1, 1], [1, 1, 1]]

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -145,10 +145,9 @@ def test_shape(backend):
     tb = pyhf.tensorlib
     assert tb.shape(tb.ones((1, 2, 3, 4, 5))) == (1, 2, 3, 4, 5)
     assert tb.shape(tb.ones((0, 0))) == (0, 0)
+    assert tb.shape(tb.astensor(1.0)) == ()
     assert tb.shape(tb.astensor([])) == (0,)
     assert tb.shape(tb.astensor([1.0])) == (1,)
-    assert tb.shape(tb.astensor(1.0)) == tb.shape(tb.astensor([1.0]))
-    assert tb.shape(tb.astensor(0.0)) == tb.shape(tb.astensor([0.0]))
     assert tb.shape(tb.astensor((1.0, 1.0))) == tb.shape(tb.astensor([1.0, 1.0]))
     assert tb.shape(tb.astensor((0.0, 0.0))) == tb.shape(tb.astensor([0.0, 0.0]))
     with pytest.raises(

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -41,16 +41,16 @@ def test_simple_tensor_ops(backend):
     assert tb.tolist(tb.abs(tb.astensor([-1, -2]))) == [1, 2]
     a = tb.astensor(1)
     b = tb.astensor(2)
-    assert tb.tolist(a < b)[0] is True
-    assert tb.tolist(b < a)[0] is False
-    assert tb.tolist(a < a)[0] is False
-    assert tb.tolist(a > b)[0] is False
-    assert tb.tolist(b > a)[0] is True
-    assert tb.tolist(a > a)[0] is False
+    assert tb.tolist(a < b) is True
+    assert tb.tolist(b < a) is False
+    assert tb.tolist(a < a) is False
+    assert tb.tolist(a > b) is False
+    assert tb.tolist(b > a) is True
+    assert tb.tolist(a > a) is False
     a = tb.astensor(4)
     b = tb.astensor(5)
-    assert tb.tolist(tb.conditional((a < b)[0], lambda: a + b, lambda: a - b)) == [9]
-    assert tb.tolist(tb.conditional((a > b)[0], lambda: a + b, lambda: a - b)) == [-1]
+    assert tb.tolist(tb.conditional((a < b), lambda: a + b, lambda: a - b)) == 9.0
+    assert tb.tolist(tb.conditional((a > b), lambda: a + b, lambda: a - b)) == -1.0
 
 
 def test_complex_tensor_ops(backend):


### PR DESCRIPTION
# Description

Resolves #954

This PR allows for tensors to take any shape, even empty `()` shapes. This effectively reverts PR #413. It also enforces that the optimizers return the objective function as a scalar (shape `()`), resulting in the test statistic being a scalar.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Allow for arbitrary shape tensors, including 0-dimensional ("empty") shape tensors (floats)
   - Reverts PR #413
* Enforce optimizers return objective function as a scalar to harmonize return type
* Revert tests that enforce minimum shape
* Add tests for return structure shape of pyhf.infer.mle.fit
* Add docstring examples for astensor
```
