### PR TITLE
feat: Add cdf method to AsymptoticTestStatDistribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup
 extras_require = {
     'shellcomplete': ['click_completion'],
     'tensorflow': [
-        'tensorflow~=2.0',
-        'tensorflow-probability~=0.10',  # TODO: Temp patch until tfp v0.11
+        'tensorflow~=2.2.0',  # TensorFlow minor releases are as volatile as major
+        'tensorflow-probability~=0.10.0',
     ],
     'torch': ['torch~=1.2'],
     'jax': ['jax~=0.1,>0.1.51', 'jaxlib~=0.1,>0.1.33'],

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -61,13 +61,13 @@ class AsymptoticTestStatDistribution(object):
 
     def cdf(self, value):
         """
-        Compute the value of the cumulative distribution funcation for a given value of the test statistic.
+        Compute the value of the cumulative distribution function for a given value of the test statistic.
 
         Args:
             value (`float`): The test statistic value.
 
         Returns:
-            Float: The integrated probability to observe a test statistic less than or equal to the observed ``value``.
+            probability (`float`): The integrated probability to observe a test statistic less than or equal to the observed ``value``.
 
         """
         tensorlib, _ = get_backend()

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -67,7 +67,7 @@ class AsymptoticTestStatDistribution(object):
             value (`float`): The test statistic value.
 
         Returns:
-            Float: The integrated probability to observe  value at up to the observed one.
+            Float: The integrated probability to observe a test statistic less than or equal to the observed ``value``.
 
         """
         tensorlib, _ = get_backend()

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -59,6 +59,20 @@ class AsymptoticTestStatDistribution(object):
         self.shift = shift
         self.sqrtqmuA_v = None
 
+    def cdf(self, value):
+        """
+        Compute the value of the cumulative distribution funcation for a given value of the test statistic.
+
+        Args:
+            value (`float`): The test statistic value.
+
+        Returns:
+            Float: The integrated probability to observe  value at up to the observed one.
+
+        """
+        tensorlib, _ = get_backend()
+        return tensorlib.normal_cdf((value - self.shift))
+
     def pvalue(self, value):
         """
         Compute the :math:`p`-value for a given value of the test statistic.

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -2,6 +2,6 @@ import pyhf
 import pyhf.infer.calculators
 
 
-def test_calc_distr():
-    a = pyhf.infer.calculators.AsymptoticTestStatDistribution(0.0)
-    assert a.pvalue(1) == a.cdf(-1)
+def test_calc_dist():
+    asymptotic_dist = pyhf.infer.calculators.AsymptoticTestStatDistribution(0.0)
+    assert asymptotic_dist.pvalue(1) == asymptotic_dist.cdf(-1)

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1,0 +1,6 @@
+import pyhf
+import pyhf.infer.calculators
+
+def test_calc_distr():
+    a = pyhf.infer.calculators.AsymptoticTestStatDistribution(0.0)    
+    assert a.pvalue(1) == a.cdf(-1)

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -4,4 +4,4 @@ import pyhf.infer.calculators
 
 def test_calc_dist():
     asymptotic_dist = pyhf.infer.calculators.AsymptoticTestStatDistribution(0.0)
-    assert asymptotic_dist.pvalue(1) == asymptotic_dist.cdf(-1)
+    assert asymptotic_dist.pvalue(-1) == 1 - asymptotic_dist.cdf(-1)

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1,6 +1,7 @@
 import pyhf
 import pyhf.infer.calculators
 
+
 def test_calc_distr():
-    a = pyhf.infer.calculators.AsymptoticTestStatDistribution(0.0)    
+    a = pyhf.infer.calculators.AsymptoticTestStatDistribution(0.0)
     assert a.pvalue(1) == a.cdf(-1)


### PR DESCRIPTION
# Description

This adds a cdf method to the asymptotic distribution. This will be useful for two-sided tests. c.f. discussion in PR #966.

ReadTheDocs build: https://pyhf.readthedocs.io/en/asymptotic_cdf

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add cumulative distribution function method to AsymptoticTestStatDistribution
* Add tests for test stat distribution calculators
```