### PR TITLE
fix: Isolate pyhf contrib commands from rest of CLI

### DIFF
--- a/src/pyhf/contrib/cli.py
+++ b/src/pyhf/contrib/cli.py
@@ -3,8 +3,6 @@ import logging
 import click
 from pathlib import Path
 
-# from . import utils
-
 logging.basicConfig()
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/contrib/cli.py
+++ b/src/pyhf/contrib/cli.py
@@ -3,7 +3,7 @@ import logging
 import click
 from pathlib import Path
 
-from . import utils
+# from . import utils
 
 logging.basicConfig()
 log = logging.getLogger(__name__)
@@ -57,6 +57,8 @@ def download(archive_url, output_directory, verbose, force, compress):
         :class:`~pyhf.exceptions.InvalidArchiveHost`: if the provided archive host name is not known to be valid
     """
     try:
+        from . import utils
+
         utils.download(archive_url, output_directory, force, compress)
 
         if verbose:

--- a/src/pyhf/contrib/cli.py
+++ b/src/pyhf/contrib/cli.py
@@ -20,6 +20,7 @@ def cli():
 
             $ python -m pip install pyhf[contrib]
     """
+    from . import utils
 
 
 @cli.command()
@@ -55,8 +56,6 @@ def download(archive_url, output_directory, verbose, force, compress):
         :class:`~pyhf.exceptions.InvalidArchiveHost`: if the provided archive host name is not known to be valid
     """
     try:
-        from . import utils
-
         utils.download(archive_url, output_directory, force, compress)
 
         if verbose:

--- a/src/pyhf/contrib/cli.py
+++ b/src/pyhf/contrib/cli.py
@@ -20,7 +20,7 @@ def cli():
 
             $ python -m pip install pyhf[contrib]
     """
-    from . import utils
+    from . import utils  # Guard CLI from missing extra
 
 
 @cli.command()
@@ -56,6 +56,8 @@ def download(archive_url, output_directory, verbose, force, compress):
         :class:`~pyhf.exceptions.InvalidArchiveHost`: if the provided archive host name is not known to be valid
     """
     try:
+        from . import utils
+
         utils.download(archive_url, output_directory, force, compress)
 
         if verbose:

--- a/src/pyhf/contrib/cli.py
+++ b/src/pyhf/contrib/cli.py
@@ -22,6 +22,9 @@ def cli():
     """
     from . import utils  # Guard CLI from missing extra
 
+    # TODO: https://github.com/scikit-hep/pyhf/issues/863
+    _ = utils  # Placate pyflakes
+
 
 @cli.command()
 @click.argument("archive-url")

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -562,7 +562,7 @@ def test_missing_contrib_extra(caplog):
         if "pyhf.contrib.utils" in sys.modules:
             reload(sys.modules["pyhf.contrib.utils"])
         else:
-            import_module("pyhf.cli")
+            import_module("pyhf.contrib.utils")
 
     with caplog.at_level(logging.ERROR):
         for line in [
@@ -577,10 +577,10 @@ def test_missing_contrib_extra(caplog):
 def test_missing_contrib_download(caplog):
     with mock.patch.dict(sys.modules):
         sys.modules["requests"] = None
-        if "pyhf.cli" in sys.modules:
-            reload(sys.modules["pyhf.cli"])
+        if "pyhf.contrib.utils" in sys.modules:
+            reload(sys.modules["pyhf.contrib.utils"])
         else:
-            import_module("pyhf.cli")
+            import_module("pyhf.contrib.utils")
 
         # Force environment for runner
         for module in [


### PR DESCRIPTION
# Description

Resolves #1182

Move the import of `pyhf.contrib.utils` inside of the `pyhf.contrib.cli` methods, as `pyhf contrib` still needs to be accessible from the CLI along with the other modules by default so that users can learn about it but the methods of the module should be able to warn if there are missing libraries. This allows for the other CLI modules to not trigger the warnings and for the warnings to still come up if the errors are directly triggered through use.

As an example, this allows for the following:

```
$ python -m pip install pyhf[xmlio]
$ pyhf json2xml --help
Usage: pyhf json2xml [OPTIONS] [WORKSPACE]

  Convert pyhf JSON back to XML + ROOT files.

Options:
  --output-dir PATH
  --specroot TEXT
  --dataroot TEXT
  --resultprefix TEXT
  -p, --patch TEXT
  -h, --help           Show this message and exit.
$ pyhf contrib --help
Usage: pyhf contrib [OPTIONS] COMMAND [ARGS]...

  Contrib experimental operations.

  .. note::

      Requires installation of the ``contrib`` extra.

      .. code-block:: shell

          $ python -m pip install pyhf[contrib]

Options:
  -h, --help  Show this message and exit.

Commands:
  download  Download the patchset archive from the remote URL and extract
            it...
$ pyhf contrib download --help
ERROR:pyhf.contrib.utils:No module named 'requests'
Installation of the contrib extra is required to use pyhf.contrib.utils.download
Please install with: python -m pip install pyhf[contrib]

Usage: pyhf contrib download [OPTIONS] ARCHIVE_URL OUTPUT_DIRECTORY

  Download the patchset archive from the remote URL and extract it in a
  directory at the path given.

  Example:

  .. code-block:: shell

      $ pyhf contrib download --verbose
      https://doi.org/10.17182/hepdata.90607.v3/r3 1Lbb-likelihoods

          1Lbb-likelihoods/patchset.json
          1Lbb-likelihoods/README.md
          1Lbb-likelihoods/BkgOnly.json

  Raises:     :class:`~pyhf.exceptions.InvalidArchiveHost`: if the provided
  archive host name is not known to be valid

Options:
  -v, --verbose   Enables verbose mode
  -f, --force     Force download from non-approved host
  -c, --compress  Keep the archive in a compressed tar.gz form
  -h, --help      Show this message and exit.

```

This isn't perfect, as it allows for the user to get information about `pyhf contrib download` instead of just being given an error, but this is probably an acceptable compromise.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Move import pyhf.contrib.utils inside the contrib CLI functions
   - Guard the CLI API from missing extras without triggering warnings from using other modules CLI API
* Update the modules to reimport in tests
```
