### PR TITLE
docs: Add ss3L hepdata likelihood record

### DIFF
--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -1,3 +1,12 @@
+@misc {1754675,
+    title = "{Search for squarks and gluinos in final states with same-sign leptons and jets using 139 fb$^{-1}$ of data collected with the ATLAS detector}",
+    doi = "10.17182/hepdata.91214.v3",
+    url = "https://doi.org/10.17182/hepdata.91214.v3",
+    year = "2020",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
 @misc {ins1755298,
     title = "{Search for direct production of electroweakinos in final states with one lepton, missing transverse momentum and a Higgs boson decaying into two $b$-jets in (pp) collisions at $\sqrt{s}=13$ TeV with the ATLAS detector}",
     doi = "10.17182/hepdata.90607.v2",

--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -1,4 +1,4 @@
-@misc {1754675,
+@misc {ins1754675,
     title = "{Search for squarks and gluinos in final states with same-sign leptons and jets using 139 fb$^{-1}$ of data collected with the ATLAS detector}",
     doi = "10.17182/hepdata.91214.v3",
     url = "https://doi.org/10.17182/hepdata.91214.v3",


### PR DESCRIPTION
# Description

Add HEPData record for published statistical model and observations for [Search for squarks and gluinos in final states with same-sign leptons and jets using 139 fb−1 of data collected with the ATLAS detector](https://www.hepdata.net/record/91214?version=3).

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add ss3L HEPData record with patchset pallet (stat model and observations)
   - c.f. https://www.hepdata.net/record/ins1754675?version=3
```
