### PR TITLE
docs: Add contributors to website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,10 @@ If you would like to make a pull request please:
 3. Commit your changes to a feature branch of your fork push to your branch
 4. Test your changes with `pytest`
 5. Update your fork to make sure your changes don't conflict with the current state of the master branch
-6. Request your changes be accepted
+6. Make sure that you've added your name to `docs/contributors.rst`.
+If you haven't **please** do so by simply appending your name to the bottom of the list.
+We are thankful for and value your contributions to `pyhf`, not matter the size.
+7. Request your changes be accepted
 
 ## Bug Reports
 

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -6,3 +6,14 @@ from its users.
 The ``pyhf`` dev team would like to thank all contributors to the project for
 their support and help.
 Thank you!
+
+Contributors include:
+
+- Jessica Forde
+- Ruggero Turra
+- Tadej Novak
+- Frank Sauerburger
+- Lars Nielsen
+- Kanishk Kalra
+- Nikolai Hartmann
+- Alex Held

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -1,0 +1,8 @@
+Contributors
+============
+
+``pyhf`` is openly developed and benefits from the contributions and feedback
+from its users.
+The ``pyhf`` dev team would like to thank all contributors to the project for
+their support and help.
+Thank you!

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -16,4 +16,4 @@ Contributors include:
 - Lars Nielsen
 - Kanishk Kalra
 - Nikolai Hartmann
-- Alex Held
+- Alexander Held

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@
    api
    citations
    governance/ROADMAP
+   contributors
 
 .. raw:: html
 


### PR DESCRIPTION
# Description

Resolves #1094 

List all the contributors to `pyhf` on the website and update the `CONTRIBUTING.md` to tell people to do so.

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-add-contributers-to-docs/contributors.html

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add list of all contributors as page to the website
* Update CONTRIBUTING.md to instruct people to add their names
```
