### PR TITLE
chore: Migrate from bumpversion to bump2version

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -62,10 +62,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
-    - name: Install bumpversion
+    - name: Install bump2version
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install bumpversion
+        python -m pip install "bump2version~=1.0"
     - name: Run bumpversion ${{ env['BV_PART'] }}
       run: |
         OLD_TAG=$(git describe --tags --abbrev=0)

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -66,11 +66,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install "bump2version~=1.0"
-    - name: Run bumpversion ${{ env['BV_PART'] }}
+    - name: Run bump2version ${{ env['BV_PART'] }}
       run: |
         OLD_TAG=$(git describe --tags --abbrev=0)
         echo "::set-env name=OLD_TAG::${OLD_TAG}"
-        bumpversion $BV_PART --message "Bump version: {current_version} → {new_version}
+        bump2version $BV_PART --message "Bump version: {current_version} → {new_version}
 
         Triggered by #${PR_NUMBER} via GitHub Actions."
         NEW_TAG=$(git describe --tags --abbrev=0)

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -84,4 +84,4 @@ A release can be created from any PR created by a core developer by adding a
 Once the PR is tagged with the label, the GitHub Actions bot will post a comment
 with information on the actions it will take once the PR is merged. When the PR
 has been reviewed, approved, and merged, the Tag Creator workflow will automatically
-create a new release with ``bumpversion`` and then deploy the release to PyPI.
+create a new release with ``bump2version`` and then deploy the release to PyPI.

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ extras_require['develop'] = sorted(
         extras_require['docs']
         + extras_require['lint']
         + extras_require['test']
-        + ['nbdime', 'bumpversion', 'ipython', 'pre-commit', 'check-manifest', 'twine']
+        + ['nbdime', 'bump2version', 'ipython', 'pre-commit', 'check-manifest', 'twine']
     )
 )
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))


### PR DESCRIPTION
# Description

Resolves #1082 

Migrate to using `bump2version` `v1.X` release series in the `tag` workflow.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Migrate from using bumpversion to bump2version in the develop extra
   - bumpversion is no longer maintained and bump2version is the recommended fork
* Use bump2version v1.X series in the tag workflow
```
