### PR TITLE
docs: Use 1Lbb DOI in contrib download docstring

### DIFF
--- a/src/pyhf/cli/contrib.py
+++ b/src/pyhf/cli/contrib.py
@@ -46,7 +46,7 @@ def download(archive_url, output_directory, verbose, force, compress):
 
     .. code-block:: shell
 
-        $ pyhf contrib download --verbose https://www.hepdata.net/record/resource/1408476?view=true 1Lbb-likelihoods
+        $ pyhf contrib download --verbose https://doi.org/10.17182/hepdata.90607.v3/r3 1Lbb-likelihoods
 
         \b
         1Lbb-likelihoods/patchset.json


### PR DESCRIPTION
# Description

using the new DOI thanks to @GraemeWatt

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use DOI in docstring example for pyhf contrib download
   - c.f. https://doi.org/10.17182/hepdata.90607.v3/r3
```