### PR TITLE
fix: Restrict iminuit to v1.4.X releases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require = {
     'torch': ['torch~=1.2'],
     'jax': ['jax~=0.1,>0.1.51', 'jaxlib~=0.1,>0.1.33'],
     'xmlio': ['uproot~=3.6'],  # Future proof against uproot4 API changes
-    'minuit': ['iminuit~=1.4.3'],  # Use "name" keyword in MINUIT optimizer
+    'minuit': ['iminuit~=1.4.3'],  # Restrict iminuit below 1.5.0 given error
 }
 extras_require['backends'] = sorted(
     set(

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require = {
     'torch': ['torch~=1.2'],
     'jax': ['jax~=0.1,>0.1.51', 'jaxlib~=0.1,>0.1.33'],
     'xmlio': ['uproot~=3.6'],  # Future proof against uproot4 API changes
-    'minuit': ['iminuit~=1.4,>=1.4.3'],  # Use "name" keyword in MINUIT optimizer
+    'minuit': ['iminuit~=1.4.3'],  # Use "name" keyword in MINUIT optimizer
 }
 extras_require['backends'] = sorted(
     set(

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require = {
     'torch': ['torch~=1.2'],
     'jax': ['jax~=0.1,>0.1.51', 'jaxlib~=0.1,>0.1.33'],
     'xmlio': ['uproot~=3.6'],  # Future proof against uproot4 API changes
-    'minuit': ['iminuit~=1.4.3'],  # Restrict iminuit below 1.5.0 given error
+    'minuit': ['iminuit~=1.4.3'],  # v1.5.0 breaks pyhf for 32b TensorFlow and PyTorch
 }
 extras_require['backends'] = sorted(
     set(


### PR DESCRIPTION
# Description

To temporarily avoid the problems of Issue #1069, restrict `iminuit` to be below `v1.5.0` as it seems that there might need to be a new release of `iminuit` before #1069 can be resolved.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Restrict iminuit to releases in the v1.4.X range for X >= 3
   - iminuit v1.5.0 breaks pyhf for 32b TensorFlow and PyTorch
   - c.f. Issue #1069
```