### PR TITLE
build: Restrict TensorFlow to v2.2.X and TensorFlow Probability to v0.10.X

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup
 extras_require = {
     'shellcomplete': ['click_completion'],
     'tensorflow': [
-        'tensorflow~=2.0',
-        'tensorflow-probability~=0.10',  # TODO: Temp patch until tfp v0.11
+        'tensorflow~=2.2.0',  # Treat TensorFlow minor releases like major
+        'tensorflow-probability~=0.10.0',
     ],
     'torch': ['torch~=1.2'],
     'jax': ['jax~=0.1,>0.1.51', 'jaxlib~=0.1,>0.1.33'],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 extras_require = {
     'shellcomplete': ['click_completion'],
     'tensorflow': [
-        'tensorflow~=2.2.0',  # Treat TensorFlow minor releases like major
+        'tensorflow~=2.2.0',  # TensorFlow minor releases are as volatile as major
         'tensorflow-probability~=0.10.0',
     ],
     'torch': ['torch~=1.2'],


### PR DESCRIPTION
# Description

Resolves #998 

As Issue #997 makes it clear that minor releases might as well be major releases for TensorFlow, then it is probably worth keeping tighter version constraints on TensorFlow and TensorFlow Probability release ranges and just watching the releases of both libraries TensorFlow and TensorFlow Probability to see when we can relax these. 

Note that Issue #997 won't be resolved until TensorFlow Probability `v0.11.0` can be released, and as a result of this the current release workflows will *also* be broken until `v0.11.0` is released. This is a good illustration of the point that with TensorFlow we need to be more restirctive.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Restrict the release ranges of TensorFlow to v2.2.X and TensorFlow Probability to v0.10.X
   - Minor releases of TensorFlow can have conflicts with TensorFlow Probability that are volatile enough to act as major releases
```
