### PR TITLE
fix: Validate fit initialization parameters

### DIFF
--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -4,6 +4,15 @@ from .. import get_backend
 from .calculators import AsymptoticCalculator
 
 
+def validate_hypotest_inputs(pdf, poi_test, init, bounds, fixed_params):
+    if not (
+        bounds[pdf.config.poi_index][0] <= poi_test <= bounds[pdf.config.poi_index][1]
+    ):
+        raise ValueError(
+            f'POI value {poi_test} of hypotest lies outside of bounds: {bounds[pdf.config.poi_index]}'
+        )
+
+
 def hypotest(
     poi_test,
     data,
@@ -126,6 +135,8 @@ def hypotest(
     init_pars = init_pars or pdf.config.suggested_init()
     par_bounds = par_bounds or pdf.config.suggested_bounds()
     fixed_params = fixed_params or pdf.config.suggested_fixed()
+
+    validate_hypotest_inputs(pdf, poi_test, init_pars, par_bounds, fixed_params)
 
     calc = AsymptoticCalculator(
         data, pdf, init_pars, par_bounds, fixed_params, qtilde=qtilde

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -4,15 +4,6 @@ from .. import get_backend
 from .calculators import AsymptoticCalculator
 
 
-def validate_hypotest_inputs(pdf, poi_test, init, bounds, fixed_params):
-    if not (
-        bounds[pdf.config.poi_index][0] <= poi_test <= bounds[pdf.config.poi_index][1]
-    ):
-        raise ValueError(
-            f'POI value {poi_test} of hypotest lies outside of bounds: {bounds[pdf.config.poi_index]}'
-        )
-
-
 def hypotest(
     poi_test,
     data,
@@ -135,8 +126,6 @@ def hypotest(
     init_pars = init_pars or pdf.config.suggested_init()
     par_bounds = par_bounds or pdf.config.suggested_bounds()
     fixed_params = fixed_params or pdf.config.suggested_fixed()
-
-    validate_hypotest_inputs(pdf, poi_test, init_pars, par_bounds, fixed_params)
 
     calc = AsymptoticCalculator(
         data, pdf, init_pars, par_bounds, fixed_params, qtilde=qtilde

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -47,7 +47,7 @@ def twice_nll(pars, data, pdf):
     return -2 * pdf.logpdf(pars, data)
 
 
-def _validate_fit_inputs(pdf, init, bounds, fixed_params):
+def _validate_fit_inputs(init, bounds, fixed_params):
     for i, (value, bound) in enumerate(zip(init, bounds)):
         if not (bound[0] <= value <= bound[1]):
             raise ValueError(
@@ -107,7 +107,7 @@ def fit(data, pdf, init_pars=None, par_bounds=None, fixed_params=None, **kwargs)
     par_bounds = par_bounds or pdf.config.suggested_bounds()
     fixed_params = fixed_params or pdf.config.suggested_fixed()
 
-    _validate_fit_inputs(pdf, init_pars, par_bounds, fixed_params)
+    _validate_fit_inputs(init_pars, par_bounds, fixed_params)
 
     # get fixed vals from the model
     fixed_vals = [

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -47,11 +47,11 @@ def twice_nll(pars, data, pdf):
     return -2 * pdf.logpdf(pars, data)
 
 
-def _validate_fit_inputs(init, bounds, fixed_params):
-    for i, (value, bound) in enumerate(zip(init, bounds)):
+def _validate_fit_inputs(init_pars, par_bounds, fixed_params):
+    for par_idx, (value, bound) in enumerate(zip(init_pars, par_bounds)):
         if not (bound[0] <= value <= bound[1]):
             raise ValueError(
-                f'parameter {i}  value {value} of hypotest lies outside of bounds: {bound}'
+                f'parameter {par_idx} value {value} of hypotest lies outside of bounds: {bound}'
             )
 
 

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -51,7 +51,10 @@ def _validate_fit_inputs(init_pars, par_bounds, fixed_params):
     for par_idx, (value, bound) in enumerate(zip(init_pars, par_bounds)):
         if not (bound[0] <= value <= bound[1]):
             raise ValueError(
-                f'parameter {par_idx} value {value} of hypotest lies outside of bounds: {bound}'
+                f"fit initialization parameter (index: {par_idx}, value: {value}) lies outside of its bounds: {bound}"
+                + "\nTo correct this adjust the initialization parameter values in the model spec or those given"
+                + "\nas arguments to pyhf.infer.fit. If this value is intended, adjust the range of the parameter"
+                + "\nbounds."
             )
 
 

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -47,6 +47,14 @@ def twice_nll(pars, data, pdf):
     return -2 * pdf.logpdf(pars, data)
 
 
+def validate_fit_inputs(pdf, init, bounds, fixed_params):
+    for i, (value, bound) in enumerate(zip(init, bounds)):
+        if not (bound[0] <= value <= bound[1]):
+            raise ValueError(
+                f'parameter {i}  value {value} of hypotest lies outside of bounds: {bound}'
+            )
+
+
 def fit(data, pdf, init_pars=None, par_bounds=None, fixed_params=None, **kwargs):
     r"""
     Run a maximum likelihood fit.
@@ -98,6 +106,8 @@ def fit(data, pdf, init_pars=None, par_bounds=None, fixed_params=None, **kwargs)
     init_pars = init_pars or pdf.config.suggested_init()
     par_bounds = par_bounds or pdf.config.suggested_bounds()
     fixed_params = fixed_params or pdf.config.suggested_fixed()
+
+    validate_fit_inputs(pdf, init_pars, par_bounds, fixed_params)
 
     # get fixed vals from the model
     fixed_vals = [

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -47,7 +47,7 @@ def twice_nll(pars, data, pdf):
     return -2 * pdf.logpdf(pars, data)
 
 
-def validate_fit_inputs(pdf, init, bounds, fixed_params):
+def _validate_fit_inputs(pdf, init, bounds, fixed_params):
     for i, (value, bound) in enumerate(zip(init, bounds)):
         if not (bound[0] <= value <= bound[1]):
             raise ValueError(
@@ -107,7 +107,7 @@ def fit(data, pdf, init_pars=None, par_bounds=None, fixed_params=None, **kwargs)
     par_bounds = par_bounds or pdf.config.suggested_bounds()
     fixed_params = fixed_params or pdf.config.suggested_fixed()
 
-    validate_fit_inputs(pdf, init_pars, par_bounds, fixed_params)
+    _validate_fit_inputs(pdf, init_pars, par_bounds, fixed_params)
 
     # get fixed vals from the model
     fixed_vals = [

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -77,6 +77,22 @@ def test_hypotest_default(tmpdir, hypotest_args):
     assert isinstance(result, type(tb.astensor(result)))
 
 
+def test_hypotest_poi_outofbounds(tmpdir, hypotest_args):
+    """
+    Check that the default return structure of pyhf.infer.hypotest is as expected
+    """
+    pdf = pyhf.simplemodels.hepdata_like(
+        signal_data=[12.0, 11.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0]
+    )
+    data = [51, 48] + pdf.config.auxdata
+
+    with pytest.raises(ValueError):
+        pyhf.infer.hypotest(-1.0, data, pdf)
+
+    with pytest.raises(ValueError):
+        pyhf.infer.hypotest(10.1, data, pdf)
+
+
 def test_hypotest_return_tail_probs(tmpdir, hypotest_args):
     """
     Check that the return structure of pyhf.infer.hypotest with the

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -79,7 +79,7 @@ def test_hypotest_default(tmpdir, hypotest_args):
 
 def test_hypotest_poi_outofbounds(tmpdir, hypotest_args):
     """
-    Test for parameter bounds
+    Check that the fit errors for POI outside of parameter bounds
     """
     pdf = pyhf.simplemodels.hepdata_like(
         signal_data=[12.0, 11.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0]

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -79,7 +79,7 @@ def test_hypotest_default(tmpdir, hypotest_args):
 
 def test_hypotest_poi_outofbounds(tmpdir, hypotest_args):
     """
-    Check that the default return structure of pyhf.infer.hypotest is as expected
+    Test for parameter bounds
     """
     pdf = pyhf.simplemodels.hepdata_like(
         signal_data=[12.0, 11.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0]


### PR DESCRIPTION
# Description

Resolves #1123 

Addresses Issue #1123 reported by @alexander-held. This raises `ValueError` if any initial parameter (fixed or not) used
in a fit lies outside of the parameter bounds.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add check to validate initialization parameters for pyhf.infer.fit
* Add test of raised error using hypotest POI out of bounds
```