### PR TITLE
feat: Add erf and erfinv to tensorlib

### DIFF
--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -4,6 +4,7 @@ config.update('jax_enable_x64', True)
 
 import jax.numpy as np
 from jax.scipy.special import gammaln
+from jax.scipy import special
 from jax.scipy.stats import norm, poisson
 import numpy as onp
 import logging
@@ -81,6 +82,47 @@ class jax_backend(object):
             JAX ndarray: A clipped `tensor`
         """
         return np.clip(tensor_in, min_value, max_value)
+
+    def erf(self, tensor_in):
+        """
+        The error function of complex argument.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("jax")
+            >>> a = pyhf.tensorlib.astensor([-2., -1., 0., 1., 2.])
+            >>> pyhf.tensorlib.erf(a)
+            DeviceArray([-0.99532227, -0.84270079,  0.        ,  0.84270079,
+                          0.99532227], dtype=float64)
+
+        Args:
+            tensor_in (`tensor`): The input tensor object
+
+        Returns:
+            JAX ndarray: The values of the error function at the given points.
+        """
+        return special.erf(tensor_in)
+
+    def erfinv(self, tensor_in):
+        """
+        The inverse of the error function of complex argument.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("jax")
+            >>> a = pyhf.tensorlib.astensor([-2., -1., 0., 1., 2.])
+            >>> pyhf.tensorlib.erfinv(pyhf.tensorlib.erf(a))
+            DeviceArray([-2., -1.,  0.,  1.,  2.], dtype=float64)
+
+        Args:
+            tensor_in (`tensor`): The input tensor object
+
+        Returns:
+            JAX ndarray: The values of the inverse of the error function at the given points.
+        """
+        return special.erfinv(tensor_in)
 
     def tile(self, tensor_in, repeats):
         """

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -2,6 +2,7 @@
 import numpy as np
 import logging
 from scipy.special import gammaln
+from scipy import special
 from scipy.stats import norm, poisson
 
 
@@ -74,6 +75,46 @@ class numpy_backend(object):
             NumPy ndarray: A clipped `tensor`
         """
         return np.clip(tensor_in, min_value, max_value)
+
+    def erf(self, tensor_in):
+        """
+        The error function of complex argument.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("numpy")
+            >>> a = pyhf.tensorlib.astensor([-2., -1., 0., 1., 2.])
+            >>> pyhf.tensorlib.erf(a)
+            array([-0.99532227, -0.84270079,  0.        ,  0.84270079,  0.99532227])
+
+        Args:
+            tensor_in (`tensor`): The input tensor object
+
+        Returns:
+            NumPy ndarray: The values of the error function at the given points.
+        """
+        return special.erf(tensor_in)
+
+    def erfinv(self, tensor_in):
+        """
+        The inverse of the error function of complex argument.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("numpy")
+            >>> a = pyhf.tensorlib.astensor([-2., -1., 0., 1., 2.])
+            >>> pyhf.tensorlib.erfinv(pyhf.tensorlib.erf(a))
+            array([-2., -1.,  0.,  1.,  2.])
+
+        Args:
+            tensor_in (`tensor`): The input tensor object
+
+        Returns:
+            NumPy ndarray: The values of the inverse of the error function at the given points.
+        """
+        return special.erfinv(tensor_in)
 
     def tile(self, tensor_in, repeats):
         """

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -51,6 +51,46 @@ class pytorch_backend(object):
         """
         return torch.clamp(tensor_in, min_value, max_value)
 
+    def erf(self, tensor_in):
+        """
+        The error function of complex argument.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("pytorch")
+            >>> a = pyhf.tensorlib.astensor([-2., -1., 0., 1., 2.])
+            >>> pyhf.tensorlib.erf(a)
+            tensor([-0.9953, -0.8427,  0.0000,  0.8427,  0.9953])
+
+        Args:
+            tensor_in (`tensor`): The input tensor object
+
+        Returns:
+            PyTorch Tensor: The values of the error function at the given points.
+        """
+        return torch.erf(tensor_in)
+
+    def erfinv(self, tensor_in):
+        """
+        The inverse of the error function of complex argument.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("pytorch")
+            >>> a = pyhf.tensorlib.astensor([-2., -1., 0., 1., 2.])
+            >>> pyhf.tensorlib.erfinv(pyhf.tensorlib.erf(a))
+            tensor([-2.0000, -1.0000,  0.0000,  1.0000,  2.0000])
+
+        Args:
+            tensor_in (`tensor`): The input tensor object
+
+        Returns:
+            PyTorch Tensor: The values of the inverse of the error function at the given points.
+        """
+        return torch.erfinv(tensor_in)
+
     def conditional(self, predicate, true_callable, false_callable):
         """
         Runs a callable conditional on the boolean value of the evaulation of a predicate

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -53,6 +53,48 @@ class tensorflow_backend(object):
             max_value = tf.reduce_max(tensor_in)
         return tf.clip_by_value(tensor_in, min_value, max_value)
 
+    def erf(self, tensor_in):
+        """
+        The error function of complex argument.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("tensorflow")
+            >>> a = pyhf.tensorlib.astensor([-2., -1., 0., 1., 2.])
+            >>> t = pyhf.tensorlib.erf(a)
+            >>> print(t)
+            tf.Tensor([-0.9953223 -0.8427007  0.         0.8427007  0.9953223], shape=(5,), dtype=float32)
+
+        Args:
+            tensor_in (`tensor`): The input tensor object
+
+        Returns:
+            TensorFlow Tensor: The values of the error function at the given points.
+        """
+        return tf.math.erf(tensor_in)
+
+    def erfinv(self, tensor_in):
+        """
+        The inverse of the error function of complex argument.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("tensorflow")
+            >>> a = pyhf.tensorlib.astensor([-2., -1., 0., 1., 2.])
+            >>> t = pyhf.tensorlib.erfinv(pyhf.tensorlib.erf(a))
+            >>> print(t)
+            tf.Tensor([-2.000001   -0.99999964  0.          0.99999964  1.9999981 ], shape=(5,), dtype=float32)
+
+        Args:
+            tensor_in (`tensor`): The input tensor object
+
+        Returns:
+            TensorFlow Tensor: The values of the inverse of the error function at the given points.
+        """
+        return tf.math.erfinv(tensor_in)
+
     def tile(self, tensor_in, repeats):
         """
         Repeat tensor data along a specific dimension

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -39,6 +39,19 @@ def test_simple_tensor_ops(backend):
     assert tb.tolist(tb.sqrt(tb.astensor([4, 9, 16]))) == [2, 3, 4]
     assert tb.tolist(tb.log(tb.exp(tb.astensor([2, 3, 4])))) == [2, 3, 4]
     assert tb.tolist(tb.abs(tb.astensor([-1, -2]))) == [1, 2]
+    assert tb.tolist(tb.erf(tb.astensor([-2.0, -1.0, 0.0, 1.0, 2.0]))) == pytest.approx(
+        [
+            -0.99532227,
+            -0.84270079,
+            0.0,
+            0.84270079,
+            0.99532227,
+        ],
+        1e-7,
+    )
+    assert tb.tolist(
+        tb.erfinv(tb.erf(tb.astensor([-2.0, -1.0, 0.0, 1.0, 2.0])))
+    ) == pytest.approx([-2.0, -1.0, 0.0, 1.0, 2.0], 1e-6)
     a = tb.astensor(1)
     b = tb.astensor(2)
     assert tb.tolist(a < b) is True


### PR DESCRIPTION
# Description

Resolves #963 

Add the functions `erf` and `erfinv` to the tensorlib backends.

ReadTheDocs build: https://pyhf.readthedocs.io/en/feat-add-erf-and-inverf/_generated/pyhf.tensor.numpy_backend.numpy_backend.html#pyhf.tensor.numpy_backend.numpy_backend.erf

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add erf and erfinv methods to the tensorlib backends
* Add tests for erf and erfinv
```
