### PR TITLE
refactor: Drop 'modifier' from parameter set requirements

### DIFF
--- a/src/pyhf/modifiers/histosys.py
+++ b/src/pyhf/modifiers/histosys.py
@@ -15,7 +15,6 @@ class histosys:
         return {
             'paramset_type': constrained_by_normal,
             'n_parameters': 1,
-            'modifier': cls.__name__,
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'inits': (0.0,),

--- a/src/pyhf/modifiers/lumi.py
+++ b/src/pyhf/modifiers/lumi.py
@@ -14,7 +14,6 @@ class lumi:
         return {
             'paramset_type': constrained_by_normal,
             'n_parameters': 1,
-            'modifier': cls.__name__,
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'op_code': cls.op_code,

--- a/src/pyhf/modifiers/normfactor.py
+++ b/src/pyhf/modifiers/normfactor.py
@@ -14,7 +14,6 @@ class normfactor:
         return {
             'paramset_type': unconstrained,
             'n_parameters': 1,
-            'modifier': cls.__name__,
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'inits': (1.0,),

--- a/src/pyhf/modifiers/normsys.py
+++ b/src/pyhf/modifiers/normsys.py
@@ -15,7 +15,6 @@ class normsys:
         return {
             'paramset_type': constrained_by_normal,
             'n_parameters': 1,
-            'modifier': cls.__name__,
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'inits': (0.0,),

--- a/src/pyhf/modifiers/shapefactor.py
+++ b/src/pyhf/modifiers/shapefactor.py
@@ -14,7 +14,6 @@ class shapefactor:
         return {
             'paramset_type': unconstrained,
             'n_parameters': len(sample_data),
-            'modifier': cls.__name__,
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'inits': (1.0,) * len(sample_data),

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -22,7 +22,6 @@ class shapesys:
         return {
             'paramset_type': constrained_by_poisson,
             'n_parameters': n_parameters,
-            'modifier': cls.__name__,
             'is_constrained': cls.is_constrained,
             'is_shared': False,
             'inits': (1.0,) * n_parameters,

--- a/src/pyhf/modifiers/staterror.py
+++ b/src/pyhf/modifiers/staterror.py
@@ -14,7 +14,6 @@ class staterror:
         return {
             'paramset_type': constrained_by_normal,
             'n_parameters': len(sample_data),
-            'modifier': cls.__name__,
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'inits': (1.0,) * len(sample_data),


### PR DESCRIPTION
# Pull Request Description

@lukasheinrich identified this. It seems that #323 and #285 are the culprit here. Primarily, as it was a large PR, the refactoring wasn't so perfect and we left some cruft in at the end. This just cleans it up.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Drop the modifier from required_parset()
   - Parameter set requirements do not need to know modifier
```
