### PR TITLE
docs: Link to conda-forge feedstock and link banner to repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -342,7 +342,7 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
 .. |PyPI version| image:: https://badge.fury.io/py/pyhf.svg
    :target: https://badge.fury.io/py/pyhf
 .. |Conda-forge version| image:: https://img.shields.io/conda/vn/conda-forge/pyhf.svg
-   :target: https://anaconda.org/conda-forge/pyhf
+   :target: https://github.com/conda-forge/pyhf-feedstock
 .. |Supported Python versions| image:: https://img.shields.io/pypi/pyversions/pyhf.svg
    :target: https://pypi.org/project/pyhf/
 .. |Docker Stars| image:: https://img.shields.io/docker/stars/pyhf/pyhf.svg

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@
 
 .. raw:: html
 
-   <a class="github-fork-ribbon right-top fixed" href="https://github.com/scikit-hep/pyhf/fork" data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>
+   <a class="github-fork-ribbon right-top fixed" href="https://github.com/scikit-hep/pyhf/" data-ribbon="View me on GitHub" title="View me on GitHub">View me on GitHub</a>
 
 .. include:: ../README.rst
 


### PR DESCRIPTION
# Description

- Resolves #1214 
- Resolves #1215 

Make the [![Conda-forge version](https://img.shields.io/conda/vn/conda-forge/pyhf.svg)](https://github.com/conda-forge/pyhf-feedstock) badge link to the conda-forge `pyhf-feedstock` page and make the docs banner redirect to the repo page instead of directly to the fork page.

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-improve-links/

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- Link conda-forge badge to pyhf-feedstock repo
   - c.f. https://github.com/conda-forge/pyhf-feedstock
- Make docs banner link to repo page and not fork page
   - Change banner text from 'Fork me' to 'View me'
```
