### PR TITLE
feat: Update model and inference defaults

### DIFF
--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -105,10 +105,6 @@ def fit(
     model = ws.model(
         measurement_name=measurement,
         patches=patches,
-        modifier_settings={
-            "normsys": {"interpcode": "code4"},
-            "histosys": {"interpcode": "code4p"},
-        },
     )
     data = ws.data(model)
 

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -11,7 +11,7 @@ def hypotest(
     init_pars=None,
     par_bounds=None,
     fixed_params=None,
-    qtilde=False,
+    qtilde=True,
     **kwargs,
 ):
     r"""

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -41,9 +41,9 @@ def hypotest(
         init_pars (:obj:`tensor`): The initial parameter values to be used for minimization
         par_bounds (:obj:`tensor`): The parameter value bounds to be used for minimization
         fixed_params (:obj:`tensor`): Whether to fix the parameter to the init_pars value during minimization
-        qtilde (:obj:`bool`): When ``True`` perform the calculation using the alternative
-         test statistic, :math:`\tilde{q}_{\mu}`, as defined under the Wald
-         approximation in Equation (62) of :xref:`arXiv:1007.1727`.
+        qtilde (:obj:`bool`): When ``True`` use :func:`~pyhf.infer.test_statistics.qmu_tilde`
+         as the test statistic.
+         When ``False`` use :func:`~pyhf.infer.test_statistics.qmu`.
 
     Keyword Args:
         return_tail_probs (bool): Bool for returning :math:`\mathrm{CL}_{s+b}` and :math:`\mathrm{CL}_{b}`

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -139,7 +139,9 @@ class AsymptoticCalculator(object):
             init_pars (:obj:`tensor`): The initial parameter values to be used for fitting.
             par_bounds (:obj:`tensor`): The parameter value bounds to be used for fitting.
             fixed_params (:obj:`tensor`): Whether to fix the parameter to the init_pars value during minimization
-            qtilde (:obj:`bool`): Whether to use qtilde as the test statistic.
+            qtilde (:obj:`bool`): When ``True`` use :func:`~pyhf.infer.test_statistics.qmu_tilde`
+             as the test statistic.
+             When ``False`` use :func:`~pyhf.infer.test_statistics.qmu`.
 
         Returns:
             ~pyhf.infer.calculators.AsymptoticCalculator: The calculator for asymptotic quantities.

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -128,7 +128,7 @@ class AsymptoticCalculator(object):
         init_pars=None,
         par_bounds=None,
         fixed_params=None,
-        qtilde=False,
+        qtilde=True,
     ):
         """
         Asymptotic Calculator.

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -158,7 +158,9 @@ class AsymptoticCalculator(object):
 
     def distributions(self, poi_test):
         """
-        Probability Distributions of the test statistic value under the signal + background and and background-only hypothesis.
+        Probability distributions of the test statistic, as defined in
+        :math:`\S` 3 of :xref:`arXiv:1007.1727` under the Wald approximation,
+        under the signal + background and background-only hypotheses.
 
         Args:
             poi_test: The value for the parameter of interest.

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -113,8 +113,8 @@ def qmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
 
 def qmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
     r"""
-    The test statistic, :math:`\tilde{q}_{\mu}`, for establishing an upper
-    limit on the strength parameter, :math:`\mu`, for models with
+    The "alternative" test statistic, :math:`\tilde{q}_{\mu}`, for establishing
+    an upper limit on the strength parameter, :math:`\mu`, for models with
     bounded POI, as defiend in Equation (16) in :xref:`arXiv:1007.1727`
 
     .. math::

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -224,7 +224,11 @@ class _ModelConfig(_ChannelSummaryMixin):
         )
         poi_name = config_kwargs.pop('poi_name', 'mu')
 
-        default_modifier_settings = {'normsys': {'interpcode': 'code1'}}
+        default_modifier_settings = {
+            'normsys': {'interpcode': 'code4'},
+            'histosys': {'interpcode': 'code4p'},
+        }
+
         self.modifier_settings = config_kwargs.pop(
             'modifier_settings', default_modifier_settings
         )

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -635,7 +635,9 @@ def test_validation(setup_and_tolerance):
     setup, tolerance = setup_and_tolerance
     source = setup['source']
 
-    pdf = pyhf.Model(setup['spec'])
+    pdf = pyhf.Model(
+        setup['spec'], modifier_settings={'normsys': {'interpcode': 'code1'}}
+    )
 
     if 'channels' in source:
         data = []


### PR DESCRIPTION
# Description

changes to saner defaults in python (same defaults used in CLI).

since this is an API change this should probably go in for `v0.6.0`.

ReadTheDocs build:

- https://pyhf.readthedocs.io/en/change_defaults/
- [`pyhf.infer.hypotest`](https://pyhf.readthedocs.io/en/change_defaults/_generated/pyhf.infer.hypotest.html)
- [`pyhf.infer.test_statistics.qmu_tilde`](https://pyhf.readthedocs.io/en/change_defaults/_generated/pyhf.infer.test_statistics.qmu_tilde.html)
- [`pyhf.infer.calculators.AsymptoticCalculator`](https://pyhf.readthedocs.io/en/change_defaults/_generated/pyhf.infer.calculators.AsymptoticCalculator.html)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use the same defaults across the Python and CLI API
   - Use interpolation code4 and code4p in default modifier settings for models
   - Use qtilde as the default test stat for inference
* Link to test stat functions in docstrings
   - Migrate mention of approximation of test stat distributions to AsymptoticCalculator.distributions
```