### PR TITLE
ci: Uninstall dependencies before installed HEAD versions

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip uninstall --yes scipy
         python -m pip install --upgrade --no-cache-dir cython
         python -m pip install --upgrade --no-cache-dir git+git://github.com/scipy/scipy.git
         python -m pip list

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -51,6 +51,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip uninstall --yes iminuit
         python -m pip install --upgrade --no-cache-dir cython
         python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/iminuit.git
         python -m pip list
@@ -76,6 +77,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip uninstall --yes uproot3
         python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/uproot3.git
         python -m pip list
     - name: Test with pytest
@@ -100,6 +102,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip uninstall --yes pytest
         python -m pip install --upgrade --no-cache-dir git+git://github.com/pytest-dev/pytest.git
         python -m pip list
     - name: Test with pytest


### PR DESCRIPTION
# Description

After doing some testing on PR #1208 I've found that if `iminuit` (installed from PyPI) is not uninstalled before it is installed from HEAD from GitHub that it is not guaranteed to properly pick up changes.

This was found when Hans reported the PyTorch fix that allowed tests to pass for `pyhf` locally for `iminuit` `v2.0` was merged into the `develop` branch (which is `iminuit`'s default branch) and yet the HEAD of dependencies workflow as failing still. After I added in a 

```yaml
python -m pip uninstall --yes iminuit
```

to the workflow things were passing. This behavior should then be applied to all HEAD of dependencies tests to make sure that the source code on GitHub is being properly tested.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* pip uninstall the dependency that is being tested before installing from the HEAD of version control
   - Has been shown for iminuit to be required to properly test the HEAD of the default repo branch
```