### PR TITLE
feat: Use iminuit v1.5.X API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require = {
     'torch': ['torch~=1.2'],
     'jax': ['jax~=0.2.4', 'jaxlib~=0.1.56'],
     'xmlio': ['uproot3~=3.14'],  # Future proof against uproot4 API changes
-    'minuit': ['iminuit~=1.5.3'],  # v1.5.0 breaks pyhf for 32b TensorFlow and PyTorch
+    'minuit': ['iminuit~=1.5.3'],
 }
 extras_require['backends'] = sorted(
     set(

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require = {
     'torch': ['torch~=1.2'],
     'jax': ['jax~=0.2.4', 'jaxlib~=0.1.56'],
     'xmlio': ['uproot3~=3.14'],  # Future proof against uproot4 API changes
-    'minuit': ['iminuit~=1.4.3'],  # v1.5.0 breaks pyhf for 32b TensorFlow and PyTorch
+    'minuit': ['iminuit~=1.5.3'],  # v1.5.0 breaks pyhf for 32b TensorFlow and PyTorch
 }
 extras_require['backends'] = sorted(
     set(

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -113,7 +113,7 @@ class minuit_optimizer(OptimizerMixin):
         minimizer.tol = tolerance
         minimizer.migrad(ncall=maxiter)
         # Following lines below come from:
-        # https://github.com/scikit-hep/iminuit/blob/22f6ed7146c1d1f3274309656d8c04461dde5ba3/src/iminuit/_minimize.py#L106-L125
+        # https://github.com/scikit-hep/iminuit/blob/64acac11cfa2fb91ccbd02d1b3c51f8a9e2cc484/src/iminuit/_minimize.py#L102-L121
         message = "Optimization terminated successfully."
         if not minimizer.valid:
             message = "Optimization failed."

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -141,7 +141,7 @@ class minuit_optimizer(OptimizerMixin):
             fun=minimizer.fval,
             hess_inv=hess_inv,
             message=message,
-            nfev=minimizer.ncalls,
-            njev=minimizer.ngrads,
+            nfev=minimizer.nfcn,
+            njev=minimizer.ngrad,
             minuit=minimizer,
         )

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -141,7 +141,7 @@ class minuit_optimizer(OptimizerMixin):
             fun=minimizer.fval,
             hess_inv=hess_inv,
             message=message,
-            nfev=minimizer.nfcn,
-            njev=minimizer.ngrad,
+            nfev=minimizer.ncalls_total,
+            njev=minimizer.ngrads_total,
             minuit=minimizer,
         )

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -420,20 +420,20 @@ def test_minuit_failed_optimization(
     monkeypatch, mocker, has_reached_call_limit, is_above_max_edm
 ):
     class BadMinuit(iminuit.Minuit):
-        @classmethod
-        def from_array_func(cls, *args, **kwargs):
-            """
-            from_array_func won't need mocker in a newer version of iminuit
-
-            See scikit-hep/iminuit#464 for more details
-            """
-            self = super().from_array_func(*args, **kwargs)
-            mock = mocker.MagicMock(wraps=self)
-            mock.valid = False
-            mock.fmin.has_reached_call_limit = has_reached_call_limit
-            mock.fmin.is_above_max_edm = is_above_max_edm
-            return mock
-
+        # @classmethod
+        # def from_array_func(cls, *args, **kwargs):
+        #     """
+        #     from_array_func won't need mocker in a newer version of iminuit
+        #
+        #     See scikit-hep/iminuit#464 for more details
+        #     """
+        #     self = super().from_array_func(*args, **kwargs)
+        #     mock = mocker.MagicMock(wraps=self)
+        #     mock.valid = False
+        #     mock.fmin.has_reached_call_limit = has_reached_call_limit
+        #     mock.fmin.is_above_max_edm = is_above_max_edm
+        #     return mock
+        #
         @property
         def valid(self):
             return False

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -420,20 +420,6 @@ def test_minuit_failed_optimization(
     monkeypatch, mocker, has_reached_call_limit, is_above_max_edm
 ):
     class BadMinuit(iminuit.Minuit):
-        # @classmethod
-        # def from_array_func(cls, *args, **kwargs):
-        #     """
-        #     from_array_func won't need mocker in a newer version of iminuit
-        #
-        #     See scikit-hep/iminuit#464 for more details
-        #     """
-        #     self = super().from_array_func(*args, **kwargs)
-        #     mock = mocker.MagicMock(wraps=self)
-        #     mock.valid = False
-        #     mock.fmin.has_reached_call_limit = has_reached_call_limit
-        #     mock.fmin.is_above_max_edm = is_above_max_edm
-        #     return mock
-        #
         @property
         def valid(self):
             return False


### PR DESCRIPTION
# Description

Update to `iminuit` `v1.5.3+` API to take advantage of https://github.com/scikit-hep/iminuit/pull/464. This allows for the mocking of `iminuit.Minuit().from_array_func` that was added in PR #951 to be removed.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Require iminuit compatible with v1.5.3 in 'minuit' extra
* Adopt iminuit v1.5.3+ API
   - ncalls -> ncalls_total
   - ngrads -> ngrads_total
* Remove mocking of iminuit.Minuit().from_array_func from tests
   - c.f. https://github.com/scikit-hep/iminuit/pull/464
```
