### PR TITLE
docs: Add information on announcement mailing list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -207,6 +207,11 @@ with the ``[pyhf]`` tag, which the ``pyhf`` dev team
 If you believe you have found a bug in ``pyhf``, please report it in the
 `GitHub
 Issues <https://github.com/scikit-hep/pyhf/issues/new?template=Bug-Report.md&labels=bug&title=Bug+Report+:+Title+Here>`__.
+If you're interested in getting updates from the ``pyhf`` dev team and release
+announcements you can also join the |pyhf-announcements mailing list|_.
+
+.. |pyhf-announcements mailing list| replace:: ``pyhf-announcements`` mailing list
+.. _pyhf-announcements mailing list: https://groups.google.com/group/pyhf-announcements/subscribe
 
 Citation
 --------

--- a/README.rst
+++ b/README.rst
@@ -208,7 +208,7 @@ If you believe you have found a bug in ``pyhf``, please report it in the
 `GitHub
 Issues <https://github.com/scikit-hep/pyhf/issues/new?template=Bug-Report.md&labels=bug&title=Bug+Report+:+Title+Here>`__.
 If you're interested in getting updates from the ``pyhf`` dev team and release
-announcements you can also join the |pyhf-announcements mailing list|_.
+announcements you can also the |pyhf-announcements mailing list|_.
 
 .. |pyhf-announcements mailing list| replace:: ``pyhf-announcements`` mailing list
 .. _pyhf-announcements mailing list: https://groups.google.com/group/pyhf-announcements/subscribe

--- a/README.rst
+++ b/README.rst
@@ -208,7 +208,7 @@ If you believe you have found a bug in ``pyhf``, please report it in the
 `GitHub
 Issues <https://github.com/scikit-hep/pyhf/issues/new?template=Bug-Report.md&labels=bug&title=Bug+Report+:+Title+Here>`__.
 If you're interested in getting updates from the ``pyhf`` dev team and release
-announcements you can also the |pyhf-announcements mailing list|_.
+announcements you can join the |pyhf-announcements mailing list|_.
 
 .. |pyhf-announcements mailing list| replace:: ``pyhf-announcements`` mailing list
 .. _pyhf-announcements mailing list: https://groups.google.com/group/pyhf-announcements/subscribe

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,9 +60,7 @@ extensions = [
 # external links
 xref_links = {"arXiv:1007.1727": ("[1007.1727]", "https://arxiv.org/abs/1007.1727")}
 
-intersphinx_mapping = {
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
-}
+intersphinx_mapping = {'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None)}
 
 # Github repo
 issues_github_path = 'scikit-hep/pyhf'

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -20,6 +20,14 @@ If you have a question about the use of ``pyhf`` not covered in the `documentati
 
 If you believe you have found a bug in ``pyhf``, please report it in the `GitHub Issues <https://github.com/scikit-hep/pyhf/issues/new?template=Bug-Report.md&labels=bug&title=Bug+Report+:+Title+Here>`__.
 
+How can I get updates on ``pyhf``?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If you're interested in getting updates from the ``pyhf`` dev team and release
+announcements you can join the |pyhf-announcements mailing list|_.
+
+.. |pyhf-announcements mailing list| replace:: ``pyhf-announcements`` mailing list
+.. _pyhf-announcements mailing list: https://groups.google.com/group/pyhf-announcements/subscribe
+
 Is it possible to set the backend from the CLI?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
# Description

Resolves #1062 

Add information to the docs on how to subscribe to the `pyhf-announcements` mailing list (run through Google Groups for the time being).

ReadTheDocs build:

- https://pyhf.readthedocs.io/en/docs-add-mailing-list-to-contact/#questions
- https://pyhf.readthedocs.io/en/docs-add-mailing-list-to-contact/faq.html#how-can-i-get-updates-on-pyhf

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add information on subscribing to the pyhf-announcements mailing list to the README and FAQ
   - https://groups.google.com/group/pyhf-announcements/subscribe
```
