### PR TITLE
fix: Ensure TensorFlow backend Poisson compatibility with other backends

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup
 extras_require = {
     'shellcomplete': ['click_completion'],
     'tensorflow': [
-        'tensorflow~=2.3.1',  # TensorFlow minor releases are as volatile as major
-        'tensorflow-probability~=0.11.0',
+        'tensorflow~=2.2,>=2.2.1',
+        'tensorflow-probability~=0.10,>=0.10.1',
     ],
     'torch': ['torch~=1.8'],
     'jax': ['jax~=0.2.8', 'jaxlib~=0.1.58,!=0.1.68'],  # c.f. Issue 1501

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup
 extras_require = {
     'shellcomplete': ['click_completion'],
     'tensorflow': [
-        'tensorflow~=2.2.1',  # TensorFlow minor releases are as volatile as major
-        'tensorflow-probability~=0.10.1',
+        'tensorflow~=2.3.1',  # TensorFlow minor releases are as volatile as major
+        'tensorflow-probability~=0.11.0',
     ],
     'torch': ['torch~=1.8'],
     'jax': ['jax~=0.2.8', 'jaxlib~=0.1.58,!=0.1.68'],  # c.f. Issue 1501

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 extras_require = {
     'shellcomplete': ['click_completion'],
     'tensorflow': [
-        'tensorflow~=2.2,>=2.2.1',
+        'tensorflow~=2.2,>=2.2.1,!=2.3.0',  # c.f. https://github.com/tensorflow/tensorflow/pull/40789
         'tensorflow-probability~=0.10,>=0.10.1',
     ],
     'torch': ['torch~=1.8'],

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -120,7 +120,7 @@ class tensorflow_backend:
         """
         try:
             return tf.tile(tensor_in, repeats)
-        except tf.python.framework.errors_impl.InvalidArgumentError:
+        except tf.errors.InvalidArgumentError:
             shape = tf.shape(tensor_in).numpy().tolist()
             diff = len(repeats) - len(shape)
             if diff < 0:

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -392,7 +392,7 @@ def test_tensor_tile(backend):
     ]
 
     if tb.name == 'tensorflow':
-        with pytest.raises(tf.python.framework.errors_impl.InvalidArgumentError):
+        with pytest.raises(tf.errors.InvalidArgumentError):
             tb.tile(tb.astensor([[[10, 20, 30]]]), (2, 1))
 
 


### PR DESCRIPTION
# Description

Resolves #997 

~~As TensorFlow Probability `v0.11.0+` is needed for PR #817, and as Issue #997 makes it clear that TF/TFP minor releases can be as breaking as normal major releases, require TensorFlow `v2.3.0+` in the `v2.3.X` range and TensorFlow Probability `v0.11.0+` in the `v0.11.X` range.~~

Ensure compatibility of TensorFlow Poisson's behavior with PyTorch and JAX while Issue #293 is being resolved by using the differentiable TensorFlow operations `tf.logical_or` and `tf.where` to allow for checking if the situation in which `Poisson(n=0 | lam=0)` is being encountered. This provides a working solution for both the TF `v2.2.X` and TFP `V0.10.X` API behavior as well as for the TF `v2.3.+` and TFP `v0.11.0+` API behavior. Also disallow TF `v2.3.0` given https://github.com/tensorflow/tensorflow/pull/40789.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use differentiable TensorFlow operations to determine if Poisson(n=0 | lam=0) is being encountered and ensure a return value compatible with PyTorch and JAX
* Use TensorFlow releases compatible with v2.X with a lower bound of v2.2.1
   - Disallow TensorFlow v2.3.0 for accidental pinning of SciPy
* Use TensorFlow Probability releases compatible with v0.X with a lower bound of v0.10.1
* Use tf.errors.InvalidArgumentError for compatibility across TensorFlow releases
```
