### PR TITLE
test: Ensure continuous approximation of Poisson implemented

### DIFF
--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -253,6 +253,7 @@ def test_pdf_calculations(backend):
         nan_ok=True,
     )
 
+    # Ensure continous approximation is valid
     assert tb.tolist(
         tb.poisson(tb.astensor([0.5, 1.1, 1.5]), tb.astensor(1.0))
     ) == pytest.approx([0.4151074974205947, 0.3515379040027489, 0.2767383316137298])

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -253,6 +253,10 @@ def test_pdf_calculations(backend):
         nan_ok=True,
     )
 
+    assert tb.tolist(
+        tb.poisson(tb.astensor([0.5, 1.1, 1.5]), tb.astensor(1.0))
+    ) == pytest.approx([0.4151074974205947, 0.3515379040027489, 0.2767383316137298])
+
 
 def test_boolean_mask(backend):
     tb = pyhf.tensorlib


### PR DESCRIPTION
# Description

Resolves #971 

Add a test to ensure the tensor backends implement a continuous approximation of the Poisson distribution.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add test to ensure tensor backends implement a continuous approximation of the Poisson distribution
```
