### PR TITLE
fix: Logic bug for outer joins of merge channels

### DIFF
--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -348,6 +348,17 @@ def test_join_items_right_outer(join_items):
     assert all(right in joined for right in right_items)
 
 
+def test_join_items_outer_deep(join_items):
+    left_items, right_items = join_items
+    joined = pyhf.workspace._join_items(
+        'outer', left_items, right_items, key='name', deep_merge_key='deep'
+    )
+    assert [k['deep'] for k in joined if k['name'] == 'common'][0] == [
+        {'name': 1},
+        {'name': 2},
+    ]
+
+
 def test_join_items_left_outer_deep(join_items):
     left_items, right_items = join_items
     joined = pyhf.workspace._join_items(
@@ -784,7 +795,7 @@ def test_workspace_inheritance(workspace_factory):
     assert isinstance(combined, FooWorkspace)
 
 
-@pytest.mark.parametrize("join", ['left outer', 'right outer'])
+@pytest.mark.parametrize("join", ['outer', 'left outer', 'right outer'])
 def test_combine_workspace_merge_channels(workspace_factory, join):
     ws = workspace_factory()
     new_ws = ws.prune(samples=ws.samples[1:]).rename(


### PR DESCRIPTION
# Description

This technically had the right tests in place, but simply forgot to add `outer` join as a join method to check the logic of the merge channels for. This PR will add it in, but then also fix the logic bug (reverse the conditionals).

See #1088 .

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Fix logic bug for merge channels of combine for outer join functionality
* Amends PR #1088
```