### PR TITLE
build: Begin move to uproot4

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -102,7 +102,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
-        python -m pip uninstall --yes uproot4 uproot
+        python -m pip uninstall --yes uproot
         python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/uproot4.git
         python -m pip list
     - name: Test with pytest

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -84,6 +84,31 @@ jobs:
       run: |
         python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
 
+  uproot4:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip uninstall --yes uproot4 uproot
+        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/uproot4.git
+        python -m pip list
+    - name: Test with pytest
+      run: |
+        python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+
   pytest:
 
     runs-on: ${{ matrix.os }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'numpy': ('http://docs.scipy.org/doc/numpy/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'uproot': ('https://uproot.readthedocs.io/en/latest/', None),
 }
 
 # Github repo

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {
     'jax': ['jax~=0.2.4', 'jaxlib~=0.1.56'],
     'xmlio': [
         'uproot3~=3.14',
-        'uproot4~=4.0',
+        'uproot~=4.0',
     ],  # uproot3 required until writing to ROOT supported in uproot4
     'minuit': ['iminuit~=2.1'],
 }

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require = {
     'xmlio': [
         'uproot3~=3.14',
         'uproot4~=4.0',
-    ],  # Future proof against uproot4 API changes
+    ],  # uproot3 required until writing to ROOT supported in uproot4
     'minuit': ['iminuit~=2.1'],
 }
 extras_require['backends'] = sorted(

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {
     'jax': ['jax~=0.2.4', 'jaxlib~=0.1.56'],
     'xmlio': [
         'uproot3~=3.14',
-        'uproot4~=0.1.2',
+        'uproot4~=4.0',
     ],  # Future proof against uproot4 API changes
     'minuit': ['iminuit~=2.1'],
 }

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,10 @@ extras_require = {
     ],
     'torch': ['torch~=1.2'],
     'jax': ['jax~=0.2.4', 'jaxlib~=0.1.56'],
-    'xmlio': ['uproot3~=3.14'],  # Future proof against uproot4 API changes
+    'xmlio': [
+        'uproot3~=3.14',
+        'uproot4~=0.1.2',
+    ],  # Future proof against uproot4 API changes
     'minuit': ['iminuit~=2.1'],
 }
 extras_require['backends'] = sorted(

--- a/src/pyhf/cli/rootio.py
+++ b/src/pyhf/cli/rootio.py
@@ -32,7 +32,7 @@ def cli():
 def xml2json(entrypoint_xml, basedir, output_file, track_progress):
     """Entrypoint XML: The top-level XML file for the PDF definition."""
     try:
-        import uproot3 as uproot
+        import uproot4 as uproot
 
         assert uproot
     except ImportError:
@@ -62,7 +62,7 @@ def xml2json(entrypoint_xml, basedir, output_file, track_progress):
 def json2xml(workspace, output_dir, specroot, dataroot, resultprefix, patch):
     """Convert pyhf JSON back to XML + ROOT files."""
     try:
-        import uproot3 as uproot
+        import uproot4 as uproot
 
         assert uproot
     except ImportError:

--- a/src/pyhf/cli/rootio.py
+++ b/src/pyhf/cli/rootio.py
@@ -32,7 +32,7 @@ def cli():
 def xml2json(entrypoint_xml, basedir, output_file, track_progress):
     """Entrypoint XML: The top-level XML file for the PDF definition."""
     try:
-        import uproot4 as uproot
+        import uproot
 
         assert uproot
     except ImportError:
@@ -62,7 +62,7 @@ def xml2json(entrypoint_xml, basedir, output_file, track_progress):
 def json2xml(workspace, output_dir, specroot, dataroot, resultprefix, patch):
     """Convert pyhf JSON back to XML + ROOT files."""
     try:
-        import uproot4 as uproot
+        import uproot
 
         assert uproot
     except ImportError:

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -23,7 +23,7 @@ def extract_error(hist):
     bin uncertainties are then Poisson, and so the `sqrt(entries)`.
 
     Args:
-        hist (`<dynamic>.Model_TH1F_v2`): The histogram
+        hist (:class:`uproot.behaviors.TH1.TH1`): The histogram
 
     Returns:
         list: The uncertainty for each bin in the histogram

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import xml.etree.ElementTree as ET
 import numpy as np
 import tqdm
-import uproot4 as uproot
+import uproot
 import re
 
 log = logging.getLogger(__name__)

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import xml.etree.ElementTree as ET
 import numpy as np
 import tqdm
-import uproot3 as uproot
+import uproot4 as uproot
 import re
 
 log = logging.getLogger(__name__)

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -232,7 +232,7 @@ def process_measurements(toplvl, other_parameter_configs=None):
     For a given XML structure, provide a parsed dictionary adhering to defs.json/#definitions/measurement.
 
     Args:
-        toplvl (:module:`xml.etree.ElementTree`): The top-level XML document to parse.
+        toplvl (:mod:`xml.etree.ElementTree`): The top-level XML document to parse.
         other_parameter_configs (:obj:`list`): A list of other parameter configurations from other non-top-level XML documents to incorporate into the resulting measurement object.
 
     Returns:

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -48,7 +48,7 @@ def import_root_histogram(rootdir, filename, path, name, filecache=None):
         f = filecache[fullpath]
     try:
         hist = f[name]
-    except KeyError or uproot.deserialization.DeserializationError:
+    except (KeyError, uproot.deserialization.DeserializationError):
         try:
             hist = f[str(Path(path).joinpath(name))]
         except KeyError:

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -52,7 +52,7 @@ def import_root_histogram(rootdir, filename, path, name, filecache=None):
         print(f"\nfile: {f}")
         print(f"file name: {name}")
         hist = f[name]
-    except KeyError or uproot4.deserialization.DeserializationError:
+    except KeyError or uproot.deserialization.DeserializationError:
         try:
             hist = f[str(Path(path).joinpath(name))]
         except KeyError:

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 __FILECACHE__ = {}
 
 
-def extract_error(h):
+def extract_error(hist):
     """
     Determine the bin uncertainties for a histogram.
 
@@ -23,12 +23,12 @@ def extract_error(h):
     bin uncertainties are then Poisson, and so the `sqrt(entries)`.
 
     Args:
-        h (uproot.rootio.TH1 object): The histogram
+        hist (uproot.rootio.TH1 object): The histogram
 
     Returns:
         list: The uncertainty for each bin in the histogram
     """
-    err = h.variances if h.variances.any() else h.numpy()[0]
+    err = hist.variances if hist.variances.any() else hist.to_numpy()[0]
     return np.sqrt(err).tolist()
 
 
@@ -46,15 +46,15 @@ def import_root_histogram(rootdir, filename, path, name, filecache=None):
     else:
         f = filecache[fullpath]
     try:
-        h = f[name]
+        hist = f[name]
     except KeyError:
         try:
-            h = f[str(Path(path).joinpath(name))]
+            hist = f[str(Path(path).joinpath(name))]
         except KeyError:
             raise KeyError(
                 f'Both {name} and {Path(path).joinpath(name)} were tried and not found in {Path(rootdir).joinpath(filename)}'
             )
-    return h.numpy()[0].tolist(), extract_error(h)
+    return hist.to_numpy()[0].tolist(), extract_error(hist)
 
 
 def process_sample(

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -29,10 +29,8 @@ def extract_error(hist):
         list: The uncertainty for each bin in the histogram
     """
 
-    sumw2 = hist.member("fSumw2", none_if_missing=True)
-    err = sumw2 if sumw2 else hist.to_numpy()[0]
-    print(f"\nerr: {err}\n")
-    return np.sqrt(err).tolist()
+    variance = hist.variances() if hist.weighted else hist.to_numpy()[0]
+    return np.sqrt(variance).tolist()
 
 
 def import_root_histogram(rootdir, filename, path, name, filecache=None):
@@ -49,8 +47,6 @@ def import_root_histogram(rootdir, filename, path, name, filecache=None):
     else:
         f = filecache[fullpath]
     try:
-        print(f"\nfile: {f}")
-        print(f"file name: {name}")
         hist = f[name]
     except KeyError or uproot.deserialization.DeserializationError:
         try:
@@ -59,7 +55,6 @@ def import_root_histogram(rootdir, filename, path, name, filecache=None):
             raise KeyError(
                 f'Both {name} and {Path(path).joinpath(name)} were tried and not found in {Path(rootdir).joinpath(filename)}'
             )
-    print(f"\nhist.to_numpy(): {hist.to_numpy()}\n")
     return hist.to_numpy()[0].tolist(), extract_error(hist)
 
 
@@ -155,9 +150,6 @@ def process_sample(
                 }
             )
         elif modtag.tag == 'ShapeSys':
-            print(modtag.tag)
-            print(modtag.attrib)
-            print(modtag.attrib['HistoName'])
             # NB: ConstraintType is ignored
             if modtag.attrib.get('ConstraintType', 'Poisson') != 'Poisson':
                 log.warning(

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -49,12 +49,12 @@ def import_root_histogram(rootdir, filename, path, name, filecache=None):
     try:
         hist = f[name]
     except (KeyError, uproot.deserialization.DeserializationError):
-        key = "/".join([path, name])
+        fullname = "/".join([path, name])
         try:
-            hist = f[key]
+            hist = f[fullname]
         except KeyError:
             raise KeyError(
-                f'Both {name} and {key} were tried and not found in {fullpath}'
+                f'Both {name} and {fullname} were tried and not found in {fullpath}'
             )
     return hist.to_numpy()[0].tolist(), extract_error(hist)
 

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -23,7 +23,7 @@ def extract_error(hist):
     bin uncertainties are then Poisson, and so the `sqrt(entries)`.
 
     Args:
-        hist (uproot.rootio.TH1 object): The histogram
+        hist (`<dynamic>.Model_TH1F_v2`): The histogram
 
     Returns:
         list: The uncertainty for each bin in the histogram
@@ -48,8 +48,10 @@ def import_root_histogram(rootdir, filename, path, name, filecache=None):
     else:
         f = filecache[fullpath]
     try:
+        print(f)
+        print(f"name: {name}")
         hist = f[name]
-    except KeyError:
+    except KeyError or uproot4.deserialization.DeserializationError:
         try:
             hist = f[str(Path(path).joinpath(name))]
         except KeyError:
@@ -151,6 +153,9 @@ def process_sample(
                 }
             )
         elif modtag.tag == 'ShapeSys':
+            print(modtag.tag)
+            print(modtag.attrib)
+            print(modtag.attrib['HistoName'])
             # NB: ConstraintType is ignored
             if modtag.attrib.get('ConstraintType', 'Poisson') != 'Poisson':
                 log.warning(

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -28,7 +28,9 @@ def extract_error(hist):
     Returns:
         list: The uncertainty for each bin in the histogram
     """
-    err = hist.variances if hist.variances.any() else hist.to_numpy()[0]
+
+    sumw2 = hist.member("fSumw2", none_if_missing=True)
+    err = sumw2 if sumw2 else hist.to_numpy()[0]
     return np.sqrt(err).tolist()
 
 

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -31,6 +31,7 @@ def extract_error(hist):
 
     sumw2 = hist.member("fSumw2", none_if_missing=True)
     err = sumw2 if sumw2 else hist.to_numpy()[0]
+    print(f"\nerr: {err}\n")
     return np.sqrt(err).tolist()
 
 
@@ -48,8 +49,8 @@ def import_root_histogram(rootdir, filename, path, name, filecache=None):
     else:
         f = filecache[fullpath]
     try:
-        print(f)
-        print(f"name: {name}")
+        print(f"\nfile: {f}")
+        print(f"file name: {name}")
         hist = f[name]
     except KeyError or uproot4.deserialization.DeserializationError:
         try:
@@ -58,6 +59,7 @@ def import_root_histogram(rootdir, filename, path, name, filecache=None):
             raise KeyError(
                 f'Both {name} and {Path(path).joinpath(name)} were tried and not found in {Path(rootdir).joinpath(filename)}'
             )
+    print(f"\nhist.to_numpy(): {hist.to_numpy()}\n")
     return hist.to_numpy()[0].tolist(), extract_error(hist)
 
 

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -49,11 +49,12 @@ def import_root_histogram(rootdir, filename, path, name, filecache=None):
     try:
         hist = f[name]
     except (KeyError, uproot.deserialization.DeserializationError):
+        key = "/".join([path, name])
         try:
-            hist = f[str(Path(path).joinpath(name))]
+            hist = f[key]
         except KeyError:
             raise KeyError(
-                f'Both {name} and {Path(path).joinpath(name)} were tried and not found in {Path(rootdir).joinpath(filename)}'
+                f'Both {name} and {key} were tried and not found in {fullpath}'
             )
     return hist.to_numpy()[0].tolist(), extract_error(hist)
 

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -5,10 +5,10 @@ import shutil
 import pkg_resources
 import xml.etree.cElementTree as ET
 import numpy as np
-import uproot3
-from uproot3_methods.classes import TH1
 
 # TODO: Move to uproot4 when ROOT file writing is supported
+import uproot3 as uproot
+from uproot3_methods.classes import TH1
 
 from .mixins import _ChannelSummaryMixin
 
@@ -271,7 +271,7 @@ def writexml(spec, specdir, data_rootdir, resultprefix):
         "Combination", OutputFilePrefix=str(Path(specdir).joinpath(resultprefix))
     )
 
-    with uproot3.recreate(
+    with uproot.recreate(
         str(Path(data_rootdir).joinpath('data.root'))
     ) as _ROOT_DATA_FILE:
         for channelspec in spec['channels']:

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -32,12 +32,12 @@ def _make_hist_name(channel, sample, modifier='', prefix='hist', suffix=''):
 
 
 def _export_root_histogram(histname, data):
-    h = TH1((np.asarray(data), np.arange(len(data) + 1)))
-    h._fName = histname
-    # NB: uproot crashes for some reason, figure out why later
+    hist = TH1((np.asarray(data), np.arange(len(data) + 1)))
+    hist._fName = histname
+    # FIXME: uproot crashes for some reason, figure out why later
     # if histname in _ROOT_DATA_FILE:
     #    raise KeyError(f'Duplicate key {histname} being written.')
-    _ROOT_DATA_FILE[histname] = h
+    _ROOT_DATA_FILE[histname] = hist
 
 
 # https://stackoverflow.com/a/4590052

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -6,7 +6,7 @@ import pkg_resources
 import xml.etree.cElementTree as ET
 import numpy as np
 import uproot3
-from uproot_methods.classes import TH1
+from uproot3_methods.classes import TH1
 
 # TODO: Move to uproot4 when ROOT file writing is supported
 

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -5,7 +5,7 @@ import shutil
 import pkg_resources
 import xml.etree.cElementTree as ET
 import numpy as np
-import uproot as uproot3
+import uproot3
 from uproot_methods.classes import TH1
 
 # TODO: Move to uproot4 when ROOT file writing is supported

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -5,7 +5,7 @@ import shutil
 import pkg_resources
 import xml.etree.cElementTree as ET
 import numpy as np
-import uproot3 as uproot
+import uproot4 as uproot
 from uproot3_methods.classes import TH1
 
 from .mixins import _ChannelSummaryMixin

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -6,7 +6,7 @@ import pkg_resources
 import xml.etree.cElementTree as ET
 import numpy as np
 import uproot4 as uproot
-from uproot3_methods.classes import TH1
+from uproot4.behaviors.TH1 import TH1
 
 from .mixins import _ChannelSummaryMixin
 
@@ -32,7 +32,7 @@ def _make_hist_name(channel, sample, modifier='', prefix='hist', suffix=''):
 
 
 def _export_root_histogram(histname, data):
-    h = TH1.from_numpy((np.asarray(data), np.arange(len(data) + 1)))
+    h = TH1((np.asarray(data), np.arange(len(data) + 1)))
     h._fName = histname
     # NB: uproot crashes for some reason, figure out why later
     # if histname in _ROOT_DATA_FILE:

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -5,8 +5,10 @@ import shutil
 import pkg_resources
 import xml.etree.cElementTree as ET
 import numpy as np
-import uproot4 as uproot
-from uproot4.behaviors.TH1 import TH1
+import uproot as uproot3
+from uproot_methods.classes import TH1
+
+# TODO: Move to uproot4 when ROOT file writing is supported
 
 from .mixins import _ChannelSummaryMixin
 
@@ -32,9 +34,9 @@ def _make_hist_name(channel, sample, modifier='', prefix='hist', suffix=''):
 
 
 def _export_root_histogram(histname, data):
-    hist = TH1((np.asarray(data), np.arange(len(data) + 1)))
+    hist = TH1.from_numpy((np.asarray(data), np.arange(len(data) + 1)))
     hist._fName = histname
-    # FIXME: uproot crashes for some reason, figure out why later
+    # FIXME: uproot3 crashes for some reason, figure out why later
     # if histname in _ROOT_DATA_FILE:
     #    raise KeyError(f'Duplicate key {histname} being written.')
     _ROOT_DATA_FILE[histname] = hist
@@ -270,7 +272,7 @@ def writexml(spec, specdir, data_rootdir, resultprefix):
         "Combination", OutputFilePrefix=str(Path(specdir).joinpath(resultprefix))
     )
 
-    with uproot.recreate(
+    with uproot3.recreate(
         str(Path(data_rootdir).joinpath('data.root'))
     ) as _ROOT_DATA_FILE:
         for channelspec in spec['channels']:

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -36,9 +36,8 @@ def _make_hist_name(channel, sample, modifier='', prefix='hist', suffix=''):
 def _export_root_histogram(histname, data):
     hist = TH1.from_numpy((np.asarray(data), np.arange(len(data) + 1)))
     hist._fName = histname
-    # FIXME: uproot3 crashes for some reason, figure out why later
-    # if histname in _ROOT_DATA_FILE:
-    #    raise KeyError(f'Duplicate key {histname} being written.')
+    if histname in _ROOT_DATA_FILE:
+        raise KeyError(f"Duplicate key {histname} being written.")
     _ROOT_DATA_FILE[histname] = hist
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -392,6 +392,14 @@ def test_export_data(mocker):
     assert pyhf.writexml._ROOT_DATA_FILE.__setitem__.called
 
 
+def test_export_duplicate_hist_name(mocker):
+    mocker.patch('pyhf.writexml._ROOT_DATA_FILE', new={'duplicate_name': True})
+    mocker.patch.object(pyhf.writexml, 'TH1')
+
+    with pytest.raises(KeyError):
+        pyhf.writexml._export_root_histogram('duplicate_name', [0, 1, 2])
+
+
 def test_integer_data(datadir, mocker):
     """
     Test that a spec with only integer data will be written correctly

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -113,7 +113,7 @@ def test_import_histogram():
         "validation/xmlimport_input/data", "example.root", "", "data"
     )
     assert data == [122.0, 112.0]
-    assert uncert == [11.045361017187261, 10.583005244258363]
+    assert uncert == [11.045360565185547, 10.58300495147705]
 
 
 def test_import_histogram_KeyError():

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,7 +1,7 @@
 import pyhf
 import pyhf.readxml
 import numpy as np
-import uproot4 as uproot
+import uproot
 from pathlib import Path
 import pytest
 import xml.etree.cElementTree as ET

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,7 +1,7 @@
 import pyhf
 import pyhf.readxml
 import numpy as np
-import uproot3 as uproot
+import uproot4 as uproot
 from pathlib import Path
 import pytest
 import xml.etree.cElementTree as ET


### PR DESCRIPTION
# Description

Following PR #930 and the release of `v0.5.0`, this PR now moves to adopting `uproot4` and its API.

As of [`uproot4` `v4.0.0`](https://github.com/scikit-hep/uproot4/releases/tag/4.0.0) `uproot4` does not support the ability to write to ROOT files, so `uproot3` must still be retained to write to ROOT. This is the only remaining requirement for `uproot3` and so the move to the `uproot4` API can begin now.

As `uproot4` is also added to the HEAD of dependnecies workflow, the pattern of

```
import uproot
```

is used instead of

```
import uproot4 as uproot
```

as installing `uproot4` from GitHub installs under the `uproot` namespace. So to test the HEAD of `uproot4`, the `uproot` namespace must be used now instead of waiting to drop `uproot3`.


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Require uproot4 in the xmlio extra
   - Require release compatible with uproot v4.X series 
* Adopt the uproot4 v4.0 API
   - uproot3 still needed for writing ROOT files
* Add uproot4 to the HEAD of dependencies workflow
   - import uproot namespace everywhere uproot4 is used to allow for testing of uproot4 HEAD
```
