### PR TITLE
fix: Avoid deprecation warnings due to invalid escape sequences

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -17,3 +17,4 @@ Contributors include:
 - Kanishk Kalra
 - Nikolai Hartmann
 - Alexander Held
+- Karthikeyan Singaravelan

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -35,7 +35,7 @@ def generate_asimov_data(asimov_mu, data, pdf, init_pars, par_bounds, fixed_para
 
 
 class AsymptoticTestStatDistribution(object):
-    """
+    r"""
     The distribution the test statistic in the asymptotic case.
 
     Note: These distributions are in :math:`-\hat{\mu}/\sigma` space.


### PR DESCRIPTION
# Description

Fix deprecation warnings due to invalid escape sequences by using raw strings

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Fix deprecation warnings due to invalid escape sequences by using raw strings
```