### PR TITLE
fix: Weakly reference callables for pub-sub model

### DIFF
--- a/src/pyhf/events.py
+++ b/src/pyhf/events.py
@@ -1,3 +1,5 @@
+import weakref
+
 __events = {}
 __disabled_events = set([])
 
@@ -6,10 +8,18 @@ def noop(*args, **kwargs):
     pass
 
 
-class Callables(list):
+class WeakList(list):
+    def append(self, item):
+        list.append(self, weakref.WeakMethod(item, self.remove))
+
+
+class Callables(WeakList):
     def __call__(self, *args, **kwargs):
-        for f in self:
-            f(*args, **kwargs)
+        for func in self:
+            if isinstance(func, weakref.WeakMethod):
+                func()(*args, **kwargs)
+            else:
+                f(*args, **kwargs)
 
     def __repr__(self):
         return "Callables(%s)" % list.__repr__(self)

--- a/src/pyhf/events.py
+++ b/src/pyhf/events.py
@@ -19,7 +19,7 @@ class Callables(WeakList):
             if isinstance(func, weakref.WeakMethod):
                 func()(*args, **kwargs)
             else:
-                f(*args, **kwargs)
+                func(*args, **kwargs)
 
     def __repr__(self):
         return "Callables(%s)" % list.__repr__(self)

--- a/src/pyhf/events.py
+++ b/src/pyhf/events.py
@@ -16,10 +16,8 @@ class WeakList(list):
 class Callables(WeakList):
     def __call__(self, *args, **kwargs):
         for func in self:
-            if isinstance(func, weakref.WeakMethod):
-                func()(*args, **kwargs)
-            else:
-                func(*args, **kwargs)
+            # weakref: needs to be de-ref'd first before calling
+            func()(*args, **kwargs)
 
     def __repr__(self):
         return "Callables(%s)" % list.__repr__(self)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -6,10 +6,10 @@ def test_subscribe_event():
     ename = 'test'
 
     m = mock.Mock()
-    events.subscribe(ename)(m)
+    events.subscribe(ename)(m.__call__)
 
     assert ename in events.__events
-    assert m in events.__events.get(ename)
+    assert m.__call__ == events.__events.get(ename)[0]()
     del events.__events[ename]
 
 
@@ -17,10 +17,22 @@ def test_event():
     ename = 'test'
 
     m = mock.Mock()
-    events.subscribe(ename)(m)
+    events.subscribe(ename)(m.__call__)
 
     events.trigger(ename)()
     m.assert_called_once()
+    del events.__events[ename]
+
+
+def test_event_weakref():
+    ename = 'test'
+
+    m = mock.Mock()
+    events.subscribe(ename)(m.__call__)
+    assert len(events.trigger(ename)) == 1
+    # should be weakly referenced
+    del m
+    assert len(events.trigger(ename)) == 0
     del events.__events[ename]
 
 
@@ -30,7 +42,7 @@ def test_disable_event():
     m = mock.Mock()
     noop, noop_m = events.noop, mock.Mock()
     events.noop = noop_m
-    events.subscribe(ename)(m)
+    events.subscribe(ename)(m.__call__)
 
     events.disable(ename)
     assert m.called is False

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -429,7 +429,7 @@ def test_trigger_tensorlib_changed_name(mocker):
     pyhf.set_backend(numpy_64)
 
     func = mocker.Mock()
-    pyhf.events.subscribe('tensorlib_changed')(func)
+    pyhf.events.subscribe('tensorlib_changed')(func.__call__)
 
     assert func.call_count == 0
     pyhf.set_backend(jax_64)
@@ -443,7 +443,7 @@ def test_trigger_tensorlib_changed_precision(mocker):
     pyhf.set_backend(jax_64)
 
     func = mocker.Mock()
-    pyhf.events.subscribe('tensorlib_changed')(func)
+    pyhf.events.subscribe('tensorlib_changed')(func.__call__)
 
     assert func.call_count == 0
     pyhf.set_backend(jax_32)


### PR DESCRIPTION
# Description

(See this nice answer for other libs: https://stackoverflow.com/a/16192256/1532974)

Fix a source of memory leaks observed by SModelS developers reported in #934, #620. This leak occurs because even though certain objects go out of scope - garbage-collect in python isn't invoked because we kept rather strong references to the bound methods of these objects. Instead, use [`weakref.WeakMethod`](https://docs.python.org/3/library/weakref.html#weakref.WeakMethod) to keep weaker references that are auto-removed from events if the objects owning those methods go out of scope (allowing python's garbage collect to actually.. collect garbage).

This was not so easy to track down, so I thank @lukasheinrich for narrowing it down a lot more with a simple MWE and his latest theory.


```python
    a = pyhf.tensorlib.astensor([0.0])
    for _ in range(10000):
        _TensorViewer([a], names=['hello'], batch_size=None)
        test = pyhf.tensorlib.astensor([1]*100000)
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Fix memory leaks seen when creating many objects that use pub-sub events API
* Store weaker references to bound methods/callables in the events API
```