### PR TITLE
fix: Pin additional dependencies in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
     rev: 20.8b1
     hooks:
     - id: black
-      language_version: python3
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.7.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,4 +13,6 @@ repos:
     rev: 0.4.0
     hooks:
     - id: nbqa-black
+      additional_dependencies: [black==20.8b1]
     - id: nbqa-pyupgrade
+      additional_dependencies: [pyupgrade==2.7.3]

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -18,3 +18,4 @@ Contributors include:
 - Nikolai Hartmann
 - Alexander Held
 - Karthikeyan Singaravelan
+- Marco Gorelli


### PR DESCRIPTION
Hi,

Thanks for trying out nbqa - our default hooks use the latest available version of each tool, but for best reproducibility it's best to pin them. Admittedly, that's something we'd neglected to document :flushed:  but [it's there now](https://github.com/nbQA-dev/nbQA#pre-commit)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Set dependency versions of black and pyupgrade for nbQA to use
* Remove language_version from Black pre-commit hook as already specified
```