### PR TITLE
fix: Tensor conversion for expected aux and actual data

### DIFF
--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -609,6 +609,8 @@ class Model(object):
             Tensor: The expected data of the auxiliary pdf
 
         """
+        tensorlib, _ = get_backend()
+        pars = tensorlib.astensor(pars)
         return self.make_pdf(pars)[1].expected_data()
 
     def _modifications(self, pars):
@@ -630,6 +632,8 @@ class Model(object):
             Tensor: The expected data of the main model (no auxiliary data)
 
         """
+        tensorlib, _ = get_backend()
+        pars = tensorlib.astensor(pars)
         return self.make_pdf(pars)[0].expected_data()
 
     def expected_data(self, pars, include_auxdata=True):

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -133,7 +133,6 @@ def test_pdf_basicapi_tests(backend):
         [60.0, 51.020408630], 1e-08
     )
 
-    # issue #1027
     assert tensorlib.tolist(pdf.expected_actualdata(pars)) == pytest.approx(
         [60.0], 1e-08
     )

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -133,6 +133,14 @@ def test_pdf_basicapi_tests(backend):
         [60.0, 51.020408630], 1e-08
     )
 
+    # issue #1027
+    assert tensorlib.tolist(pdf.expected_actualdata(pars)) == pytest.approx(
+        [60.0], 1e-08
+    )
+    assert tensorlib.tolist(pdf.expected_auxdata(pars)) == pytest.approx(
+        [51.020408630], 1e-08
+    )
+
     pdf = pyhf.simplemodels.hepdata_like(
         source['bindata']['sig'],
         source['bindata']['bkg'],


### PR DESCRIPTION
# Description

This resolves #1027.

Both `pyhf.pdf.Model.expected_actualdata` and `pyhf.pdf.Model.expected_auxdata` only take tensors as arguments, while `pyhf.pdf.Model.expected_data` converts its arguments to the appropriate tensor format. This PR adds the conversion also to `expected_actualdata` and `expected_auxdata`.

This enables running the following:
```python
import pyhf

model = pyhf.simplemodels.hepdata_like(
    signal_data=[12.0, 11.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0]
)

model.expected_data(model.config.suggested_init())
model.expected_actualdata(model.config.suggested_init())
model.expected_auxdata(model.config.suggested_init())
```

Also adding a test for the behavior that would fail on the current master branch.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Make args of Model.expected_actualdata and Model.expected_auxdata tensors
   - Gives parity with Model.expected_data
* Add tests for Model object interaction with own API
```