### PR TITLE
chore: Add file types for diff to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 .git_archival.txt  export-subst
+*.py  diff=python

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 .git_archival.txt  export-subst
-*.py  diff=python
+*.py diff=python
+*.md diff=markdown


### PR DESCRIPTION
# Description

Help `git diff` give more information in the diff by giving it information on file type via file extensions. HT [this Tweet from Raymond Hettinger](https://twitter.com/raymondh/status/1318260360789454848) on this article "[Better Git diff output for Ruby, Python, Elixir, Go and more](https://tekin.co.uk/2020/10/better-git-diff-output-for-ruby-python-elixir-and-more)" by [Tekin Süleyman](https://tekin.co.uk/) (@tekin) &mdash; thanks Tekin!

This is labeled as "chore" given that this only helps the devs and has no other impact on the project.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add file information for Python and Markdown to .gitattributes for git diff to use
   - c.f. https://tekin.co.uk/2020/10/better-git-diff-output-for-ruby-python-elixir-and-more
   - https://git-scm.com/docs/gitattributes#_generating_diff_text
```
