### PR TITLE
fix: Clean apt path after apt-get install

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,3 +26,7 @@ jobs:
     - name: Lint with Black
       run: |
         black --check --diff --verbose .
+    - name: Lint Dockerfile
+      uses: brpaz/hadolint-action@v1.1.0
+      with:
+        dockerfile: "docker/Dockerfile"

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,2 @@
+ignored:
+  - DL3008 # Pin versions in apt get install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,7 @@ FROM ${BASE_IMAGE} as base
 
 FROM base as builder
 COPY . /code
+# hadolint ignore=DL3003
 RUN apt-get -qq -y update && \
     apt-get -qq -y install --no-install-recommends \
         git && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get -qq -y update && \
         git && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
-    rm -rf /var/lib/apt-get/lists/* && \
+    rm -rf /var/lib/apt/lists/* && \
     cd /code && \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
     python -m pip install --no-cache-dir .[xmlio] && \
@@ -21,6 +21,6 @@ RUN apt-get -qq -y update && \
         curl && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
-    rm -rf /var/lib/apt-get/lists/*
+    rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local /usr/local
 ENTRYPOINT ["/usr/local/bin/pyhf"]

--- a/docker/gpu/Dockerfile
+++ b/docker/gpu/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -y && \
       python3-pip && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
-    rm -rf /var/lib/apt-get/lists/*
+    rm -rf /var/lib/apt/lists/*
 COPY . /code
 COPY ./docker/gpu/install_backend.sh /code/install_backend.sh
 WORKDIR /code


### PR DESCRIPTION
# Description

Even if you install something with `apt-get` the underlying `lists` directory will be under `/var/lib/apt/lists/` and not `/var/lib/apt-get/lists/`. This is wrong in every Dockerfile I've created in the last 2 years. Thanks to @QuLogic for finding this in https://github.com/matplotlib/mpl-docker/pull/11#discussion_r461160828

This is also a Hadolint error: [DL3009: Delete the apt-get lists after installing something.](https://github.com/hadolint/hadolint/wiki/DL3009)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Clean /var/lib/apt/lists/ as /var/lib/apt-get/lists/ does not exist
   - c.f. https://github.com/hadolint/hadolint/wiki/DL3009
* Add linting of Dockerfile with Hadolint action to lint workflow
* Add Hadolint config file
```
