### PR TITLE
ci: Test only latest Python runtime on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8]
         exclude:
           - os: macos-latest
+            python-version: [3.6, 3.7]
+          - os: windows-latest
             python-version: [3.6, 3.7]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8]
+        exclude:
+          - os: macos-latest
+            python-version: [3.6, 3.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
         exclude:
           - os: macos-latest
-            python-version: [3.6, 3.7]
+            python-version: 3.6
+          - os: macos-latest
+            python-version: 3.7
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8]
         exclude:
           - os: macos-latest
-            python-version: [3.6, 3.7]
-          - os: windows-latest
             python-version: [3.6, 3.7]
 
     steps:

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -15,7 +15,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
+        exclude:
+          - os: macos-latest
+            python-version: 3.6
+          - os: macos-latest
+            python-version: 3.7
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
# Description

The MacOS VMs are quite slow and the level of redundency in testing all the Python runtimes across all the OS seems to give a minimal advantage while incuring a lot of lag in CI speed. This PR excludes Python 3.6 and Python 3.7 on MacOS from the testing matrix. Python 3.6, 3.7, and 3.8 are still tested on Linux.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Exclude Python 3.6 and Python 3.7 from the testing matrix for macos-latest
   - Speed up CI significantly while still testing the latest Python runtime on macos-latest
* Add testing of Python 3.6 to current release tests
* c.f. https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#example-excluding-configurations-from-a-matrix
```
