### PR TITLE
build: Use compatible release syntax to give ranges for install_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     click~=7.0  # for console scripts,
     tqdm~=4.25  # for readxml
     jsonschema~=3.2  # for utils
-    jsonpatch~=1.0
+    jsonpatch~=1.23
     pyyaml~=5.3  # for parsing CLI equal-delimited options
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ python_requires = >=3.6
 install_requires =
     scipy~=1.4  # requires numpy, which is required by pyhf and tensorflow
     click~=7.0  # for console scripts,
-    tqdm~=4.0  # for readxml
+    tqdm~=4.25  # for readxml
     jsonschema~=3.2  # for utils
     jsonpatch~=1.0
     pyyaml~=5.3  # for parsing CLI equal-delimited options

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ packages = find:
 include_package_data = True
 python_requires = >=3.6
 install_requires =
-    scipy>=1.4.0  # requires numpy, which is required by pyhf and tensorflow
+    scipy~=1.4  # requires numpy, which is required by pyhf and tensorflow
     click>=6.0  # for console scripts,
     tqdm  # for readxml
     jsonschema>=3.2.0  # for utils

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ include_package_data = True
 python_requires = >=3.6
 install_requires =
     scipy~=1.4  # requires numpy, which is required by pyhf and tensorflow
-    click~=7.0  # for console scripts,
+    click~=7.0  # for console scripts
     tqdm~=4.25  # for readxml
     jsonschema~=3.2  # for utils
     jsonpatch~=1.23

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,11 +39,11 @@ include_package_data = True
 python_requires = >=3.6
 install_requires =
     scipy~=1.4  # requires numpy, which is required by pyhf and tensorflow
-    click>=6.0  # for console scripts,
-    tqdm  # for readxml
-    jsonschema>=3.2.0  # for utils
-    jsonpatch
-    pyyaml  # for parsing CLI equal-delimited options
+    click~=7.0  # for console scripts,
+    tqdm~=4.0  # for readxml
+    jsonschema~=3.2  # for utils
+    jsonpatch~=1.0
+    pyyaml~=5.3  # for parsing CLI equal-delimited options
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     tqdm~=4.25  # for readxml
     jsonschema~=3.2  # for utils
     jsonpatch~=1.23
-    pyyaml~=5.3  # for parsing CLI equal-delimited options
+    pyyaml~=5.1  # for parsing CLI equal-delimited options
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
# Description

To give releases longer stability and lifetimes upper bounds are required on core dependencies to ensure that breaking API changes to not break old releases. This is a builtin functionality of [PEP 440's compatible release syntax](https://www.python.org/dev/peps/pep-0440/#compatible-release). This PR applies compatible release syntax (`~=`) to all of the dependencies in `install_requires`, establishing lower bounds from when they were added and similarly upper bounds.

---
[Quick summary of compatible release syntax](https://github.com/mwouts/jupytext/pull/596):

In [PEP 440's "Compatible release" section](https://www.python.org/dev/peps/pep-0440/#compatible-release)

> For a given release identifier V.N, the compatible release clause is approximately equivalent to the pair of comparison clauses:
> ```
>>= V.N, == V.*
>```

As an example, in a fresh virtual environment

```
(myst-example) $ pip install -qq "myst-parser~=0.8"
(myst-example) $ pip list | grep myst
myst-parser                   0.12.10
(myst-example) $ pip install --upgrade -qq "myst-parser~=0.8.0"
(myst-example) $ pip list | grep myst
myst-parser                   0.8.2
```
---

To be explicit, this will be the effects on the ranges:

- `scipy~=1.4`: 1.4 <= scipy <2.0
- `click~=7.0`: 7.0 <= click <8.0
- `tqdm~=4.25`: 4.25 <= tqdm <5.0 ([`4.25` was release when added](https://pypi.org/project/tqdm/4.25.0/#history))
- `jsonschema~=3.2`: 3.2 <= jsonschema <4.0
- `jsonpatch~=1.23`: 1.23 <= jsonpatch <2.0 ([`1.23` was release when added](https://pypi.org/project/jsonpatch/1.23/#history))
- `pyyaml~=5.1`: 5.1 <= pyyaml <6.0 ([`5.1` was release when added](https://pypi.org/project/PyYAML/5.1/#history))



Related PRs:
- https://github.com/alexander-held/cabinetry/pull/168
- https://github.com/scikit-hep/pylhe/pull/62
- https://github.com/cranmer/stats-ds-book/pull/8

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use compatible release syntax to establish release ranges for core dependencies
   - c.f. https://www.python.org/dev/peps/pep-0440/#compatible-release
   - Lower bounds established from releases on PyPI on date dependency added
```
