### PR TITLE
fix: Use JAX v0.2.4+ API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ extras_require = {
         'tensorflow-probability~=0.10.0',
     ],
     'torch': ['torch~=1.2'],
-    'jax': ['jax~=0.1,>0.1.51', 'jaxlib~=0.1,>0.1.33'],
+    'jax': ['jax~=0.2,>=0.2.4', 'jaxlib~=0.1,>=0.1.56'],
     'xmlio': ['uproot~=3.6'],  # Future proof against uproot4 API changes
     'minuit': ['iminuit~=1.4.3'],  # v1.5.0 breaks pyhf for 32b TensorFlow and PyTorch
 }

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ extras_require = {
         'tensorflow-probability~=0.10.0',
     ],
     'torch': ['torch~=1.2'],
-    'jax': ['jax~=0.2,>=0.2.4', 'jaxlib~=0.1,>=0.1.56'],
+    'jax': ['jax~=0.2.4', 'jaxlib~=0.1.56'],
     'xmlio': ['uproot~=3.6'],  # Future proof against uproot4 API changes
     'minuit': ['iminuit~=1.4.3'],  # v1.5.0 breaks pyhf for 32b TensorFlow and PyTorch
 }

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -7,6 +7,7 @@ from jax.scipy.special import gammaln
 from jax.scipy import special
 from jax.scipy.stats import norm, poisson
 import numpy as onp
+import scipy.stats as osp_stats
 import logging
 
 log = logging.getLogger(__name__)
@@ -17,9 +18,7 @@ class _BasicPoisson(object):
         self.rate = rate
 
     def sample(self, sample_shape):
-        return poisson.osp_stats.poisson(self.rate).rvs(
-            size=sample_shape + self.rate.shape
-        )
+        return osp_stats.poisson(self.rate).rvs(size=sample_shape + self.rate.shape)
 
     def log_prob(self, value):
         tensorlib = jax_backend()
@@ -32,7 +31,7 @@ class _BasicNormal(object):
         self.scale = scale
 
     def sample(self, sample_shape):
-        return norm.osp_stats.norm(self.loc, self.scale).rvs(
+        return osp_stats.norm(self.loc, self.scale).rvs(
             size=sample_shape + self.loc.shape
         )
 

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -18,7 +18,10 @@ class _BasicPoisson(object):
         self.rate = rate
 
     def sample(self, sample_shape):
-        return osp_stats.poisson(self.rate).rvs(size=sample_shape + self.rate.shape)
+        tensorlib = jax_backend()
+        return tensorlib.astensor(
+            osp_stats.poisson(self.rate).rvs(size=sample_shape + self.rate.shape)
+        )
 
     def log_prob(self, value):
         tensorlib = jax_backend()
@@ -31,8 +34,9 @@ class _BasicNormal(object):
         self.scale = scale
 
     def sample(self, sample_shape):
-        return osp_stats.norm(self.loc, self.scale).rvs(
-            size=sample_shape + self.loc.shape
+        tensorlib = jax_backend()
+        return tensorlib.astensor(
+            osp_stats.norm(self.loc, self.scale).rvs(size=sample_shape + self.loc.shape)
         )
 
     def log_prob(self, value):

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -18,9 +18,10 @@ class _BasicPoisson(object):
         self.rate = rate
 
     def sample(self, sample_shape):
-        tensorlib = jax_backend()
-        return tensorlib.astensor(
-            osp_stats.poisson(self.rate).rvs(size=sample_shape + self.rate.shape)
+        # TODO: Support other dtypes
+        return np.asarray(
+            osp_stats.poisson(self.rate).rvs(size=sample_shape + self.rate.shape),
+            dtype=np.float64,
         )
 
     def log_prob(self, value):
@@ -34,9 +35,12 @@ class _BasicNormal(object):
         self.scale = scale
 
     def sample(self, sample_shape):
-        tensorlib = jax_backend()
-        return tensorlib.astensor(
-            osp_stats.norm(self.loc, self.scale).rvs(size=sample_shape + self.loc.shape)
+        # TODO: Support other dtypes
+        return np.asarray(
+            osp_stats.norm(self.loc, self.scale).rvs(
+                size=sample_shape + self.loc.shape
+            ),
+            dtype=np.float64,
         )
 
     def log_prob(self, value):

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -5,7 +5,7 @@ config.update('jax_enable_x64', True)
 import jax.numpy as np
 from jax.scipy.special import gammaln
 from jax.scipy import special
-from jax.scipy.stats import norm, poisson
+from jax.scipy.stats import norm
 import numpy as onp
 import scipy.stats as osp_stats
 import logging

--- a/tests/test_probability.py
+++ b/tests/test_probability.py
@@ -20,6 +20,9 @@ def test_poisson(backend):
     )
     assert result.shape == (1, 2)
 
+    sample = probability.Poisson(tb.astensor([10.0, 10.0])).sample((10,))
+    assert sample.shape == (10, 2)
+
 
 def test_normal(backend):
     tb, _ = backend
@@ -42,6 +45,11 @@ def test_normal(backend):
         tb.astensor([10.0, 10.0]), tb.astensor([10.0, 10.0])
     ).log_prob(tb.astensor([[2.0, 3.0]]))
     assert result.shape == (1, 2)
+
+    sample = probability.Normal(
+        tb.astensor([10.0, 10.0]), tb.astensor([10.0, 10.0])
+    ).sample((10,))
+    assert sample.shape == (10, 2)
 
 
 def test_joint(backend):


### PR DESCRIPTION
# Description

With release [`v0.2.4` of JAX](https://github.com/google/jax/releases/tag/jax-v0.2.4) the underlying stats API has changed as there is no longer a `jax.scipy.stats.norm.osp_stats` or `jax.scipy.stats.poisson.osp_stats` API, but instead [JAX now just uses the SciPy API directly with](https://github.com/google/jax/blob/4b8334ab0b8d9d3f1c676866d177f3e3e6b4c250/jax/_src/scipy/stats/poisson.py#L16)

```
import scipy.stats as osp_stats
```

As such, this requires a minimum version bump of `jax` and `jaxlib` and then also requires changing the imports to use SciPy directly. Given that the continuous approximation to the Poisson is used there is actually no need to import `jax.scipy.stats.poisson` anymore either.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR


```
* Use JAX v0.2.4 API with regards to using scipy.stats directly
* Update to jax v0.2.4+ and jaxlib v0.1.56+
   - Restrict to jax v0.2.X and jaxlib v0.1.X to ensure stability
* Add tests for Poisson and Normal sample shape
```