### PR TITLE
fix: Enable jax.np.stack for axis !=0

### DIFF
--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -199,9 +199,7 @@ class jax_backend(object):
         return np.exp(tensor_in)
 
     def stack(self, sequence, axis=0):
-        if axis == 0:
-            return np.stack(sequence)
-        raise RuntimeError('stack axis!=0')
+        return np.stack(sequence, axis=axis)
 
     def where(self, mask, tensor_in_1, tensor_in_2):
         return np.where(mask, tensor_in_1, tensor_in_2)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -65,6 +65,9 @@ def test_complex_tensor_ops(backend):
         [4, 5, 6],
     ]
     assert tb.tolist(
+        tb.stack([tb.astensor([1, 2, 3]), tb.astensor([4, 5, 6])], axis=1)
+    ) == [[1, 4], [2, 5], [3, 6]]
+    assert tb.tolist(
         tb.concatenate([tb.astensor([1, 2, 3]), tb.astensor([4, 5, 6])])
     ) == [1, 2, 3, 4, 5, 6]
     assert tb.tolist(tb.clip(tb.astensor([-2, -1, 0, 1, 2]), -1, 1)) == [


### PR DESCRIPTION
# Pull Request Description

Not sure why we have axis!=0, but it works just fine. Needed for #951.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Enable jax.np.stack for axis != 0
   - Amends PR #377
* Add test for stack along axis !=0
```
