### PR TITLE
docs: Add NSF award badge for Throughput project tracking

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@
 pure-python fitting/limit-setting/interval estimation HistFactory-style
 =======================================================================
 
-|GitHub Project| |DOI| |Scikit-HEP|
+|GitHub Project| |DOI| |Scikit-HEP| |NSF Award Number|
 
 |GitHub Actions Status: CI| |GitHub Actions Status: Publish| |Docker
 Automated| |Code Coverage| |Language grade: Python| |CodeFactor| |Code

--- a/README.rst
+++ b/README.rst
@@ -249,6 +249,8 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
    :target: https://doi.org/10.5281/zenodo.1169739
 .. |Scikit-HEP| image:: https://scikit-hep.org/assets/images/Scikit--HEP-Project-blue.svg
    :target: https://scikit-hep.org/
+.. |NSF Award Number| image:: https://img.shields.io/badge/NSF-1836650-blue.svg
+   :target: https://nsf.gov/awardsearch/showAward?AWD_ID=1836650
 .. |GitHub Actions Status: CI| image:: https://github.com/scikit-hep/pyhf/workflows/CI/CD/badge.svg
    :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3ACI%2FCD+branch%3Amaster
 .. |GitHub Actions Status: Publish| image:: https://github.com/scikit-hep/pyhf/workflows/publish%20distributions/badge.svg


### PR DESCRIPTION
# Description

To help the [Throughput project](http://throughputdb.com/) track NSF funded software projects add a badge with the IRIS-HEP NSF award number to the `README`

[![NSF-1836650](https://img.shields.io/badge/NSF-1836650-blue.svg)](https://nsf.gov/awardsearch/showAward?AWD_ID=1836650)

as requested by @SimonGoring [on Twitter](https://twitter.com/sjGoring/status/1291452923612762112?s=20).

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-add-nsf-badge

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add IRIS-HEP NSF award number badge to README
   - Helps Throughput project with tracking (http://throughputdb.com/)
```
