### PR TITLE
docs: Add CHEP 2019 proceedings use citation

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,17 @@
+% 2020-11-16
+@article{Feickert:2020chep2019,
+    author = "Feickert, Matthew and Heinrich, Lukas and Stark, Giordon",
+    title = "{Likelihood preservation and statistical reproduction of searches for new physics}",
+    primaryClass = "hep-ex",
+    doi = "10.1051/epjconf/202024506017",
+    journal = "EPJ Web Conf.",
+    volume = "245",
+    number = "06017",
+    pages = "7",
+    year = "2020"
+}
+
+% 2020-09-03
 @article{Alguero:2020grj,
     author = "Alguero, Gaël and Kraml, Sabine and Waltenberger, Wolfgang",
     title = "{A SModelS interface for pyhf likelihoods}",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -7,7 +7,6 @@
     journal = "EPJ Web Conf.",
     volume = "245",
     number = "06017",
-    pages = "7",
     year = "2020"
 }
 


### PR DESCRIPTION
# Description

Add use citation from [the published CHEP 2019 conference proceedings](https://doi.org/10.1051/epjconf/202024506017) for @matthewfeickert's talk "Likelihood preservation and statistical reproduction of searches for new physics" that was given on behalf of ATLAS.

Resolves the last part of Issue #658.

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-add-chep-2019-proceedings/citations.html#use-in-publications

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation for the published CHEP 2019 conference proceedings
   - c.f. https://doi.org/10.1051/epjconf/202024506017
```
