### PR TITLE
fix: stitch_pars bug in stitching values other than fixed values

### DIFF
--- a/src/pyhf/optimize/common.py
+++ b/src/pyhf/optimize/common.py
@@ -5,16 +5,20 @@ from ..tensor.common import _TensorViewer
 
 def _make_stitch_pars(tv=None, fixed_values=None):
     """
-    Construct a callable to stitch fixed paramter values into the unfixed parameters.
+    Construct a callable to stitch fixed paramter values into the unfixed parameters. See :func:`shim`.
+
+    This is extracted out to be unit-tested for proper behavior.
+
+    If ``tv`` or ``fixed_values`` are not provided, this returns the identity callable.
 
     Args:
-        tv (`_TensorViewer`): The `_TensorViewer` defining the parameter composition
-        fixed_vals (`list`): The fixed parameter values
+        tv (~pyhf.tensor.common._TensorViewer): tensor viewer instance
+        fixed_values (`list`): default set of values to stitch parameters with
 
     Returns:
-        stitch_pars (`func`): Callable that stitches fixed parameters into the unfixed parameters
+        callable (`func`): a callable that takes nuisance parameter values as input
     """
-    if tv is None:
+    if tv is None or fixed_values is None:
         return lambda pars, stitch_with=None: pars
 
     def stitch_pars(pars, stitch_with=fixed_values):

--- a/src/pyhf/optimize/common.py
+++ b/src/pyhf/optimize/common.py
@@ -4,6 +4,16 @@ from ..tensor.common import _TensorViewer
 
 
 def _make_stitch_pars(tv=None, fixed_values=None):
+    """
+    Construct a callable to stitch fixed paramter values into the unfixed parameters.
+
+    Args:
+        tv (`_TensorViewer`): The `_TensorViewer` defining the parameter composition
+        fixed_vals (`list`): The fixed parameter values
+
+    Returns:
+        stitch_pars (`func`): Callable that stitches fixed parameters into the unfixed parameters
+    """
     if tv is None:
         return lambda pars, stitch_with=None: pars
 

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -1,6 +1,7 @@
 import pyhf
 from pyhf.optimize.mixins import OptimizerMixin
-from pyhf.optimize.common import _get_tensor_shim
+from pyhf.optimize.common import _get_tensor_shim, _make_stitch_pars
+from pyhf.tensor.common import _TensorViewer
 import pytest
 from scipy.optimize import minimize, OptimizeResult
 import iminuit
@@ -409,3 +410,29 @@ def test_get_tensor_shim(monkeypatch):
         _get_tensor_shim()
 
     assert 'No optimizer shim for fake_backend.' == str(excinfo.value)
+
+
+def test_stitch_pars(backend):
+    tb, _ = backend
+
+    passthrough = make_stitch_pars()
+    pars = ['a', 'b', 1.0, 2.0, object()]
+    assert passthrough(pars) == pars
+
+    fixed_idx = [0, 3, 4]
+    variable_idx = [1, 2, 5]
+    fixed_vals = [10, 40, 50]
+    variable_vals = [20, 30, 60]
+    tv = _TensorViewer([fixed_idx, variable_idx])
+    stitch_pars = make_stitch_pars(tv, fixed_vals)
+
+    pars = tb.astensor(variable_vals)
+    assert tb.tolist(stitch_pars(pars)) == [10, 20, 30, 40, 50, 60]
+    assert tb.tolist(stitch_pars(pars, stitch_with=tb.zeros(3))) == [
+        0,
+        20,
+        30,
+        0,
+        0,
+        60,
+    ]

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -415,7 +415,7 @@ def test_get_tensor_shim(monkeypatch):
 def test_stitch_pars(backend):
     tb, _ = backend
 
-    passthrough = make_stitch_pars()
+    passthrough = _make_stitch_pars()
     pars = ['a', 'b', 1.0, 2.0, object()]
     assert passthrough(pars) == pars
 
@@ -424,7 +424,7 @@ def test_stitch_pars(backend):
     fixed_vals = [10, 40, 50]
     variable_vals = [20, 30, 60]
     tv = _TensorViewer([fixed_idx, variable_idx])
-    stitch_pars = make_stitch_pars(tv, fixed_vals)
+    stitch_pars = _make_stitch_pars(tv, fixed_vals)
 
     pars = tb.astensor(variable_vals)
     assert tb.tolist(stitch_pars(pars)) == [10, 20, 30, 40, 50, 60]


### PR DESCRIPTION
# Description

Unfortunately, #951 wasn't perfect. This fixes one minor bug 

https://github.com/scikit-hep/pyhf/blob/27f35e98739adc7a91d67c8a99581aa1020d407d/src/pyhf/optimize/common.py#L99-L101

where anything specified in `stitch_with` is unused, as `fixed_values` is just used directly. To also make sure this doesn't bite us in the future, I refactored the function slightly, and added tests for the expected behavior/functionality.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Fix bug in stitch_pars to use stitch_with argument
* Refactor stitch_pars to inside _make_stitch_pars function 
* Add test for stitch_pars
```