### PR TITLE
docs: Add SModelS paper to citations list

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -5,7 +5,8 @@
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
     month = "9",
-    year = "2020"
+    year = "2020",
+    journal = ""
 }
 
 @article{Abdallah:2020pec,

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -7,6 +7,7 @@
     month = "9",
     year = "2020"
 }
+
 @article{Abdallah:2020pec,
       author         = "Abdallah, Waleed and others",
       title          = "{Reinterpretation of LHC Results for New Physics: Status

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -4,7 +4,7 @@
     eprint = "2009.01809",
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
-    month = "9",
+    month = "Sep",
     year = "2020",
     journal = ""
 }

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,12 @@
+@article{Alguero:2020grj,
+    author = "Alguero, Gaël and Kraml, Sabine and Waltenberger, Wolfgang",
+    title = "{A SModelS interface for pyhf likelihoods}",
+    eprint = "2009.01809",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    month = "9",
+    year = "2020"
+}
 @article{Abdallah:2020pec,
       author         = "Abdallah, Waleed and others",
       title          = "{Reinterpretation of LHC Results for New Physics: Status


### PR DESCRIPTION
# Description

Add [_A SModelS interface for pyhf likelihoods_](https://inspirehep.net/literature/1814793) by @Ga0l, @sabinekraml, and @WolfgangWaltenberger to list of papers that cite `pyhf`. :clap: to the SModelS team on both the [release of `v1.2.4`](https://github.com/SModelS/smodels/releases/tag/v1.2.4) as well as the nice paper. :rocket:

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-add-citation-from-smodels/citations.html#use-in-publications

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add SModelS paper on SModelS v1.2.4 pyhf interface and use of public likelihoods
   - c.f. https://inspirehep.net/literature/1814793
```