### PR TITLE
feat: Support ShapeFactor for import/export

### DIFF
--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -171,6 +171,10 @@ def process_sample(
                     'data': [a * b for a, b in zip(data, shapesys_data)],
                 }
             )
+        elif modtag.tag == 'ShapeFactor':
+            modifiers.append(
+                {'name': modtag.attrib['Name'], 'type': 'shapefactor', 'data': None}
+            )
         else:
             log.warning('not considering modifier tag %s', modtag)
 

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -205,9 +205,11 @@ def build_modifier(spec, modifierspec, channelname, samplename, sampledata):
                 for a, b in np.array((modifierspec['data'], sampledata)).T
             ],
         )
+    elif modifierspec['type'] == 'shapefactor':
+        pass
     else:
         log.warning(
-            'Skipping {0}({1}) for now'.format(
+            'Skipping modifier {0}({1}) for now'.format(
                 modifierspec['name'], modifierspec['type']
             )
         )

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -213,6 +213,7 @@ def build_modifier(spec, modifierspec, channelname, samplename, sampledata):
                 modifierspec['name'], modifierspec['type']
             )
         )
+        return None
 
     modifier = ET.Element(mod_map[modifierspec['type']], **attrs)
     return modifier

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -258,6 +258,18 @@ def test_export_modifier(mocker, caplog, spec, has_root_data, attrs):
     assert pyhf.writexml._ROOT_DATA_FILE.__setitem__.called == has_root_data
 
 
+def test_export_bad_modifier(caplog):
+    with caplog.at_level(logging.DEBUG, 'pyhf.writexml'):
+        pyhf.writexml.build_modifier(
+            {'measurements': [{'config': {'parameters': []}}]},
+            {'name': 'fakeModifier', 'type': 'unknown-modifier'},
+            'fakeChannel',
+            'fakeSample',
+            None,
+        )
+    assert "Skipping modifier fakeModifier(unknown-modifier)" in caplog.text
+
+
 @pytest.mark.parametrize(
     "spec, normfactor_config",
     [

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -3,6 +3,7 @@ import pyhf.writexml
 import pytest
 import json
 import xml.etree.cElementTree as ET
+import logging
 
 
 def spec_staterror():
@@ -143,6 +144,34 @@ def spec_shapesys():
     return spec
 
 
+def spec_shapefactor():
+    source = json.load(open('validation/data/2bin_histosys_example2.json'))
+    spec = {
+        'channels': [
+            {
+                'name': 'singlechannel',
+                'samples': [
+                    {
+                        'name': 'signal',
+                        'data': source['bindata']['sig'],
+                        'modifiers': [
+                            {'name': 'mu', 'type': 'normfactor', 'data': None}
+                        ],
+                    },
+                    {
+                        'name': 'background',
+                        'data': source['bindata']['bkg'],
+                        'modifiers': [
+                            {'name': 'bkg_norm', 'type': 'shapefactor', 'data': None}
+                        ],
+                    },
+                ],
+            }
+        ]
+    }
+    return spec
+
+
 def test_export_measurement():
     measurementspec = {
         "config": {
@@ -198,10 +227,11 @@ def test_export_measurement():
         (spec_histosys(), True, ['HistoNameHigh', 'HistoNameLow']),
         (spec_normsys(), False, ['High', 'Low']),
         (spec_shapesys(), True, ['ConstraintType', 'HistoName']),
+        (spec_shapefactor(), False, []),
     ],
-    ids=['staterror', 'histosys', 'normsys', 'shapesys'],
+    ids=['staterror', 'histosys', 'normsys', 'shapesys', 'shapefactor'],
 )
-def test_export_modifier(mocker, spec, has_root_data, attrs):
+def test_export_modifier(mocker, caplog, spec, has_root_data, attrs):
     channelspec = spec['channels'][0]
     channelname = channelspec['name']
     samplespec = channelspec['samples'][1]
@@ -210,13 +240,17 @@ def test_export_modifier(mocker, spec, has_root_data, attrs):
     modifierspec = samplespec['modifiers'][0]
 
     mocker.patch('pyhf.writexml._ROOT_DATA_FILE')
-    modifier = pyhf.writexml.build_modifier(
-        {'measurements': [{'config': {'parameters': []}}]},
-        modifierspec,
-        channelname,
-        samplename,
-        sampledata,
-    )
+
+    with caplog.at_level(logging.DEBUG, 'pyhf.writexml'):
+        modifier = pyhf.writexml.build_modifier(
+            {'measurements': [{'config': {'parameters': []}}]},
+            modifierspec,
+            channelname,
+            samplename,
+            sampledata,
+        )
+    assert "Skipping modifier" not in caplog.text
+
     # if the modifier is a staterror, it has no Name
     if 'Name' in modifier.attrib:
         assert modifier.attrib['Name'] == modifierspec['name']


### PR DESCRIPTION
# Description

Resolves #1080. This adds in the shapefactor import. ./cc @alexander-held 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add ShapeFactor support to pyhf.readxml
* Add ShapeFactor support to pyhf.writexml
* Add ShapeFactor test
```