### PR TITLE
chore: Specify exceptions to remove inline ignores of E722

### DIFF
--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -731,9 +731,10 @@ class Model:
             ):  # force to be not scalar, should we changed with #522
                 return tensorlib.reshape(result, (1,))
             return result
-        except:  # noqa: E722
+        except Exception as excep:
             log.error(
-                f'eval failed for data {tensorlib.tolist(data)} pars: {tensorlib.tolist(pars)}'
+                str(excep)
+                + f'\nEval failed for data {tensorlib.tolist(data)} pars: {tensorlib.tolist(pars)}'
             )
             raise
 

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -733,8 +733,8 @@ class Model:
             return result
         except Exception as excep:
             log.error(
-                repr(excep)
-                + f'\nEval failed for data {tensorlib.tolist(data)} pars: {tensorlib.tolist(pars)}'
+                f"Eval failed for data {tensorlib.tolist(data)} pars: {tensorlib.tolist(pars)}",
+                exc_info=True,
             )
             raise
 

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -731,7 +731,7 @@ class Model:
             ):  # force to be not scalar, should we changed with #522
                 return tensorlib.reshape(result, (1,))
             return result
-        except Exception as excep:
+        except Exception:
             log.error(
                 f"Eval failed for data {tensorlib.tolist(data)} pars: {tensorlib.tolist(pars)}",
                 exc_info=True,

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -733,7 +733,7 @@ class Model:
             return result
         except Exception as excep:
             log.error(
-                str(excep)
+                repr(excep)
                 + f'\nEval failed for data {tensorlib.tolist(data)} pars: {tensorlib.tolist(pars)}'
             )
             raise

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -41,7 +41,7 @@ def test_missing_backends(isolate_modules, param):
 
     try:
         delattr(pyhf.tensor, module_name)
-    except:  # noqa: E722
+    except AttributeError:
         pass
 
     with expectation:
@@ -80,7 +80,7 @@ def test_missing_optimizer(isolate_modules, param):
     )
     try:
         delattr(pyhf.optimize, module_name)
-    except:  # noqa: E722
+    except AttributeError:
         pass
 
     with expectation:


### PR DESCRIPTION
# Description

As a follow up to PR #1191, this PR specify some exception for all exception cases, allowing for the `#noqa`s for [E722: Do not use bare except, specify exception instead](https://www.flake8rules.com/rules/E722.html) to be removed.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Specify exception for all exception cases
* Remove all inline noqa: E722
   - E722: Do not use bare except, specify exception instead
```
