### PR TITLE
fix: Use uproot3-methods with uproot3

### DIFF
--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -6,7 +6,7 @@ import pkg_resources
 import xml.etree.cElementTree as ET
 import numpy as np
 import uproot3 as uproot
-from uproot_methods.classes import TH1
+from uproot3_methods.classes import TH1
 
 from .mixins import _ChannelSummaryMixin
 


### PR DESCRIPTION
# Description

With the release of [`uproot3` `v3.14.1`](https://github.com/scikit-hep/uproot3/releases/tag/3.14.1) and the [yanking of release of `v3.14.0`](https://pypi.org/project/uproot3/3.14.0/#history), `uproot3` requires `uproot3-methods`. To quote the release notes:

> Rename `uproot-methods` → `uproot3-methods`, since the fact that "`uproot-methods`" as a package with different versions was breaking dependencies for people with old versions of this package.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use uproot3-methods namespace
   - Required by uproot3 since the release of v3.14.1 and the yank of v3.14.0
```
