### PR TITLE
feat: Merge channel functionality in pyhf combine

### DIFF
--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -283,7 +283,12 @@ def rename(workspace, output_file, channel, sample, modifier, measurement):
     help='The location of the output json file. If not specified, prints to screen.',
     default=None,
 )
-def combine(workspace_one, workspace_two, join, output_file):
+@click.option(
+    '--merge-channels/--no-merge-channels',
+    help='Whether or not to deeply merge channels. Can only be done with left/right outer joins.',
+    default=False,
+)
+def combine(workspace_one, workspace_two, join, output_file, merge_channels):
     """
     Combine two workspaces into a single workspace.
 
@@ -297,7 +302,9 @@ def combine(workspace_one, workspace_two, join, output_file):
 
     ws_one = Workspace(spec_one)
     ws_two = Workspace(spec_two)
-    combined_ws = Workspace.combine(ws_one, ws_two, join=join)
+    combined_ws = Workspace.combine(
+        ws_one, ws_two, join=join, merge_channels=merge_channels
+    )
 
     if output_file is None:
         click.echo(json.dumps(combined_ws, indent=4, sort_keys=True))

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -698,7 +698,7 @@ class Workspace(_ChannelSummaryMixin, dict):
             left (~pyhf.workspace.Workspace): A workspace
             right (~pyhf.workspace.Workspace): Another workspace
             join (:obj:`str`): How to join the two workspaces. Pick from "none", "outer", "left outer", or "right outer".
-            merge (:obj:`bool`): Whether or not to merge channels when performing the combine. This is only done with "left outer" or "right outer" options.
+            merge_channels (:obj:`bool`): Whether or not to merge channels when performing the combine. This is only done with "left outer" or "right outer" options.
 
         Returns:
             ~pyhf.workspace.Workspace: A new combined workspace object

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -17,7 +17,7 @@ from .mixins import _ChannelSummaryMixin
 log = logging.getLogger(__name__)
 
 
-def _join_items(join, left_items, right_items, key='name', deep_merge_key=''):
+def _join_items(join, left_items, right_items, key='name', deep_merge_key=None):
     """
     Join two lists of dictionaries along the given key.
 
@@ -47,7 +47,7 @@ def _join_items(join, left_items, right_items, key='name', deep_merge_key=''):
         # NB: this will be slow for large numbers of items
         elif join in ['left outer', 'right outer'] and secondary_item[key] in keys:
             # Deeply merge a sublist as well, if we need to
-            if deep_merge_key:
+            if deep_merge_key is not None:
                 _deep_left_items = joined_items[keys.index(secondary_item[key])][
                     deep_merge_key
                 ]
@@ -103,7 +103,7 @@ def _join_channels(join, left_channels, right_channels, merge=False):
     """
 
     joined_channels = _join_items(
-        join, left_channels, right_channels, deep_merge_key='samples' if merge else ''
+        join, left_channels, right_channels, deep_merge_key='samples' if merge else None
     )
     if join == 'none':
         common_channels = set(c['name'] for c in left_channels).intersection(

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -715,7 +715,7 @@ class Workspace(_ChannelSummaryMixin, dict):
         else:
             if merge_channels:
                 raise ValueError(
-                    f"You can only merge channels using the 'left outer' or 'right outer' join operations."
+                    f"You can only merge channels using the 'left outer' or 'right outer' join operations; not {join}"
                 )
 
         new_version = _join_versions(join, left['version'], right['version'])

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -534,12 +534,14 @@ def test_combine_merge_channels(tmpdir, script_runner):
     temp_2 = tmpdir.join("renamed_output.json")
     command = f'pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {temp_1.strpath} --hide-progress'
     ret = script_runner.run(*shlex.split(command))
+    assert ret.success
 
     command = (
         f'pyhf prune {temp_1.strpath} --sample signal --output-file {temp_2.strpath}'
     )
 
     ret = script_runner.run(*shlex.split(command))
+    assert ret.success
 
     command = f'pyhf combine --merge-channels --join "left outer" {temp_1.strpath} {temp_2.strpath}'
     ret = script_runner.run(*shlex.split(command))

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -529,6 +529,23 @@ def test_combine_outfile(tmpdir, script_runner):
     assert len(combined_ws.measurement_names) == 8
 
 
+def test_combine_merge_channels(tmpdir, script_runner):
+    temp_1 = tmpdir.join("parsed_output.json")
+    temp_2 = tmpdir.join("renamed_output.json")
+    command = f'pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {temp_1.strpath} --hide-progress'
+    ret = script_runner.run(*shlex.split(command))
+
+    command = (
+        f'pyhf prune {temp_1.strpath} --sample signal --output-file {temp_2.strpath}'
+    )
+
+    ret = script_runner.run(*shlex.split(command))
+
+    command = f'pyhf combine --merge-channels --join "left outer" {temp_1.strpath} {temp_2.strpath}'
+    ret = script_runner.run(*shlex.split(command))
+    assert ret.success
+
+
 @pytest.mark.parametrize('do_json', [False, True])
 @pytest.mark.parametrize(
     'algorithms', [['md5'], ['sha256'], ['sha256', 'md5'], ['sha256', 'md5']]

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -140,10 +140,14 @@ def test_workspace_observations(workspace_factory):
     assert w.observations
 
 
-def test_get_workspace_data(workspace_factory):
+@pytest.mark.parametrize(
+    "with_aux",
+    [True, False],
+)
+def test_get_workspace_data(workspace_factory, with_aux):
     w = workspace_factory()
     m = w.model()
-    assert w.data(m)
+    assert w.data(m, with_aux=with_aux)
 
 
 def test_get_workspace_data_bad_model(workspace_factory, caplog):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6,6 +6,7 @@ import json
 import logging
 import pyhf.workspace
 import pyhf.utils
+import copy
 
 
 @pytest.fixture(
@@ -602,6 +603,17 @@ def test_combine_workspace_compatible_parameter_configs_outer_join(
     )
     assert pyhf.workspace._join_measurements(
         join, ws['measurements'], ws['measurements']
+    )
+
+
+@pytest.mark.parametrize("join", ['outer'])
+def test_combine_workspace_measurements_outer_join(workspace_factory, join):
+    ws = workspace_factory()
+    left_measurements = ws['measurements']
+    right_measurements = copy.deepcopy(ws['measurements'])
+    right_measurements[0]['config']['parameters'][0]['name'] = 'fake'
+    assert pyhf.workspace._join_measurements(
+        join, left_measurements, right_measurements
     )
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -582,6 +582,25 @@ def test_combine_workspace_incompatible_parameter_configs_outer_join(
     ][0]['name'] in str(excinfo.value)
 
 
+@pytest.mark.parametrize("join", ['outer'])
+def test_combine_workspace_compatible_parameter_configs_outer_join(
+    workspace_factory, join
+):
+    ws = workspace_factory()
+    left_parameters = ws.get_measurement(measurement_name='GaussExample')['config'][
+        'parameters'
+    ]
+    right_parameters = ws.get_measurement(measurement_name='GaussExample')['config'][
+        'parameters'
+    ]
+    assert pyhf.workspace._join_parameter_configs(
+        'GaussExample', left_parameters, right_parameters
+    )
+    assert pyhf.workspace._join_measurements(
+        join, ws['measurements'], ws['measurements']
+    )
+
+
 def test_combine_workspace_incompatible_parameter_configs_left_outer_join(
     workspace_factory,
 ):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -539,7 +539,7 @@ def test_combine_workspace_invalid_join_operation(workspace_factory, join):
     assert join in str(excinfo.value)
 
 
-@pytest.mark.parametrize("join", ['none', 'outer'])
+@pytest.mark.parametrize("join", ['none'])
 def test_combine_workspace_invalid_join_operation_merge(workspace_factory, join):
     ws = workspace_factory()
     new_ws = ws.rename(

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -314,7 +314,6 @@ def join_items():
 def test_join_items_none(join_items):
     left_items, right_items = join_items
     joined = pyhf.workspace._join_items('none', left_items, right_items, key='name')
-    breakpoint()
     assert all(left in joined for left in left_items)
     assert all(right in joined for right in right_items)
 


### PR DESCRIPTION
# Description

This adds functionality to get channel merging as part of a "combination". Can only be done with `outer`, `left outer`, or `right outer`:

```
pyhf combine --join "left outer" \
             --merge-channels \
             <(pyhf prune --sample C1N2_Wh_hbb_800_250 pyhf_likelihood.json)\
             test.json
```

Additionally, clean up the logic in `pyhf.workspace._join_items` to fix up coverage.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Extend combine to allow for merging channels from two workspaces when performing an outer join
  - This is generally useful when you want to combine a bkg-only workspace with a signal-only workspace with the same set of channels, but need to merge the channels together (extend bkg-only samples with signal-only samples for each channel)
* Improve the coverage of pyhf/workspace.py by cleaning up the pyhf.workspace._join_items logic
```