### PR TITLE
feat: Add kwarg for AsymptoticCalculator base distribution

### DIFF
--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -15,6 +15,7 @@ def hypotest(
     return_tail_probs=False,
     return_expected=False,
     return_expected_set=False,
+    calc_kwargs=None,
     **kwargs,
 ):
     r"""
@@ -138,6 +139,9 @@ def hypotest(
         **kwargs,
     )
 
+    calc = AsymptoticCalculator(
+        data, pdf, init_pars, par_bounds, **(calc_kwargs or {})
+    )
     teststat = calc.teststatistic(poi_test)
     sig_plus_bkg_distribution, bkg_only_distribution = calc.distributions(poi_test)
 

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -15,7 +15,6 @@ def hypotest(
     return_tail_probs=False,
     return_expected=False,
     return_expected_set=False,
-    calc_kwargs=None,
     **kwargs,
 ):
     r"""
@@ -139,9 +138,6 @@ def hypotest(
         **kwargs,
     )
 
-    calc = AsymptoticCalculator(
-        data, pdf, init_pars, par_bounds, **(calc_kwargs or {})
-    )
     teststat = calc.teststatistic(poi_test)
     sig_plus_bkg_distribution, bkg_only_distribution = calc.distributions(poi_test)
 

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -89,7 +89,7 @@ class AsymptoticTestStatDistribution:
             >>> import pyhf
             >>> pyhf.set_backend("numpy")
             >>> bkg_dist = pyhf.infer.calculators.AsymptoticTestStatDistribution(0.0)
-            >>> bkg_dist.pvalue(0)
+            >>> bkg_dist.cdf(0.0)
             0.5
 
         Args:
@@ -119,6 +119,14 @@ class AsymptoticTestStatDistribution:
             \frac{(\mu-\mu')}{\sigma} = \sqrt{\Lambda}= \sqrt{q_{\mu,A}}
 
         given the observed test statistics :math:`q_{\mu}` and :math:`q_{\mu,A}`.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("numpy")
+            >>> bkg_dist = pyhf.infer.calculators.AsymptoticTestStatDistribution(0.0)
+            >>> bkg_dist.pvalue(0.0)
+            array(0.5)
 
         Args:
             value (:obj:`float`): The test statistic value.
@@ -227,7 +235,7 @@ class AsymptoticCalculator:
             >>> _ = asymptotic_calculator.teststatistic(mu_test)
             >>> sig_plus_bkg_dist, bkg_dist = asymptotic_calculator.distributions(mu_test)
             >>> sig_plus_bkg_dist.pvalue(mu_test), bkg_dist.pvalue(mu_test)
-            (0.002192624107163899, 0.15865525393145707)
+            (array(0.00219262), array(0.15865525))
 
         Args:
             poi_test (:obj:`float` or :obj:`tensor`): The value for the parameter of interest.
@@ -351,7 +359,7 @@ class AsymptoticCalculator:
             >>> sig_plus_bkg_dist, bkg_dist = asymptotic_calculator.distributions(mu_test)
             >>> CLsb, CLb, CLs = asymptotic_calculator.pvalues(q_tilde, sig_plus_bkg_dist, bkg_dist)
             >>> CLsb, CLb, CLs
-            (0.023325019427864607, 0.4441593996111411, 0.05251497423736956)
+            (array(0.02332502), array(0.4441594), 0.05251497423736956)
 
         Args:
             teststat (:obj:`tensor`): The test statistic.

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -66,7 +66,7 @@ class AsymptoticTestStatDistribution:
     the :math:`-\mu'`, where :math:`\mu'` is the true poi value of the hypothesis.
     """
 
-    def __init__(self, shift, cutoff):
+    def __init__(self, shift, cutoff=float('-inf')):
         """
         Asymptotic test statistic distribution.
 

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -209,11 +209,13 @@ class AsymptoticCalculator:
             calc_base_dist (:obj:`str`): The statistical distribution, ``'normal'`` or
               ``'clipped_normal'``, to use for calculating the :math:`p`-values.
 
-              * ``'normal'``: (default) use the full Normal distribution in :math:`\mu/\sigma` space.
+              * ``'normal'``: (default) use the full Normal distribution in :math:`\hat{\mu}/\sigma`
+                space.
                 Note that expected limits may correspond to unphysical test statistics from scenarios
                 with the expected :math:`\hat{\mu} > \mu`.
-              * ``'clipped_normal'``: use a clipped Normal distribution in :math:`\mu/\sigma` space to
-                avoid expected limits that correspond to scenarios with the expected :math:`\hat{\mu} > \mu`.
+              * ``'clipped_normal'``: use a clipped Normal distribution in :math:`\hat{\mu}/\sigma`
+                space to avoid expected limits that correspond to scenarios with the expected
+                :math:`\hat{\mu} > \mu`.
                 This will properly cap the test statistic at ``0``, as noted in Equation (14) and
                 Equation (16) in :xref:`arXiv:1007.1727`.
 

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -601,15 +601,18 @@ class ToyCalculator:
             pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``.
             init_pars (:obj:`tensor`): The initial parameter values to be used for fitting.
             par_bounds (:obj:`tensor`): The parameter value bounds to be used for fitting.
-            fixed_params (:obj:`tensor`): Whether to fix the parameter to the init_pars value during minimization
-            test_stat (:obj:`str`): The test statistic to use as a numerical summary of the data.
-            qtilde (:obj:`bool`): When ``True`` perform the calculation using the alternative
-             test statistic, :math:`\tilde{q}_{\mu}`, as defined under the Wald
-             approximation in Equation (62) of :xref:`arXiv:1007.1727`
-             (:func:`~pyhf.infer.test_statistics.qmu_tilde`).
-             When ``False`` use :func:`~pyhf.infer.test_statistics.qmu`.
-            ntoys (:obj:`int`): Number of toys to use (how many times to sample the underlying distributions)
-            track_progress (:obj:`bool`): Whether to display the `tqdm` progress bar or not (outputs to `stderr`)
+            fixed_params (:obj:`tensor`): Whether to fix the parameter to the init_pars value
+              during minimization.
+            test_stat (:obj:`str`): The test statistic to use as a numerical summary of the
+              data: ``'qtilde'``, ``'q'``, or ``'q0'``.
+              ``'qtilde'`` (default) performs the calculation using the alternative test statistic,
+              :math:`\tilde{q}_{\mu}`, as defined under the Wald approximation in Equation (62)
+              of :xref:`arXiv:1007.1727` (:func:`~pyhf.infer.test_statistics.qmu_tilde`), ``'q'``
+              performs the calculation using the test statistic :math:`q_{\mu}`
+              (:func:`~pyhf.infer.test_statistics.qmu`), and ``'q0'`` perfoms the calculation using
+              the discovery test statistic :math:`q_{0}` (:func:`~pyhf.infer.test_statistics.q0`).
+            ntoys (:obj:`int`): Number of toys to use (how many times to sample the underlying distributions).
+            track_progress (:obj:`bool`): Whether to display the `tqdm` progress bar or not (outputs to `stderr`).
 
         Returns:
             ~pyhf.infer.calculators.ToyCalculator: The calculator for toy-based quantities.

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -66,7 +66,7 @@ class AsymptoticTestStatDistribution:
     the :math:`-\mu'`, where :math:`\mu'` is the true poi value of the hypothesis.
     """
 
-    def __init__(self, shift, cutoff=float('-inf')):
+    def __init__(self, shift, cutoff=float("-inf")):
         """
         Asymptotic test statistic distribution.
 
@@ -128,12 +128,12 @@ class AsymptoticTestStatDistribution:
 
         """
         tensorlib, _ = get_backend()
-        # computing cdf(-x) instead of 1-cdf(x) for right-tail p-value for improved numerical stability\\
+        # computing cdf(-x) instead of 1-cdf(x) for right-tail p-value for improved numerical stability
 
         return_value = tensorlib.normal_cdf(-(value - self.shift))
-        invalid_value = tensorlib.ones(tensorlib.shape(return_value)) * float('nan')
+        invalid_value = tensorlib.ones(tensorlib.shape(return_value)) * float("nan")
         return tensorlib.where(
-            tensorlib.astensor(value >= self.cutoff, dtype='bool'),
+            tensorlib.astensor(value >= self.cutoff, dtype="bool"),
             return_value,
             invalid_value,
         )
@@ -159,7 +159,7 @@ class AsymptoticTestStatDistribution:
         """
         tensorlib, _ = get_backend()
         return tensorlib.where(
-            tensorlib.astensor(self.shift + nsigma > self.cutoff, dtype='bool'),
+            tensorlib.astensor(self.shift + nsigma > self.cutoff, dtype="bool"),
             tensorlib.astensor(self.shift + nsigma),
             tensorlib.astensor(self.cutoff),
         )
@@ -237,15 +237,15 @@ class AsymptoticCalculator:
 
         """
         if self.sqrtqmuA_v is None:
-            raise RuntimeError('need to call .teststatistic(poi_test) first')
+            raise RuntimeError("need to call .teststatistic(poi_test) first")
 
-        if self.base_distr == 'normal':
-            cutoff = float('-inf')
-        elif self.base_distr == 'clipped_normal':
+        if self.base_distr == "normal":
+            cutoff = float("-inf")
+        elif self.base_distr == "clipped_normal":
             cutoff = -self.sqrtqmuA_v
         else:
             raise ValueError(
-                f'unknown base distribution for asymptotics {self.base_distr}'
+                f"unknown base distribution for asymptotics {self.base_distr}"
             )
         sb_dist = AsymptoticTestStatDistribution(-self.sqrtqmuA_v, cutoff)
         b_dist = AsymptoticTestStatDistribution(0.0, cutoff)

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -159,7 +159,9 @@ class AsymptoticTestStatDistribution:
         """
         tensorlib, _ = get_backend()
         return tensorlib.where(
-            self.shift + nsigma > self.cutoff, self.shift + nsigma, self.cutoff
+            tensorlib.astensor(self.shift + nsigma > self.cutoff, dtype='bool'),
+            tensorlib.astensor(self.shift + nsigma),
+            tensorlib.astensor(self.cutoff),
         )
 
 

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -204,6 +204,14 @@ class AsymptoticCalculator:
               performs the calculation using the test statistic :math:`q_{\mu}`
               (:func:`~pyhf.infer.test_statistics.qmu`), and ``'q0'`` perfoms the calculation using
               the discovery test statistic :math:`q_{0}` (:func:`~pyhf.infer.test_statistics.q0`).
+            calc_base_dist (:obj:`str`): The statistical distribution, ``'normal'`` or
+              ``'clipped_normal'`` to use for calculating the :math:`p`-values.
+              ``'normal'`` (default) corresponds to the common misconception that :math:`p`-values
+              greater than the observed :math:`p`-value are obtainable for POI less than 1.
+              ``'clipped_normal'`` corresponds to limiting the :math:`p`-values for expected limits
+              to a maximum of the observed :math:`p`-value.
+              The choice of ``calc_base_dist`` only affects the :math:`p`-values for expected limits,
+              and the default value will be changed in a future release.
 
         Returns:
             ~pyhf.infer.calculators.AsymptoticCalculator: The calculator for asymptotic quantities.

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -199,12 +199,12 @@ class AsymptoticCalculator:
             test_stat (:obj:`str`): The test statistic to use as a numerical summary of the
               data: ``'qtilde'``, ``'q'``, or ``'q0'``.
 
-              * ``'qtilde'`` (default) performs the calculation using the alternative test statistic,
+              * ``'qtilde'``: (default) performs the calculation using the alternative test statistic,
                 :math:`\tilde{q}_{\mu}`, as defined under the Wald approximation in Equation (62)
                 of :xref:`arXiv:1007.1727` (:func:`~pyhf.infer.test_statistics.qmu_tilde`).
-              * ``'q'`` performs the calculation using the test statistic :math:`q_{\mu}`
+              * ``'q'``: performs the calculation using the test statistic :math:`q_{\mu}`
                 (:func:`~pyhf.infer.test_statistics.qmu`).
-              * ``'q0'`` performs the calculation using the discovery test statistic
+              * ``'q0'``: performs the calculation using the discovery test statistic
                 :math:`q_{0}` (:func:`~pyhf.infer.test_statistics.q0`).
             calc_base_dist (:obj:`str`): The statistical distribution, ``'normal'`` or
               ``'clipped_normal'``, to use for calculating the :math:`p`-values.

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -130,12 +130,13 @@ class AsymptoticTestStatDistribution:
         tensorlib, _ = get_backend()
         # computing cdf(-x) instead of 1-cdf(x) for right-tail p-value for improved numerical stability\\
 
-        if value < self.cutoff:
-            raise RuntimeError(
-                'cannot evaluate pvalue outside of domain of the distribution'
-            )
-
-        return tensorlib.normal_cdf(-(value - self.shift))
+        return_value = tensorlib.normal_cdf(-(value - self.shift))
+        invalid_value = tensorlib.ones(tensorlib.shape(return_value)) * float('nan')
+        return tensorlib.where(
+            tensorlib.astensor(value >= self.cutoff, dtype='bool'),
+            return_value,
+            invalid_value,
+        )
 
     def expected_value(self, nsigma):
         """

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -176,7 +176,7 @@ class AsymptoticCalculator:
         par_bounds=None,
         fixed_params=None,
         test_stat="qtilde",
-        base_distr="normal",
+        calc_base_dist="normal",
     ):
         r"""
         Asymptotic Calculator.
@@ -204,7 +204,7 @@ class AsymptoticCalculator:
         self.par_bounds = par_bounds or pdf.config.suggested_bounds()
         self.fixed_params = fixed_params or pdf.config.suggested_fixed()
         self.test_stat = test_stat
-        self.base_distr = base_distr
+        self.calc_base_dist = calc_base_dist
         self.sqrtqmuA_v = None
 
     def distributions(self, poi_test):
@@ -239,13 +239,13 @@ class AsymptoticCalculator:
         if self.sqrtqmuA_v is None:
             raise RuntimeError("need to call .teststatistic(poi_test) first")
 
-        if self.base_distr == "normal":
+        if self.calc_base_dist == "normal":
             cutoff = float("-inf")
-        elif self.base_distr == "clipped_normal":
+        elif self.calc_base_dist == "clipped_normal":
             cutoff = -self.sqrtqmuA_v
         else:
             raise ValueError(
-                f"unknown base distribution for asymptotics {self.base_distr}"
+                f"unknown base distribution for asymptotics {self.calc_base_dist}"
             )
         sb_dist = AsymptoticTestStatDistribution(-self.sqrtqmuA_v, cutoff)
         b_dist = AsymptoticTestStatDistribution(0.0, cutoff)

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -237,7 +237,7 @@ class AsymptoticCalculator:
             raise RuntimeError('need to call .teststatistic(poi_test) first')
 
         if self.base_distr == 'normal':
-            cutoff = -1e10
+            cutoff = float('-inf')
         elif self.base_distr == 'clipped_normal':
             cutoff = -self.sqrtqmuA_v
         else:

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -241,7 +241,7 @@ class AsymptoticCalculator:
         elif self.base_distr == 'clipped_normal':
             cutoff = -self.sqrtqmuA_v
         else:
-            raise RuntimeError(
+            raise ValueError(
                 f'unknown base distribution for asymptotics {self.base_distr}'
             )
         sb_dist = AsymptoticTestStatDistribution(-self.sqrtqmuA_v, cutoff)

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -194,13 +194,16 @@ class AsymptoticCalculator:
             pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``.
             init_pars (:obj:`tensor`): The initial parameter values to be used for fitting.
             par_bounds (:obj:`tensor`): The parameter value bounds to be used for fitting.
-            fixed_params (:obj:`tensor`): Whether to fix the parameter to the init_pars value during minimization
-            test_stat (:obj:`str`): The test statistic to use as a numerical summary of the data.
-            qtilde (:obj:`bool`): When ``True`` perform the calculation using the alternative
-             test statistic, :math:`\tilde{q}_{\mu}`, as defined under the Wald
-             approximation in Equation (62) of :xref:`arXiv:1007.1727`
-             (:func:`~pyhf.infer.test_statistics.qmu_tilde`).
-             When ``False`` use :func:`~pyhf.infer.test_statistics.qmu`.
+            fixed_params (:obj:`tensor`): Whether to fix the parameter to the init_pars value
+              during minimization.
+            test_stat (:obj:`str`): The test statistic to use as a numerical summary of the
+              data: ``'qtilde'``, ``'q'``, or ``'q0'``.
+              ``'qtilde'`` (default) performs the calculation using the alternative test statistic,
+              :math:`\tilde{q}_{\mu}`, as defined under the Wald approximation in Equation (62)
+              of :xref:`arXiv:1007.1727` (:func:`~pyhf.infer.test_statistics.qmu_tilde`), ``'q'``
+              performs the calculation using the test statistic :math:`q_{\mu}`
+              (:func:`~pyhf.infer.test_statistics.qmu`), and ``'q0'`` perfoms the calculation using
+              the discovery test statistic :math:`q_{0}` (:func:`~pyhf.infer.test_statistics.q0`).
 
         Returns:
             ~pyhf.infer.calculators.AsymptoticCalculator: The calculator for asymptotic quantities.

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -205,11 +205,16 @@ class AsymptoticCalculator:
               (:func:`~pyhf.infer.test_statistics.qmu`), and ``'q0'`` perfoms the calculation using
               the discovery test statistic :math:`q_{0}` (:func:`~pyhf.infer.test_statistics.q0`).
             calc_base_dist (:obj:`str`): The statistical distribution, ``'normal'`` or
-              ``'clipped_normal'`` to use for calculating the :math:`p`-values.
-              ``'normal'`` (default) corresponds to the common misconception that :math:`p`-values
-              greater than the observed :math:`p`-value are obtainable for POI less than 1.
-              ``'clipped_normal'`` corresponds to limiting the :math:`p`-values for expected limits
-              to a maximum of the observed :math:`p`-value.
+              ``'clipped_normal'``, to use for calculating the :math:`p`-values.
+
+              * ``'normal'``: (default) use the full Normal distribution in :math:`\mu/\sigma` space.
+                Note that expected limits may correspond to unphysical test statistics from scenarios
+                with the expected :math:`\hat{\mu} > \mu`.
+              * ``'clipped_normal'``: use a clipped Normal distribution in :math:`\mu/\sigma` space to
+                avoid expected limits that correspond to scenarios with the expected :math:`\hat{\mu} > \mu`.
+                This will properly cap the test statistic at ``0``, as noted in Equation (14) and
+                Equation (16) in :xref:`arXiv:1007.1727`.
+
               The choice of ``calc_base_dist`` only affects the :math:`p`-values for expected limits,
               and the default value will be changed in a future release.
 

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -198,12 +198,14 @@ class AsymptoticCalculator:
               during minimization.
             test_stat (:obj:`str`): The test statistic to use as a numerical summary of the
               data: ``'qtilde'``, ``'q'``, or ``'q0'``.
-              ``'qtilde'`` (default) performs the calculation using the alternative test statistic,
-              :math:`\tilde{q}_{\mu}`, as defined under the Wald approximation in Equation (62)
-              of :xref:`arXiv:1007.1727` (:func:`~pyhf.infer.test_statistics.qmu_tilde`), ``'q'``
-              performs the calculation using the test statistic :math:`q_{\mu}`
-              (:func:`~pyhf.infer.test_statistics.qmu`), and ``'q0'`` perfoms the calculation using
-              the discovery test statistic :math:`q_{0}` (:func:`~pyhf.infer.test_statistics.q0`).
+
+              * ``'qtilde'`` (default) performs the calculation using the alternative test statistic,
+                :math:`\tilde{q}_{\mu}`, as defined under the Wald approximation in Equation (62)
+                of :xref:`arXiv:1007.1727` (:func:`~pyhf.infer.test_statistics.qmu_tilde`).
+              * ``'q'`` performs the calculation using the test statistic :math:`q_{\mu}`
+                (:func:`~pyhf.infer.test_statistics.qmu`).
+              * ``'q0'`` performs the calculation using the discovery test statistic
+                :math:`q_{0}` (:func:`~pyhf.infer.test_statistics.q0`).
             calc_base_dist (:obj:`str`): The statistical distribution, ``'normal'`` or
               ``'clipped_normal'``, to use for calculating the :math:`p`-values.
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -238,6 +238,30 @@ def test_inferapi_pyhf_independence():
     assert np.isclose(cls, 0.7267836451638846)
 
 
+def test_clipped_normal_calc(hypotest_args):
+    mu_test, data, pdf = hypotest_args
+    _, exp1 = pyhf.infer.hypotest(
+        0.2,
+        data,
+        pdf,
+        calc_kwargs={"base_distr": "clipped_normal"},
+        return_expected_set=True,
+    )
+    _, exp2 = pyhf.infer.hypotest(
+        0.2, data, pdf, calc_kwargs={"base_distr": "normal"}, return_expected_set=True
+    )
+    assert exp1[-1] < exp2[-1]
+
+    with pytest.raises(ValueError):
+        _, exp2 = pyhf.infer.hypotest(
+            0.2,
+            data,
+            pdf,
+            calc_kwargs={"base_distr": "unknown"},
+            return_expected_set=True,
+        )
+
+
 @pytest.mark.parametrize("test_stat", ["qtilde", "q"])
 def test_calculator_distributions_without_teststatistic(test_stat):
     calc = pyhf.infer.calculators.AsymptoticCalculator(

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -240,29 +240,29 @@ def test_inferapi_pyhf_independence():
 
 def test_clipped_normal_calc(hypotest_args):
     mu_test, data, pdf = hypotest_args
-    _, exp1 = pyhf.infer.hypotest(
-        0.2,
+    _, expected_clipped_normal = pyhf.infer.hypotest(
+        mu_test,
         data,
         pdf,
+        return_expected_set=True,
         calc_base_dist="clipped_normal",
-        return_expected_set=True,
     )
-    _, exp2 = pyhf.infer.hypotest(
-        0.2,
+    _, expected_normal = pyhf.infer.hypotest(
+        mu_test,
         data,
         pdf,
-        calc_base_dist="normal",
         return_expected_set=True,
+        calc_base_dist="normal",
     )
-    assert exp1[-1] < exp2[-1]
+    assert expected_clipped_normal[-1] < expected_normal[-1]
 
     with pytest.raises(ValueError):
-        _, exp2 = pyhf.infer.hypotest(
-            0.2,
+        _ = pyhf.infer.hypotest(
+            mu_test,
             data,
             pdf,
-            calc_base_dist="unknown",
             return_expected_set=True,
+            calc_base_dist="unknown",
         )
 
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -244,11 +244,15 @@ def test_clipped_normal_calc(hypotest_args):
         0.2,
         data,
         pdf,
-        calc_kwargs={"base_distr": "clipped_normal"},
+        base_distr="clipped_normal",
         return_expected_set=True,
     )
     _, exp2 = pyhf.infer.hypotest(
-        0.2, data, pdf, calc_kwargs={"base_distr": "normal"}, return_expected_set=True
+        0.2,
+        data,
+        pdf,
+        base_distr="normal",
+        return_expected_set=True,
     )
     assert exp1[-1] < exp2[-1]
 
@@ -257,7 +261,7 @@ def test_clipped_normal_calc(hypotest_args):
             0.2,
             data,
             pdf,
-            calc_kwargs={"base_distr": "unknown"},
+            base_distr="unknown",
             return_expected_set=True,
         )
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -244,14 +244,14 @@ def test_clipped_normal_calc(hypotest_args):
         0.2,
         data,
         pdf,
-        base_distr="clipped_normal",
+        calc_base_dist="clipped_normal",
         return_expected_set=True,
     )
     _, exp2 = pyhf.infer.hypotest(
         0.2,
         data,
         pdf,
-        base_distr="normal",
+        calc_base_dist="normal",
         return_expected_set=True,
     )
     assert exp1[-1] < exp2[-1]
@@ -261,7 +261,7 @@ def test_clipped_normal_calc(hypotest_args):
             0.2,
             data,
             pdf,
-            base_distr="unknown",
+            calc_base_dist="unknown",
             return_expected_set=True,
         )
 


### PR DESCRIPTION
# Description

Resolves #1159

In the standard brazil band plot ROOT HypotestInverter produces, there is a bit of an imprecision as the expected limits are calculated in $mu^/sigma$ space but for significant upward fluctuations it returns p-values that are not actually realizable with any data since if $expected µ^ > µ$ the test stat can at most be the one returned for $µ=µ^$, namely $q_µ = 0$, that in turn means that the p-value is capped at $CLs_obs$.

For compatibility and recognizability the default behavior is unchanged but it's now possible to get the correct asymptotic bahaviorr with `calc_kwargs = {'base_dir': 'clipped_normal'}`

![image](https://user-images.githubusercontent.com/2318083/88560788-dba02500-d02e-11ea-9be8-6352d0f8ea40.png)

ReadTheDocs build: https://pyhf.readthedocs.io/en/clipped_expected/api.html#inference

- [`pyhf.infer.calculators.AsymptoticTestStatDistribution`](https://pyhf.readthedocs.io/en/clipped_expected/_generated/pyhf.infer.calculators.AsymptoticTestStatDistribution.html#pyhf.infer.calculators.AsymptoticTestStatDistribution)
- [`pyhf.infer.calculators.AsymptoticCalculator`](https://pyhf.readthedocs.io/en/clipped_expected/_generated/pyhf.infer.calculators.AsymptoticCalculator.html)
- [`pyhf.infer.calculators.ToyCalculator`](https://pyhf.readthedocs.io/en/clipped_expected/_generated/pyhf.infer.calculators.ToyCalculator.html)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add calc_base_dist kwarg to AsymptoticCalculator to control cutoff for AsymptoticTestStatDistribution
* Add test for calc_base_dist behavior for 'clipped_normal'
* Add docstring example for pvalue
* Update docstring for AsymptoticCalculator and ToyCalculator

Co-authored-by: Matthew Feickert <matthew.feickert@cern.ch>
```