### PR TITLE
chore: Update GitHub Action releases and Python runtimes in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
     - name: Report coverage with Codecov
-      if: github.event_name == 'push' && matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
+      if: github.event_name == 'push' && matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -41,7 +41,7 @@ jobs:
       run: |
         python -m pytest -r sx tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
     - name: Run benchmarks
-      if: github.event_name == 'schedule' && matrix.python-version == 3.7
+      if: github.event_name == 'schedule' && matrix.python-version == 3.8
       run: |
         python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/test_benchmark.py
 
@@ -50,11 +50,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
@@ -72,13 +72,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
     - name: Report coverage with Codecov
       if: github.event_name == 'push' && matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
-      uses: codecov/codecov-action@v1.0.5
+      uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -65,12 +65,12 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master
       if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pyhf'
-      uses: pypa/gh-action-pypi-publish@v1.2.2
+      uses: pypa/gh-action-pypi-publish@v1.3.1
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == 'scikit-hep/pyhf'
-      uses: pypa/gh-action-pypi-publish@v1.2.2
+      uses: pypa/gh-action-pypi-publish@v1.3.1
       with:
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pyhf[backends,xmlio]
-        python -m pip install 'pytest~=3.5' pytest-cov
+        python -m pip install 'pytest~=6.0' pytest-cov
         python -m pip list
     - name: Canary test public API
       run: |

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -58,10 +58,10 @@ jobs:
       run: |
         git merge --squash "origin/${GITHUB_HEAD_REF}"
         git commit -m "${PR_TITLE} (#${PR_NUMBER})"
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install bumpversion
       run: |
         python -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
# Description

Update the releases of the GitHub Actions uses in the CI workflows and update to using Python 3.8 as the default for testing actions.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update releases of GitHub Actions used in workflow
   - codecov-action @v1, gh-action-pypi-publish@v1.3.1
* Use Python 3.8 as the runtime for all reporting in CI
```
