### PR TITLE
refactor: Use jax.numpy for JAX backend tensorlib.tolist

### DIFF
--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -180,7 +180,7 @@ class jax_backend:
     def tolist(self, tensor_in):
         try:
             return jnp.asarray(tensor_in).tolist()
-        except AttributeError:
+        except TypeError:
             if isinstance(tensor_in, list):
                 return tensor_in
             raise

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -6,6 +6,7 @@ import jax.numpy as jnp
 from jax.scipy.special import gammaln, xlogy
 from jax.scipy import special
 from jax.scipy.stats import norm
+import numpy as np
 import scipy.stats as osp_stats
 import logging
 

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -178,7 +178,7 @@ class jax_backend:
 
     def tolist(self, tensor_in):
         try:
-            return np.asarray(tensor_in).tolist()
+            return jnp.asarray(tensor_in).tolist()
         except AttributeError:
             if isinstance(tensor_in, list):
                 return tensor_in

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -6,7 +6,6 @@ import jax.numpy as jnp
 from jax.scipy.special import gammaln, xlogy
 from jax.scipy import special
 from jax.scipy.stats import norm
-import numpy as np
 import scipy.stats as osp_stats
 import logging
 


### PR DESCRIPTION
# Description

Resolves #1137 

In more recent releases of JAX the `jax.numpy` module is more filled out and it now supports `jax.numpy.tolist`, which was the only thing NumPy was used for previously.

NumPy must still be kept as JAX relies on `numpy` itself to convert from JAX DeviceArray to NumPy

https://github.com/scikit-hep/pyhf/blob/2b2b28181a038b25bd4634808cdfec869b30d834/src/pyhf/tensor/jax_backend.py#L568-L593

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use jax.numpy.tolist to provide the tolist method for the JAX backend
   - Note that NumPy dependency can never be removed as JAX depends on
     NumPy for JAX to NumPy conversion
```
