### PR TITLE
ci: Make docs separate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,64 +46,6 @@ jobs:
       run: |
         python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/test_benchmark.py
 
-  docs:
-
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.8]
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[docs,test]
-        python -m pip list
-        sudo apt-get update
-        sudo apt-get -qq install pandoc
-    - name: Check docstrings
-      run: |
-        # Group 1 is related to docstrings
-        pydocstyle --select D1 src/pyhf/pdf.py \
-                               src/pyhf/workspace.py \
-                               src/pyhf/probability.py \
-                               src/pyhf/patchset.py \
-                               src/pyhf/interpolators \
-                               src/pyhf/infer \
-                               src/pyhf/optimize \
-                               src/pyhf/contrib \
-                               src/pyhf/cli
-    - name: Test and build docs
-      run: |
-        python -m doctest README.rst
-        python setup.py build_sphinx
-        touch docs/_build/html/.nojekyll
-    - name: Check schemas are copied over
-      run: |
-        # is a directory
-        [ -d "docs/_build/html/schemas" ]
-        # is not a symlink
-        [ ! -L "docs/_build/html/schemas" ]
-        # is not empty
-        [ "$(ls -A docs/_build/html/schemas)" ]
-    - name: Deploy docs to GitHub Pages
-      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/_build/html
-        force_orphan: true
-        user_name: 'github-actions[bot]'
-        user_email: 'github-actions[bot]@users.noreply.github.com'
-        commit_message: Deploy to GitHub pages
-
   docker:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,65 @@
+name: Docs
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  docs:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --quiet --no-cache-dir --ignore-installed --upgrade .[docs,test]
+        python -m pip list
+        sudo apt-get update
+        sudo apt-get -qq install pandoc
+    - name: Check docstrings
+      run: |
+        # Group 1 is related to docstrings
+        pydocstyle --select D1 src/pyhf/pdf.py \
+                               src/pyhf/workspace.py \
+                               src/pyhf/probability.py \
+                               src/pyhf/patchset.py \
+                               src/pyhf/interpolators \
+                               src/pyhf/infer \
+                               src/pyhf/optimize \
+                               src/pyhf/contrib \
+                               src/pyhf/cli
+    - name: Test and build docs
+      run: |
+        python -m doctest README.rst
+        python setup.py build_sphinx
+        touch docs/_build/html/.nojekyll
+    - name: Check schemas are copied over
+      run: |
+        # is a directory
+        [ -d "docs/_build/html/schemas" ]
+        # is not a symlink
+        [ ! -L "docs/_build/html/schemas" ]
+        # is not empty
+        [ "$(ls -A docs/_build/html/schemas)" ]
+    - name: Deploy docs to GitHub Pages
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/_build/html
+        force_orphan: true
+        user_name: 'github-actions[bot]'
+        user_email: 'github-actions[bot]@users.noreply.github.com'
+        commit_message: Deploy to GitHub pages

--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,8 @@ pure-python fitting/limit-setting/interval estimation HistFactory-style
 
 |GitHub Project| |DOI| |Scikit-HEP| |NSF Award Number|
 
-|GitHub Actions Status: CI| |GitHub Actions Status: Publish| |Docker
-Automated| |Code Coverage| |Language grade: Python| |CodeFactor| |Code
-style: black|
+|GitHub Actions Status: CI| |GitHub Actions Status: Docs| |GitHub Actions Status: Publish|
+|Docker Automated| |Code Coverage| |Language grade: Python| |CodeFactor| |Code style: black|
 
 |Docs| |Binder|
 
@@ -318,6 +317,8 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
    :target: https://nsf.gov/awardsearch/showAward?AWD_ID=1836650
 .. |GitHub Actions Status: CI| image:: https://github.com/scikit-hep/pyhf/workflows/CI/CD/badge.svg
    :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3ACI%2FCD+branch%3Amaster
+.. |GitHub Actions Status: Docs| image:: https://github.com/scikit-hep/pyhf/workflows/Docs/badge.svg?branch=master
+   :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3ADocs+branch%3Amaster
 .. |GitHub Actions Status: Publish| image:: https://github.com/scikit-hep/pyhf/workflows/publish%20distributions/badge.svg
    :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3A%22publish+distributions%22+branch%3Amaster
 .. |Docker Automated| image:: https://img.shields.io/docker/automated/pyhf/pyhf.svg

--- a/README.rst
+++ b/README.rst
@@ -315,11 +315,11 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
    :target: https://scikit-hep.org/
 .. |NSF Award Number| image:: https://img.shields.io/badge/NSF-1836650-blue.svg
    :target: https://nsf.gov/awardsearch/showAward?AWD_ID=1836650
-.. |GitHub Actions Status: CI| image:: https://github.com/scikit-hep/pyhf/workflows/CI/CD/badge.svg
+.. |GitHub Actions Status: CI| image:: https://github.com/scikit-hep/pyhf/workflows/CI/CD/badge.svg?branch=master
    :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3ACI%2FCD+branch%3Amaster
 .. |GitHub Actions Status: Docs| image:: https://github.com/scikit-hep/pyhf/workflows/Docs/badge.svg?branch=master
    :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3ADocs+branch%3Amaster
-.. |GitHub Actions Status: Publish| image:: https://github.com/scikit-hep/pyhf/workflows/publish%20distributions/badge.svg
+.. |GitHub Actions Status: Publish| image:: https://github.com/scikit-hep/pyhf/workflows/publish%20distributions/badge.svg?branch=master
    :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3A%22publish+distributions%22+branch%3Amaster
 .. |Docker Automated| image:: https://img.shields.io/docker/automated/pyhf/pyhf.svg
    :target: https://hub.docker.com/r/pyhf/pyhf/


### PR DESCRIPTION
# Description

As there are certain times when the docs fail or needs to be rerun it is more convenient if they can be run by themselves rather than the full CI workflow. This PR migrates the doc testing and deployment into a separate GitHub Actions workflow.

ReadTheDocs build: https://pyhf.readthedocs.io/en/ci-migrate-docs-to-seperate-workflow/

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Migrate the testing and deploying of the docs into a separate GitHub Actions workflow
   - Allows for running independently using workflow dispatch
* Add Docs build status on master badge to README
```
