### PR TITLE
docs: Match docstring style format

### DIFF
--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -67,7 +67,7 @@ class AsymptoticTestStatDistribution(object):
             value (`float`): The test statistic value.
 
         Returns:
-            probability (`float`): The integrated probability to observe a test statistic less than or equal to the observed ``value``.
+            Float: The integrated probability to observe a test statistic less than or equal to the observed ``value``.
 
         """
         tensorlib, _ = get_backend()


### PR DESCRIPTION
# Description

Amends PR #1010. The return type is rendered on the left hand side of the colon, so the style is different from the function arguments.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Correct return type format
   - Amends PR #1010
```
