### PR TITLE
docs: Add citations from 2019 and 2020 papers

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -36,6 +36,22 @@
       SLACcitation   = "%%CITATION = ARXIV:2002.12220;%%"
 }
 
+% 2020-02-13
+@article{Angelescu:2020uug,
+    author = "Angelescu, Andrei and Faroughy, Darius A. and Sumensari, Olcyr",
+    title = "{Lepton Flavor Violation and Dilepton Tails at the LHC}",
+    eprint = "2002.05684",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "ZU-TH 02/20",
+    doi = "10.1140/epjc/s10052-020-8210-5",
+    journal = "Eur. Phys. J. C",
+    volume = "80",
+    number = "7",
+    pages = "641",
+    year = "2020"
+}
+
 % 2019-11-11
 @article{Allanach:2019zfr,
     author = "Allanach, B.C. and Corbett, Tyler and Madigan, Maeve",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -36,6 +36,21 @@
       SLACcitation   = "%%CITATION = ARXIV:2002.12220;%%"
 }
 
+% 2019-11-11
+@article{Allanach:2019zfr,
+    author = "Allanach, B.C. and Corbett, Tyler and Madigan, Maeve",
+    title = "{Sensitivity of Future Hadron Colliders to Leptoquark Pair Production in the Di-Muon Di-Jets Channel}",
+    eprint = "1911.04455",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    doi = "10.1140/epjc/s10052-020-7722-3",
+    journal = "Eur. Phys. J. C",
+    volume = "80",
+    number = "2",
+    pages = "170",
+    year = "2020"
+}
+
 @inproceedings{DiMicco:2019ngk,
     author = "Alison, J. and others",
     editor = "Di Micco, B. and Gouzevitch, M. and Mazzitelli, J. and Vernieri, C.",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -9,6 +9,33 @@
     journal = ""
 }
 
+% 2020-06-20
+@article{Krupa:2020bwg,
+    author = "Krupa, Jeffrey and others",
+    title = "{GPU coprocessors as a service for deep learning inference in high energy physics}",
+    eprint = "2007.10359",
+    archivePrefix = "arXiv",
+    primaryClass = "physics.comp-ph",
+    reportNumber = "FERMILAB-PUB-20-338-E-SCD",
+    month = "7",
+    year = "2020"
+}
+
+% 2020-05-01
+@article{Khosa:2020zar,
+    author = "Khosa, Charanjit K. and Kraml, Sabine and Lessa, Andre and Neuhuber, Philipp and Waltenberger, Wolfgang",
+    title = "{SModelS database update v1.2.3}",
+    eprint = "2005.00555",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    doi = "10.31526/lhep.2020.158",
+    journal = "LHEP",
+    volume = "158",
+    pages = "2020",
+    month = "5",
+    year = "2020"
+}
+
 @article{Abdallah:2020pec,
       author         = "Abdallah, Waleed and others",
       title          = "{Reinterpretation of LHC Results for New Physics: Status

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -18,7 +18,8 @@
     primaryClass = "physics.comp-ph",
     reportNumber = "FERMILAB-PUB-20-338-E-SCD",
     month = "7",
-    year = "2020"
+    year = "2020",
+    journal = ""
 }
 
 % 2020-05-01


### PR DESCRIPTION
# Description

Add citations from the following papers that @lukasheinrich discovered had cited us with a `site:arxiv.org pyhf` search on Google. :)

- [Sensitivity of Future Hadron Colliders to Leptoquark Pair Production in the Di-Muon Di-Jets Channel](https://inspirehep.net/literature/1764068)
- [Lepton Flavor Violation and Dilepton Tails at the LHC](https://inspirehep.net/literature/1780095)
- [SModelS database update v1.2.3](https://inspirehep.net/literature/1794162)
- [GPU coprocessors as a service for deep learning inference in high energy physics](https://inspirehep.net/literature/1808088)

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-add-new-citations/citations.html#use-in-publications

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add citations from papers in 2019 and 2020
   - https://inspirehep.net/literature/1764068
   - https://inspirehep.net/literature/1780095
   - https://inspirehep.net/literature/1794162
   - https://inspirehep.net/literature/1808088
```
