### PR TITLE
fix: Ensure pytest.approx only compares floats

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -80,3 +80,27 @@ jobs:
     - name: Test with pytest
       run: |
         python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+
+  pytest:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip install --upgrade --no-cache-dir git+git://github.com/pytest-dev/pytest.git
+        python -m pip list
+    - name: Test with pytest
+      run: |
+        python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
 
-  uproot:
+  uproot3:
 
     runs-on: ${{ matrix.os }}
     strategy:
@@ -75,7 +75,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
-        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/uproot.git
+        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/uproot3.git
         python -m pip list
     - name: Test with pytest
       run: |

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ extras_require['test'] = sorted(
 extras_require['docs'] = sorted(
     {
         'sphinx>=3.1.2',
-        'sphinxcontrib-bibtex',
+        'sphinxcontrib-bibtex~=1.0',
         'sphinx-click',
         'sphinx_rtd_theme',
         'nbsphinx',

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -380,7 +380,7 @@ def test_optim_with_value(backend, source, spec, mu):
     )
     assert pyhf.tensorlib.tolist(result)
     assert pyhf.tensorlib.shape(fitted_val) == ()
-    assert pytest.approx(17.52954975, rel=1e-5) == fitted_val
+    assert pytest.approx(17.52954975, rel=1e-5) == pyhf.tensorlib.tolist(fitted_val)
 
 
 @pytest.mark.parametrize('mu', [1.0], ids=['mu=1'])


### PR DESCRIPTION
# Description

Resolves #1219

~~In response to Issue #1219, this PR avoids the issues that `pytest` `v6.2.0` brings by restricting `pytest` to the `v6.1.X` series.~~ 
This PR ensures that there `floats` are compared instead of `floats` to `tensors`. To try to catch these sorts of issues sooner and maybe bring them up with the `pytest` devs add `pytest` to the HEAD of dependencies workflow as well.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Compare floats to floats and not tensors in pytest.approx
* Add pytest and uproot3 to HEAD of dependencies workflow
* Restrict sphinxcontrib-bibtex to v1.X
   - c.f. PR #1221
```
