### PR TITLE
chore: Set minimum version for iminuit to v1.4.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require = {
     'torch': ['torch~=1.2'],
     'jax': ['jax~=0.1,>0.1.51', 'jaxlib~=0.1,>0.1.33'],
     'xmlio': ['uproot~=3.6'],  # Future proof against uproot4 API changes
-    'minuit': ['iminuit'],
+    'minuit': ['iminuit>=1.4.3'],  # Use "name" keyword in MINUIT optimizer
 }
 extras_require['backends'] = sorted(
     set(

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require = {
     'torch': ['torch~=1.2'],
     'jax': ['jax~=0.1,>0.1.51', 'jaxlib~=0.1,>0.1.33'],
     'xmlio': ['uproot~=3.6'],  # Future proof against uproot4 API changes
-    'minuit': ['iminuit>=1.4.3'],  # Use "name" keyword in MINUIT optimizer
+    'minuit': ['iminuit~=1.4,>=1.4.3'],  # Use "name" keyword in MINUIT optimizer
 }
 extras_require['backends'] = sorted(
     set(


### PR DESCRIPTION
# Description

Set a minimum version of `iminuit` to [`v1.4.3`](https://github.com/scikit-hep/iminuit/releases/tag/v1.4.3) as PR #951 uses the `name` keyword in creating the instance of MINUIT. Additionally, use the compatible release syntax to ensure that `imuniuit` stays in the `v1.X` release series so that when it hits `v2.X` a conscious decision will be made to switch over for the next release of `pyhf`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Corresponds to use of 'name' keyword in Minuit class in the MINUIT optimizer
   - c.f. https://github.com/scikit-hep/iminuit/releases/tag/v1.4.3
```