### PR TITLE
docs: Remove fixed parameters caveat for TRexFitter in babel

### DIFF
--- a/docs/babel.rst
+++ b/docs/babel.rst
@@ -99,6 +99,5 @@ which will read all of the XML files and load the histogram data from the histog
 
     There are a few caveats one needs to be aware of with this conversion:
 
-    - Custom parameters cannot be held constant (e.g. lumi), see PR :pr:`846` and Issue :issue:`739`.
     - Uncorrelated shape systematics cannot be pruned, see Issue :issue:`662`.
     - Custom expressions for normalization factors cannot be used, see Issue :issue:`850`.


### PR DESCRIPTION
# Description

Clean up docs a bit. This is supported as of #846 / #1051.

/cc @alexander-held 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Remove fixed parameters caveat for TRexFitter in babel as it is now supported
```