### PR TITLE
docs: Correct spelling of continuous

### DIFF
--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -351,7 +351,7 @@ class jax_backend:
 
     def poisson(self, n, lam):
         r"""
-        The continous approximation, using :math:`n! = \Gamma\left(n+1\right)`,
+        The continuous approximation, using :math:`n! = \Gamma\left(n+1\right)`,
         to the probability mass function of the Poisson distribution evaluated
         at :code:`n` given the parameter :code:`lam`.
 
@@ -373,7 +373,7 @@ class jax_backend:
                                     (the expected number of events)
 
         Returns:
-            JAX ndarray: Value of the continous approximation to Poisson(n|lam)
+            JAX ndarray: Value of the continuous approximation to Poisson(n|lam)
         """
         n = jnp.asarray(n)
         lam = jnp.asarray(lam)

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -333,7 +333,7 @@ class numpy_backend:
 
     def poisson(self, n, lam):
         r"""
-        The continous approximation, using :math:`n! = \Gamma\left(n+1\right)`,
+        The continuous approximation, using :math:`n! = \Gamma\left(n+1\right)`,
         to the probability mass function of the Poisson distribution evaluated
         at :code:`n` given the parameter :code:`lam`.
 
@@ -355,7 +355,7 @@ class numpy_backend:
                                     (the expected number of events)
 
         Returns:
-            NumPy float: Value of the continous approximation to Poisson(n|lam)
+            NumPy float: Value of the continuous approximation to Poisson(n|lam)
         """
         n = np.asarray(n)
         lam = np.asarray(lam)

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -319,7 +319,7 @@ class pytorch_backend:
 
     def poisson(self, n, lam):
         r"""
-        The continous approximation, using :math:`n! = \Gamma\left(n+1\right)`,
+        The continuous approximation, using :math:`n! = \Gamma\left(n+1\right)`,
         to the probability mass function of the Poisson distribution evaluated
         at :code:`n` given the parameter :code:`lam`.
 
@@ -341,7 +341,7 @@ class pytorch_backend:
                                     (the expected number of events)
 
         Returns:
-            PyTorch FloatTensor: Value of the continous approximation to Poisson(n|lam)
+            PyTorch FloatTensor: Value of the continuous approximation to Poisson(n|lam)
         """
         return torch.exp(torch.distributions.Poisson(lam).log_prob(n))
 

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -383,7 +383,7 @@ class tensorflow_backend:
 
     def poisson_logpdf(self, n, lam):
         r"""
-        The log of the continous approximation, using :math:`n! = \Gamma\left(n+1\right)`,
+        The log of the continuous approximation, using :math:`n! = \Gamma\left(n+1\right)`,
         to the probability mass function of the Poisson distribution evaluated
         at :code:`n` given the parameter :code:`lam`.
 
@@ -406,13 +406,13 @@ class tensorflow_backend:
                                     (the expected number of events)
 
         Returns:
-            TensorFlow Tensor: Value of the continous approximation to log(Poisson(n|lam))
+            TensorFlow Tensor: Value of the continuous approximation to log(Poisson(n|lam))
         """
         return tfp.distributions.Poisson(lam).log_prob(n)
 
     def poisson(self, n, lam):
         r"""
-        The continous approximation, using :math:`n! = \Gamma\left(n+1\right)`,
+        The continuous approximation, using :math:`n! = \Gamma\left(n+1\right)`,
         to the probability mass function of the Poisson distribution evaluated
         at :code:`n` given the parameter :code:`lam`.
 
@@ -435,7 +435,7 @@ class tensorflow_backend:
                                     (the expected number of events)
 
         Returns:
-            TensorFlow Tensor: Value of the continous approximation to Poisson(n|lam)
+            TensorFlow Tensor: Value of the continuous approximation to Poisson(n|lam)
         """
         return tf.exp(tfp.distributions.Poisson(lam).log_prob(n))
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -278,7 +278,7 @@ def test_pdf_calculations(backend):
         nan_ok=True,
     )
 
-    # Ensure continous approximation is valid
+    # Ensure continuous approximation is valid
     assert tb.tolist(
         tb.poisson(tb.astensor([0.5, 1.1, 1.5]), tb.astensor(1.0))
     ) == pytest.approx([0.4151074974205947, 0.3515379040027489, 0.2767383316137298])


### PR DESCRIPTION
# Description

Fixes the typo `continous` -> `continuous` in a few docstrings and a comment.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Fix typo of the word "continous" in a few docstrings and a comment
```