### PR TITLE
feat: Add precision setting string API to set_backend

### DIFF
--- a/src/pyhf/__init__.py
+++ b/src/pyhf/__init__.py
@@ -85,21 +85,17 @@ def set_backend(backend, custom_optimizer=None, precision=None):
             backend_kwargs["precision"] = precision
 
         try:
-            backend = getattr(tensor, "{0:s}_backend".format(backend))(**backend_kwargs)
+            backend = getattr(tensor, f"{backend:s}_backend")(**backend_kwargs)
         except TypeError:
             raise InvalidBackend(
-                "The backend provided is not supported: {0:s}. Select from one of the supported backends: numpy, tensorflow, pytorch".format(
-                    backend
-                )
+                f"The backend provided is not supported: {backend:s}. Select from one of the supported backends: numpy, tensorflow, pytorch"
             )
 
-    _name_supported = getattr(tensor, "{0:s}_backend".format(backend.name))
+    _name_supported = getattr(tensor, f"{backend.name:s}_backend")
     if _name_supported:
         if not isinstance(backend, _name_supported):
             raise AttributeError(
-                "'{0:s}' is not a valid name attribute for backend type {1}\n                 Custom backends must have names unique from supported backends".format(
-                    backend.name, type(backend)
-                )
+                f"'{backend.name:s}' is not a valid name attribute for backend type {type(backend)}\n                 Custom backends must have names unique from supported backends"
             )
     if backend.precision not in _valid_precisions:
         raise Unsupported(
@@ -131,9 +127,7 @@ def set_backend(backend, custom_optimizer=None, precision=None):
                     f"The optimizer provided is not supported: {custom_optimizer}. Select from one of the supported optimizers: scipy, minuit"
                 )
         else:
-            _name_supported = getattr(
-                optimize, "{0:s}_optimizer".format(custom_optimizer.name)
-            )
+            _name_supported = getattr(optimize, f"{custom_optimizer.name:s}_optimizer")
             if _name_supported:
                 if not isinstance(custom_optimizer, _name_supported):
                     raise AttributeError(

--- a/src/pyhf/__init__.py
+++ b/src/pyhf/__init__.py
@@ -71,6 +71,10 @@ def set_backend(backend, custom_optimizer=None, precision=None):
     _valid_precisions = ["32b", "64b"]
     if precision is None:
         precision = "64b"
+    elif isinstance(precision, (str, bytes)):
+        if isinstance(precision, bytes):
+            precision = precision.decode("utf-8")
+        precision = precision.lower()
 
     if isinstance(backend, (str, bytes)):
         if isinstance(backend, bytes):

--- a/src/pyhf/__init__.py
+++ b/src/pyhf/__init__.py
@@ -68,7 +68,7 @@ def set_backend(backend, custom_optimizer=None, precision=None):
     global tensorlib
     global optimizer
 
-    _valid_precisions = ["32b", "64b"]
+    _supported_precisions = ["32b", "64b"]
     backend_kwargs = {}
 
     if isinstance(precision, (str, bytes)):
@@ -97,10 +97,10 @@ def set_backend(backend, custom_optimizer=None, precision=None):
             raise AttributeError(
                 f"'{backend.name:s}' is not a valid name attribute for backend type {type(backend)}\n                 Custom backends must have names unique from supported backends"
             )
-    if backend.precision not in _valid_precisions:
-        raise Unsupported(
-            f"The backend precision provided is not supported: {backend.precision:s}. Select from one of the supported precisions: {', '.join([str(v) for v in _valid_precisions])}"
-        )
+        if backend.precision not in _supported_precisions:
+            raise Unsupported(
+                f"The backend precision provided is not supported: {backend.precision:s}. Select from one of the supported precisions: {', '.join([str(v) for v in _supported_precisions])}"
+            )
     # If "precision" arg passed, it should always win
     # If no "precision" arg, defer to tensor backend object API if set there
     if precision is not None:

--- a/src/pyhf/__init__.py
+++ b/src/pyhf/__init__.py
@@ -102,8 +102,8 @@ def set_backend(backend, custom_optimizer=None, precision=None):
         raise InvalidBackend(
             f"The backend precision provided is not supported: {backend.precision:s}. Select from one of the supported precisions: {', '.join([str(v) for v in _valid_precisions])}"
         )
-    # If kwarg passed, it should always win
-    # If no kwarg, defer to tensor backend object API if set there
+    # If "precision" arg passed, it should always win
+    # If no "precision" arg, defer to tensor backend object API if set there
     if precision is not None:
         if backend.precision != precision:
             backend = getattr(tensor, "{0:s}_backend".format(backend.name))(

--- a/src/pyhf/__init__.py
+++ b/src/pyhf/__init__.py
@@ -103,6 +103,11 @@ def set_backend(backend, custom_optimizer=None, precision=None):
         raise InvalidBackend(
             f"The backend precision provided is not supported: {precision:s}. Select from one of the supported precisions: {', '.join([str(v) for v in _valid_precisions])}"
         )
+    # If kwarg passed, it should always win
+    if backend.precision != precision:
+        backend = getattr(tensor, "{0:s}_backend".format(backend.name))(
+            precision=precision
+        )
 
     # need to determine if the tensorlib changed or the optimizer changed for events
     tensorlib_changed = bool(

--- a/src/pyhf/__init__.py
+++ b/src/pyhf/__init__.py
@@ -44,12 +44,18 @@ def set_backend(backend, custom_optimizer=None, precision=None):
         >>> pyhf.set_backend("tensorflow")
         >>> pyhf.tensorlib.name
         'tensorflow'
-        >>> pyhf.set_backend(b"pytorch")
+        >>> pyhf.tensorlib.precision
+        '64b'
+        >>> pyhf.set_backend(b"pytorch", precision="32b")
         >>> pyhf.tensorlib.name
         'pytorch'
+        >>> pyhf.tensorlib.precision
+        '32b'
         >>> pyhf.set_backend(pyhf.tensor.numpy_backend())
         >>> pyhf.tensorlib.name
         'numpy'
+        >>> pyhf.tensorlib.precision
+        '64b'
 
     Args:
         backend (`str` or `pyhf.tensor` backend): One of the supported pyhf backends: NumPy, TensorFlow, PyTorch, and JAX

--- a/src/pyhf/__init__.py
+++ b/src/pyhf/__init__.py
@@ -1,7 +1,7 @@
 from .tensor import BackendRetriever as tensor
 from .optimize import OptimizerRetriever as optimize
 from .version import __version__
-from .exceptions import InvalidBackend, InvalidOptimizer
+from .exceptions import InvalidBackend, InvalidOptimizer, Unsupported
 from . import events
 
 tensorlib = None
@@ -99,7 +99,7 @@ def set_backend(backend, custom_optimizer=None, precision=None):
                 )
             )
     if backend.precision not in _valid_precisions:
-        raise InvalidBackend(
+        raise Unsupported(
             f"The backend precision provided is not supported: {backend.precision:s}. Select from one of the supported precisions: {', '.join([str(v) for v in _valid_precisions])}"
         )
     # If "precision" arg passed, it should always win

--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -7,7 +7,7 @@ import json
 from ..utils import EqDelimStringParamType
 from ..infer import hypotest
 from ..workspace import Workspace
-from .. import tensor, get_backend, set_backend, optimize
+from .. import get_backend, set_backend, optimize
 
 log = logging.getLogger(__name__)
 
@@ -87,11 +87,11 @@ def cls(
 
     # set the backend if not NumPy
     if backend in ['pytorch', 'torch']:
-        set_backend(tensor.pytorch_backend(precision='64b'))
+        set_backend("pytorch", precision="64b")
     elif backend in ['tensorflow', 'tf']:
-        set_backend(tensor.tensorflow_backend(precision='64b'))
+        set_backend("tensorflow", precision="64b")
     elif backend in ['jax']:
-        set_backend(tensor.jax_backend())
+        set_backend("jax")
     tensorlib, _ = get_backend()
 
     optconf = {k: v for item in optconf for k, v in item.items()}

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -36,7 +36,7 @@ class tensorflow_backend(object):
             >>> a = pyhf.tensorlib.astensor([-2, -1, 0, 1, 2])
             >>> t = pyhf.tensorlib.clip(a, -1, 1)
             >>> print(t)
-            tf.Tensor([-1. -1.  0.  1.  1.], shape=(5,), dtype=float64)
+            tf.Tensor([-1. -1.  0.  1.  1.], shape=(5,), dtype=float32)
 
         Args:
             tensor_in (`tensor`): The input tensor object
@@ -65,7 +65,7 @@ class tensorflow_backend(object):
             >>> print(t)
             tf.Tensor(
             [[1. 1.]
-             [2. 2.]], shape=(2, 2), dtype=float64)
+             [2. 2.]], shape=(2, 2), dtype=float32)
 
         Args:
             tensor_in (`Tensor`): The tensor to be repeated
@@ -89,7 +89,7 @@ class tensorflow_backend(object):
             >>> b = tensorlib.astensor([5])
             >>> t = tensorlib.conditional((a < b)[0], lambda: a + b, lambda: a - b)
             >>> print(t)
-            tf.Tensor([9.], shape=(1,), dtype=float64)
+            tf.Tensor([9.], shape=(1,), dtype=float32)
 
         Args:
             predicate (`scalar`): The logical condition that determines which callable to evaluate
@@ -226,7 +226,7 @@ class tensorflow_backend(object):
             ...     pyhf.tensorlib.astensor([2, 2, 2]),
             ... )
             >>> print(t)
-            tf.Tensor([1. 2. 1.], shape=(3,), dtype=float64)
+            tf.Tensor([1. 2. 1.], shape=(3,), dtype=float32)
 
         Args:
             mask (bool): Boolean mask (boolean or tensor object of booleans)
@@ -265,9 +265,9 @@ class tensorflow_backend(object):
             ...   pyhf.tensorlib.astensor([2, 3, 4]),
             ...   pyhf.tensorlib.astensor([5, 6, 7]))
             >>> print([str(t) for t in b]) # doctest: +NORMALIZE_WHITESPACE
-            ['tf.Tensor([1. 1. 1.], shape=(3,), dtype=float64)',
-             'tf.Tensor([2. 3. 4.], shape=(3,), dtype=float64)',
-             'tf.Tensor([5. 6. 7.], shape=(3,), dtype=float64)']
+            ['tf.Tensor([1. 1. 1.], shape=(3,), dtype=float32)',
+             'tf.Tensor([2. 3. 4.], shape=(3,), dtype=float32)',
+             'tf.Tensor([5. 6. 7.], shape=(3,), dtype=float32)']
 
         Args:
             args (Array of Tensors): Sequence of arrays
@@ -326,7 +326,7 @@ class tensorflow_backend(object):
             >>> rates = pyhf.tensorlib.astensor([6., 8.])
             >>> t = pyhf.tensorlib.poisson_logpdf(values, rates)
             >>> print(t)
-            tf.Tensor([-1.8286944 -2.0868536], shape=(2,), dtype=float64)
+            tf.Tensor([-1.8286943 -2.086854 ], shape=(2,), dtype=float32)
 
         Args:
             n (`tensor` or `float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
@@ -355,7 +355,7 @@ class tensorflow_backend(object):
             >>> rates = pyhf.tensorlib.astensor([6., 8.])
             >>> t = pyhf.tensorlib.poisson(values, rates)
             >>> print(t)
-            tf.Tensor([0.16062314 0.12407692], shape=(2,), dtype=float64)
+            tf.Tensor([0.16062315 0.12407687], shape=(2,), dtype=float32)
 
         Args:
             n (`tensor` or `float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
@@ -385,7 +385,7 @@ class tensorflow_backend(object):
             >>> sigmas = pyhf.tensorlib.astensor([1., 0.8])
             >>> t = pyhf.tensorlib.normal_logpdf(values, means, sigmas)
             >>> print(t)
-            tf.Tensor([-1.04393853 -0.76610747], shape=(2,), dtype=float64)
+            tf.Tensor([-1.0439385 -0.7661075], shape=(2,), dtype=float32)
 
         Args:
             x (`tensor` or `float`): The value at which to evaluate the Normal distribution p.d.f.
@@ -415,7 +415,7 @@ class tensorflow_backend(object):
             >>> sigmas = pyhf.tensorlib.astensor([1., 0.8])
             >>> t = pyhf.tensorlib.normal(values, means, sigmas)
             >>> print(t)
-            tf.Tensor([0.35206533 0.46481887], shape=(2,), dtype=float64)
+            tf.Tensor([0.35206532 0.46481887], shape=(2,), dtype=float32)
 
         Args:
             x (`tensor` or `float`): The value at which to evaluate the Normal distribution p.d.f.
@@ -437,11 +437,11 @@ class tensorflow_backend(object):
             >>> pyhf.set_backend("tensorflow")
             >>> t = pyhf.tensorlib.normal_cdf(0.8)
             >>> print(t)
-            tf.Tensor(0.7881446014166034, shape=(), dtype=float64)
+            tf.Tensor(0.7881446, shape=(), dtype=float32)
             >>> values = pyhf.tensorlib.astensor([0.8, 2.0])
             >>> t = pyhf.tensorlib.normal_cdf(values)
             >>> print(t)
-            tf.Tensor([0.7881446  0.97724987], shape=(2,), dtype=float64)
+            tf.Tensor([0.7881446  0.97724986], shape=(2,), dtype=float32)
 
         Args:
             x (`tensor` or `float`): The observed value of the random variable to evaluate the CDF for
@@ -468,7 +468,7 @@ class tensorflow_backend(object):
             >>> poissons = pyhf.tensorlib.poisson_dist(rates)
             >>> t = poissons.log_prob(values)
             >>> print(t)
-            tf.Tensor([-1.74030218 -2.0868536 ], shape=(2,), dtype=float64)
+            tf.Tensor([-1.7403021 -2.086854 ], shape=(2,), dtype=float32)
 
         Args:
             rate (`tensor` or `float`): The mean of the Poisson distribution (the expected number of events)
@@ -492,7 +492,7 @@ class tensorflow_backend(object):
             >>> normals = pyhf.tensorlib.normal_dist(means, stds)
             >>> t = normals.log_prob(values)
             >>> print(t)
-            tf.Tensor([-1.41893853 -2.22579135], shape=(2,), dtype=float64)
+            tf.Tensor([-1.4189385 -2.2257915], shape=(2,), dtype=float32)
 
         Args:
             mu (`tensor` or `float`): The mean of the Normal distribution

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -36,7 +36,7 @@ class tensorflow_backend(object):
             >>> a = pyhf.tensorlib.astensor([-2, -1, 0, 1, 2])
             >>> t = pyhf.tensorlib.clip(a, -1, 1)
             >>> print(t)
-            tf.Tensor([-1. -1.  0.  1.  1.], shape=(5,), dtype=float32)
+            tf.Tensor([-1. -1.  0.  1.  1.], shape=(5,), dtype=float64)
 
         Args:
             tensor_in (`tensor`): The input tensor object
@@ -65,7 +65,7 @@ class tensorflow_backend(object):
             >>> print(t)
             tf.Tensor(
             [[1. 1.]
-             [2. 2.]], shape=(2, 2), dtype=float32)
+             [2. 2.]], shape=(2, 2), dtype=float64)
 
         Args:
             tensor_in (`Tensor`): The tensor to be repeated
@@ -89,7 +89,7 @@ class tensorflow_backend(object):
             >>> b = tensorlib.astensor([5])
             >>> t = tensorlib.conditional((a < b)[0], lambda: a + b, lambda: a - b)
             >>> print(t)
-            tf.Tensor([9.], shape=(1,), dtype=float32)
+            tf.Tensor([9.], shape=(1,), dtype=float64)
 
         Args:
             predicate (`scalar`): The logical condition that determines which callable to evaluate
@@ -226,7 +226,7 @@ class tensorflow_backend(object):
             ...     pyhf.tensorlib.astensor([2, 2, 2]),
             ... )
             >>> print(t)
-            tf.Tensor([1. 2. 1.], shape=(3,), dtype=float32)
+            tf.Tensor([1. 2. 1.], shape=(3,), dtype=float64)
 
         Args:
             mask (bool): Boolean mask (boolean or tensor object of booleans)
@@ -265,9 +265,9 @@ class tensorflow_backend(object):
             ...   pyhf.tensorlib.astensor([2, 3, 4]),
             ...   pyhf.tensorlib.astensor([5, 6, 7]))
             >>> print([str(t) for t in b]) # doctest: +NORMALIZE_WHITESPACE
-            ['tf.Tensor([1. 1. 1.], shape=(3,), dtype=float32)',
-             'tf.Tensor([2. 3. 4.], shape=(3,), dtype=float32)',
-             'tf.Tensor([5. 6. 7.], shape=(3,), dtype=float32)']
+            ['tf.Tensor([1. 1. 1.], shape=(3,), dtype=float64)',
+             'tf.Tensor([2. 3. 4.], shape=(3,), dtype=float64)',
+             'tf.Tensor([5. 6. 7.], shape=(3,), dtype=float64)']
 
         Args:
             args (Array of Tensors): Sequence of arrays
@@ -326,7 +326,7 @@ class tensorflow_backend(object):
             >>> rates = pyhf.tensorlib.astensor([6., 8.])
             >>> t = pyhf.tensorlib.poisson_logpdf(values, rates)
             >>> print(t)
-            tf.Tensor([-1.8286943 -2.086854 ], shape=(2,), dtype=float32)
+            tf.Tensor([-1.8286944 -2.0868536], shape=(2,), dtype=float64)
 
         Args:
             n (`tensor` or `float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
@@ -355,7 +355,7 @@ class tensorflow_backend(object):
             >>> rates = pyhf.tensorlib.astensor([6., 8.])
             >>> t = pyhf.tensorlib.poisson(values, rates)
             >>> print(t)
-            tf.Tensor([0.16062315 0.12407687], shape=(2,), dtype=float32)
+            tf.Tensor([0.16062314 0.12407692], shape=(2,), dtype=float64)
 
         Args:
             n (`tensor` or `float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
@@ -385,7 +385,7 @@ class tensorflow_backend(object):
             >>> sigmas = pyhf.tensorlib.astensor([1., 0.8])
             >>> t = pyhf.tensorlib.normal_logpdf(values, means, sigmas)
             >>> print(t)
-            tf.Tensor([-1.0439385 -0.7661075], shape=(2,), dtype=float32)
+            tf.Tensor([-1.04393853 -0.76610747], shape=(2,), dtype=float64)
 
         Args:
             x (`tensor` or `float`): The value at which to evaluate the Normal distribution p.d.f.
@@ -415,7 +415,7 @@ class tensorflow_backend(object):
             >>> sigmas = pyhf.tensorlib.astensor([1., 0.8])
             >>> t = pyhf.tensorlib.normal(values, means, sigmas)
             >>> print(t)
-            tf.Tensor([0.35206532 0.46481887], shape=(2,), dtype=float32)
+            tf.Tensor([0.35206533 0.46481887], shape=(2,), dtype=float64)
 
         Args:
             x (`tensor` or `float`): The value at which to evaluate the Normal distribution p.d.f.
@@ -437,11 +437,11 @@ class tensorflow_backend(object):
             >>> pyhf.set_backend("tensorflow")
             >>> t = pyhf.tensorlib.normal_cdf(0.8)
             >>> print(t)
-            tf.Tensor(0.7881446, shape=(), dtype=float32)
+            tf.Tensor(0.7881446014166034, shape=(), dtype=float64)
             >>> values = pyhf.tensorlib.astensor([0.8, 2.0])
             >>> t = pyhf.tensorlib.normal_cdf(values)
             >>> print(t)
-            tf.Tensor([0.7881446  0.97724986], shape=(2,), dtype=float32)
+            tf.Tensor([0.7881446  0.97724987], shape=(2,), dtype=float64)
 
         Args:
             x (`tensor` or `float`): The observed value of the random variable to evaluate the CDF for
@@ -468,7 +468,7 @@ class tensorflow_backend(object):
             >>> poissons = pyhf.tensorlib.poisson_dist(rates)
             >>> t = poissons.log_prob(values)
             >>> print(t)
-            tf.Tensor([-1.7403021 -2.086854 ], shape=(2,), dtype=float32)
+            tf.Tensor([-1.74030218 -2.0868536 ], shape=(2,), dtype=float64)
 
         Args:
             rate (`tensor` or `float`): The mean of the Poisson distribution (the expected number of events)
@@ -492,7 +492,7 @@ class tensorflow_backend(object):
             >>> normals = pyhf.tensorlib.normal_dist(means, stds)
             >>> t = normals.log_prob(values)
             >>> print(t)
-            tf.Tensor([-1.4189385 -2.2257915], shape=(2,), dtype=float32)
+            tf.Tensor([-1.41893853 -2.22579135], shape=(2,), dtype=float64)
 
         Args:
             mu (`tensor` or `float`): The mean of the Normal distribution

--- a/tests/test_jit.py
+++ b/tests/test_jit.py
@@ -10,7 +10,7 @@ import logging
 @pytest.mark.parametrize('do_grad', [False, True], ids=['no_grad', 'do_grad'])
 @pytest.mark.parametrize('optimizer', ['scipy', 'minuit'])
 def test_jax_jit(caplog, optimizer, do_grad, do_stitch, return_fitted_val):
-    pyhf.set_backend(pyhf.tensor.jax_backend(precision='64b'), optimizer)
+    pyhf.set_backend("jax", optimizer, precision="64b")
     pdf = pyhf.simplemodels.hepdata_like([50.0], [100.0], [10.0])
     data = pyhf.tensorlib.astensor([125.0] + pdf.config.auxdata)
 
@@ -76,7 +76,7 @@ def test_jax_jit(caplog, optimizer, do_grad, do_stitch, return_fitted_val):
 @pytest.mark.parametrize('do_stitch', [False, True], ids=['no_stitch', 'do_stitch'])
 @pytest.mark.parametrize('do_grad', [False, True], ids=['no_grad', 'do_grad'])
 def test_jax_jit_switch_optimizer(caplog, do_grad, do_stitch, return_fitted_val):
-    pyhf.set_backend(pyhf.tensor.jax_backend(precision='64b'), 'scipy')
+    pyhf.set_backend("jax", "scipy", precision="64b")
     pdf = pyhf.simplemodels.hepdata_like([50.0], [100.0], [10.0])
     data = pyhf.tensorlib.astensor([125.0] + pdf.config.auxdata)
 
@@ -132,7 +132,7 @@ def test_jax_jit_switch_optimizer(caplog, do_grad, do_stitch, return_fitted_val)
 )
 @pytest.mark.parametrize('do_grad', [False, True], ids=['no_grad', 'do_grad'])
 def test_jax_jit_enable_stitching(caplog, do_grad, return_fitted_val):
-    pyhf.set_backend(pyhf.tensor.jax_backend(precision='64b'), 'scipy')
+    pyhf.set_backend("jax", "scipy", precision="64b")
     pdf = pyhf.simplemodels.hepdata_like([50.0], [100.0], [10.0])
     data = pyhf.tensorlib.astensor([125.0] + pdf.config.auxdata)
 
@@ -166,7 +166,7 @@ def test_jax_jit_enable_stitching(caplog, do_grad, return_fitted_val):
 )
 @pytest.mark.parametrize('do_stitch', [False, True], ids=['no_stitch', 'do_stitch'])
 def test_jax_jit_enable_autograd(caplog, do_stitch, return_fitted_val):
-    pyhf.set_backend(pyhf.tensor.jax_backend(precision='64b'), 'scipy')
+    pyhf.set_backend("jax", "scipy", precision="64b")
     pdf = pyhf.simplemodels.hepdata_like([50.0], [100.0], [10.0])
     data = pyhf.tensorlib.astensor([125.0] + pdf.config.auxdata)
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -90,7 +90,7 @@ def test_supported_optimizers(optimizer_name):
 
 @pytest.mark.parametrize("precision_level", ["fail", b"fail"])
 def test_supported_precision(precision_level):
-    with pytest.raises(pyhf.exceptions.InvalidBackend):
+    with pytest.raises(pyhf.exceptions.Unsupported):
         pyhf.set_backend("numpy", precision=precision_level)
 
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -32,6 +32,12 @@ def test_set_optimizer_by_string(optimizer_name):
     )
 
 
+@pytest.mark.parametrize("precision_level", ["32b", "64b"])
+def test_set_precision_by_string(precision_level):
+    pyhf.set_backend(pyhf.tensorlib.name, precision=precision_level)
+    assert pyhf.tensorlib.precision == precision_level.lower()
+
+
 @pytest.mark.parametrize("backend_name", [b"numpy", b"tensorflow", b"pytorch"])
 def test_set_backend_by_bytestring(backend_name):
     pyhf.set_backend(backend_name)
@@ -50,6 +56,12 @@ def test_set_optimizer_by_bytestring(optimizer_name):
             pyhf.optimize, "{0:s}_optimizer".format(optimizer_name.decode("utf-8"))
         ),
     )
+
+
+@pytest.mark.parametrize("precision_level", [b"32b", b"64b"])
+def test_set_precision_by_bytestring(precision_level):
+    pyhf.set_backend(pyhf.tensorlib.name, precision=precision_level)
+    assert pyhf.tensorlib.precision == precision_level.decode("utf-8")
 
 
 @pytest.mark.parametrize("backend_name", ["fail", b"fail"])

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -68,7 +68,7 @@ def test_set_precision_by_bytestring(precision_level):
 
 @pytest.mark.parametrize("precision_level", ["32b", "64b"])
 def test_set_precision_by_string_wins(precision_level):
-    conflicting_precision = "32b" if precision_level is "64b" else "64b"
+    conflicting_precision = "32b" if precision_level == "64b" else "64b"
     pyhf.set_backend(
         pyhf.tensor.numpy_backend(precision=conflicting_precision),
         precision=precision_level,

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -76,6 +76,12 @@ def test_supported_optimizers(optimizer_name):
         pyhf.set_backend(pyhf.tensorlib, optimizer_name)
 
 
+@pytest.mark.parametrize("precision_level", ["fail", b"fail"])
+def test_supported_precision(precision_level):
+    with pytest.raises(pyhf.exceptions.InvalidBackend):
+        pyhf.set_backend("numpy", precision=precision_level)
+
+
 def test_custom_backend_name_supported():
     class custom_backend(object):
         def __init__(self, **kwargs):

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -64,6 +64,16 @@ def test_set_precision_by_bytestring(precision_level):
     assert pyhf.tensorlib.precision == precision_level.decode("utf-8")
 
 
+@pytest.mark.parametrize("precision_level", ["32b", "64b"])
+def test_set_precision_by_string_wins(precision_level):
+    conflicting_precision = "32b" if precision_level is "64b" else "64b"
+    pyhf.set_backend(
+        pyhf.tensor.numpy_backend(precision=conflicting_precision),
+        precision=precision_level,
+    )
+    assert pyhf.tensorlib.precision == precision_level.lower()
+
+
 @pytest.mark.parametrize("backend_name", ["fail", b"fail"])
 def test_supported_backends(backend_name):
     with pytest.raises(pyhf.exceptions.InvalidBackend):

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -36,6 +36,8 @@ def test_set_optimizer_by_string(optimizer_name):
 def test_set_precision_by_string(precision_level):
     pyhf.set_backend(pyhf.tensorlib.name, precision=precision_level)
     assert pyhf.tensorlib.precision == precision_level.lower()
+    pyhf.set_backend(pyhf.tensor.numpy_backend(precision=precision_level))
+    assert pyhf.tensorlib.precision == precision_level.lower()
 
 
 @pytest.mark.parametrize("backend_name", [b"numpy", b"tensorflow", b"pytorch"])


### PR DESCRIPTION
# Description

Resolves #982

Add the ability to set the backend precision through a `str` argument in `pyhf.set_backend`. This allows the following

```python
>>> import pyhf
>>> pyhf.set_backend("pytorch", precision="64b")  # string API
>>> pyhf.tensorlib.precision
'64b'
>>> pyhf.set_backend(pyhf.tensor.pytorch_backend(precision="32b"))  # object API 
>>> pyhf.tensorlib.precision
'32b'
>>> pyhf.set_backend("pytorch")  # no default, so defer to backend for precision
>>> pyhf.tensorlib.precision
'32b'
>>> pyhf.set_backend(pyhf.tensor.pytorch_backend(precision="32b"), precision="64b")  # set_backend string API wins if conflict
>>> pyhf.tensorlib.precision
'64b'
```

~~Additionally, set the default backend precision for _all_ backends to `64b`.~~

ReadTheDocs build: https://pyhf.readthedocs.io/en/api-add-precision-to-set_backend/

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add support for setting backend precision through str kwarg in set_backend
   - N.B.: If the kwarg is provided it will always be used even if backend is set with tensor backend object
* Adopt use of the str API internally for the CLI
```
