### PR TITLE
chore: Use flake8 for linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E203, E266, E501, W503
+max-line-length = 88
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,4 @@
 [flake8]
 ignore = E203, E266, E402, E501, W503
 max-line-length = 88
-max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E203, E266, E501, W503
+ignore = E203, E266, E402, E501, W503
 max-line-length = 88
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-extend-ignore = E203, E266, E402, E501, W503
-max-line-length = 88
-select = B,C,E,F,W,T4,B9

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-ignore = E203, E266, E402, E501, W503
+extend-ignore = E203, E266, E402, E501, W503
 max-line-length = 88
 select = B,C,E,F,W,T4,B9

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,9 +21,9 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed -U -q --no-cache-dir -e .[lint]
         python -m pip list
-    - name: Lint with Pyflakes
+    - name: Lint with flake8
       run: |
-        python -m pyflakes .
+        python -m flake8 .
     - name: Lint with Black
       run: |
         black --check --diff --verbose .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,10 @@ repos:
     rev: 20.8b1
     hooks:
     - id: black
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+    - id: flake8
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.7.4
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,4 +65,5 @@ warning-is-error = 1
 # E501: line too long
 extend-ignore = E203, E402, E501
 max-line-length = 88
-select = B,C,E,F,W,T4,B9
+count = True
+statistics = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,6 @@ all-files = 1
 warning-is-error = 1
 
 [flake8]
-extend-ignore = E203, E266, E402, E501
+extend-ignore = E203, E402, E501
 max-line-length = 88
 select = B,C,E,F,W,T4,B9

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,3 +58,7 @@ source-dir = docs
 build-dir = docs/_build
 all-files = 1
 warning-is-error = 1
+
+[flake8]
+max-line-length = 88
+max-complexity = 18

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,5 +60,6 @@ all-files = 1
 warning-is-error = 1
 
 [flake8]
+extend-ignore = E203, E266, E402, E501, W503
 max-line-length = 88
-max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,6 @@ all-files = 1
 warning-is-error = 1
 
 [flake8]
-extend-ignore = E203, E266, E402, E501, W503
+extend-ignore = E203, E266, E402, E501
 max-line-length = 88
 select = B,C,E,F,W,T4,B9

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,9 @@ all-files = 1
 warning-is-error = 1
 
 [flake8]
+# E203: whitespace before ':'
+# E402: module level import not at top of file
+# E501: line too long
 extend-ignore = E203, E402, E501
 max-line-length = 88
 select = B,C,E,F,W,T4,B9

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ extras_require['test'] = sorted(
         + extras_require['contrib']
         + extras_require['shellcomplete']
         + [
+            'flake8',
             'pytest~=6.0',
             'pytest-cov>=2.5.1',
             'pytest-mock',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ extras_require['backends'] = sorted(
     )
 )
 extras_require['contrib'] = sorted({'matplotlib', 'requests'})
-extras_require['lint'] = sorted({'pyflakes', 'black'})
+extras_require['lint'] = sorted({'flake8', 'black'})
 
 extras_require['test'] = sorted(
     set(
@@ -29,7 +29,6 @@ extras_require['test'] = sorted(
         + extras_require['contrib']
         + extras_require['shellcomplete']
         + [
-            'flake8',
             'pytest~=6.0',
             'pytest-cov>=2.5.1',
             'pytest-mock',

--- a/src/pyhf/contrib/cli.py
+++ b/src/pyhf/contrib/cli.py
@@ -20,10 +20,7 @@ def cli():
 
             $ python -m pip install pyhf[contrib]
     """
-    from . import utils  # Guard CLI from missing extra
-
-    # TODO: https://github.com/scikit-hep/pyhf/issues/863
-    _ = utils  # Placate pyflakes
+    from . import utils  # Guard CLI from missing extra # noqa: F401
 
 
 @cli.command()

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -186,7 +186,6 @@ def hypotest(
     return tuple(_returns) if len(_returns) > 1 else _returns[0]
 
 
-from . import intervals
+from . import intervals  # noqa: F401
 
-# TODO: Can remove intervals when switch to flake8 (Issue #863)
-__all__ = ["hypotest", "intervals"]
+__all__ = ["hypotest"]

--- a/src/pyhf/infer/utils.py
+++ b/src/pyhf/infer/utils.py
@@ -36,6 +36,6 @@ def create_calculator(calctype, *args, **kwargs):
     Returns:
         calculator (:obj:`object`): A calculator.
     """
-    return {'asymptotics': AsymptoticCalculator, 'toybased': ToyCalculator,}[
-        calctype
-    ](*args, **kwargs)
+    return {'asymptotics': AsymptoticCalculator, 'toybased': ToyCalculator}[calctype](
+        *args, **kwargs
+    )

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -52,8 +52,8 @@ class minuit_optimizer(OptimizerMixin):
 
         # Minuit requires jac=callable
         if do_grad:
-            wrapped_objective = lambda pars: objective_and_grad(pars)[0]
-            jac = lambda pars: objective_and_grad(pars)[1]
+            wrapped_objective = lambda pars: objective_and_grad(pars)[0]  # noqa: E731
+            jac = lambda pars: objective_and_grad(pars)[1]  # noqa: E731
         else:
             wrapped_objective = objective_and_grad
             jac = None

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -731,7 +731,7 @@ class Model:
             ):  # force to be not scalar, should we changed with #522
                 return tensorlib.reshape(result, (1,))
             return result
-        except:
+        except:  # noqa: E722
             log.error(
                 f'eval failed for data {tensorlib.tolist(data)} pars: {tensorlib.tolist(pars)}'
             )

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -40,7 +40,7 @@ def import_root_histogram(rootdir, filename, path, name, filecache=None):
     path = path or ''
     path = path.strip('/')
     fullpath = str(Path(rootdir).joinpath(filename))
-    if not fullpath in filecache:
+    if fullpath not in filecache:
         f = uproot.open(fullpath)
         filecache[fullpath] = f
     else:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -41,7 +41,7 @@ def test_missing_backends(isolate_modules, param):
 
     try:
         delattr(pyhf.tensor, module_name)
-    except:
+    except:  # noqa: E722
         pass
 
     with expectation:
@@ -80,7 +80,7 @@ def test_missing_optimizer(isolate_modules, param):
     )
     try:
         delattr(pyhf.optimize, module_name)
-    except:
+    except:  # noqa: E722
         pass
 
     with expectation:

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -13,6 +13,7 @@ modifiers_to_test = [
 ]
 modifier_pdf_types = ["normal", None, "normal", None, "poisson", "normal"]
 
+
 # we make sure we can import all of our pre-defined modifiers correctly
 @pytest.mark.parametrize(
     "test_modifierPair", zip(modifiers_to_test, modifier_pdf_types)

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -7,6 +7,7 @@ from scipy.optimize import minimize, OptimizeResult
 import iminuit
 import itertools
 
+
 # from https://docs.scipy.org/doc/scipy/reference/tutorial/optimize.html#nelder-mead-simplex-algorithm-method-nelder-mead
 @pytest.mark.skip_pytorch
 @pytest.mark.skip_pytorch64
@@ -81,10 +82,10 @@ def test_minimize(tensorlib, precision, optimizer, do_grad, do_stitch):
             # no grad, minuit, 32b - not very consistent for pytorch
             'no_grad-minuit-numpy-32b': [0.49622172117233276, 1.0007264614105225],
             #    nb: macos gives different numerics than CI
-            #'no_grad-minuit-pytorch-32b': [0.7465415000915527, 0.8796938061714172],
+            # 'no_grad-minuit-pytorch-32b': [0.7465415000915527, 0.8796938061714172],
             'no_grad-minuit-pytorch-32b': [0.9684963226318359, 0.9171305894851685],
             'no_grad-minuit-tensorflow-32b': [0.5284154415130615, 0.9911751747131348],
-            #'no_grad-minuit-jax-32b': [0.5144518613815308, 0.9927923679351807],
+            # 'no_grad-minuit-jax-32b': [0.5144518613815308, 0.9927923679351807],
             'no_grad-minuit-jax-32b': [0.49620240926742554, 1.0018986463546753],
             # no grad, minuit, 64b - quite consistent
             'no_grad-minuit-numpy-64b': [0.5000493563629738, 1.0000043833598724],
@@ -94,7 +95,7 @@ def test_minimize(tensorlib, precision, optimizer, do_grad, do_stitch):
             # do grad, minuit, 32b
             'do_grad-minuit-pytorch-32b': [0.5017611384391785, 0.9997190237045288],
             'do_grad-minuit-tensorflow-32b': [0.5012885928153992, 1.0000673532485962],
-            #'do_grad-minuit-jax-32b': [0.5029529333114624, 0.9991086721420288],
+            # 'do_grad-minuit-jax-32b': [0.5029529333114624, 0.9991086721420288],
             'do_grad-minuit-jax-32b': [0.5007095336914062, 0.9999282360076904],
             # do grad, minuit, 64b
             'do_grad-minuit-pytorch-64b': [0.500273961181471, 0.9996310135736226],

--- a/validation/manualonoff_roofit/onoff.py
+++ b/validation/manualonoff_roofit/onoff.py
@@ -59,7 +59,7 @@ getattr(w, 'import')(modelConfig)
 w.Print()
 
 
-##### model building complete
+# model building complete
 
 
 sbModel = w.obj('ModelConfig')


### PR DESCRIPTION
# Description

Resolves #863

Switch from `pyflakes` to the more configurable and modern `flake8` for linting.

In `setup.cfg` ignore
- [E203: whitespace before ':'](https://www.flake8rules.com/rules/E203.html) (avoid things like `text[len(prefix) :]`)
- [E402: module level import not at top of file](https://www.flake8rules.com/rules/E402.html) (sometimes needed)
- [E501: line too long](https://www.flake8rules.com/rules/E501.html) (not worth changing)

and fix:
- `src/pyhf/readxml.py:43:8:` [E713 test for membership should be 'not in'](https://www.flake8rules.com/rules/E713.html)
- `src/pyhf/infer/utils.py`: [E231 missing whitespace after ','](https://www.flake8rules.com/rules/E23.html)

and inline ignore `# noqa` (special cases):
- [F401: Module imported but unused](https://www.flake8rules.com/rules/F401.html)
- [E731: Do not assign a lambda expression, use a def](https://www.flake8rules.com/rules/E731.html)
- [E722: Do not use bare except, specify exception instead](https://www.flake8rules.com/rules/E722.html) (this could be removed, but would need to go back and identify all the exception cases)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Switch from pyflakes to flake8 for linting in pre-commit hooks and CI
   - Use flake8 in 'lint' extra
* Add flake8 config options to setup.cfg (as opposed to .flake8)
* Remove code that existed only to placate pyflakes
```
