### PR TITLE
docs: Add readxml and writexml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
-  fail_on_warning: true
+  #fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,7 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
+  fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all

--- a/docs/_templates/autosummary/module.rst
+++ b/docs/_templates/autosummary/module.rst
@@ -1,0 +1,29 @@
+{{ fullname | escape | underline }}
+
+.. rubric:: Description
+
+.. automodule:: {{ fullname }}
+
+.. currentmodule:: {{ fullname }}
+
+{% if classes %}
+.. rubric:: Classes
+
+.. autosummary::
+    :toctree: .
+    {% for class in classes %}
+    {{ class }}
+    {% endfor %}
+
+{% endif %}
+
+{% if functions %}
+.. rubric:: Functions
+
+.. autosummary::
+    :toctree: .
+    {% for function in functions %}
+    {{ function }}
+    {% endfor %}
+
+{% endif %}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,6 +15,8 @@ Top-Level
    optimizer
    get_backend
    set_backend
+   readxml
+   writexml
 
 Probability Distribution Functions (PDFs)
 -----------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -49,16 +49,19 @@ extras_require['test'] = sorted(
     )
 )
 extras_require['docs'] = sorted(
-    {
-        'sphinx>=3.1.2',
-        'sphinxcontrib-bibtex~=1.0',
-        'sphinx-click',
-        'sphinx_rtd_theme',
-        'nbsphinx',
-        'ipywidgets',
-        'sphinx-issues',
-        'sphinx-copybutton>0.2.9',
-    }
+    set(
+        extras_require['xmlio']
+        + [
+            'sphinx>=3.1.2',
+            'sphinxcontrib-bibtex~=1.0',
+            'sphinx-click',
+            'sphinx_rtd_theme',
+            'nbsphinx',
+            'ipywidgets',
+            'sphinx-issues',
+            'sphinx-copybutton>0.2.9',
+        ]
+    )
 )
 extras_require['develop'] = sorted(
     set(


### PR DESCRIPTION
# Pull Request Description

This needs #1002. Add `readxml` and `writexml` to our documented API. Resolves #1131.

Related issue: #943.

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-importexport/api.html#top-level

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add readxml and writexml to docs API
* Add template for autosummary module to render classes/functions properly
* Update [docs] option for installation to depend on [xmlio]
* Teach RTD to fail on warnings (be more strict)
```
