### PR TITLE
fix: Update JAX DeviceArray type in docstrings for doctest

### DIFF
--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -210,13 +210,13 @@ class jax_backend:
             DeviceArray([[1., 2., 3.],
                          [4., 5., 6.]], dtype=float64)
             >>> type(tensor)
-            <class 'jax.interpreters.xla.DeviceArray'>
+            <class 'jax.interpreters.xla._DeviceArray'>
 
         Args:
             tensor_in (Number or Tensor): Tensor object
 
         Returns:
-            `jax.interpreters.xla.DeviceArray`: A multi-dimensional, fixed-size homogenous array.
+            `jax.interpreters.xla._DeviceArray`: A multi-dimensional, fixed-size homogenous array.
         """
         try:
             dtype = self.dtypemap[dtype]
@@ -320,7 +320,7 @@ class jax_backend:
             tensor (Tensor): Tensor object
 
         Returns:
-            `jax.interpreters.xla.DeviceArray`: A flattened array.
+            `jax.interpreters.xla._DeviceArray`: A flattened array.
         """
         return jnp.ravel(tensor)
 


### PR DESCRIPTION
# Description

The nightly CI is failing doctest as there was a change from the `type` of a JAX `DeviceArray` from `jax.interpreters.xla.DeviceArray` -> `jax.interpreters.xla._DeviceArray`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update JAX DeviceArray type in docstrings to jax.interpreters.xla._DeviceArray
   - Needed to pass doctest
```
