### PR TITLE
test: Verify NLL values and Minuit parameter uncertainties

### DIFF
--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -406,7 +406,7 @@ def test_optim_uncerts(backend, source, spec, mu):
         return_uncertainties=True,
     )
     assert result.shape[1] == 2
-    assert pyhf.tensorlib.tolist(result)
+    assert pytest.approx([0.0, 0.26418431]) == pyhf.tensorlib.tolist(result[:, 1])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -351,7 +351,7 @@ def test_optim(backend, source, spec, mu):
         pdf,
         init_pars,
         par_bounds,
-        [(pdf.config.poi_index, mu)],
+        fixed_vals=[(pdf.config.poi_index, mu)],
     )
     assert pyhf.tensorlib.tolist(result)
 
@@ -375,7 +375,7 @@ def test_optim_with_value(backend, source, spec, mu):
         pdf,
         init_pars,
         par_bounds,
-        [(pdf.config.poi_index, mu)],
+        fixed_vals=[(pdf.config.poi_index, mu)],
         return_fitted_val=True,
     )
     assert pyhf.tensorlib.tolist(result)
@@ -403,7 +403,7 @@ def test_optim_uncerts(backend, source, spec, mu):
         pdf,
         init_pars,
         par_bounds,
-        [(pdf.config.poi_index, mu)],
+        fixed_vals=[(pdf.config.poi_index, mu)],
         return_uncertainties=True,
     )
     assert result.shape[1] == 2

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -380,6 +380,7 @@ def test_optim_with_value(backend, source, spec, mu):
     )
     assert pyhf.tensorlib.tolist(result)
     assert pyhf.tensorlib.shape(fitted_val) == ()
+    assert pytest.approx(17.52954975, rel=1e-5) == fitted_val
 
 
 @pytest.mark.parametrize('mu', [1.0], ids=['mu=1'])


### PR DESCRIPTION
# Description

Resolves #1193.

This adds a check for the NLL value returned by minimization with various backends, which is compared against a reference.

It also adds a check for the parameter uncertainties returned by Minuit, which was motivated by #1183 (the addition of the HESSE call would have resulted in a slight change in the uncertainties returned here). A test for the parameter values could also be added here, but since that behavior is tested in `test_minimize` already I did not add it again here.

I noticed that three functions set parameters constant without using the keyword argument `fixed_vals`, which I expect is not on purpose. I added another commit in here that changes that.


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add a test for the NLL value returned by minimization
* Explicitly specify the fixed_vals kwarg for function calls passing in fixed parameter values
```