### PR TITLE
fix: Fixed parameter naming for compatibility with ROOT import/export

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,10 @@ extensions = [
 # external links
 xref_links = {"arXiv:1007.1727": ("[1007.1727]", "https://arxiv.org/abs/1007.1727")}
 
-intersphinx_mapping = {'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+}
 
 # Github repo
 issues_github_path = 'scikit-hep/pyhf'

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -7,6 +7,7 @@ import xml.etree.ElementTree as ET
 import numpy as np
 import tqdm
 import uproot
+import re
 
 log = logging.getLogger(__name__)
 
@@ -270,6 +271,12 @@ def process_measurements(toplvl, other_parameter_configs=None):
             if param.text:
                 for param_name in param.text.split(' '):
                     param_name = utils.remove_prefix(param_name, 'alpha_')
+                    if param_name.startswith('gamma_') and re.search(
+                        '^gamma_.+_\d+$', param_name
+                    ):
+                        raise ValueError(
+                            f'pyhf does not support setting individual gamma parameters constant, such as for {param_name}.'
+                        )
                     param_name = utils.remove_prefix(param_name, 'gamma_')
                     # lumi will always be the first parameter
                     if param_name == 'Lumi':

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -258,6 +258,8 @@ def process_measurements(toplvl, other_parameter_configs=None):
             # might be specifying multiple parameters in the same ParamSetting
             if param.text:
                 for param_name in param.text.split(' '):
+                    param_name = utils.remove_prefix(param_name, 'alpha_')
+                    param_name = utils.remove_prefix(param_name, 'gamma_')
                     # lumi will always be the first parameter
                     if param_name == 'Lumi':
                         result['config']['parameters'][0].update(overall_param_obj)

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -223,6 +223,17 @@ def process_channel(channelxml, rootdir, track_progress=False):
 
 
 def process_measurements(toplvl, other_parameter_configs=None):
+    """
+    For a given XML structure, provide a parsed dictionary adhering to defs.json/#definitions/measurement.
+
+    Args:
+        toplvl (:module:`xml.etree.ElementTree`): The top-level XML document to parse.
+        other_parameter_configs (:obj:`list`): A list of other parameter configurations from other non-top-level XML documents to incorporate into the resulting measurement object.
+
+    Returns:
+        :obj:`dict`: A measurement object.
+
+    """
     results = []
     other_parameter_configs = other_parameter_configs if other_parameter_configs else []
 

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -120,8 +120,8 @@ def remove_prefix(text, prefix):
     Example:
 
         >>> import pyhf
-        >>> pyhf.utils.remove_prefix("alpha_syst1", "alpha")
-        "syst1"
+        >>> pyhf.utils.remove_prefix("alpha_syst1", "alpha_")
+        'syst1'
 
     Args:
         text (:obj:`str`): A provided input to manipulate.

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -111,3 +111,26 @@ def digest(obj, algorithm='sha256'):
             f"{algorithm} is not an algorithm provided by Python's hashlib library."
         )
     return hash_alg(stringified).hexdigest()
+
+
+def remove_prefix(text, prefix):
+    """
+    Remove a prefix from the beginning of the provided text.
+
+    Example:
+
+        >>> import pyhf
+        >>> pyhf.utils.remove_prefix("alpha_syst1", "alpha")
+        "syst1"
+
+    Args:
+        text (:obj:`str`): A provided input to manipulate.
+        prefix (:obj:`str`): A prefix to remove from provided input, if it exists.
+
+    Returns:
+        stripped_text (:obj:`str`): Text with the prefix removed.
+    """
+    # NB: python3.9 can be `return text.removeprefix(prefix)`
+    if text.startswith(prefix):
+        return text[len(prefix) :]
+    return text

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -61,6 +61,17 @@ def indent(elem, level=0):
 
 
 def build_measurement(measurementspec, modifiertypes):
+    """
+    Build the XML measurement specification for a given measurement adhering to defs.json/#definitions/measurement.
+
+    Args:
+        measurementspec (:obj:`dict`): The measurements specification from a :class:`~pyhf.workspace.Workspace`.
+        modifiertypes (:obj:`dict`): A mapping from modifier name (:obj:`str`) to modifier type (:obj:`str`).
+
+    Returns:
+        :class:`xml.etree.cElementTree.Element`: The XML measurement specification.
+
+    """
     # need to determine prefixes
     prefixes = {
         'normsys': 'alpha_',

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -153,13 +153,24 @@ def test_export_measurement():
                     "inits": [1.0],
                     "name": "lumi",
                     "sigmas": [0.029],
-                }
+                },
+                {"name": "syst1", "fixed": True},
+                {"name": "syst2", "fixed": True},
+                {"name": "syst3", "fixed": True},
+                {"name": "syst4", "fixed": True},
             ],
             "poi": "mu",
         },
         "name": "NormalMeasurement",
     }
-    modifiertypes = {'mu': 'normfactor', 'lumi': 'lumi'}
+    modifiertypes = {
+        'mu': 'normfactor',
+        'lumi': 'lumi',
+        'syst1': 'normsys',
+        'syst2': 'histosys',
+        'syst3': 'shapesys',
+        'syst4': 'staterror',
+    }
     m = pyhf.writexml.build_measurement(measurementspec, modifiertypes)
     assert m is not None
     assert m.attrib['Name'] == measurementspec['name']
@@ -173,7 +184,11 @@ def test_export_measurement():
     assert poi is not None
     assert poi.text == measurementspec['config']['poi']
     paramsetting = m.find('ParamSetting')
-    assert paramsetting is None
+    assert paramsetting is not None
+    assert 'alpha_syst1' in paramsetting.text
+    assert 'alpha_syst2' in paramsetting.text
+    assert 'gamma_syst3' in paramsetting.text
+    assert 'gamma_syst4' in paramsetting.text
 
 
 @pytest.mark.parametrize(

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -159,7 +159,8 @@ def test_export_measurement():
         },
         "name": "NormalMeasurement",
     }
-    m = pyhf.writexml.build_measurement(measurementspec)
+    modifiertypes = {'mu': 'normfactor', 'lumi': 'lumi'}
+    m = pyhf.writexml.build_measurement(measurementspec, modifiertypes)
     assert m is not None
     assert m.attrib['Name'] == measurementspec['name']
     assert m.attrib['Lumi'] == str(

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -147,6 +147,34 @@ def test_import_measurements():
     assert lumi_param_config['sigmas'] == [0.1]
 
 
+@pytest.mark.parametrize("const", ['False', 'True'])
+def test_import_measurement_gamma_bins(const):
+    toplvl = ET.Element("Combination")
+    meas = ET.Element(
+        "Measurement",
+        Name='NormalMeasurement',
+        Lumi=str(1.0),
+        LumiRelErr=str(0.017),
+        ExportOnly=str(True),
+    )
+    poiel = ET.Element('POI')
+    poiel.text = 'mu_SIG'
+    meas.append(poiel)
+
+    setting = ET.Element('ParamSetting', Const=const)
+    setting.text = ' '.join(['Lumi', 'alpha_mu_both', 'gamma_bin_0'])
+    meas.append(setting)
+
+    setting = ET.Element('ParamSetting', Val='2.0')
+    setting.text = ' '.join(['gamma_bin_0'])
+    meas.append(setting)
+
+    toplvl.append(meas)
+
+    with pytest.raises(ValueError):
+        pyhf.readxml.process_measurements(toplvl)
+
+
 def test_import_prepHistFactory():
     parsed_xml = pyhf.readxml.parse(
         'validation/xmlimport_input/config/example.xml', 'validation/xmlimport_input/'

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -47,11 +47,11 @@ def test_process_normfactor_configs():
     meas.append(poiel)
 
     setting = ET.Element('ParamSetting', Const='True')
-    setting.text = ' '.join(['Lumi', 'mu_both', 'mu_paramSettingOnly'])
+    setting.text = ' '.join(['Lumi', 'alpha_mu_both', 'alpha_mu_paramSettingOnly'])
     meas.append(setting)
 
     setting = ET.Element('ParamSetting', Val='2.0')
-    setting.text = ' '.join(['mu_both'])
+    setting.text = ' '.join(['alpha_mu_both'])
     meas.append(setting)
 
     toplvl.append(meas)
@@ -68,7 +68,7 @@ def test_process_normfactor_configs():
     meas.append(poiel)
 
     setting = ET.Element('ParamSetting', Val='3.0')
-    setting.text = ' '.join(['mu_both'])
+    setting.text = ' '.join(['alpha_mu_both'])
     meas.append(setting)
 
     toplvl.append(meas)
@@ -134,7 +134,7 @@ def test_import_measurements():
     assert 'parameters' in measurement_configs
     assert len(measurement_configs['parameters']) == 3
     parnames = [p['name'] for p in measurement_configs['parameters']]
-    assert sorted(parnames) == sorted(['lumi', 'SigXsecOverSM', 'alpha_syst1'])
+    assert sorted(parnames) == sorted(['lumi', 'SigXsecOverSM', 'syst1'])
 
     lumi_param_config = measurement_configs['parameters'][0]
     assert 'auxdata' in lumi_param_config

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -554,8 +554,8 @@ def test_combine_merge_channels(tmpdir, script_runner):
 )
 def test_workspace_digest(tmpdir, script_runner, algorithms, do_json):
     results = {
-        'md5': '202eb7615102c35ba86be47eb6fa5e78',
-        'sha256': '7c32ca3b8db75cbafcf5cd7ed4672fa2b1fa69e391c9b89068dd947a521866ec',
+        'md5': '7de8930ff37e5a4f6a31da11bda7813f',
+        'sha256': '6d416ee67a40460499ea2ef596fb1e682a563d7df06e690018a211d35238aecc',
     }
 
     temp = tmpdir.join("parsed_output.json")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,3 +58,9 @@ def test_digest_bad_alg():
     with pytest.raises(ValueError) as excinfo:
         pyhf.utils.digest({}, algorithm='nonexistent_algorithm')
     assert 'nonexistent_algorithm' in str(excinfo.value)
+
+
+def test_remove_prefix():
+    assert pyhf.utils.remove_prefix('abcDEF123', 'abc') == 'DEF123'
+    assert pyhf.utils.remove_prefix('abcDEF123', 'Abc') == 'abcDEF123'
+    assert pyhf.utils.remove_prefix('abcDEF123', '123') == 'abcDEF123'


### PR DESCRIPTION
# Description

Resolves #1107. ROOT, in all its glory, decides to prefix parameter names in the measurement specification. We need to update `readxml.py` to strip this prefix, but additionally update `writexml.py` to prepend this prefix.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Fix parameter naming for compatibility with ROOT import/export
  - prefixes alpha_ and gamma_ are stripped when importing from ROOT workspaces
  - prefixes alpha_ and gamma_ are added when exporting to ROOT workspaces
```