### PR TITLE
feat: Add developer tools helper scripts

### DIFF
--- a/.github/workflows/dev-tools.yml
+++ b/.github/workflows/dev-tools.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dev-tools
       run: |
         bash dev_tools/install-devtools.sh
-        ls -lhtra /usr/local/bin/
+        ls -lhtra "$(dirname $(command -v doctest-on))"
     - name: Test doctest-on
       run: |
         doctest-on src/pyhf/infer/test_statistics.py

--- a/.github/workflows/dev-tools.yml
+++ b/.github/workflows/dev-tools.yml
@@ -1,0 +1,34 @@
+name: dev-tools
+
+on:
+  pull_request:
+
+jobs:
+  test:
+
+    name: Check dev-tools
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .
+        python -m pip list
+    - name: Lint with shellcheck
+      run: |
+        shellcheck dev_tools/*.sh
+    - name: Install dev-tools
+      run: |
+        echo $PATH
+        ls -lhtra /usr/local/
+        bash dev_tools/install-devtools.sh
+    - name: Test doctest-on
+      run: |
+        doctest-on src/pyhf/infer/test_statistics.py
+        doctest-on pyhf.infer.test_statistics

--- a/.github/workflows/dev-tools.yml
+++ b/.github/workflows/dev-tools.yml
@@ -25,9 +25,8 @@ jobs:
         shellcheck dev_tools/*.sh
     - name: Install dev-tools
       run: |
-        echo $PATH
-        ls -lhtra /usr/local/
         bash dev_tools/install-devtools.sh
+        ls -lhtra /usr/local/bin/
     - name: Test doctest-on
       run: |
         doctest-on src/pyhf/infer/test_statistics.py

--- a/dev_tools/doctest-on.sh
+++ b/dev_tools/doctest-on.sh
@@ -22,8 +22,6 @@ function main() {
   source_path="${1}"
   module_path="$(path_to_module "${source_path}")"
   python -c "import doctest; import pyhf; doctest.testmod(${module_path})"
-  # Write check for this. Be optimistic now
-  echo "# doctest succeeded!"
 }
 
 main "$@" || exit 1

--- a/dev_tools/doctest-on.sh
+++ b/dev_tools/doctest-on.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+function path_to_module() {
+  #1: source path
+  local source_path
+  source_path="${1}"
+  if [[ ${source_path: -3} == ".py" ]]; then
+    source_path="${source_path::-3}"
+    if [[ ${source_path:0:4} == "src/" ]]; then
+      source_path="${source_path:4}"
+      # Replace "/" with "."
+      source_path="${source_path////.}"
+    fi
+  fi
+  echo "${source_path}"
+}
+
+function main() {
+  #1: python module to run doctest on
+  local source_path
+  local module_path
+  source_path="${1}"
+  module_path="$(path_to_module "${source_path}")"
+  python -c "import doctest; import pyhf; doctest.testmod(${module_path})"
+}
+
+main "$@" || exit 1

--- a/dev_tools/doctest-on.sh
+++ b/dev_tools/doctest-on.sh
@@ -22,6 +22,8 @@ function main() {
   source_path="${1}"
   module_path="$(path_to_module "${source_path}")"
   python -c "import doctest; import pyhf; doctest.testmod(${module_path})"
+  # Write check for this. Be optimistic now
+  echo "# doctest succeeded!"
 }
 
 main "$@" || exit 1

--- a/dev_tools/install-devtools.sh
+++ b/dev_tools/install-devtools.sh
@@ -28,8 +28,8 @@ function cp_to_bin() {
   source_path="${1}"
   path_to_bin="${2}"
   target_path="${path_to_bin}/$(strip_file_extension "${source_path}")"
-  sudo cp "${source_path}" "${target_path}"
-  sudo chmod +x "${target_path}"
+  cp "${source_path}" "${target_path}"
+  chmod +x "${target_path}"
 }
 
 function main() {

--- a/dev_tools/install-devtools.sh
+++ b/dev_tools/install-devtools.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+function python_bin_path {
+  local python_runtime_path
+  local strip_out_string
+  local python_bin_path
+  python_runtime_path="$(command -v python3)"
+  strip_out_string="${python_runtime_path##*/}"
+  python_bin_path="${python_runtime_path::-${#strip_out_string}}"
+  echo "${python_bin_path}"
+}
+
 function strip_file_extension() {
   #1: file path
   # assumes there is a "/" in argument
@@ -25,8 +35,9 @@ function cp_to_bin() {
 }
 
 function main() {
-  #1: (optional) full path to bin directory. Default: /usr/local/bin
-  local path_to_bin="/usr/local/bin"
+  #1: (optional) full path to bin directory. Default: virtual environment bin
+  # local path_to_bin="/usr/local/bin"
+  local path_to_bin="$(python_bin_path)"
   cp_to_bin dev_tools/doctest-on.sh "${path_to_bin}"
 
   # test install

--- a/dev_tools/install-devtools.sh
+++ b/dev_tools/install-devtools.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+function strip_file_extension() {
+  #1: file path
+  # assumes there is a "/" in argument
+  local file_path
+  local file_name
+  file_path="${1}"
+  file_name="${file_path##*/}"
+  # strip out file extension
+  echo "${file_name%.*}"
+}
+
+function cp_to_bin() {
+  #1: path to source file
+  #2: path to target bin
+  local source_path
+  local path_to_bin
+  local target_path
+  source_path="${1}"
+  path_to_bin="${2}"
+  target_path="${path_to_bin}/$(strip_file_extension "${source_path}")"
+  sudo cp "${source_path}" "${target_path}"
+  sudo chmod +x "${target_path}"
+}
+
+function main() {
+  #1: (optional) full path to bin directory. Default: /usr/local/bin
+  local path_to_bin="/usr/local/bin"
+  cp_to_bin dev_tools/doctest-on.sh "${path_to_bin}"
+
+  # test install
+  command -v doctest-on
+}
+
+main "$@" || exit 1

--- a/dev_tools/install-devtools.sh
+++ b/dev_tools/install-devtools.sh
@@ -2,11 +2,9 @@
 
 function python_bin_path {
   local python_runtime_path
-  local strip_out_string
-  local python_bin_path
   python_runtime_path="$(command -v python3)"
-  strip_out_string="${python_runtime_path##*/}"
-  python_bin_path="${python_runtime_path::-${#strip_out_string}}"
+  local strip_out_string="${python_runtime_path##*/}"
+  local python_bin_path="${python_runtime_path::-${#strip_out_string}}"
   echo "${python_bin_path}"
 }
 
@@ -37,7 +35,8 @@ function cp_to_bin() {
 function main() {
   #1: (optional) full path to bin directory. Default: virtual environment bin
   # local path_to_bin="/usr/local/bin"
-  local path_to_bin="$(python_bin_path)"
+  local path_to_bin
+  path_to_bin="$(python_bin_path)"
   cp_to_bin dev_tools/doctest-on.sh "${path_to_bin}"
 
   # test install


### PR DESCRIPTION
# Description

Add some helper scripts for core devs to debug with

```
# doctest-on.sh has parity between source paths and imports
$ pwd
/home/feickert/Code/GitHub/pyhf
$ bash dev_tools/doctest-on.sh src/pyhf/infer/test_statistics.py 
/home/feickert/Code/GitHub/pyhf/src/pyhf/tensor/numpy_backend.py:271: RuntimeWarning: invalid value encountered in log
  return n * np.log(lam) - lam - gammaln(n + 1.0)
$ bash dev_tools/doctest-on.sh pyhf.infer.test_statistics
/home/feickert/Code/GitHub/pyhf/src/pyhf/tensor/numpy_backend.py:271: RuntimeWarning: invalid value encountered in log
  return n * np.log(lam) - lam - gammaln(n + 1.0)
```

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
- [ ] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR
