### PR TITLE
refactor: Clean up docstrings and remove qtilde from hypotest

### DIFF
--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -11,7 +11,6 @@ def hypotest(
     init_pars=None,
     par_bounds=None,
     fixed_params=None,
-    qtilde=True,
     calctype="asymptotics",
     return_tail_probs=False,
     return_expected=False,
@@ -33,7 +32,7 @@ def hypotest(
         >>> data = pyhf.tensorlib.astensor(observations + model.config.auxdata)
         >>> mu_test = 1.0
         >>> CLs_obs, CLs_exp_band = pyhf.infer.hypotest(
-        ...     mu_test, data, model, qtilde=True, return_expected_set=True
+        ...     mu_test, data, model, return_expected_set=True, qtilde=True
         ... )
         >>> CLs_obs
         array(0.05251497)
@@ -47,9 +46,6 @@ def hypotest(
         init_pars (:obj:`tensor`): The initial parameter values to be used for minimization
         par_bounds (:obj:`tensor`): The parameter value bounds to be used for minimization
         fixed_params (:obj:`tensor`): Whether to fix the parameter to the init_pars value during minimization
-        qtilde (:obj:`bool`): When ``True`` perform the calculation using the alternative
-         test statistic, :math:`\tilde{q}_{\mu}`, as defined under the Wald
-         approximation in Equation (62) of :xref:`arXiv:1007.1727`.
         calctype (:obj:`str`): The calculator to create. Choose either 'asymptotics' (default) or 'toybased'.
         return_tail_probs (:obj:`bool`): Bool for returning :math:`\mathrm{CL}_{s+b}` and :math:`\mathrm{CL}_{b}`
         return_expected (:obj:`bool`): Bool for returning :math:`\mathrm{CL}_{\mathrm{exp}}`
@@ -139,7 +135,6 @@ def hypotest(
         init_pars,
         par_bounds,
         fixed_params,
-        qtilde=qtilde,
         **kwargs,
     )
 

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -161,7 +161,7 @@ class AsymptoticCalculator:
         fixed_params=None,
         qtilde=True,
     ):
-        """
+        r"""
         Asymptotic Calculator.
 
         Args:
@@ -453,7 +453,7 @@ class ToyCalculator:
         ntoys=2000,
         track_progress=True,
     ):
-        """
+        r"""
         Toy-based Calculator.
 
         Args:

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -170,11 +170,9 @@ class AsymptoticCalculator:
             init_pars (:obj:`tensor`): The initial parameter values to be used for fitting.
             par_bounds (:obj:`tensor`): The parameter value bounds to be used for fitting.
             fixed_params (:obj:`tensor`): Whether to fix the parameter to the init_pars value during minimization
-            qtilde (:obj:`bool`): When ``True`` use :func:`~pyhf.infer.test_statistics.qmu_tilde`
-             as the test statistic.
-             When ``False`` use :func:`~pyhf.infer.test_statistics.qmu`.
-            qtilde (:obj:`bool`): When ``True`` perform the calculation using the alternative test statistic,
-             :math:`\\tilde{q}`, as defined in Equation (62) of :xref:`arXiv:1007.1727`
+            qtilde (:obj:`bool`): When ``True`` perform the calculation using the alternative
+             test statistic, :math:`\tilde{q}_{\mu}`, as defined under the Wald
+             approximation in Equation (62) of :xref:`arXiv:1007.1727`
              (:func:`~pyhf.infer.test_statistics.qmu_tilde`).
              When ``False`` use :func:`~pyhf.infer.test_statistics.qmu`.
 
@@ -464,7 +462,11 @@ class ToyCalculator:
             init_pars (:obj:`tensor`): The initial parameter values to be used for fitting.
             par_bounds (:obj:`tensor`): The parameter value bounds to be used for fitting.
             fixed_params (:obj:`tensor`): Whether to fix the parameter to the init_pars value during minimization
-            qtilde (:obj:`bool`): When ``True`` perform the calculation using the alternative test statistic, :math:`\\tilde{q}`, as defined in Equation (62) of :xref:`arXiv:1007.1727`.
+            qtilde (:obj:`bool`): When ``True`` perform the calculation using the alternative
+             test statistic, :math:`\tilde{q}_{\mu}`, as defined under the Wald
+             approximation in Equation (62) of :xref:`arXiv:1007.1727`
+             (:func:`~pyhf.infer.test_statistics.qmu_tilde`).
+             When ``False`` use :func:`~pyhf.infer.test_statistics.qmu`.
             ntoys (:obj:`int`): Number of toys to use (how many times to sample the underlying distributions)
             track_progress (:obj:`bool`): Whether to display the `tqdm` progress bar or not (outputs to `stderr`)
 


### PR DESCRIPTION
# Description

More work towards making #520 easy to support/add in. This PR will clean up docstrings first and get qtilde removed from hypotest signature. One would argue it's a change to the API, but in actuality, we never do anything with `qtilde` inside hypotest, as it's forwarded straight to the calculators.

docs: https://pyhf.readthedocs.io/en/refactor-calculators/

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Remove duplicated qtilde description in AsymptoticCalculator description
* Remove qtilde from hypotest docs and function signature to demote it to kwargs
```