### PR TITLE
feat: Add to_numpy API to tensorlib

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,7 @@ xref_links = {"arXiv:1007.1727": ("[1007.1727]", "https://arxiv.org/abs/1007.172
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
+    'numpy': ('http://docs.scipy.org/doc/numpy/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
 }
 

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -490,3 +490,30 @@ class jax_backend:
 
         """
         return _BasicNormal(mu, sigma)
+
+    def to_numpy(self, tensor_in):
+        """
+        Convert the TensorFlow tensor to a :class:`numpy.ndarray`.
+
+        Example:
+            >>> import pyhf
+            >>> pyhf.set_backend("jax")
+            >>> tensor = pyhf.tensorlib.astensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+            >>> tensor
+            DeviceArray([[1., 2., 3.],
+                         [4., 5., 6.]], dtype=float64)
+            >>> numpy_ndarray = pyhf.tensorlib.to_numpy(tensor)
+            >>> numpy_ndarray
+            array([[1., 2., 3.],
+                   [4., 5., 6.]])
+            >>> type(numpy_ndarray)
+            <class 'numpy.ndarray'>
+
+        Args:
+            tensor_in (:obj:`tensor`): The input tensor object.
+
+        Returns:
+            :class:`numpy.ndarray`: The tensor conversion to a NumPy ``ndarray``.
+
+        """
+        return np.asarray(tensor_in, dtype=tensor_in.dtype)

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -513,7 +513,7 @@ class jax_backend:
             tensor_in (:obj:`tensor`): The input tensor object.
 
         Returns:
-            :class:`numpy.ndarray`: The tensor conversion to a NumPy ``ndarray``.
+            :class:`numpy.ndarray`: The tensor converted to a NumPy ``ndarray``.
 
         """
         return np.asarray(tensor_in, dtype=tensor_in.dtype)

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -472,3 +472,31 @@ class numpy_backend:
 
         """
         return _BasicNormal(mu, sigma)
+
+    def to_numpy(self, tensor_in):
+        """
+        Return the input tensor as it already is a :class:`numpy.ndarray`.
+        This API exists only for ``pyhf.tensorlib`` compatibility.
+
+        Example:
+            >>> import pyhf
+            >>> pyhf.set_backend("numpy")
+            >>> tensor = pyhf.tensorlib.astensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+            >>> tensor
+            array([[1., 2., 3.],
+                   [4., 5., 6.]])
+            >>> numpy_ndarray = pyhf.tensorlib.to_numpy(tensor)
+            >>> numpy_ndarray
+            array([[1., 2., 3.],
+                   [4., 5., 6.]])
+            >>> type(numpy_ndarray)
+            <class 'numpy.ndarray'>
+
+        Args:
+            tensor_in (:obj:`tensor`): The input tensor object.
+
+        Returns:
+            :class:`numpy.ndarray`: The tensor converted to a NumPy ``ndarray``.
+
+        """
+        return tensor_in

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -458,3 +458,30 @@ class pytorch_backend:
 
         """
         return torch.distributions.Normal(mu, sigma)
+
+    def to_numpy(self, tensor_in):
+        """
+        Convert the PyTorch tensor to a NumPy ``ndarray``.
+
+        Example:
+            >>> import pyhf
+            >>> pyhf.set_backend("pytorch")
+            >>> tensor = pyhf.tensorlib.astensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+            >>> tensor
+            tensor([[1., 2., 3.],
+                    [4., 5., 6.]])
+            >>> numpy_ndarray = pyhf.tensorlib.to_numpy(tensor)
+            >>> numpy_ndarray
+            array([[1., 2., 3.],
+                   [4., 5., 6.]], dtype=float32)
+            >>> type(numpy_ndarray)
+            <class 'numpy.ndarray'>
+
+        Args:
+            tensor_in (:obj:`tensor`): The input tensor object.
+
+        Returns:
+            ``numpy.ndarray``: The tensor conversion to a NumPy ``ndarray``.
+
+        """
+        return tensor_in.numpy()

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -461,7 +461,7 @@ class pytorch_backend:
 
     def to_numpy(self, tensor_in):
         """
-        Convert the PyTorch tensor to a NumPy ``ndarray``.
+        Convert the PyTorch tensor to a :class:`numpy.ndarray`.
 
         Example:
             >>> import pyhf
@@ -481,7 +481,7 @@ class pytorch_backend:
             tensor_in (:obj:`tensor`): The input tensor object.
 
         Returns:
-            ``numpy.ndarray``: The tensor conversion to a NumPy ``ndarray``.
+            :class:`numpy.ndarray`: The tensor conversion to a NumPy ``ndarray``.
 
         """
         return tensor_in.numpy()

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -481,7 +481,7 @@ class pytorch_backend:
             tensor_in (:obj:`tensor`): The input tensor object.
 
         Returns:
-            :class:`numpy.ndarray`: The tensor conversion to a NumPy ``ndarray``.
+            :class:`numpy.ndarray`: The tensor converted to a NumPy ``ndarray``.
 
         """
         return tensor_in.numpy()

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -600,7 +600,7 @@ class tensorflow_backend:
             tensor_in (:obj:`tensor`): The input tensor object.
 
         Returns:
-            :class:`numpy.ndarray`: The tensor conversion to a NumPy ``ndarray``.
+            :class:`numpy.ndarray`: The tensor converted to a NumPy ``ndarray``.
 
         """
         return tensor_in.numpy()

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -576,3 +576,31 @@ class tensorflow_backend:
 
         """
         return tfp.distributions.Normal(mu, sigma)
+
+    def to_numpy(self, tensor_in):
+        """
+        Convert the TensorFlow tensor to a :class:`numpy.ndarray`.
+
+        Example:
+            >>> import pyhf
+            >>> pyhf.set_backend("tensorflow")
+            >>> tensor = pyhf.tensorlib.astensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+            >>> print(tensor)
+            tf.Tensor(
+            [[1. 2. 3.]
+             [4. 5. 6.]], shape=(2, 3), dtype=float32)
+            >>> numpy_ndarray = pyhf.tensorlib.to_numpy(tensor)
+            >>> numpy_ndarray
+            array([[1., 2., 3.],
+                   [4., 5., 6.]], dtype=float32)
+            >>> type(numpy_ndarray)
+            <class 'numpy.ndarray'>
+
+        Args:
+            tensor_in (:obj:`tensor`): The input tensor object.
+
+        Returns:
+            :class:`numpy.ndarray`: The tensor conversion to a NumPy ``ndarray``.
+
+        """
+        return tensor_in.numpy()

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -85,6 +85,12 @@ def test_tensor_where_tensor(backend):
     )
 
 
+def test_tensor_to_numpy(backend):
+    tb = pyhf.tensorlib
+    array = [[1, 2, 3], [4, 5, 6]]
+    assert np.array_equal(tb.to_numpy(tb.astensor(array)), np.array(array))
+
+
 def test_tensor_ravel(backend):
     tb = pyhf.tensorlib
     assert (


### PR DESCRIPTION
# Description

Resolves #1225 

Add `.to_numpy()` API that returns the tensor converted to a [NumPy `ndarray`](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html#numpy.ndarray).

Example:

```python
>>> import pyhf
>>> pyhf.set_backend("jax")
>>> tensor = pyhf.tensorlib.astensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
>>> tensor
DeviceArray([[1., 2., 3.],
             [4., 5., 6.]], dtype=float64)
>>> numpy_ndarray = pyhf.tensorlib.to_numpy(tensor)
>>> numpy_ndarray
array([[1., 2., 3.],
       [4., 5., 6.]])
>>> type(numpy_ndarray)
<class 'numpy.ndarray'>
```

`.to_numpy()` is used rather than `.numpy()` as this is being called from tensorlib (rather than by a tensor object) and the grammar seems to make more sense this way. c.f. [Awkward's API.](https://awkward-array.readthedocs.io/en/latest/_auto/ak.to_numpy.html)

ReadTheDocs build: https://pyhf.readthedocs.io/en/feat-add-tensor-to-numpy-api/api.html#backends
* [NumPy backend](https://pyhf.readthedocs.io/en/feat-add-tensor-to-numpy-api/_generated/pyhf.tensor.numpy_backend.numpy_backend.html#pyhf.tensor.numpy_backend.numpy_backend.to_numpy)
* [TensorFlow backend](https://pyhf.readthedocs.io/en/feat-add-tensor-to-numpy-api/_generated/pyhf.tensor.tensorflow_backend.tensorflow_backend.html#pyhf.tensor.tensorflow_backend.tensorflow_backend.to_numpy)
* [JAX backend](https://pyhf.readthedocs.io/en/feat-add-tensor-to-numpy-api/_generated/pyhf.tensor.jax_backend.jax_backend.html#pyhf.tensor.jax_backend.jax_backend.to_numpy)
* [PyTorch backend](https://pyhf.readthedocs.io/en/feat-add-tensor-to-numpy-api/_generated/pyhf.tensor.pytorch_backend.pytorch_backend.html#pyhf.tensor.pytorch_backend.pytorch_backend.to_numpy)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add pyhf.tensorlib.to_numpy API to convert tensor to NumPy ndarray
* Add intersphinx mapping to NumPy docs
* Add tests for to_numpy
```
