### PR TITLE
fix: Use uproot3 namespace

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ extras_require['test'] = sorted(
             'papermill~=2.0',
             'nteract-scrapbook~=0.2',
             'jupyter',
-            'uproot~=3.3',
             'graphviz',
             'jsonpatch',
         ]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ extras_require = {
     ],
     'torch': ['torch~=1.2'],
     'jax': ['jax~=0.2.4', 'jaxlib~=0.1.56'],
-    'xmlio': ['uproot~=3.6'],  # Future proof against uproot4 API changes
+    'xmlio': ['uproot3~=3.14'],  # Future proof against uproot4 API changes
     'minuit': ['iminuit~=1.4.3'],  # v1.5.0 breaks pyhf for 32b TensorFlow and PyTorch
 }
 extras_require['backends'] = sorted(

--- a/src/pyhf/cli/rootio.py
+++ b/src/pyhf/cli/rootio.py
@@ -32,7 +32,7 @@ def cli():
 def xml2json(entrypoint_xml, basedir, output_file, track_progress):
     """Entrypoint XML: The top-level XML file for the PDF definition."""
     try:
-        import uproot
+        import uproot3 as uproot
 
         assert uproot
     except ImportError:
@@ -61,7 +61,7 @@ def xml2json(entrypoint_xml, basedir, output_file, track_progress):
 def json2xml(workspace, output_dir, specroot, dataroot, resultprefix, patch):
     """Convert pyhf JSON back to XML + ROOT files."""
     try:
-        import uproot
+        import uproot3 as uproot
 
         assert uproot
     except ImportError:

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import xml.etree.ElementTree as ET
 import numpy as np
 import tqdm
-import uproot
+import uproot3 as uproot
 import re
 
 log = logging.getLogger(__name__)

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -5,7 +5,7 @@ import shutil
 import pkg_resources
 import xml.etree.cElementTree as ET
 import numpy as np
-import uproot
+import uproot3 as uproot
 from uproot_methods.classes import TH1
 
 from .mixins import _ChannelSummaryMixin

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,7 +1,7 @@
 import pyhf
 import pyhf.readxml
 import numpy as np
-import uproot
+import uproot3 as uproot
 from pathlib import Path
 import pytest
 import xml.etree.cElementTree as ET


### PR DESCRIPTION
# Description

Avoid errors seen in CI with by switching over to using the new [`uproot3`](https://pypi.org/project/uproot3/) namespace. It is seen that some of the tests like

https://github.com/scikit-hep/pyhf/blob/a33baddf6620df371338c6d1b98fdbab1b9da5c4/tests/test_scripts.py#L169

 find an 

```
ModuleNotFoundError: No module named 'uproot3'
```

without the namespace switch. cc-ing @jpivarski just in case this is of interest.

I think this is because in `uproot_methods` instances of 'uproot' were renamed to 'uproot3': https://github.com/scikit-hep/uproot-methods/commit/02f9911b4437ae895a742a173eb88094e27eb65c

We could require a max on `uproot_methods` of `v0.9` so that we never get `v0.9.1` in which this takes place, but it seems easier to just update to `uproot3` and we'll probably be able to switch over to `uproot4` as well soon.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use uproot3 library namespace explicitly to avoid errors from uproot-methods v0.9.1
   - Use uproot3 in 'xmlio' extra
* Use pattern: import uproot3 as uproot
```
