### PR TITLE
feat: Add fit to infer CLI API

### DIFF
--- a/src/pyhf/cli/cli.py
+++ b/src/pyhf/cli/cli.py
@@ -29,6 +29,7 @@ pyhf.add_command(spec.digest)
 pyhf.add_command(spec.sort)
 
 # pyhf.add_command(infer.cli)
+pyhf.add_command(infer.fit)
 pyhf.add_command(infer.cls)
 
 pyhf.add_command(patchset.cli)

--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -34,7 +34,12 @@ def cli():
     help="The tensor backend used for the calculation.",
     default="numpy",
 )
-@click.option("--optimizer")
+@click.option(
+    "--optimizer",
+    type=click.Choice(["scipy", "minuit"]),
+    help="The optimizer used for the calculation.",
+    default="scipy",
+)
 @click.option("--optconf", type=EqDelimStringParamType(), multiple=True)
 def fit(
     workspace,
@@ -138,7 +143,12 @@ def fit(
     help='The tensor backend used for the calculation.',
     default='numpy',
 )
-@click.option('--optimizer')
+@click.option(
+    "--optimizer",
+    type=click.Choice(["scipy", "minuit"]),
+    help="The optimizer used for the calculation.",
+    default="scipy",
+)
 @click.option('--optconf', type=EqDelimStringParamType(), multiple=True)
 def cls(
     workspace,

--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -69,9 +69,6 @@ def fit(
             "twice_nll": 23.19636590468879
         }
     """
-    with click.open_file(workspace, "r") as specstream:
-        spec = json.load(specstream)
-
     # set the backend if not NumPy
     if backend in ["pytorch", "torch"]:
         set_backend("pytorch", precision="64b")
@@ -90,8 +87,11 @@ def fit(
         )
         set_backend(tensorlib, new_optimizer(**optconf))
 
+    with click.open_file(workspace, "r") as specstream:
+        spec = json.load(specstream)
     ws = Workspace(spec)
     patches = [json.loads(click.open_file(pfile, "r").read()) for pfile in patch]
+
     model = ws.model(
         measurement_name=measurement,
         patches=patches,

--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -104,19 +104,14 @@ def fit(
 
     fit_result = mle_fit(data, model, return_fitted_val=value)
 
-    bestfit_pars = fit_result
-    if value:
-        bestfit_pars = fit_result[0]
-        bestfit_value = fit_result[-1]
-
-    parameters = {
-        k: tensorlib.tolist(bestfit_pars[v["slice"]])
-        for k, v in model.config.par_map.items()
+    _pars = fit_result if not value else fit_result[0]
+    bestfit_pars = {
+        k: tensorlib.tolist(_pars[v["slice"]]) for k, v in model.config.par_map.items()
     }
 
-    result = {"mle_parameters": parameters}
+    result = {"mle_parameters": bestfit_pars}
     if value:
-        result["twice_nll"] = tensorlib.tolist(bestfit_value)
+        result["twice_nll"] = tensorlib.tolist(fit_result[-1])
 
     if output_file is None:
         click.echo(json.dumps(result, indent=4, sort_keys=True))

--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -114,9 +114,7 @@ def fit(
         for k, v in model.config.par_map.items()
     }
 
-    result = {
-        "mle_parameters": parameters,
-    }
+    result = {"mle_parameters": parameters}
     if value:
         result["twice_nll"] = tensorlib.tolist(bestfit_value)
 

--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -110,7 +110,8 @@ def fit(
         bestfit_value = fit_result[-1]
 
     parameters = {
-        k: bestfit_pars[v["slice"]].tolist() for k, v in model.config.par_map.items()
+        k: tensorlib.tolist(bestfit_pars[v["slice"]])
+        for k, v in model.config.par_map.items()
     }
 
     result = {

--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -26,7 +26,12 @@ def cli():
     default=None,
 )
 @click.option("--measurement", default=None)
-@click.option("--value", default=False, is_flag=True)
+@click.option(
+    "--value",
+    help="Flag for returning the fitted value of the objective function.",
+    default=False,
+    is_flag=True,
+)
 @click.option("-p", "--patch", multiple=True)
 @click.option(
     "--backend",

--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -26,13 +26,13 @@ def cli():
     default=None,
 )
 @click.option("--measurement", default=None)
+@click.option("-p", "--patch", multiple=True)
 @click.option(
     "--value",
     help="Flag for returning the fitted value of the objective function.",
     default=False,
     is_flag=True,
 )
-@click.option("-p", "--patch", multiple=True)
 @click.option(
     "--backend",
     type=click.Choice(["numpy", "pytorch", "tensorflow", "jax", "np", "torch", "tf"]),
@@ -50,8 +50,8 @@ def fit(
     workspace,
     output_file,
     measurement,
-    value,
     patch,
+    value,
     backend,
     optimizer,
     optconf,

--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -57,7 +57,7 @@ def fit(
     optconf,
 ):
     """
-    Perforam a maximum likelihood fit for a given pyhf workspace.
+    Perform a maximum likelihood fit for a given pyhf workspace.
 
     Example:
 

--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -6,7 +6,7 @@ import json
 
 from ..utils import EqDelimStringParamType
 from ..infer import hypotest
-from ..infer.mle import fit as mle_fit  # Avoid namespace collision
+from ..infer import mle
 from ..workspace import Workspace
 from .. import get_backend, set_backend, optimize
 
@@ -112,7 +112,7 @@ def fit(
     )
     data = ws.data(model)
 
-    fit_result = mle_fit(data, model, return_fitted_val=value)
+    fit_result = mle.fit(data, model, return_fitted_val=value)
 
     _pars = fit_result if not value else fit_result[0]
     bestfit_pars = {

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -306,7 +306,7 @@ def test_fit_optimizer(tmpdir, script_runner, optimizer, opts, success):
     ret = script_runner.run(*shlex.split(command))
 
     optconf = " ".join(f"--optconf {opt}" for opt in opts)
-    command = f"pyhf fit {temp.strpath} --optimizer {optimizer} {optconf}"
+    command = f"pyhf fit --optimizer {optimizer} {optconf} {temp.strpath}"
     ret = script_runner.run(*shlex.split(command))
 
     assert ret.success == success

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -295,6 +295,26 @@ def test_testpoi(tmpdir, script_runner):
 
 
 @pytest.mark.parametrize(
+    "optimizer", ["scipy", "minuit", "scipy_optimizer", "minuit_optimizer"]
+)
+@pytest.mark.parametrize(
+    "opts,success", [(["maxiter=1000"], True), (["maxiter=1"], False)]
+)
+def test_fit_optimizer(tmpdir, script_runner, optimizer, opts, success):
+    temp = tmpdir.join("parsed_output.json")
+    command = "pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s}".format(
+        temp.strpath
+    )
+    ret = script_runner.run(*shlex.split(command))
+
+    optconf = " ".join(f"--optconf {opt}" for opt in opts)
+    command = f"pyhf fit {temp.strpath} --optimizer {optimizer} {optconf}"
+    ret = script_runner.run(*shlex.split(command))
+
+    assert ret.success == success
+
+
+@pytest.mark.parametrize(
     'optimizer', ['scipy', 'minuit', 'scipy_optimizer', 'minuit_optimizer']
 )
 @pytest.mark.parametrize(

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -294,9 +294,7 @@ def test_testpoi(tmpdir, script_runner):
     assert len(list(set(results_obs))) == len(pois)
 
 
-@pytest.mark.parametrize(
-    "optimizer", ["scipy", "minuit", "scipy_optimizer", "minuit_optimizer"]
-)
+@pytest.mark.parametrize("optimizer", ["scipy", "minuit"])
 @pytest.mark.parametrize(
     "opts,success", [(["maxiter=1000"], True), (["maxiter=1"], False)]
 )
@@ -314,9 +312,7 @@ def test_fit_optimizer(tmpdir, script_runner, optimizer, opts, success):
     assert ret.success == success
 
 
-@pytest.mark.parametrize(
-    'optimizer', ['scipy', 'minuit', 'scipy_optimizer', 'minuit_optimizer']
-)
+@pytest.mark.parametrize('optimizer', ['scipy', 'minuit'])
 @pytest.mark.parametrize(
     'opts,success', [(['maxiter=1000'], True), (['maxiter=1'], False)]
 )

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -55,6 +55,49 @@ def test_import_prepHistFactory_stdout(tmpdir, script_runner):
     assert d
 
 
+def test_import_prepHistFactory_and_fit(tmpdir, script_runner):
+    temp = tmpdir.join("parsed_output.json")
+    command = "pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s}".format(
+        temp.strpath
+    )
+    ret = script_runner.run(*shlex.split(command))
+
+    command = "pyhf fit {0:s}".format(temp.strpath)
+    ret = script_runner.run(*shlex.split(command))
+
+    assert ret.success
+    ret_json = json.loads(ret.stdout)
+    assert ret_json
+    assert "mle_parameters" in ret_json
+    assert "twice_nll" not in ret_json
+
+    for measurement in [
+        "GaussExample",
+        "GammaExample",
+        "LogNormExample",
+        "ConstExample",
+    ]:
+        command = "pyhf fit {0:s} --value --measurement {1:s}".format(
+            temp.strpath, measurement
+        )
+        ret = script_runner.run(*shlex.split(command))
+
+        assert ret.success
+        ret_json = json.loads(ret.stdout)
+        assert ret_json
+        assert "mle_parameters" in ret_json
+        assert "twice_nll" in ret_json
+
+        tmp_out = tmpdir.join("{0:s}_output.json".format(measurement))
+        # make sure output file works too
+        command += " --output-file {0:s}".format(tmp_out.strpath)
+        ret = script_runner.run(*shlex.split(command))
+        assert ret.success
+        ret_json = json.load(tmp_out)
+        assert "mle_parameters" in ret_json
+        assert "twice_nll" in ret_json
+
+
 def test_import_prepHistFactory_and_cls(tmpdir, script_runner):
     temp = tmpdir.join("parsed_output.json")
     command = 'pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s}'.format(
@@ -94,6 +137,23 @@ def test_import_prepHistFactory_and_cls(tmpdir, script_runner):
         d = json.load(tmp_out)
         assert 'CLs_obs' in d
         assert 'CLs_exp' in d
+
+
+@pytest.mark.parametrize("backend", ["numpy", "tensorflow", "pytorch", "jax"])
+def test_fit_backend_option(tmpdir, script_runner, backend):
+    temp = tmpdir.join("parsed_output.json")
+    command = "pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s}".format(
+        temp.strpath
+    )
+    ret = script_runner.run(*shlex.split(command))
+
+    command = "pyhf fit --backend {0:s} {1:s}".format(backend, temp.strpath)
+    ret = script_runner.run(*shlex.split(command))
+
+    assert ret.success
+    ret_json = json.loads(ret.stdout)
+    assert ret_json
+    assert "mle_parameters" in ret_json
 
 
 @pytest.mark.parametrize("backend", ["numpy", "tensorflow", "pytorch", "jax"])


### PR DESCRIPTION
# Description

* Resolves #784 
* Resolves #828

Adds the following functionality to the CLI API:

```
$ pyhf fit --help
Usage: pyhf fit [OPTIONS] [WORKSPACE]

  Perform a maximum likelihood fit for a given pyhf workspace.

  Example:

  .. code-block:: shell

      $ curl -sL https://git.io/JJYDE | pyhf fit --value

          {
              "mle_parameters": {
                  "mu": [
                      0.00017298628839781602
                  ],
                  "uncorr_bkguncrt": [
                      1.0000015671710816,
                      0.9999665895859197
                  ]
              },
              "twice_nll": 23.19636590468879
          }

Options:
  --output-file TEXT              The location of the output json file. If not
                                  specified, prints to screen.

  --measurement TEXT
  -p, --patch TEXT
  --value                         Flag for returning the fitted value of the
                                  objective function.

  --backend [numpy|pytorch|tensorflow|jax|np|torch|tf]
                                  The tensor backend used for the calculation.
  --optimizer [scipy|minuit]      The optimizer used for the calculation.
  --optconf EQUAL-DELIMITED OPTION
  -h, --help                      Show this message and exit.
```

ReadTheDocs build: https://pyhf.readthedocs.io/en/feat-add-fit-cli-api/cli.html#pyhf-fit

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add fit command to CLI API
   - Performs pyhf.infer.mle.fit
* Add tests for functionality
* Add optimizer options to pyhf cls CLI API docs
```
