### PR TITLE
fix: Import all infer submodules

### DIFF
--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -175,5 +175,5 @@ def hypotest(
 
 from . import intervals
 
-# TODO: Can remove when switch to flake8 (Issue #863)
-__all__ = ["intervals"]
+# TODO: Can remove intervals when switch to flake8 (Issue #863)
+__all__ = ["hypotest", "intervals"]

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -174,7 +174,7 @@ def hypotest(
 
 
 # Make intervals available as top level import
-from pyhf.infer import intervals
+from . import intervals
 
 # TODO: Can remove when switch to flake8 (Issue #863)
 __all__ = ["intervals"]

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -1,6 +1,5 @@
 """Inference for Statistical Models."""
 
-from .test_statistics import qmu
 from .. import get_backend
 from .calculators import AsymptoticCalculator
 
@@ -172,6 +171,3 @@ def hypotest(
         _returns.append(tensorlib.astensor(CLs))
     # Enforce a consistent return type of the observed CLs
     return tuple(_returns) if len(_returns) > 1 else _returns[0]
-
-
-__all__ = ['qmu', 'hypotest']

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -173,7 +173,6 @@ def hypotest(
     return tuple(_returns) if len(_returns) > 1 else _returns[0]
 
 
-# Make intervals available as top level import
 from . import intervals
 
 # TODO: Can remove when switch to flake8 (Issue #863)

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -171,3 +171,10 @@ def hypotest(
         _returns.append(tensorlib.astensor(CLs))
     # Enforce a consistent return type of the observed CLs
     return tuple(_returns) if len(_returns) > 1 else _returns[0]
+
+
+# Make intervals available as top level import
+from pyhf.infer import intervals
+
+# TODO: Can remove when switch to flake8 (Issue #863)
+__all__ = ["intervals"]

--- a/src/pyhf/infer/intervals.py
+++ b/src/pyhf/infer/intervals.py
@@ -17,7 +17,6 @@ def upperlimit(data, model, scan, level=0.05, return_results=False):
     Example:
         >>> import numpy as np
         >>> import pyhf
-        >>> import pyhf.infer.intervals
         >>> pyhf.set_backend("numpy")
         >>> model = pyhf.simplemodels.hepdata_like(
         ...     signal_data=[12.0, 11.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0]

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1,6 +1,5 @@
 import pytest
 import pyhf
-import pyhf.infer.intervals
 import numpy as np
 import scipy.stats
 


### PR DESCRIPTION
# Description

Make `infer.intervals` available upon import of `pyhf`. This comes from a request from @alexander-held.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Make infer.intervals available at import of infer
* Remove unneeded imports
```
