### PR TITLE
ci: Add workflow for nightly tests of notebooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,28 +46,6 @@ jobs:
       run: |
         python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/test_benchmark.py
 
-  notebooks:
-
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.8]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[complete]
-        python -m pip list
-    - name: Test example notebooks
-      run: |
-        python -m pytest -r sx tests/test_notebooks.py
-
   docs:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -1,0 +1,30 @@
+name: Notebooks
+
+on:
+  # Run daily at 0:01 UTC
+  schedule:
+  - cron:  '1 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[complete]
+        python -m pip list
+    - name: Test example notebooks
+      run: |
+        python -m pytest -r sx tests/test_notebooks.py

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[complete]
+        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[complete]
         python -m pip list
     - name: Test example notebooks
       run: |


### PR DESCRIPTION
# Description

Resolves #1077 

To speed up the PR process, as the notebooks are the slowest tests by far, have the notebooks no longer be tested every PR but in a workflow that runs nightly on a CRON job and through workflow dispatch. This will ensure that any breaking changes that get through are caught within 24 hours, while speeding up CI. Workflow dispatch will also allow for the notebook tests to be run on any branch.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Migrate notebook tests from main CI to notebook testing workflow to speed up PRs
   - Run on as a nightly CRON job as well as through workflow dispatch
   - Don't run on pushes or PRs
```
