### PR TITLE
docs: Use sphinx obj scope in docs by default

### DIFF
--- a/src/pyhf/__init__.py
+++ b/src/pyhf/__init__.py
@@ -58,9 +58,9 @@ def set_backend(backend, custom_optimizer=None, precision=None):
         '64b'
 
     Args:
-        backend (`str` or `pyhf.tensor` backend): One of the supported pyhf backends: NumPy, TensorFlow, PyTorch, and JAX
+        backend (:obj:`str` or `pyhf.tensor` backend): One of the supported pyhf backends: NumPy, TensorFlow, PyTorch, and JAX
         custom_optimizer (`pyhf.optimize` optimizer): Optional custom optimizer defined by the user
-        precision (`str`): Floating point precision to use in the backend: ``64b`` or ``32b``. Default is backend dependent.
+        precision (:obj:`str`): Floating point precision to use in the backend: ``64b`` or ``32b``. Default is backend dependent.
 
     Returns:
         None

--- a/src/pyhf/constraints.py
+++ b/src/pyhf/constraints.py
@@ -84,14 +84,14 @@ class gaussian_constraint_combined(object):
     def has_pdf(self):
         """
         Returns:
-            flag (`bool`): Whether the model has a Gaussian Constraint
+            flag (:obj:`bool`): Whether the model has a Gaussian Constraint
         """
         return bool(self.param_viewer.index_selection)
 
     def make_pdf(self, pars):
         """
         Args:
-            pars (`tensor`): The model parameters
+            pars (:obj:`tensor`): The model parameters
 
         Returns:
             pdf: The pdf object for the Normal Constraint
@@ -118,8 +118,8 @@ class gaussian_constraint_combined(object):
     def logpdf(self, auxdata, pars):
         """
         Args:
-            auxdata (`tensor`): The auxiliary data (a subset of the full data in a HistFactory model)
-            pars (`tensor`): The model parameters
+            auxdata (:obj:`tensor`): The auxiliary data (a subset of the full data in a HistFactory model)
+            pars (:obj:`tensor`): The model parameters
 
         Returns:
             log pdf value: The log of the pdf value of the Normal constraints
@@ -215,14 +215,14 @@ class poisson_constraint_combined(object):
     def has_pdf(self):
         """
         Returns:
-            flag (`bool`): Whether the model has a Gaussian Constraint
+            flag (:obj:`bool`): Whether the model has a Gaussian Constraint
         """
         return bool(self.param_viewer.index_selection)
 
     def make_pdf(self, pars):
         """
         Args:
-            pars (`tensor`): The model parameters
+            pars (:obj:`tensor`): The model parameters
 
         Returns:
             pdf: the pdf object for the Poisson Constraint
@@ -250,8 +250,8 @@ class poisson_constraint_combined(object):
     def logpdf(self, auxdata, pars):
         """
         Args:
-            auxdata (`tensor`): The auxiliary data (a subset of the full data in a HistFactory model)
-            pars (`tensor`): The model parameters
+            auxdata (:obj:`tensor`): The auxiliary data (a subset of the full data in a HistFactory model)
+            pars (:obj:`tensor`): The model parameters
 
         Returns:
             log pdf value: The log of the pdf value of the Poisson constraints

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -30,10 +30,10 @@ try:
             ['1Lbb-likelihoods.tar.gz']
 
         Args:
-            archive_url (`str`): The URL of the :class:`~pyhf.patchset.PatchSet` archive to download.
-            output_directory (`str`): Name of the directory to unpack the archive into.
-            force (`Bool`): Force download from non-approved host. Default is ``False``.
-            compress (`Bool`): Keep the archive in a compressed ``tar.gz`` form. Default is ``False``.
+            archive_url (:obj:`str`): The URL of the :class:`~pyhf.patchset.PatchSet` archive to download.
+            output_directory (:obj:`str`): Name of the directory to unpack the archive into.
+            force (:obj:`bool`): Force download from non-approved host. Default is ``False``.
+            compress (:obj:`bool`): Keep the archive in a compressed ``tar.gz`` form. Default is ``False``.
 
         Raises:
             :class:`~pyhf.exceptions.InvalidArchiveHost`: if the provided archive host name is not known to be valid

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -38,10 +38,10 @@ def hypotest(
         poi_test (Number or Tensor): The value of the parameter of interest (POI)
         data (Number or Tensor): The data considered
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``
-        init_pars (`tensor`): The initial parameter values to be used for minimization
-        par_bounds (`tensor`): The parameter value bounds to be used for minimization
-        fixed_params (`tensor`): Whether to fix the parameter to the init_pars value during minimization
-        qtilde (Bool): When ``True`` perform the calculation using the alternative
+        init_pars (:obj:`tensor`): The initial parameter values to be used for minimization
+        par_bounds (:obj:`tensor`): The parameter value bounds to be used for minimization
+        fixed_params (:obj:`tensor`): Whether to fix the parameter to the init_pars value during minimization
+        qtilde (:obj:`bool`): When ``True`` perform the calculation using the alternative
          test statistic, :math:`\tilde{q}_{\mu}`, as defined under the Wald
          approximation in Equation (62) of :xref:`arXiv:1007.1727`.
 

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -17,12 +17,12 @@ def generate_asimov_data(asimov_mu, data, pdf, init_pars, par_bounds, fixed_para
     Compute Asimov Dataset (expected yields at best-fit values) for a given POI value.
 
     Args:
-        asimov_mu (`float`): The value for the parameter of interest to be used.
-        data (`tensor`): The observed data.
+        asimov_mu (:obj:`float`): The value for the parameter of interest to be used.
+        data (:obj:`tensor`): The observed data.
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``.
-        init_pars (`tensor`): The initial parameter values to be used for fitting.
-        par_bounds (`tensor`): The parameter value bounds to be used for fitting.
-        fixed_params (`tensor`): Parameters to be held constant in the fit.
+        init_pars (:obj:`tensor`): The initial parameter values to be used for fitting.
+        par_bounds (:obj:`tensor`): The parameter value bounds to be used for fitting.
+        fixed_params (:obj:`tensor`): Parameters to be held constant in the fit.
 
     Returns:
         Tensor: The Asimov dataset.
@@ -53,7 +53,7 @@ class AsymptoticTestStatDistribution(object):
         Asymptotic test statistic distribution.
 
         Args:
-            shift (`float`): The displacement of the test statistic distribution.
+            shift (:obj:`float`): The displacement of the test statistic distribution.
 
         Returns:
             ~pyhf.infer.calculators.AsymptoticTestStatDistribution: The asymptotic distribution of test statistic.
@@ -67,7 +67,7 @@ class AsymptoticTestStatDistribution(object):
         Compute the value of the cumulative distribution function for a given value of the test statistic.
 
         Args:
-            value (`float`): The test statistic value.
+            value (:obj:`float`): The test statistic value.
 
         Returns:
             Float: The integrated probability to observe a test statistic less than or equal to the observed ``value``.
@@ -95,7 +95,7 @@ class AsymptoticTestStatDistribution(object):
         given the observed test statistics :math:`q_{\mu}` and :math:`q_{\mu,A}`.
 
         Args:
-            value (`float`): The test statistic value.
+            value (:obj:`float`): The test statistic value.
 
         Returns:
             Float: The integrated probability to observe a value at least as large as the observed one.
@@ -110,7 +110,7 @@ class AsymptoticTestStatDistribution(object):
         Return the expected value of the test statistic.
 
         Args:
-            nsigma (`int` or `tensor`): The number of standard deviations.
+            nsigma (:obj:`int` or :obj:`tensor`): The number of standard deviations.
 
         Returns:
             Float: The expected value of the test statistic.
@@ -134,12 +134,12 @@ class AsymptoticCalculator(object):
         Asymptotic Calculator.
 
         Args:
-            data (`tensor`): The observed data.
+            data (:obj:`tensor`): The observed data.
             pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``.
-            init_pars (`tensor`): The initial parameter values to be used for fitting.
-            par_bounds (`tensor`): The parameter value bounds to be used for fitting.
-            fixed_params (`tensor`): Whether to fix the parameter to the init_pars value during minimization
-            qtilde (`bool`): Whether to use qtilde as the test statistic.
+            init_pars (:obj:`tensor`): The initial parameter values to be used for fitting.
+            par_bounds (:obj:`tensor`): The parameter value bounds to be used for fitting.
+            fixed_params (:obj:`tensor`): Whether to fix the parameter to the init_pars value during minimization
+            qtilde (:obj:`bool`): Whether to use qtilde as the test statistic.
 
         Returns:
             ~pyhf.infer.calculators.AsymptoticCalculator: The calculator for asymptotic quantities.

--- a/src/pyhf/infer/intervals.py
+++ b/src/pyhf/infer/intervals.py
@@ -33,11 +33,11 @@ def upperlimit(data, model, scan, level=0.05, return_results=False):
         [array(0.59576921), array(0.76169166), array(1.08504773), array(1.50170482), array(2.06654952)]
 
     Args:
-        data (`tensor`): The observed data.
+        data (:obj:`tensor`): The observed data.
         model (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``.
-        scan (`Iterable`): Iterable of POI values.
-        level (`float`): The threshold value to evaluate the interpolated results at.
-        return_results (`bool`): Whether to return the per-point results.
+        scan (:obj:`iterable`): Iterable of POI values.
+        level (:obj:`float`): The threshold value to evaluate the interpolated results at.
+        return_results (:obj:`bool`): Whether to return the per-point results.
 
     Returns:
         Tuple of Tensors:

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -37,8 +37,8 @@ def twice_nll(pars, data, pdf):
         array([ True])
 
     Args:
-        pars (`tensor`): The parameters of the HistFactory model
-        data (`tensor`): The data to be considered
+        pars (:obj:`tensor`): The parameters of the HistFactory model
+        data (:obj:`tensor`): The data to be considered
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
 
     Returns:
@@ -83,11 +83,11 @@ def fit(data, pdf, init_pars=None, par_bounds=None, fixed_params=None, **kwargs)
         array([ True])
 
     Args:
-        data (`tensor`): The data
+        data (:obj:`tensor`): The data
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
-        init_pars (`list`): Values to initialize the model parameters at for the fit
-        par_bounds (`list` of `list`\s or `tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
-        fixed_params (`list`): Parameters to be held constant in the fit.
+        init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
+        par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
+        fixed_params (:obj:`list`): Parameters to be held constant in the fit.
         kwargs: Keyword arguments passed through to the optimizer API
 
     Returns:
@@ -154,9 +154,9 @@ def fixed_poi_fit(
     Args:
         data: The data
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
-        init_pars (`list`): Values to initialize the model parameters at for the fit
-        par_bounds (`list` of `list`\s or `tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
-        fixed_params (`list`): Parameters to be held constant in the fit.
+        init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
+        par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
+        fixed_params (:obj:`list`): Parameters to be held constant in the fit.
         kwargs: Keyword arguments passed through to the optimizer API
 
     Returns:

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -92,9 +92,9 @@ def qmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
         mu (Number or Tensor): The signal strength parameter
         data (Tensor): The data to be considered
         pdf (~pyhf.pdf.Model): The HistFactory statistical model used in the likelihood ratio calculation
-        init_pars (`list`): Values to initialize the model parameters at for the fit
-        par_bounds (`list` of `list`\s or `tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
-        fixed_params (`list`): Parameters held constant in the fit
+        init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
+        par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
+        fixed_params (:obj:`list`): Parameters held constant in the fit
 
     Returns:
         Float: The calculated test statistic, :math:`q_{\mu}`
@@ -156,11 +156,11 @@ def qmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
 
     Args:
         mu (Number or Tensor): The signal strength parameter
-        data (Tensor): The data to be considered
+        data (:obj:`tensor`): The data to be considered
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
-        init_pars (`list`): Values to initialize the model parameters at for the fit
-        par_bounds (`list` of `list`\s or `tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
-        fixed_params (`list`): Parameters held constant in the fit
+        init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
+        par_bounds (:obj:`list` of `list`\s or `tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
+        fixed_params (:obj:`list`): Parameters held constant in the fit
 
     Returns:
         Float: The calculated test statistic, :math:`\tilde{q}_{\mu}`
@@ -213,9 +213,9 @@ def tmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
         mu (Number or Tensor): The signal strength parameter
         data (Tensor): The data to be considered
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
-        init_pars (`list`): Values to initialize the model parameters at for the fit
-        par_bounds (`list` of `list`\s or `tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
-        fixed_params (`list`): Parameters held constant in the fit
+        init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
+        par_bounds (:obj:`list` of `list`\s or `tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
+        fixed_params (:obj:`list`): Parameters held constant in the fit
 
     Returns:
         Float: The calculated test statistic, :math:`t_{\mu}`
@@ -271,11 +271,11 @@ def tmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
 
     Args:
         mu (Number or Tensor): The signal strength parameter
-        data (Tensor): The data to be considered
+        data (:obj:`tensor`): The data to be considered
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
-        init_pars (`list`): Values to initialize the model parameters at for the fit
-        par_bounds (`list` of `list`\s or `tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
-        fixed_params (`list`): Parameters held constant in the fit
+        init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
+        par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
+        fixed_params (:obj:`list`): Parameters held constant in the fit
 
     Returns:
         Float: The calculated test statistic, :math:`\tilde{t}_{\mu}`

--- a/src/pyhf/modifiers/__init__.py
+++ b/src/pyhf/modifiers/__init__.py
@@ -70,10 +70,10 @@ def modifier(*args, **kwargs):
 
 
     Args:
-        name: the name of the modifier to use. Use the class name by default. (default: None)
-        constrained: whether the modifier is constrained or not. (default: False)
-        pdf_type: the name of the pdf to use from tensorlib if constrained. (default: normal)
-        op_code: the name of the operation the modifier performs on the data (e.g. addition, multiplication)
+        name (:obj:`str`): the name of the modifier to use. Use the class name by default. (default: None)
+        constrained (:obj:`bool`): whether the modifier is constrained or not. (default: False)
+        pdf_type (:obj:`str): the name of the pdf to use from tensorlib if constrained. (default: normal)
+        op_code (:obj:`str`): the name of the operation the modifier performs on the data (e.g. addition, multiplication)
 
     Returns:
         modifier

--- a/src/pyhf/optimize/common.py
+++ b/src/pyhf/optimize/common.py
@@ -13,10 +13,10 @@ def _make_stitch_pars(tv=None, fixed_values=None):
 
     Args:
         tv (~pyhf.tensor.common._TensorViewer): tensor viewer instance
-        fixed_values (`list`): default set of values to stitch parameters with
+        fixed_values (:obj:`list`): default set of values to stitch parameters with
 
     Returns:
-        callable (`func`): a callable that takes nuisance parameter values as input
+        callable (:obj:`func`): a callable that takes nuisance parameter values as input
     """
     if tv is None or fixed_values is None:
         return lambda pars, stitch_with=None: pars
@@ -72,22 +72,22 @@ def shim(
     Prepare Minimization for Optimizer.
 
     Args:
-        objective (`func`): objective function
-        data (`list`): observed data
+        objective (:obj:`func`): objective function
+        data (:obj:`list`): observed data
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
-        init_pars (`list`): initial parameters
-        par_bounds (`list`): parameter boundaries
-        fixed_vals (`list`): fixed parameter values
+        init_pars (:obj:`list`): initial parameters
+        par_bounds (:obj:`list`): parameter boundaries
+        fixed_vals (:obj:`list`): fixed parameter values
 
     .. note::
 
         ``minimizer_kwargs`` is a dictionary containing
 
-          - ``func`` (`func`): backend-wrapped ``objective`` function (potentially with gradient)
-          - ``x0`` (`list`):  modified initializations for minimizer
-          - ``do_grad`` (`bool`): whether or not gradient is used
-          - ``bounds`` (`list`): modified bounds for minimizer
-          - ``fixed_vals`` (`list`): modified fixed values for minimizer
+          - ``func`` (:obj:`func`): backend-wrapped ``objective`` function (potentially with gradient)
+          - ``x0`` (:obj:`list`):  modified initializations for minimizer
+          - ``do_grad`` (:obj:`bool`): whether or not gradient is used
+          - ``bounds`` (:obj:`list`): modified bounds for minimizer
+          - ``fixed_vals`` (:obj:`list`): modified fixed values for minimizer
 
     .. note::
 
@@ -100,8 +100,8 @@ def shim(
         ``do_stitch`` will modify the ``init_pars``, ``par_bounds``, and ``fixed_vals`` by stripping away the entries associated with fixed parameters. The parameters can be stitched back in via ``stitch_pars``.
 
     Returns:
-        minimizer_kwargs (`dict`): arguments to pass to a minimizer following the :func:`scipy.optimize.minimize` API (see notes)
-        stitch_pars (`func`): callable that stitches fixed parameters into the unfixed parameters
+        minimizer_kwargs (:obj:`dict`): arguments to pass to a minimizer following the :func:`scipy.optimize.minimize` API (see notes)
+        stitch_pars (:obj:`func`): callable that stitches fixed parameters into the unfixed parameters
     """
     tensorlib, _ = get_backend()
 

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -17,8 +17,8 @@ class OptimizerMixin(object):
         Create an optimizer.
 
         Args:
-            maxiter (`int`): maximum number of iterations. Default is 100000.
-            verbose (`int`): verbose output level during minimization. Default is off (0).
+            maxiter (:obj:`int`): maximum number of iterations. Default is 100000.
+            verbose (:obj:`int`): verbose output level during minimization. Default is off (0).
         """
         self.maxiter = kwargs.pop('maxiter', 100000)
         self.verbose = kwargs.pop('verbose', 0)
@@ -99,23 +99,23 @@ class OptimizerMixin(object):
         Find parameters that minimize the objective.
 
         Args:
-            objective (`func`): objective function
-            data (`list`): observed data
+            objective (:obj:`func`): objective function
+            data (:obj:`list`): observed data
             pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
-            init_pars (`list`): initial parameters
-            par_bounds (`list`): parameter boundaries
-            fixed_vals (`list`): fixed parameter values
-            return_fitted_val (`bool`): return bestfit value of the objective
-            return_result_obj (`bool`): return :class:`scipy.optimize.OptimizeResult`
-            do_grad (`bool`): enable autodifferentiation mode. Default depends on backend (:attr:`pyhf.tensorlib.default_do_grad`).
-            do_stitch (`bool`): enable splicing/stitching fixed parameter.
+            init_pars (:obj:`list`): initial parameters
+            par_bounds (:obj:`list`): parameter boundaries
+            fixed_vals (:obj:`list`): fixed parameter values
+            return_fitted_val (:obj:`bool`): return bestfit value of the objective
+            return_result_obj (:obj:`bool`): return :class:`scipy.optimize.OptimizeResult`
+            do_grad (:obj:`bool`): enable autodifferentiation mode. Default depends on backend (:attr:`pyhf.tensorlib.default_do_grad`).
+            do_stitch (:obj:`bool`): enable splicing/stitching fixed parameter.
             kwargs: other options to pass through to underlying minimizer
 
         Returns:
             Fitted parameters or tuple of results:
 
-                - parameters (`tensor`): fitted parameters
-                - minimum (`float`): if ``return_fitted_val`` flagged, return minimized objective value
+                - parameters (:obj:`tensor`): fitted parameters
+                - minimum (:obj:`float`): if ``return_fitted_val`` flagged, return minimized objective value
                 - result (:class:`scipy.optimize.OptimizeResult`): if ``return_result_obj`` flagged
         """
         # Configure do_grad based on backend "automagically" if not set by user

--- a/src/pyhf/optimize/opt_jax.py
+++ b/src/pyhf/optimize/opt_jax.py
@@ -36,14 +36,14 @@ def wrap_objective(objective, data, pdf, stitch_pars, do_grad=False, jit_pieces=
     Wrap the objective function for the minimization.
 
     Args:
-        objective (`func`): objective function
-        data (`list`): observed data
+        objective (:obj:`func`): objective function
+        data (:obj:`list`): observed data
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
-        stitch_pars (`func`): callable that stitches parameters, see :func:`pyhf.optimize.common.shim`.
-        do_grad (`bool`): enable autodifferentiation mode. Default is off.
+        stitch_pars (:obj:`func`): callable that stitches parameters, see :func:`pyhf.optimize.common.shim`.
+        do_grad (:obj:`bool`): enable autodifferentiation mode. Default is off.
 
     Returns:
-        objective_and_grad (`func`): tensor backend wrapped objective,gradient pair
+        objective_and_grad (:obj:`func`): tensor backend wrapped objective,gradient pair
     """
     tensorlib, _ = get_backend()
     # NB: tuple arguments that need to be hashable (static_argnums)

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -25,8 +25,8 @@ class minuit_optimizer(OptimizerMixin):
 
 
         Args:
-            errordef (`float`): See minuit docs. Default is 1.0.
-            steps (`int`): Number of steps for the bounds. Default is 1000.
+            errordef (:obj:`float`): See minuit docs. Default is 1.0.
+            steps (:obj:`int`): Number of steps for the bounds. Default is 1000.
         """
         self.name = 'minuit'
         self.errordef = kwargs.pop('errordef', 1)
@@ -85,8 +85,8 @@ class minuit_optimizer(OptimizerMixin):
         underlying minimizer.
 
         Minimizer Options:
-            maxiter (`int`): maximum number of iterations. Default is 100000.
-            return_uncertainties (`bool`): Return uncertainties on the fitted parameters. Default is off.
+            maxiter (:obj:`int`): maximum number of iterations. Default is 100000.
+            return_uncertainties (:obj:`bool`): Return uncertainties on the fitted parameters. Default is off.
 
         Returns:
             fitresult (scipy.optimize.OptimizeResult): the fit result

--- a/src/pyhf/optimize/opt_numpy.py
+++ b/src/pyhf/optimize/opt_numpy.py
@@ -9,14 +9,14 @@ def wrap_objective(objective, data, pdf, stitch_pars, do_grad=False, jit_pieces=
     Wrap the objective function for the minimization.
 
     Args:
-        objective (`func`): objective function
-        data (`list`): observed data
+        objective (:obj:`func`): objective function
+        data (:obj:`list`): observed data
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
-        stitch_pars (`func`): callable that stitches parameters, see :func:`pyhf.optimize.common.shim`.
-        do_grad (`bool`): enable autodifferentiation mode. Default is off.
+        stitch_pars (:obj:`func`): callable that stitches parameters, see :func:`pyhf.optimize.common.shim`.
+        do_grad (:obj:`bool`): enable autodifferentiation mode. Default is off.
 
     Returns:
-        objective_and_grad (`func`): tensor backend wrapped objective,gradient pair
+        objective_and_grad (:obj:`func`): tensor backend wrapped objective,gradient pair
     """
 
     tensorlib, _ = get_backend()

--- a/src/pyhf/optimize/opt_pytorch.py
+++ b/src/pyhf/optimize/opt_pytorch.py
@@ -9,14 +9,14 @@ def wrap_objective(objective, data, pdf, stitch_pars, do_grad=False, jit_pieces=
     Wrap the objective function for the minimization.
 
     Args:
-        objective (`func`): objective function
-        data (`list`): observed data
+        objective (:obj:`func`): objective function
+        data (:obj:`list`): observed data
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
-        stitch_pars (`func`): callable that stitches parameters, see :func:`pyhf.optimize.common.shim`.
-        do_grad (`bool`): enable autodifferentiation mode. Default is off.
+        stitch_pars (:obj:`func`): callable that stitches parameters, see :func:`pyhf.optimize.common.shim`.
+        do_grad (:obj:`bool`): enable autodifferentiation mode. Default is off.
 
     Returns:
-        objective_and_grad (`func`): tensor backend wrapped objective,gradient pair
+        objective_and_grad (:obj:`func`): tensor backend wrapped objective,gradient pair
     """
 
     tensorlib, _ = get_backend()

--- a/src/pyhf/optimize/opt_tflow.py
+++ b/src/pyhf/optimize/opt_tflow.py
@@ -8,14 +8,14 @@ def wrap_objective(objective, data, pdf, stitch_pars, do_grad=False, jit_pieces=
     Wrap the objective function for the minimization.
 
     Args:
-        objective (`func`): objective function
-        data (`list`): observed data
+        objective (:obj:`func`): objective function
+        data (:obj:`list`): observed data
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
-        stitch_pars (`func`): callable that stitches parameters, see :func:`pyhf.optimize.common.shim`.
-        do_grad (`bool`): enable autodifferentiation mode. Default is off.
+        stitch_pars (:obj:`func`): callable that stitches parameters, see :func:`pyhf.optimize.common.shim`.
+        do_grad (:obj:`bool`): enable autodifferentiation mode. Default is off.
 
     Returns:
-        objective_and_grad (`func`): tensor backend wrapped objective,gradient pair
+        objective_and_grad (:obj:`func`): tensor backend wrapped objective,gradient pair
     """
     tensorlib, _ = get_backend()
 

--- a/src/pyhf/patchset.py
+++ b/src/pyhf/patchset.py
@@ -27,7 +27,7 @@ class Patch(jsonpatch.JsonPatch):
         Construct a Patch.
 
         Args:
-            spec (`jsonable`): The patch JSON specification
+            spec (:obj:`jsonable`): The patch JSON specification
 
         Returns:
             patch (:class:`~pyhf.patchset.Patch`): The Patch instance.
@@ -146,7 +146,7 @@ class PatchSet(object):
         Construct a PatchSet.
 
         Args:
-            spec (`jsonable`): The patchset JSON specification
+            spec (:obj:`jsonable`): The patchset JSON specification
             config_kwargs: Possible keyword arguments for the patchset validation
 
         Returns:

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -365,7 +365,7 @@ class _ConstraintModel(object):
         Construct a pdf object for a given set of parameter values.
 
         Args:
-            pars (`tensor`): The model parameters
+            pars (:obj:`tensor`): The model parameters
 
         Returns:
             pdf: A distribution object implementing the constraint pdf of HistFactory.
@@ -392,8 +392,8 @@ class _ConstraintModel(object):
         Compute the logarithm of the value of the probability density.
 
         Args:
-            auxdata (`tensor`): The auxiliary data (a subset of the full data in a HistFactory model)
-            pars (`tensor`): The model parameters
+            auxdata (:obj:`tensor`): The auxiliary data (a subset of the full data in a HistFactory model)
+            pars (:obj:`tensor`): The model parameters
 
         Returns:
             Tensor: The log of the pdf value
@@ -461,8 +461,8 @@ class _MainModel(object):
         Compute the logarithm of the value of the probability density.
 
         Args:
-            maindata (`tensor`): The main channnel data (a subset of the full data in a HistFactory model)
-            pars (`tensor`): The model parameters
+            maindata (:obj:`tensor`): The main channnel data (a subset of the full data in a HistFactory model)
+            pars (:obj:`tensor`): The model parameters
 
         Returns:
             Tensor: The log of the pdf value
@@ -547,12 +547,12 @@ class Model(object):
         Construct a HistFactory Model.
 
         Args:
-            spec (`jsonable`): The HistFactory JSON specification
-            batch_size (`None` or `int`): Number of simultaneous (batched) Models to compute.
+            spec (:obj:`jsonable`): The HistFactory JSON specification
+            batch_size (:obj:`None` or :obj:`int`): Number of simultaneous (batched) Models to compute.
             config_kwargs: Possible keyword arguments for the model configuration
 
         Returns:
-            model (`Model`): The Model instance.
+            model (:class:`~pyhf.pdf.Model`): The Model instance.
 
         """
         self.batch_size = batch_size
@@ -604,7 +604,7 @@ class Model(object):
         Compute the expected value of the auxiliary measurements.
 
         Args:
-            pars (`tensor`): The parameter values
+            pars (:obj:`tensor`): The parameter values
 
         Returns:
             Tensor: The expected data of the auxiliary pdf
@@ -627,7 +627,7 @@ class Model(object):
         Compute the expected value of the main model.
 
         Args:
-            pars (`tensor`): The parameter values
+            pars (:obj:`tensor`): The parameter values
 
         Returns:
             Tensor: The expected data of the main model (no auxiliary data)
@@ -642,7 +642,7 @@ class Model(object):
         Compute the expected value of the main model
 
         Args:
-            pars (`tensor`): The parameter values
+            pars (:obj:`tensor`): The parameter values
 
         Returns:
             Tensor: The expected data of the main and auxiliary model
@@ -659,8 +659,8 @@ class Model(object):
         Compute the log value of the constraint pdf.
 
         Args:
-            auxdata (`tensor`): The auxiliary measurement data
-            pars (`tensor`): The parameter values
+            auxdata (:obj:`tensor`): The auxiliary measurement data
+            pars (:obj:`tensor`): The parameter values
 
         Returns:
             Tensor: The log density value
@@ -673,8 +673,8 @@ class Model(object):
         Compute the log value of the main term.
 
         Args:
-            maindata (`tensor`): The main measurement data
-            pars (`tensor`): The parameter values
+            maindata (:obj:`tensor`): The main measurement data
+            pars (:obj:`tensor`): The parameter values
 
         Returns:
             Tensor: The log density value
@@ -687,7 +687,7 @@ class Model(object):
         Construct a pdf object for a given set of parameter values.
 
         Args:
-            pars (`tensor`): The model parameters
+            pars (:obj:`tensor`): The model parameters
 
         Returns:
             pdf: A distribution object implementing the main measurement pdf of HistFactory
@@ -711,8 +711,8 @@ class Model(object):
         Compute the log value of the full density.
 
         Args:
-            pars (`tensor`): The parameter values
-            data (`tensor`): The measurement data
+            pars (:obj:`tensor`): The parameter values
+            data (:obj:`tensor`): The measurement data
 
         Returns:
             Tensor: The log density value
@@ -758,8 +758,8 @@ class Model(object):
         Compute the density at a given observed point in data space of the full model.
 
         Args:
-            pars (`tensor`): The parameter values
-            data (`tensor`): The measurement data
+            pars (:obj:`tensor`): The parameter values
+            data (:obj:`tensor`): The measurement data
 
         Returns:
             Tensor: The density value

--- a/src/pyhf/probability.py
+++ b/src/pyhf/probability.py
@@ -10,7 +10,7 @@ class _SimpleDistributionMixin(object):
         The log of the probability density function at the given value.
 
         Args:
-            value (`tensor` or `float`): The value at which to evaluate the distribution
+            value (:obj:`tensor` or :obj:`float`): The value at which to evaluate the distribution
 
         Returns:
             Tensor: The value of :math:`\log(f\left(x\middle|\theta\right))` for :math:`x=`:code:`value`
@@ -33,7 +33,7 @@ class _SimpleDistributionMixin(object):
         The collection of values sampled from the probability density function.
 
         Args:
-            sample_shape (`tuple`): The shape of the sample to be returned
+            sample_shape (:obj:`tuple`): The shape of the sample to be returned
 
         Returns:
             Tensor: The values :math:`x \sim f(\theta)` where :math:`x` has shape :code:`sample_shape`
@@ -57,7 +57,7 @@ class Poisson(_SimpleDistributionMixin):
     def __init__(self, rate):
         """
         Args:
-            rate (`tensor` or `float`): The mean of the Poisson distribution (the expected number of events)
+            rate (:obj:`tensor` or :obj:`float`): The mean of the Poisson distribution (the expected number of events)
         """
         tensorlib, _ = get_backend()
         self.rate = rate
@@ -96,8 +96,8 @@ class Normal(_SimpleDistributionMixin):
     def __init__(self, loc, scale):
         """
         Args:
-            loc (`tensor` or `float`): The mean of the Normal distribution
-            scale (`tensor` or `float`): The standard deviation of the Normal distribution
+            loc (:obj:`tensor` or :obj:`float`): The mean of the Normal distribution
+            scale (:obj:`tensor` or :obj:`float`): The standard deviation of the Normal distribution
         """
 
         tensorlib, _ = get_backend()
@@ -143,8 +143,8 @@ class Independent(_SimpleDistributionMixin):
     def __init__(self, batched_pdf, batch_size=None):
         """
         Args:
-            batched_pdf (`pyhf.probability` distribution): The batch of pdfs of the same type (e.g. Poisson)
-            batch_size (`int`): The size of the batch
+            batched_pdf (:obj:`pyhf.probability` distribution): The batch of pdfs of the same type (e.g. Poisson)
+            batch_size (:obj:`int`): The size of the batch
         """
         self.batch_size = batch_size
         self._pdf = batched_pdf
@@ -170,7 +170,7 @@ class Independent(_SimpleDistributionMixin):
             -4.347743645878765
 
         Args:
-            value (`tensor` or `float`): The value at which to evaluate the distribution
+            value (:obj:`tensor` or :obj:`float`): The value at which to evaluate the distribution
 
         Returns:
             Tensor: The value of :math:`\log(f\left(x\middle|\theta\right))` for :math:`x=`:code:`value`
@@ -210,9 +210,9 @@ class Simultaneous(object):
 
         Args:
 
-            pdfobjs (`Distribution`): The constituent pdf objects
-            tensorview (`_TensorViewer`): The :code:`_TensorViewer` defining the data composition
-            batch_size (`int`): The size of the batch
+            pdfobjs (:class:`Distribution`): The constituent pdf objects
+            tensorview (:class:`_TensorViewer`): The :code:`_TensorViewer` defining the data composition
+            batch_size (:obj:`int`): The size of the batch
 
         """
         self.tv = tensorview
@@ -224,7 +224,7 @@ class Simultaneous(object):
         Iterate over the constituent pdf objects
 
         Returns:
-            pdfobj (`Distribution`): A constituent pdf object
+            pdfobj (:class:`Distribution`): A constituent pdf object
 
         """
         for pdfobj in self._pdfobjs:
@@ -236,10 +236,10 @@ class Simultaneous(object):
 
         Args:
 
-            index (`int`): The index to access the constituent pdf object
+            index (:obj:`int`): The index to access the constituent pdf object
 
         Returns:
-            pdfobj (`Distribution`): A constituent pdf object
+            pdfobj (:class:`Distribution`): A constituent pdf object
 
         """
         return self._pdfobjs[index]
@@ -260,7 +260,7 @@ class Simultaneous(object):
         The collection of values sampled from the probability density function.
 
         Args:
-            sample_shape (`tuple`): The shape of the sample to be returned
+            sample_shape (:obj:`tuple`): The shape of the sample to be returned
 
         Returns:
             Tensor: The values :math:`x \sim f(\theta)` where :math:`x` has shape :code:`sample_shape`
@@ -273,7 +273,7 @@ class Simultaneous(object):
         The log of the probability density function at the given value.
 
         Args:
-            value (`tensor`): The observed value
+            value (:obj:`tensor`): The observed value
 
         Returns:
             Tensor: The value of :math:`\log(f\left(x\middle|\theta\right))` for :math:`x=`:code:`value`

--- a/src/pyhf/simplemodels.py
+++ b/src/pyhf/simplemodels.py
@@ -25,10 +25,10 @@ def hepdata_like(signal_data, bkg_data, bkg_uncerts, batch_size=None):
         array([ 62.        ,  63.        , 277.77777778,  55.18367347])
 
     Args:
-        signal_data (`list`): The data in the signal sample
-        bkg_data (`list`): The data in the background sample
-        bkg_uncerts (`list`): The statistical uncertainty on the background sample counts
-        batch_size (`None` or `int`): Number of simultaneous (batched) Models to compute
+        signal_data (:obj:`list`): The data in the signal sample
+        bkg_data (:obj:`list`): The data in the background sample
+        bkg_uncerts (:obj:`list`): The statistical uncertainty on the background sample counts
+        batch_size (:obj:`None` or :obj:`int`): Number of simultaneous (batched) Models to compute
 
     Returns:
         ~pyhf.pdf.Model: The statistical model adhering to the :obj:`model.json` schema

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -74,9 +74,9 @@ class jax_backend(object):
             DeviceArray([-1., -1.,  0.,  1.,  1.], dtype=float64)
 
         Args:
-            tensor_in (`tensor`): The input tensor object
-            min_value (`scalar` or `tensor` or `None`): The minimum value to be cliped to
-            max_value (`scalar` or `tensor` or `None`): The maximum value to be cliped to
+            tensor_in (:obj:`tensor`): The input tensor object
+            min_value (:obj:`scalar` or :obj:`tensor` or :obj:`None`): The minimum value to be cliped to
+            max_value (:obj:`scalar` or :obj:`tensor` or :obj:`None`): The maximum value to be cliped to
 
         Returns:
             JAX ndarray: A clipped `tensor`
@@ -97,7 +97,7 @@ class jax_backend(object):
                           0.99532227], dtype=float64)
 
         Args:
-            tensor_in (`tensor`): The input tensor object
+            tensor_in (:obj:`tensor`): The input tensor object
 
         Returns:
             JAX ndarray: The values of the error function at the given points.
@@ -117,7 +117,7 @@ class jax_backend(object):
             DeviceArray([-2., -1.,  0.,  1.,  2.], dtype=float64)
 
         Args:
-            tensor_in (`tensor`): The input tensor object
+            tensor_in (:obj:`tensor`): The input tensor object
 
         Returns:
             JAX ndarray: The values of the inverse of the error function at the given points.
@@ -138,8 +138,8 @@ class jax_backend(object):
                          [2., 2.]], dtype=float64)
 
         Args:
-            tensor_in (`Tensor`): The tensor to be repeated
-            repeats (`Tensor`): The tuple of multipliers for each dimension
+            tensor_in (:obj:`tensor`): The tensor to be repeated
+            repeats (:obj:`tensor`): The tuple of multipliers for each dimension
 
         Returns:
             JAX ndarray: The tensor with repeated axes
@@ -161,9 +161,9 @@ class jax_backend(object):
             DeviceArray([9.], dtype=float64)
 
         Args:
-            predicate (`scalar`): The logical condition that determines which callable to evaluate
-            true_callable (`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`true`
-            false_callable (`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`false`
+            predicate (:obj:`scalar`): The logical condition that determines which callable to evaluate
+            true_callable (:obj:`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`true`
+            false_callable (:obj:`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`false`
 
         Returns:
             JAX ndarray: The output of the callable that was evaluated
@@ -340,9 +340,9 @@ class jax_backend(object):
             DeviceArray([0.16062314, 0.12407692], dtype=float64)
 
         Args:
-            n (`tensor` or `float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
+            n (:obj:`tensor` or :obj:`float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
                                   (the observed number of events)
-            lam (`tensor` or `float`): The mean of the Poisson distribution p.m.f.
+            lam (:obj:`tensor` or :obj:`float`): The mean of the Poisson distribution p.m.f.
                                     (the expected number of events)
 
         Returns:
@@ -384,9 +384,9 @@ class jax_backend(object):
             DeviceArray([0.35206533, 0.46481887], dtype=float64)
 
         Args:
-            x (`tensor` or `float`): The value at which to evaluate the Normal distribution p.d.f.
-            mu (`tensor` or `float`): The mean of the Normal distribution
-            sigma (`tensor` or `float`): The standard deviation of the Normal distribution
+            x (:obj:`tensor` or :obj:`float`): The value at which to evaluate the Normal distribution p.d.f.
+            mu (:obj:`tensor` or :obj:`float`): The mean of the Normal distribution
+            sigma (:obj:`tensor` or :obj:`float`): The standard deviation of the Normal distribution
 
         Returns:
             JAX ndarray: Value of Normal(x|mu, sigma)
@@ -408,9 +408,9 @@ class jax_backend(object):
             DeviceArray([0.7881446 , 0.97724987], dtype=float64)
 
         Args:
-            x (`tensor` or `float`): The observed value of the random variable to evaluate the CDF for
-            mu (`tensor` or `float`): The mean of the Normal distribution
-            sigma (`tensor` or `float`): The standard deviation of the Normal distribution
+            x (:obj:`tensor` or :obj:`float`): The observed value of the random variable to evaluate the CDF for
+            mu (:obj:`tensor` or :obj:`float`): The mean of the Normal distribution
+            sigma (:obj:`tensor` or :obj:`float`): The standard deviation of the Normal distribution
 
         Returns:
             JAX ndarray: The CDF
@@ -431,7 +431,7 @@ class jax_backend(object):
             DeviceArray([-1.74030218, -2.0868536 ], dtype=float64)
 
         Args:
-            rate (`tensor` or `float`): The mean of the Poisson distribution (the expected number of events)
+            rate (:obj:`tensor` or :obj:`float`): The mean of the Poisson distribution (the expected number of events)
 
         Returns:
             Poisson distribution: The Poisson distribution class
@@ -453,8 +453,8 @@ class jax_backend(object):
             DeviceArray([-1.41893853, -2.22579135], dtype=float64)
 
         Args:
-            mu (`tensor` or `float`): The mean of the Normal distribution
-            sigma (`tensor` or `float`): The standard deviation of the Normal distribution
+            mu (:obj:`tensor` or :obj:`float`): The mean of the Normal distribution
+            sigma (:obj:`tensor` or :obj:`float`): The standard deviation of the Normal distribution
 
         Returns:
             Normal distribution: The Normal distribution class

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -67,9 +67,9 @@ class numpy_backend(object):
             array([-1., -1.,  0.,  1.,  1.])
 
         Args:
-            tensor_in (`tensor`): The input tensor object
-            min_value (`scalar` or `tensor` or `None`): The minimum value to be cliped to
-            max_value (`scalar` or `tensor` or `None`): The maximum value to be cliped to
+            tensor_in (:obj:`tensor`): The input tensor object
+            min_value (:obj:`scalar` or :obj:`tensor` or :obj:`None`): The minimum value to be cliped to
+            max_value (:obj:`scalar` or :obj:`tensor` or :obj:`None`): The maximum value to be cliped to
 
         Returns:
             NumPy ndarray: A clipped `tensor`
@@ -89,7 +89,7 @@ class numpy_backend(object):
             array([-0.99532227, -0.84270079,  0.        ,  0.84270079,  0.99532227])
 
         Args:
-            tensor_in (`tensor`): The input tensor object
+            tensor_in (:obj:`tensor`): The input tensor object
 
         Returns:
             NumPy ndarray: The values of the error function at the given points.
@@ -109,7 +109,7 @@ class numpy_backend(object):
             array([-2., -1.,  0.,  1.,  2.])
 
         Args:
-            tensor_in (`tensor`): The input tensor object
+            tensor_in (:obj:`tensor`): The input tensor object
 
         Returns:
             NumPy ndarray: The values of the inverse of the error function at the given points.
@@ -130,8 +130,8 @@ class numpy_backend(object):
                    [2., 2.]])
 
         Args:
-            tensor_in (`Tensor`): The tensor to be repeated
-            repeats (`Tensor`): The tuple of multipliers for each dimension
+            tensor_in (:obj:`tensor`): The tensor to be repeated
+            repeats (:obj:`tensor`): The tuple of multipliers for each dimension
 
         Returns:
             NumPy ndarray: The tensor with repeated axes
@@ -153,9 +153,9 @@ class numpy_backend(object):
             array([9.])
 
         Args:
-            predicate (`scalar`): The logical condition that determines which callable to evaluate
-            true_callable (`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`true`
-            false_callable (`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`false`
+            predicate (:obj:`scalar`): The logical condition that determines which callable to evaluate
+            true_callable (:obj:`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`true`
+            false_callable (:obj:`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`false`
 
         Returns:
             NumPy ndarray: The output of the callable that was evaluated
@@ -329,9 +329,9 @@ class numpy_backend(object):
             array([0.16062314, 0.12407692])
 
         Args:
-            n (`tensor` or `float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
+            n (:obj:`tensor` or :obj:`float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
                                   (the observed number of events)
-            lam (`tensor` or `float`): The mean of the Poisson distribution p.m.f.
+            lam (:obj:`tensor` or :obj:`float`): The mean of the Poisson distribution p.m.f.
                                     (the expected number of events)
 
         Returns:
@@ -373,9 +373,9 @@ class numpy_backend(object):
             array([0.35206533, 0.46481887])
 
         Args:
-            x (`tensor` or `float`): The value at which to evaluate the Normal distribution p.d.f.
-            mu (`tensor` or `float`): The mean of the Normal distribution
-            sigma (`tensor` or `float`): The standard deviation of the Normal distribution
+            x (:obj:`tensor` or :obj:`float`): The value at which to evaluate the Normal distribution p.d.f.
+            mu (:obj:`tensor` or :obj:`float`): The mean of the Normal distribution
+            sigma (:obj:`tensor` or :obj:`float`): The standard deviation of the Normal distribution
 
         Returns:
             NumPy float: Value of Normal(x|mu, sigma)
@@ -397,9 +397,9 @@ class numpy_backend(object):
             array([0.7881446 , 0.97724987])
 
         Args:
-            x (`tensor` or `float`): The observed value of the random variable to evaluate the CDF for
-            mu (`tensor` or `float`): The mean of the Normal distribution
-            sigma (`tensor` or `float`): The standard deviation of the Normal distribution
+            x (:obj:`tensor` or :obj:`float`): The observed value of the random variable to evaluate the CDF for
+            mu (:obj:`tensor` or :obj:`float`): The mean of the Normal distribution
+            sigma (:obj:`tensor` or :obj:`float`): The standard deviation of the Normal distribution
 
         Returns:
             NumPy float: The CDF
@@ -420,7 +420,7 @@ class numpy_backend(object):
             array([-1.74030218, -2.0868536 ])
 
         Args:
-            rate (`tensor` or `float`): The mean of the Poisson distribution (the expected number of events)
+            rate (:obj:`tensor` or :obj:`float`): The mean of the Poisson distribution (the expected number of events)
 
         Returns:
             Poisson distribution: The Poisson distribution class
@@ -442,8 +442,8 @@ class numpy_backend(object):
             array([-1.41893853, -2.22579135])
 
         Args:
-            mu (`tensor` or `float`): The mean of the Normal distribution
-            sigma (`tensor` or `float`): The standard deviation of the Normal distribution
+            mu (:obj:`tensor` or :obj:`float`): The mean of the Normal distribution
+            sigma (:obj:`tensor` or :obj:`float`): The standard deviation of the Normal distribution
 
         Returns:
             Normal distribution: The Normal distribution class

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -42,9 +42,9 @@ class pytorch_backend(object):
             tensor([-1., -1.,  0.,  1.,  1.])
 
         Args:
-            tensor_in (`tensor`): The input tensor object
-            min_value (`scalar` or `tensor` or `None`): The minimum value to be cliped to
-            max_value (`scalar` or `tensor` or `None`): The maximum value to be cliped to
+            tensor_in (:obj:`tensor`): The input tensor object
+            min_value (:obj:`scalar` or :obj:`tensor` or :obj:`None`): The minimum value to be cliped to
+            max_value (:obj:`scalar` or :obj:`tensor` or :obj:`None`): The maximum value to be cliped to
 
         Returns:
             PyTorch tensor: A clipped `tensor`
@@ -64,7 +64,7 @@ class pytorch_backend(object):
             tensor([-0.9953, -0.8427,  0.0000,  0.8427,  0.9953])
 
         Args:
-            tensor_in (`tensor`): The input tensor object
+            tensor_in (:obj:`tensor`): The input tensor object
 
         Returns:
             PyTorch Tensor: The values of the error function at the given points.
@@ -84,7 +84,7 @@ class pytorch_backend(object):
             tensor([-2.0000, -1.0000,  0.0000,  1.0000,  2.0000])
 
         Args:
-            tensor_in (`tensor`): The input tensor object
+            tensor_in (:obj:`tensor`): The input tensor object
 
         Returns:
             PyTorch Tensor: The values of the inverse of the error function at the given points.
@@ -106,9 +106,9 @@ class pytorch_backend(object):
             tensor([9.])
 
         Args:
-            predicate (`scalar`): The logical condition that determines which callable to evaluate
-            true_callable (`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`true`
-            false_callable (`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`false`
+            predicate (:obj:`scalar`): The logical condition that determines which callable to evaluate
+            true_callable (:obj:`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`true`
+            false_callable (:obj:`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`false`
 
         Returns:
             PyTorch Tensor: The output of the callable that was evaluated
@@ -137,8 +137,8 @@ class pytorch_backend(object):
                     [2., 2.]])
 
         Args:
-            tensor_in (`Tensor`): The tensor to be repeated
-            repeats (`Tensor`): The tuple of multipliers for each dimension
+            tensor_in (:obj:`tensor`): The tensor to be repeated
+            repeats (:obj:`tensor`): The tuple of multipliers for each dimension
 
         Returns:
             PyTorch tensor: The tensor with repeated axes
@@ -315,9 +315,9 @@ class pytorch_backend(object):
             tensor([0.1606, 0.1241])
 
         Args:
-            n (`tensor` or `float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
+            n (:obj:`tensor` or :obj:`float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
                                   (the observed number of events)
-            lam (`tensor` or `float`): The mean of the Poisson distribution p.m.f.
+            lam (:obj:`tensor` or :obj:`float`): The mean of the Poisson distribution p.m.f.
                                     (the expected number of events)
 
         Returns:
@@ -348,9 +348,9 @@ class pytorch_backend(object):
             tensor([0.3521, 0.4648])
 
         Args:
-            x (`tensor` or `float`): The value at which to evaluate the Normal distribution p.d.f.
-            mu (`tensor` or `float`): The mean of the Normal distribution
-            sigma (`tensor` or `float`): The standard deviation of the Normal distribution
+            x (:obj:`tensor` or :obj:`float`): The value at which to evaluate the Normal distribution p.d.f.
+            mu (:obj:`tensor` or :obj:`float`): The mean of the Normal distribution
+            sigma (:obj:`tensor` or :obj:`float`): The standard deviation of the Normal distribution
 
         Returns:
             PyTorch FloatTensor: Value of Normal(x|mu, sigma)
@@ -373,9 +373,9 @@ class pytorch_backend(object):
             tensor([0.7881, 0.9772])
 
         Args:
-            x (`tensor` or `float`): The observed value of the random variable to evaluate the CDF for
-            mu (`tensor` or `float`): The mean of the Normal distribution
-            sigma (`tensor` or `float`): The standard deviation of the Normal distribution
+            x (:obj:`tensor` or :obj:`float`): The observed value of the random variable to evaluate the CDF for
+            mu (:obj:`tensor` or :obj:`float`): The mean of the Normal distribution
+            sigma (:obj:`tensor` or :obj:`float`): The standard deviation of the Normal distribution
 
         Returns:
             PyTorch FloatTensor: The CDF
@@ -403,7 +403,7 @@ class pytorch_backend(object):
             tensor([-1.7403, -2.0869])
 
         Args:
-            rate (`tensor` or `float`): The mean of the Poisson distribution (the expected number of events)
+            rate (:obj:`tensor` or :obj:`float`): The mean of the Poisson distribution (the expected number of events)
 
         Returns:
             PyTorch Poisson distribution: The Poisson distribution class
@@ -426,8 +426,8 @@ class pytorch_backend(object):
             tensor([-1.4189, -2.2258])
 
         Args:
-            mu (`tensor` or `float`): The mean of the Normal distribution
-            sigma (`tensor` or `float`): The standard deviation of the Normal distribution
+            mu (:obj:`tensor` or :obj:`float`): The mean of the Normal distribution
+            sigma (:obj:`tensor` or :obj:`float`): The standard deviation of the Normal distribution
 
         Returns:
             PyTorch Normal distribution: The Normal distribution class

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -39,9 +39,9 @@ class tensorflow_backend(object):
             tf.Tensor([-1. -1.  0.  1.  1.], shape=(5,), dtype=float32)
 
         Args:
-            tensor_in (`tensor`): The input tensor object
-            min_value (`scalar` or `tensor` or `None`): The minimum value to be cliped to
-            max_value (`scalar` or `tensor` or `None`): The maximum value to be cliped to
+            tensor_in (:obj:`tensor`): The input tensor object
+            min_value (:obj:`scalar` or :obj:`tensor` or :obj:`None`): The minimum value to be cliped to
+            max_value (:obj:`scalar` or :obj:`tensor` or :obj:`None`): The maximum value to be cliped to
 
         Returns:
             TensorFlow Tensor: A clipped `tensor`
@@ -67,7 +67,7 @@ class tensorflow_backend(object):
             tf.Tensor([-0.9953223 -0.8427007  0.         0.8427007  0.9953223], shape=(5,), dtype=float32)
 
         Args:
-            tensor_in (`tensor`): The input tensor object
+            tensor_in (:obj:`tensor`): The input tensor object
 
         Returns:
             TensorFlow Tensor: The values of the error function at the given points.
@@ -88,7 +88,7 @@ class tensorflow_backend(object):
             tf.Tensor([-2.000001   -0.99999964  0.          0.99999964  1.9999981 ], shape=(5,), dtype=float32)
 
         Args:
-            tensor_in (`tensor`): The input tensor object
+            tensor_in (:obj:`tensor`): The input tensor object
 
         Returns:
             TensorFlow Tensor: The values of the inverse of the error function at the given points.
@@ -110,8 +110,8 @@ class tensorflow_backend(object):
              [2. 2.]], shape=(2, 2), dtype=float32)
 
         Args:
-            tensor_in (`Tensor`): The tensor to be repeated
-            repeats (`Tensor`): The tuple of multipliers for each dimension
+            tensor_in (:obj:`tensor`): The tensor to be repeated
+            repeats (:obj:`tensor`): The tuple of multipliers for each dimension
 
         Returns:
             TensorFlow Tensor: The tensor with repeated axes
@@ -141,9 +141,9 @@ class tensorflow_backend(object):
             tf.Tensor([9.], shape=(1,), dtype=float32)
 
         Args:
-            predicate (`scalar`): The logical condition that determines which callable to evaluate
-            true_callable (`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`true`
-            false_callable (`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`false`
+            predicate (:obj:`scalar`): The logical condition that determines which callable to evaluate
+            true_callable (:obj:`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`true`
+            false_callable (:obj:`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`false`
 
         Returns:
             TensorFlow Tensor: The output of the callable that was evaluated
@@ -379,9 +379,9 @@ class tensorflow_backend(object):
             tf.Tensor([-1.8286943 -2.086854 ], shape=(2,), dtype=float32)
 
         Args:
-            n (`tensor` or `float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
+            n (:obj:`tensor` or :obj:`float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
                                   (the observed number of events)
-            lam (`tensor` or `float`): The mean of the Poisson distribution p.m.f.
+            lam (:obj:`tensor` or :obj:`float`): The mean of the Poisson distribution p.m.f.
                                     (the expected number of events)
 
         Returns:
@@ -408,9 +408,9 @@ class tensorflow_backend(object):
             tf.Tensor([0.16062315 0.12407687], shape=(2,), dtype=float32)
 
         Args:
-            n (`tensor` or `float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
+            n (:obj:`tensor` or :obj:`float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
                                   (the observed number of events)
-            lam (`tensor` or `float`): The mean of the Poisson distribution p.m.f.
+            lam (:obj:`tensor` or :obj:`float`): The mean of the Poisson distribution p.m.f.
                                     (the expected number of events)
 
         Returns:
@@ -438,9 +438,9 @@ class tensorflow_backend(object):
             tf.Tensor([-1.0439385 -0.7661075], shape=(2,), dtype=float32)
 
         Args:
-            x (`tensor` or `float`): The value at which to evaluate the Normal distribution p.d.f.
-            mu (`tensor` or `float`): The mean of the Normal distribution
-            sigma (`tensor` or `float`): The standard deviation of the Normal distribution
+            x (:obj:`tensor` or :obj:`float`): The value at which to evaluate the Normal distribution p.d.f.
+            mu (:obj:`tensor` or :obj:`float`): The mean of the Normal distribution
+            sigma (:obj:`tensor` or :obj:`float`): The standard deviation of the Normal distribution
 
         Returns:
             TensorFlow Tensor: Value of log(Normal(x|mu, sigma))
@@ -468,9 +468,9 @@ class tensorflow_backend(object):
             tf.Tensor([0.35206532 0.46481887], shape=(2,), dtype=float32)
 
         Args:
-            x (`tensor` or `float`): The value at which to evaluate the Normal distribution p.d.f.
-            mu (`tensor` or `float`): The mean of the Normal distribution
-            sigma (`tensor` or `float`): The standard deviation of the Normal distribution
+            x (:obj:`tensor` or :obj:`float`): The value at which to evaluate the Normal distribution p.d.f.
+            mu (:obj:`tensor` or :obj:`float`): The mean of the Normal distribution
+            sigma (:obj:`tensor` or :obj:`float`): The standard deviation of the Normal distribution
 
         Returns:
             TensorFlow Tensor: Value of Normal(x|mu, sigma)
@@ -494,9 +494,9 @@ class tensorflow_backend(object):
             tf.Tensor([0.7881446  0.97724986], shape=(2,), dtype=float32)
 
         Args:
-            x (`tensor` or `float`): The observed value of the random variable to evaluate the CDF for
-            mu (`tensor` or `float`): The mean of the Normal distribution
-            sigma (`tensor` or `float`): The standard deviation of the Normal distribution
+            x (:obj:`tensor` or :obj:`float`): The observed value of the random variable to evaluate the CDF for
+            mu (:obj:`tensor` or :obj:`float`): The mean of the Normal distribution
+            sigma (:obj:`tensor` or :obj:`float`): The standard deviation of the Normal distribution
 
         Returns:
             TensorFlow Tensor: The CDF
@@ -521,7 +521,7 @@ class tensorflow_backend(object):
             tf.Tensor([-1.7403021 -2.086854 ], shape=(2,), dtype=float32)
 
         Args:
-            rate (`tensor` or `float`): The mean of the Poisson distribution (the expected number of events)
+            rate (:obj:`tensor` or :obj:`float`): The mean of the Poisson distribution (the expected number of events)
 
         Returns:
             TensorFlow Probability Poisson distribution: The Poisson distribution class
@@ -545,8 +545,8 @@ class tensorflow_backend(object):
             tf.Tensor([-1.4189385 -2.2257915], shape=(2,), dtype=float32)
 
         Args:
-            mu (`tensor` or `float`): The mean of the Normal distribution
-            sigma (`tensor` or `float`): The standard deviation of the Normal distribution
+            mu (:obj:`tensor` or :obj:`float`): The mean of the Normal distribution
+            sigma (:obj:`tensor` or :obj:`float`): The standard deviation of the Normal distribution
 
         Returns:
             TensorFlow Probability Normal distribution: The Normal distribution class

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -91,11 +91,11 @@ def digest(obj, algorithm='sha256'):
         ValueError: If the object is not JSON-serializable or if the algorithm is not supported.
 
     Args:
-        obj (`obj`): A JSON-serializable object to compute the digest of. Usually a :class:`~pyhf.workspace.Workspace` object.
-        algorithm (`str`): The hashing algorithm to use.
+        obj (:obj:`jsonable`): A JSON-serializable object to compute the digest of. Usually a :class:`~pyhf.workspace.Workspace` object.
+        algorithm (:obj:`str`): The hashing algorithm to use.
 
     Returns:
-        digest (`str`): The digest for the JSON-serialized object provided and hash algorithm specified.
+        digest (:obj:`str`): The digest for the JSON-serialized object provided and hash algorithm specified.
     """
 
     try:

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -24,10 +24,10 @@ def _join_items(join, left_items, right_items, key='name', deep_merge_key=None):
     This is meant to be as generic as possible for any pairs of lists of dictionaries for many join operations.
 
     Args:
-        join (`str`): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
-        left_items (`list`): A list of dictionaries to join on the left
-        right_items (`list`): A list of dictionaries to join on the right
-        deep_merge_key (`str`): A key on which to deeply merge items if set.
+        join (:obj:`str`): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
+        left_items (:obj:`list`): A list of dictionaries to join on the left
+        right_items (:obj:`list`): A list of dictionaries to join on the right
+        deep_merge_key (:obj:`str`): A key on which to deeply merge items if set.
 
     Returns:
         :obj:`list`: A joined list of dictionaries.
@@ -75,9 +75,9 @@ def _join_versions(join, left_version, right_version):
       ~pyhf.exceptions.InvalidWorkspaceOperation: Versions are incompatible.
 
     Args:
-        join (`str`): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
-        left_version (`str`): The left workspace version.
-        right_version (`str`): The right workspace version.
+        join (:obj:`str`): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
+        left_version (:obj:`str`): The left workspace version.
+        right_version (:obj:`str`): The right workspace version.
 
     Returns:
         :obj:`str`: The workspace version.
@@ -98,10 +98,10 @@ def _join_channels(join, left_channels, right_channels, merge=False):
       ~pyhf.exceptions.InvalidWorkspaceOperation: Channel specifications are incompatible.
 
     Args:
-        join (`str`): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
-        left_channels (`list`): The left channel specification.
-        right_channels (`list`): The right channel specification.
-        merge (`bool`): Whether to deeply merge channels or not.
+        join (:obj:`str`): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
+        left_channels (:obj:`list`): The left channel specification.
+        right_channels (:obj:`list`): The right channel specification.
+        merge (:obj:`bool`): Whether to deeply merge channels or not.
 
     Returns:
         :obj:`list`: A joined list of channels. Each channel follows the :obj:`defs.json#/definitions/channel` `schema <https://scikit-hep.org/pyhf/likelihood.html#channel>`__
@@ -142,9 +142,9 @@ def _join_observations(join, left_observations, right_observations):
       ~pyhf.exceptions.InvalidWorkspaceOperation: Observation specifications are incompatible.
 
     Args:
-        join (`str`): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
-        left_observations (`list`): The left observation specification.
-        right_observations (`list`): The right observation specification.
+        join (:obj:`str`): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
+        left_observations (:obj:`list`): The left observation specification.
+        right_observations (:obj:`list`): The right observation specification.
 
     Returns:
         :obj:`list`: A joined list of observations. Each observation follows the :obj:`defs.json#/definitions/observation` `schema <https://scikit-hep.org/pyhf/likelihood.html#observations>`__
@@ -186,9 +186,9 @@ def _join_parameter_configs(measurement_name, left_parameters, right_parameters)
       ~pyhf.exceptions.InvalidWorkspaceOperation: Parameter configuration specifications are incompatible.
 
     Args:
-        measurement_name (`str`): The name of the measurement being joined (a detail for raising exceptions correctly)
-        left_parameters (`list`): The left parameter configuration specification.
-        right_parameters (`list`): The right parameter configuration specification.
+        measurement_name (:obj:`str`): The name of the measurement being joined (a detail for raising exceptions correctly)
+        left_parameters (:obj:`list`): The left parameter configuration specification.
+        right_parameters (:obj:`list`): The right parameter configuration specification.
 
     Returns:
         :obj:`list`: A joined list of parameter configurations. Each parameter configuration follows the :obj:`defs.json#/definitions/config` schema
@@ -216,9 +216,9 @@ def _join_measurements(join, left_measurements, right_measurements):
       ~pyhf.exceptions.InvalidWorkspaceOperation: Measurement specifications are incompatible.
 
     Args:
-        join (`str`): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
-        left_measurements (`list`): The left measurement specification.
-        right_measurements (`list`): The right measurement specification.
+        join (:obj:`str`): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
+        left_measurements (:obj:`list`): The left measurement specification.
+        right_measurements (:obj:`list`): The right measurement specification.
 
     Returns:
         :obj:`list`: A joined list of measurements. Each measurement follows the :obj:`defs.json#/definitions/measurement` `schema <https://scikit-hep.org/pyhf/likelihood.html#measurements>`__
@@ -330,9 +330,9 @@ class Workspace(_ChannelSummaryMixin, dict):
           ~pyhf.exceptions.InvalidMeasurement: If the measurement was not found
 
         Args:
-            poi_name (`str`): The name of the parameter of interest to create a new measurement from
-            measurement_name (`str`): The name of the measurement to use
-            measurement_index (`int`): The index of the measurement to use
+            poi_name (:obj:`str`): The name of the parameter of interest to create a new measurement from
+            measurement_name (:obj:`str`): The name of the measurement to use
+            measurement_index (:obj:`int`): The index of the measurement to use
 
         Returns:
             :obj:`dict`: A measurement object adhering to the schema defs.json#/definitions/measurement

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -779,8 +779,8 @@ class Workspace(_ChannelSummaryMixin, dict):
 
         Args:
             model (~pyhf.pdf.Model): A model to store into a workspace
-            data (tensor): A array holding observations to store into a workspace
-            name (str): The name of the workspace measurement
+            data (:obj:`tensor`): A array holding observations to store into a workspace
+            name (:obj:`str`): The name of the workspace measurement
 
         Returns:
             ~pyhf.workspace.Workspace: A new workspace object

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -430,7 +430,7 @@ class Workspace(_ChannelSummaryMixin, dict):
 
         Args:
             model (~pyhf.pdf.Model): A model object adhering to the schema model.json
-            with_aux (bool): Whether to include auxiliary data from the model or not
+            with_aux (:obj:`bool`): Whether to include auxiliary data from the model or not
 
         Returns:
             :obj:`list`: data


### PR DESCRIPTION
# Description

Resolves #1116 . Use `:obj:` notation consistently everywhere in our docs.

Docs: https://pyhf.readthedocs.io/en/docs-fixdocstringnotation/

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Harmonize use of sphinx :obj: notation in docs
```