### PR TITLE
docs: Add citation in Higgs boson potential at colliders paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,16 +1,3 @@
-@inproceedings{DiMicco:2019ngk,
-    author = "Alison, J. and others",
-    editor = "Di Micco, B. and Gouzevitch, M. and Mazzitelli, J. and Vernieri, C.",
-    title = "{Higgs Boson Pair Production at Colliders: Status and Perspectives}",
-    booktitle = "{Double Higgs Production at Colliders}",
-    eprint = "1910.00012",
-    archivePrefix = "arXiv",
-    primaryClass = "hep-ph",
-    reportNumber = "FERMILAB-CONF-19-468-E-T, LHCXSWG-2019-005",
-    month = "9",
-    year = "2019"
-}
-
 @article{Abdallah:2020pec,
       author         = "Abdallah, Waleed and others",
       title          = "{Reinterpretation of LHC Results for New Physics: Status
@@ -36,6 +23,19 @@
       archivePrefix  = "arXiv",
       primaryClass   = "hep-ph",
       SLACcitation   = "%%CITATION = ARXIV:2002.12220;%%"
+}
+
+@inproceedings{DiMicco:2019ngk,
+    author = "Alison, J. and others",
+    editor = "Di Micco, B. and Gouzevitch, M. and Mazzitelli, J. and Vernieri, C.",
+    title = "{Higgs Boson Pair Production at Colliders: Status and Perspectives}",
+    booktitle = "{Double Higgs Production at Colliders}",
+    eprint = "1910.00012",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "FERMILAB-CONF-19-468-E-T, LHCXSWG-2019-005",
+    month = "9",
+    year = "2019"
 }
 
 @booklet{ATL-PHYS-PUB-2019-029,

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,16 @@
+@inproceedings{DiMicco:2019ngk,
+    author = "Alison, J. and others",
+    editor = "Di Micco, B. and Gouzevitch, M. and Mazzitelli, J. and Vernieri, C.",
+    title = "{Higgs Boson Pair Production at Colliders: Status and Perspectives}",
+    booktitle = "{Double Higgs Production at Colliders}",
+    eprint = "1910.00012",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "FERMILAB-CONF-19-468-E-T, LHCXSWG-2019-005",
+    month = "9",
+    year = "2019"
+}
+
 @article{Abdallah:2020pec,
       author         = "Abdallah, Waleed and others",
       title          = "{Reinterpretation of LHC Results for New Physics: Status


### PR DESCRIPTION
# Description

Add the citation of `pyhf` in [_Higgs boson potential at colliders: status and perspectives_](https://inspirehep.net/literature/1757043). The citation is currently incorrect, but it should still be listed.

Thanks to @mswiatlo and @msneubauer for bringing this to our attention through some emails chains. :)

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-add-higgs-boson-potential-paper/citations.html#use-in-publications

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add citation in "Higgs boson potential at colliders: status and perspectives" paper
   - c.f. https://inspirehep.net/literature/1757043
```