### PR TITLE
fix: Remove improper defaults for contrib download

### DIFF
--- a/src/pyhf/cli/contrib.py
+++ b/src/pyhf/cli/contrib.py
@@ -25,7 +25,7 @@ def cli():
 
 
 @cli.command()
-@click.argument("archive-url", default="-")
+@click.argument("archive-url")
 @click.argument("output-directory", default="-")
 @click.option("-v", "--verbose", is_flag=True, help="Enables verbose mode")
 @click.option(

--- a/src/pyhf/cli/contrib.py
+++ b/src/pyhf/cli/contrib.py
@@ -26,7 +26,7 @@ def cli():
 
 @cli.command()
 @click.argument("archive-url")
-@click.argument("output-directory", default="-")
+@click.argument("output-directory")
 @click.option("-v", "--verbose", is_flag=True, help="Enables verbose mode")
 @click.option(
     "-f", "--force", is_flag=True, help="Force download from non-approved host"


### PR DESCRIPTION
# Description

Resolves #1103 

Remove defaults for `pyhf contrib download` that were wrongly set.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove contrib download defaults for arguments ARCHIVE_URL OUTPUT_DIRECTORY
* Amends PR #1046
```
