### PR TITLE
docs: Use sphinxcontrib-bibtex v2.1 and bibtex_bibfiles setting

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,9 +43,10 @@ jobs:
     - name: Test and build docs
       run: |
         python -m doctest README.rst
-        python setup.py build_sphinx
+        cd docs
+        make html
+        make html # Second time for sphinxcontrib-bibtex
         touch docs/_build/html/.nojekyll
-        python setup.py build_sphinx
     - name: Check schemas are copied over
       run: |
         # is a directory

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,6 +45,7 @@ jobs:
         python -m doctest README.rst
         python setup.py build_sphinx
         touch docs/_build/html/.nojekyll
+        python setup.py build_sphinx
     - name: Check schemas are copied over
       run: |
         # is a directory

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,9 +43,7 @@ jobs:
     - name: Test and build docs
       run: |
         python -m doctest README.rst
-        pushd docs
-        make html
-        popd
+        python setup.py build_sphinx
         touch docs/_build/html/.nojekyll
     - name: Check schemas are copied over
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,6 @@ jobs:
         python -m doctest README.rst
         cd docs
         make html
-        make html # Second time for sphinxcontrib-bibtex
         cd ..
         touch docs/_build/html/.nojekyll
     - name: Check schemas are copied over

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,6 +46,7 @@ jobs:
         cd docs
         make html
         make html # Second time for sphinxcontrib-bibtex
+        cd ..
         touch docs/_build/html/.nojekyll
     - name: Check schemas are copied over
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,9 +43,9 @@ jobs:
     - name: Test and build docs
       run: |
         python -m doctest README.rst
-        cd docs
+        pushd docs
         make html
-        cd ..
+        popd
         touch docs/_build/html/.nojekyll
     - name: Check schemas are copied over
       run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,7 @@ formats: all
 
 # python -m pip install .[docs]
 python:
-  version: 3.7
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,16 @@ extensions = [
     'sphinx_copybutton',
     'xref',
 ]
+bibtex_bibfiles = [
+    "bib/docs.bib",
+    "bib/HEPData_likelihoods.bib",
+    "bib/media.bib",
+    "bib/posters.bib",
+    "bib/preferred.bib",
+    "bib/talks.bib",
+    "bib/tutorials.bib",
+    "bib/use_citations.bib",
+]
 
 # external links
 xref_links = {"arXiv:1007.1727": ("[1007.1727]", "https://arxiv.org/abs/1007.1727")}

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ extras_require['docs'] = sorted(
         extras_require['xmlio']
         + [
             'sphinx>=3.1.2',
-            'sphinxcontrib-bibtex~=1.0',
+            'sphinxcontrib-bibtex~=2.1',
             'sphinx-click',
             'sphinx_rtd_theme',
             'nbsphinx',


### PR DESCRIPTION
# Description

~~Require `sphinxcontrib-bibtex` releases compatible with `v2.0`, which requires the definition of the `bibtex_bibfiles` in the Sphinx `conf.py`. With `v2.0` [Sphinx must be run twice to generate the bibliography](https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#running-sphinx):~~

> ~~It is good to be aware that the extension stores all citation information in a `bibtex.json` file in the source folder. If it does not exist, the file will be created on your first sphinx build, and you will have to rerun the build to make use of it. The file is automatically kept up to date, with a warning whenever you need to rerun the build (i.e. whenever your citations change). The file can be stored in version control if you do not want your users to have to run sphinx twice when they clone your project, or when you need your documentation to be built on an external service which only runs sphinx once.~~

Require `sphinxcontrib-bibtex` releases compatible with `v2.1`, which requires the definition of the `bibtex_bibfiles` in the Sphinx `conf.py`, thanks to https://github.com/mcmtroffaes/sphinxcontrib-bibtex/pull/219 making the `sphinxcontrib-bibtex` `v2.1` release series able to run with a single pass through a Sphinx build. :tada: 

Requires PR #1220 to go in first.

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-use-sphinxcontrib-bibtex-v2.0/

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Require sphinxcontrib-bibtex releases compatible with v2.1
* Add bibtex_bibfiles list to Sphinx conf.py
* Update RTD to Python 3.8 runtime
```
