### PR TITLE
chore: Migrate from pep517 to python-build

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
-    - name: Install build, check-manifest, and twine
+    - name: Install build-python, check-manifest, and twine
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install build check-manifest twine

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -35,7 +35,7 @@ jobs:
         python -m pep517.check .
     - name: Build a wheel and a sdist
       run: |
-        python -m build --source --wheel --out-dir dist/ .
+        python -m build --source --wheel --outdir dist/ .
     - name: Verify untagged commits have dev versions
       if: "!startsWith(github.ref, 'refs/tags/')"
       run: |

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -21,20 +21,21 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
-    - name: Install pep517, check-manifest, and twine
+    - name: Install build, check-manifest, and twine
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pep517 --user
-        python -m pip install check-manifest twine
+        python -m pip install build check-manifest twine
     - name: Check MANIFEST
       run: |
         check-manifest
+    # TODO: Find equivalent for pep517.check
     - name: Test the build backend is compliant with PEP517
       run: |
         python -m pep517.check .
     - name: Build a wheel and a sdist
       run: |
-        python -m pep517.build --source --binary --out-dir dist/ .
+        python -m build --source --wheel --out-dir dist/ .
     - name: Verify untagged commits have dev versions
       if: "!startsWith(github.ref, 'refs/tags/')"
       run: |

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -45,7 +45,7 @@ jobs:
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
         if [[ "${latest_tag_revlist_SHA}" != "${master_SHA}" ]]; then # don't check master push events coming from tags
           if [[ "${wheel_name}" == *"pyhf-0.1.dev"* || "${wheel_name}" != *"dev"* ]]; then
-            echo "pep517.build incorrectly named built distribution: ${wheel_name}"
+            echo "build incorrectly named built distribution: ${wheel_name}"
             echo "pep517 is lacking the history and tags required to determine version number"
             echo "intentionally erroring with 'return 1' now"
             return 1
@@ -53,18 +53,18 @@ jobs:
         else
           echo "Push event to origin/master was triggered by push of tag ${latest_tag}"
         fi
-        echo "pep517.build named built distribution: ${wheel_name}"
+        echo "build named built distribution: ${wheel_name}"
     - name: Verify tagged commits don't have dev versions
       if: startsWith(github.ref, 'refs/tags')
       run: |
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
         if [[ "${wheel_name}" == *"dev"* ]]; then
-          echo "pep517.build incorrectly named built distribution: ${wheel_name}"
+          echo "build incorrectly named built distribution: ${wheel_name}"
           echo "this is incorrrectly being treated as a dev release"
           echo "intentionally erroring with 'return 1' now"
           return 1
         fi
-        echo "pep517.build named built distribution: ${wheel_name}"
+        echo "build named built distribution: ${wheel_name}"
     - name: Verify the distribution
       run: twine check dist/*
     - name: Publish distribution 📦 to Test PyPI

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -24,15 +24,10 @@ jobs:
     - name: Install build, check-manifest, and twine
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install pep517 --user
         python -m pip install build check-manifest twine
     - name: Check MANIFEST
       run: |
         check-manifest
-    # TODO: Find equivalent for pep517.check
-    - name: Test the build backend is compliant with PEP517
-      run: |
-        python -m pep517.check .
     - name: Build a wheel and a sdist
       run: |
         python -m build --sdist --wheel --outdir dist/ .

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -35,7 +35,7 @@ jobs:
         python -m pep517.check .
     - name: Build a wheel and a sdist
       run: |
-        python -m build --source --wheel --outdir dist/ .
+        python -m build --sdist --wheel --outdir dist/ .
     - name: Verify untagged commits have dev versions
       if: "!startsWith(github.ref, 'refs/tags/')"
       run: |

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -40,7 +40,7 @@ jobs:
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
         if [[ "${latest_tag_revlist_SHA}" != "${master_SHA}" ]]; then # don't check master push events coming from tags
           if [[ "${wheel_name}" == *"pyhf-0.1.dev"* || "${wheel_name}" != *"dev"* ]]; then
-            echo "build incorrectly named built distribution: ${wheel_name}"
+            echo "build-python incorrectly named built distribution: ${wheel_name}"
             echo "pep517 is lacking the history and tags required to determine version number"
             echo "intentionally erroring with 'return 1' now"
             return 1
@@ -48,18 +48,18 @@ jobs:
         else
           echo "Push event to origin/master was triggered by push of tag ${latest_tag}"
         fi
-        echo "build named built distribution: ${wheel_name}"
+        echo "build-python named built distribution: ${wheel_name}"
     - name: Verify tagged commits don't have dev versions
       if: startsWith(github.ref, 'refs/tags')
       run: |
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
         if [[ "${wheel_name}" == *"dev"* ]]; then
-          echo "build incorrectly named built distribution: ${wheel_name}"
+          echo "build-python incorrectly named built distribution: ${wheel_name}"
           echo "this is incorrrectly being treated as a dev release"
           echo "intentionally erroring with 'return 1' now"
           return 1
         fi
-        echo "build named built distribution: ${wheel_name}"
+        echo "build-python named built distribution: ${wheel_name}"
     - name: Verify the distribution
       run: twine check dist/*
     - name: Publish distribution 📦 to Test PyPI

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
-    - name: Install build-python, check-manifest, and twine
+    - name: Install python-build, check-manifest, and twine
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install build check-manifest twine
@@ -40,26 +40,26 @@ jobs:
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
         if [[ "${latest_tag_revlist_SHA}" != "${master_SHA}" ]]; then # don't check master push events coming from tags
           if [[ "${wheel_name}" == *"pyhf-0.1.dev"* || "${wheel_name}" != *"dev"* ]]; then
-            echo "build-python incorrectly named built distribution: ${wheel_name}"
-            echo "pep517 is lacking the history and tags required to determine version number"
+            echo "python-build incorrectly named built distribution: ${wheel_name}"
+            echo "python-build is lacking the history and tags required to determine version number"
             echo "intentionally erroring with 'return 1' now"
             return 1
           fi
         else
           echo "Push event to origin/master was triggered by push of tag ${latest_tag}"
         fi
-        echo "build-python named built distribution: ${wheel_name}"
+        echo "python-build named built distribution: ${wheel_name}"
     - name: Verify tagged commits don't have dev versions
       if: startsWith(github.ref, 'refs/tags')
       run: |
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
         if [[ "${wheel_name}" == *"dev"* ]]; then
-          echo "build-python incorrectly named built distribution: ${wheel_name}"
+          echo "python-build incorrectly named built distribution: ${wheel_name}"
           echo "this is incorrrectly being treated as a dev release"
           echo "intentionally erroring with 'return 1' now"
           return 1
         fi
-        echo "build-python named built distribution: ${wheel_name}"
+        echo "python-build named built distribution: ${wheel_name}"
     - name: Verify the distribution
       run: twine check dist/*
     - name: Publish distribution 📦 to Test PyPI


### PR DESCRIPTION
# Description

Resolves #1065 

Switch from using the now deprecated [`pep517`](https://github.com/pypa/pep517/) to build sdist and wheels to the new [`python-build`](https://github.com/FFY00/python-build) library.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Migrate from the deprecated pep517.build to python-build CLI for builds for packaging
   - c.f. https://github.com/pypa/pep517/pull/83
* Remove check stage as done implicitly with python-build
   - c.f. https://github.com/FFY00/python-build/issues/105
```
