### PR TITLE
fix: Use functools.wraps with events.register to render docstrings

### DIFF
--- a/src/pyhf/events.py
+++ b/src/pyhf/events.py
@@ -1,4 +1,5 @@
 import weakref
+from functools import wraps
 
 __events = {}
 __disabled_events = set([])

--- a/src/pyhf/events.py
+++ b/src/pyhf/events.py
@@ -72,6 +72,7 @@ def register(event):
     # >>>
 
     def _register(func):
+        @wraps(func)
         def register_wrapper(*args, **kwargs):
             trigger("{0:s}::before".format(event))()
             result = func(*args, **kwargs)


### PR DESCRIPTION
# Description

Resolves #984 

Use [`functools.wraps`](https://docs.python.org/3.8/library/functools.html#functools.wraps) to wrap the [`events.register` decorator](https://github.com/scikit-hep/pyhf/blob/f248db092dcfbe6e3354bc1d0731a7713258dc2a/src/pyhf/events.py#L47) to properly get docstrings for `pyhf.set_backend`.

https://github.com/scikit-hep/pyhf/blob/f248db092dcfbe6e3354bc1d0731a7713258dc2a/src/pyhf/__init__.py#L37-L58

ReadTheDocs build: https://pyhf.readthedocs.io/en/fix-use-functools-wraps-for-docs/_generated/pyhf.set_backend.html#pyhf.set_backend

HT to @kratsg for identifying the fix. :+1: 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use functools.wraps to wrap events.register decorator to properly get docstrings for pyhf.set_backend
```
