### PR TITLE
fix: Step sizes for fixed parameters in minuit should be 0.0

### DIFF
--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -38,7 +38,6 @@ class minuit_optimizer(OptimizerMixin):
     ):
 
         step_sizes = [(b[1] - b[0]) / float(self.steps) for b in init_bounds]
-
         fixed_vals = fixed_vals or []
         # Minuit wants True/False for each parameter
         fixed_bools = [False] * len(init_pars)

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -38,12 +38,14 @@ class minuit_optimizer(OptimizerMixin):
     ):
 
         step_sizes = [(b[1] - b[0]) / float(self.steps) for b in init_bounds]
+
         fixed_vals = fixed_vals or []
         # Minuit wants True/False for each parameter
         fixed_bools = [False] * len(init_pars)
         for index, val in fixed_vals:
             fixed_bools[index] = True
             init_pars[index] = val
+            step_sizes[index] = 0.0
 
         # Minuit requires jac=callable
         if do_grad:

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -454,3 +454,15 @@ def test_init_pars_sync_fixed_values_minuit(mocker):
     opt._get_minimizer(None, [9, 9, 9], [(0, 10)] * 3, fixed_vals=[(0, 1)])
     assert minimizer.Minuit.from_array_func.call_args[1]['start'] == [1, 9, 9]
     assert minimizer.Minuit.from_array_func.call_args[1]['fix'] == [True, False, False]
+
+
+def test_step_sizes_fixed_parameters_minuit(mocker):
+    opt = pyhf.optimize.minuit_optimizer()
+
+    # patch all we need
+    from pyhf.optimize import opt_minuit
+
+    minimizer = mocker.patch.object(opt_minuit, 'iminuit')
+    opt._get_minimizer(None, [9, 9, 9], [(0, 10)] * 3, fixed_vals=[(0, 1)])
+    assert minimizer.Minuit.from_array_func.call_args[1]['fix'] == [True, False, False]
+    assert minimizer.Minuit.from_array_func.call_args[1]['error'] == [0.0, 0.01, 0.01]


### PR DESCRIPTION
# Description

This resolves a comment made in #1051 where step sizes were not being zero'd out correctly.

> Suggestion: For the minuit optimizer, the initial step size is set in minuit_optimizer._get_minimizer. For a fixed Gaussian-constrained nuisance parameter with default bounds [-5, 5], this is 0.01 with the default 1000 steps. This will be the parameter uncertainty reported by minuit after the fit. Given that it does not make sense to have an uncertainty for a fixed parameter, it might be nice to set the entries of step_sizes corresponding to fixed parameters to 0 instead.

_Originally posted by @alexander-held in https://github.com/scikit-hep/pyhf/pull/1051#issuecomment-687117202_

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Step sizes are set to 0.0 for fixed parameters in a fit for minuit
   - The step size acts as the uncertainty for fixed parameters
* Add test for step sizes for fixed parameters
```