### PR TITLE
fix: Make pyhf.Workspace.combine return CLs instead of Workspace

### DIFF
--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -675,4 +675,4 @@ class Workspace(_ChannelSummaryMixin, dict):
             'observations': new_observations,
             'version': new_version,
         }
-        return Workspace(newspec)
+        return cls(newspec)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -717,3 +717,32 @@ def test_workspace_equality(workspace_factory):
     assert ws == ws
     assert ws == ws_other
     assert ws != 'not a workspace'
+
+
+def test_workspace_inheritance(workspace_factory):
+    ws = workspace_factory()
+    new_ws = ws.rename(
+        channels={'channel1': 'channel3', 'channel2': 'channel4'},
+        samples={
+            'background1': 'background3',
+            'background2': 'background4',
+            'signal': 'signal2',
+        },
+        modifiers={
+            'syst1': 'syst4',
+            'bkg1Shape': 'bkg3Shape',
+            'bkg2Shape': 'bkg4Shape',
+        },
+        measurements={
+            'GaussExample': 'OtherGaussExample',
+            'GammaExample': 'OtherGammaExample',
+            'ConstExample': 'OtherConstExample',
+            'LogNormExample': 'OtherLogNormExample',
+        },
+    )
+
+    class FooWorkspace(pyhf.Workspace):
+        pass
+
+    combined = FooWorkspace.combine(ws, new_ws)
+    assert isinstance(combined, FooWorkspace)


### PR DESCRIPTION
# Description

Resolves #1023 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Workspace.combine returns cls() instead of Workspace() allowing for others to inherit pyhf.Workspace
```