### PR TITLE
ci: Add nightly tests using HEAD of dependencies

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed -U -q --no-cache-dir -e .[test]
+        python -m pip install --upgrade --no-cache-dir cython
         python -m pip install --upgrade --no-cache-dir git+git://github.com/scipy/scipy.git
         python -m pip list
     - name: Test with pytest

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -1,6 +1,7 @@
 name: HEAD of dependencies
 
 on:
+  workflow_dispatch:
   # Run daily at 0:01 UTC
   push:
   schedule:

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -3,7 +3,6 @@ name: HEAD of dependencies
 on:
   workflow_dispatch:
   # Run daily at 0:01 UTC
-  push:
   schedule:
   - cron:  '1 0 * * *'
 

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[test]
+        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
         python -m pip install --upgrade --no-cache-dir cython
         python -m pip install --upgrade --no-cache-dir git+git://github.com/scipy/scipy.git
         python -m pip list
@@ -49,7 +49,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[test]
+        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
         python -m pip install --upgrade --no-cache-dir cython
         python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/iminuit.git
         python -m pip list
@@ -74,7 +74,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[test]
+        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
         python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/uproot.git
         python -m pip list
     - name: Test with pytest

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -1,0 +1,81 @@
+name: HEAD of dependencies
+
+on:
+  # Run daily at 0:01 UTC
+  push:
+  schedule:
+  - cron:  '1 0 * * *'
+
+jobs:
+  scipy:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[test]
+        python -m pip install --upgrade --no-cache-dir git+git://github.com/scipy/scipy.git
+        python -m pip list
+    - name: Test with pytest
+      run: |
+        python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+
+  iminuit:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[test]
+        python -m pip install --upgrade --no-cache-dir cython
+        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/iminuit.git
+        python -m pip list
+    - name: Test with pytest
+      run: |
+        python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+
+  uproot:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[test]
+        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/uproot.git
+        python -m pip list
+    - name: Test with pytest
+      run: |
+        python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py


### PR DESCRIPTION
# Description

In light of Issue #1069, this PR adds nightly tests that run at the `HEAD` of dependencies that are the most reasonable for us to check and interact with. If we detect breaking changes in these dependencies at their `HEAD` then we should have time to either proactively address this in `pyhf` or work with the dependency dev team to mitigate them. They can also be run on demand with workflow dispatch.

Note that these tests only run on CRON jobs and on demand, but never on pushes of PRs.

Example workflow: https://github.com/scikit-hep/pyhf/actions/runs/265261547

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add nightly tests to run test suite at HEAD of dependencies
   - Use as early alert for breaking changes in dependencies
   - Run for SciPy, iminuit, and uproot
```
