### PR TITLE
fix: Tensorflow tile tensor backend feature parity

### DIFF
--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -75,7 +75,16 @@ class tensorflow_backend(object):
             TensorFlow Tensor: The tensor with repeated axes
 
         """
-        return tf.tile(tensor_in, repeats)
+        try:
+            return tf.tile(tensor_in, repeats)
+        except tf.python.framework.errors_impl.InvalidArgumentError:
+            diff = len(repeats) - len(tf.shape(tensor_in))
+            if diff < 0:
+                raise
+            return tf.tile(
+                tf.reshape(tensor_in, [1] * diff + tf.shape([10, 20]).numpy().tolist()),
+                repeats,
+            )
 
     def conditional(self, predicate, true_callable, false_callable):
         """

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -82,7 +82,7 @@ class tensorflow_backend(object):
             diff = len(repeats) - len(shape)
             if diff < 0:
                 raise
-            return tf.tile(tf.reshape(tensor_in, [1] * diff + shape), repeats,)
+            return tf.tile(tf.reshape(tensor_in, [1] * diff + shape), repeats)
 
     def conditional(self, predicate, true_callable, false_callable):
         """

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -78,13 +78,11 @@ class tensorflow_backend(object):
         try:
             return tf.tile(tensor_in, repeats)
         except tf.python.framework.errors_impl.InvalidArgumentError:
-            diff = len(repeats) - len(tf.shape(tensor_in))
+            shape = tf.shape(tensor_in).numpy().tolist()
+            diff = len(repeats) - len(shape)
             if diff < 0:
                 raise
-            return tf.tile(
-                tf.reshape(tensor_in, [1] * diff + tf.shape([10, 20]).numpy().tolist()),
-                repeats,
-            )
+            return tf.tile(tf.reshape(tensor_in, [1] * diff + shape), repeats,)
 
     def conditional(self, predicate, true_callable, false_callable):
         """

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -240,9 +240,9 @@ def test_tensor_tile(backend):
     a = [10, 20]
     tb = pyhf.tensorlib
     assert tb.tolist(tb.tile(tb.astensor(a), (2, 1))) == [[10, 20], [10, 20]]
-    assert tb.tolist(tb.tile(tb.astensor(a), (2, 1, 2))) == [
-        [[10.0, 20.0, 10.0, 20.0]],
-        [[10.0, 20.0, 10.0, 20.0]],
+    assert tb.tolist(tb.tile(tb.astensor(a), (2, 1, 3))) == [
+        [[10.0, 20.0, 10.0, 20.0, 10.0, 20.0]],
+        [[10.0, 20.0, 10.0, 20.0, 10.0, 20.0]],
     ]
 
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -237,6 +237,14 @@ def test_tensor_tile(backend):
     tb = pyhf.tensorlib
     assert tb.tolist(tb.tile(tb.astensor(a), (2,))) == [1, 2, 3, 1, 2, 3]
 
+    a = [10, 20]
+    tb = pyhf.tensorlib
+    assert tb.tolist(tb.tile(tb.astensor(a), (2, 1))) == [[10, 20], [10, 20]]
+    assert tb.tolist(tb.tile(tb.astensor(a), (2, 1, 2))) == [
+        [[10.0, 20.0, 10.0, 20.0]],
+        [[10.0, 20.0, 10.0, 20.0]],
+    ]
+
 
 def test_1D_gather(backend):
     tb = pyhf.tensorlib

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -234,11 +234,9 @@ def test_tensor_tile(backend):
     assert tb.tolist(tb.tile(tb.astensor(a), (1, 2))) == [[1, 1], [2, 2], [3, 3]]
 
     a = [1, 2, 3]
-    tb = pyhf.tensorlib
     assert tb.tolist(tb.tile(tb.astensor(a), (2,))) == [1, 2, 3, 1, 2, 3]
 
     a = [10, 20]
-    tb = pyhf.tensorlib
     assert tb.tolist(tb.tile(tb.astensor(a), (2, 1))) == [[10, 20], [10, 20]]
     assert tb.tolist(tb.tile(tb.astensor(a), (2, 1, 3))) == [
         [[10.0, 20.0, 10.0, 20.0, 10.0, 20.0]],

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -243,6 +243,10 @@ def test_tensor_tile(backend):
         [[10.0, 20.0, 10.0, 20.0, 10.0, 20.0]],
     ]
 
+    if tb.name == 'tensorflow':
+        with pytest.raises(tf.python.framework.errors_impl.InvalidArgumentError):
+            tb.tile(tb.astensor([[[10, 20, 30]]]), (2, 1))
+
 
 def test_1D_gather(backend):
     tb = pyhf.tensorlib


### PR DESCRIPTION
# Description

Resolves #1025 

Implements a workaround solution for tensorflow/tensorflow#42332. Essentially, tensorflow's `tile` should technically work when the repeats has more dimensions than the input tensor (works in numpy, torch, jax). Make this possible by using `tf.reshape` to add in extra dimensions to the front.

Needed by #731.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add support to tensorlib.tile for tensorflow for repeats with more dimensions than the input tensor
* Add test for new behaviour
```