### PR TITLE
feat: Set minuit strategy automatically for gradient/non-gradient mode

### DIFF
--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -87,7 +87,7 @@ class minuit_optimizer(OptimizerMixin):
         Minimizer Options:
             maxiter (:obj:`int`): maximum number of iterations. Default is 100000.
             return_uncertainties (:obj:`bool`): Return uncertainties on the fitted parameters. Default is off.
-            strategy: (:obj:`int`): See :attr:`iminuit.Minuit.strategy`. Default is to configure based on `do_grad`.
+            strategy: (:obj:`int`): See :attr:`iminuit.Minuit.strategy`. Default is to configure in response to `do_grad`.
 
         Returns:
             fitresult (scipy.optimize.OptimizeResult): the fit result

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -10,7 +10,7 @@ class minuit_optimizer(OptimizerMixin):
     Optimizer that uses iminuit.Minuit.migrad.
     """
 
-    __slots__ = ['name', 'errordef', 'steps']
+    __slots__ = ['name', 'errordef', 'steps', 'strategy']
 
     def __init__(self, *args, **kwargs):
         """

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -96,7 +96,7 @@ class minuit_optimizer(OptimizerMixin):
         return_uncertainties = options.pop('return_uncertainties', False)
         # 0: Fast, user-provided gradient
         # 1: Default, no user-provided gradient
-        strategy = options.pop('strategy', not(do_grad))
+        strategy = options.pop('strategy', not (do_grad))
         if options:
             raise exceptions.Unsupported(
                 f"Unsupported options were passed in: {list(options.keys())}."

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -98,7 +98,9 @@ class minuit_optimizer(OptimizerMixin):
         return_uncertainties = options.pop('return_uncertainties', False)
         # 0: Fast, user-provided gradient
         # 1: Default, no user-provided gradient
-        strategy = options.pop('strategy', self.strategy if self.strategy else not do_grad)
+        strategy = options.pop(
+            'strategy', self.strategy if self.strategy else not do_grad
+        )
         if options:
             raise exceptions.Unsupported(
                 f"Unsupported options were passed in: {list(options.keys())}."

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -118,6 +118,8 @@ class minuit_optimizer(OptimizerMixin):
         n = len(x0)
         hess_inv = default_backend.ones((n, n))
         if minimizer.valid:
+            # Extra call to hesse() after migrad() is always needed for good error estimates. If you pass a user-provided gradient to MINUIT, convergence is faster.
+            minimizer.hesse()
             hess_inv = minimizer.np_covariance()
 
         unc = None

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -27,10 +27,12 @@ class minuit_optimizer(OptimizerMixin):
         Args:
             errordef (:obj:`float`): See minuit docs. Default is 1.0.
             steps (:obj:`int`): Number of steps for the bounds. Default is 1000.
+            strategy (:obj:`int`): See :attr:`iminuit.Minuit.strategy`. Default is None.
         """
         self.name = 'minuit'
         self.errordef = kwargs.pop('errordef', 1)
         self.steps = kwargs.pop('steps', 1000)
+        self.strategy = kwargs.pop('strategy', None)
         super().__init__(*args, **kwargs)
 
     def _get_minimizer(
@@ -87,7 +89,7 @@ class minuit_optimizer(OptimizerMixin):
         Minimizer Options:
             maxiter (:obj:`int`): maximum number of iterations. Default is 100000.
             return_uncertainties (:obj:`bool`): Return uncertainties on the fitted parameters. Default is off.
-            strategy: (:obj:`int`): See :attr:`iminuit.Minuit.strategy`. Default is to configure in response to `do_grad`.
+            strategy (:obj:`int`): See :attr:`iminuit.Minuit.strategy`. Default is to configure in response to `do_grad`.
 
         Returns:
             fitresult (scipy.optimize.OptimizeResult): the fit result
@@ -96,7 +98,7 @@ class minuit_optimizer(OptimizerMixin):
         return_uncertainties = options.pop('return_uncertainties', False)
         # 0: Fast, user-provided gradient
         # 1: Default, no user-provided gradient
-        strategy = options.pop('strategy', not do_grad)
+        strategy = options.pop('strategy', self.strategy if self.strategy else not do_grad)
         if options:
             raise exceptions.Unsupported(
                 f"Unsupported options were passed in: {list(options.keys())}."

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -87,17 +87,22 @@ class minuit_optimizer(OptimizerMixin):
         Minimizer Options:
             maxiter (:obj:`int`): maximum number of iterations. Default is 100000.
             return_uncertainties (:obj:`bool`): Return uncertainties on the fitted parameters. Default is off.
+            strategy: (:obj:`int`): See :attr:`iminuit.Minuit.strategy`. Default is to configure based on `do_grad`.
 
         Returns:
             fitresult (scipy.optimize.OptimizeResult): the fit result
         """
         maxiter = options.pop('maxiter', self.maxiter)
         return_uncertainties = options.pop('return_uncertainties', False)
+        # 0: Fast, user-provided gradient
+        # 1: Default, no user-provided gradient
+        strategy = options.pop('strategy', not(do_grad))
         if options:
             raise exceptions.Unsupported(
                 f"Unsupported options were passed in: {list(options.keys())}."
             )
 
+        minimizer.strategy = strategy
         minimizer.migrad(ncall=maxiter)
         # Following lines below come from:
         # https://github.com/scikit-hep/iminuit/blob/22f6ed7146c1d1f3274309656d8c04461dde5ba3/src/iminuit/_minimize.py#L106-L125

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -96,7 +96,7 @@ class minuit_optimizer(OptimizerMixin):
         return_uncertainties = options.pop('return_uncertainties', False)
         # 0: Fast, user-provided gradient
         # 1: Default, no user-provided gradient
-        strategy = options.pop('strategy', not (do_grad))
+        strategy = options.pop('strategy', not do_grad)
         if options:
             raise exceptions.Unsupported(
                 f"Unsupported options were passed in: {list(options.keys())}."

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -204,6 +204,27 @@ def test_minuit_strategy_do_grad(mocker, backend):
     assert spy.spy_return.minuit.strategy == 1
 
 
+@pytest.mark.parametrize('strategy', [0, 1])
+def test_minuit_strategy_global(mocker, backend, strategy):
+    pyhf.set_backend(pyhf.tensorlib, pyhf.optimize.minuit_optimizer(strategy=strategy))
+    spy = mocker.spy(pyhf.optimize.minuit_optimizer, '_minimize')
+    m = pyhf.simplemodels.hepdata_like([50.0], [100.0], [10.0])
+    data = pyhf.tensorlib.astensor([125.0] + m.config.auxdata)
+
+    do_grad = pyhf.tensorlib.default_do_grad
+    pyhf.infer.mle.fit(data, m)
+    assert spy.call_count == 1
+    assert spy.spy_return.minuit.strategy == strategy if do_grad else 1
+
+    pyhf.infer.mle.fit(data, m, strategy=0)
+    assert spy.call_count == 2
+    assert spy.spy_return.minuit.strategy == 0
+
+    pyhf.infer.mle.fit(data, m, strategy=1)
+    assert spy.call_count == 3
+    assert spy.spy_return.minuit.strategy == 1
+
+
 @pytest.mark.parametrize(
     'optimizer',
     [pyhf.optimize.scipy_optimizer, pyhf.optimize.minuit_optimizer],

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -93,7 +93,7 @@ def test_minimize(tensorlib, precision, optimizer, do_grad, do_stitch):
             'no_grad-minuit-jax-64b': [0.5000493563528641, 1.0000043833614634],
             # do grad, minuit, 32b
             'do_grad-minuit-pytorch-32b': [0.5017611384391785, 0.9997190237045288],
-            'do_grad-minuit-tensorflow-32b': [0.501288652420044, 1.0000219345092773],
+            'do_grad-minuit-tensorflow-32b': [0.5012885928153992, 1.0000673532485962],
             #'do_grad-minuit-jax-32b': [0.5029529333114624, 0.9991086721420288],
             'do_grad-minuit-jax-32b': [0.5007095336914062, 0.9999282360076904],
             # do grad, minuit, 64b

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -193,7 +193,7 @@ def test_minuit_strategy_do_grad(mocker, backend):
     do_grad = pyhf.tensorlib.default_do_grad
     pyhf.infer.mle.fit(data, m)
     assert spy.call_count == 1
-    assert spy.spy_return.minuit.strategy == not do_grad
+    assert not spy.spy_return.minuit.strategy == do_grad
 
 
 @pytest.mark.parametrize(

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -195,6 +195,14 @@ def test_minuit_strategy_do_grad(mocker, backend):
     assert spy.call_count == 1
     assert not spy.spy_return.minuit.strategy == do_grad
 
+    pyhf.infer.mle.fit(data, m, strategy=0)
+    assert spy.call_count == 2
+    assert spy.spy_return.minuit.strategy == 0
+
+    pyhf.infer.mle.fit(data, m, strategy=1)
+    assert spy.call_count == 3
+    assert spy.spy_return.minuit.strategy == 1
+
 
 @pytest.mark.parametrize(
     'optimizer',


### PR DESCRIPTION
# Pull Request Description

Teach pyhf to set the minuit strategy correctly depending on whether user provides gradient or not. Additionally allow for this to be configurable via `strategy` kwarg.

Resolves #1172.

ReadTheDocs build: https://pyhf.readthedocs.io/en/feat-userprovidedgradientstominuit/_generated/pyhf.optimize.opt_minuit.minuit_optimizer.html

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Set MINUIT strategy to 0/1 automatically if using gradients/no-gradient
* Allow for MINUIT strategy to be configurable
* Add test for strategy selection
```
