### PR TITLE
docs: Fix math mode syntax in contrib.viz.brazil.plot_results docstring

### DIFF
--- a/src/pyhf/contrib/viz/brazil.py
+++ b/src/pyhf/contrib/viz/brazil.py
@@ -30,9 +30,9 @@ def plot_results(ax, mutests, tests, test_size=0.05):
         ax (`matplotlib.axes.Axes`): The matplotlib axis object to plot on.
         mutests (:obj:`list` or :obj:`array`): The values of the POI where the
           hypothesis tests were performed.
-        tests (:obj:`list` or :obj:`array`): The :math:$\\mathrm{CL}_{s}$ values
+        tests (:obj:`list` or :obj:`array`): The :math:`\\mathrm{CL}_{s}` values
           from the hypothesis tests.
-        test_size (:obj:`float`): The size, :math:$\alpha$, of the test.
+        test_size (:obj:`float`): The size, :math:`\\alpha`, of the test.
     """
     cls_obs = np.array([test[0] for test in tests]).flatten()
     cls_exp = [np.array([test[1][i] for test in tests]).flatten() for i in range(5)]


### PR DESCRIPTION
# Description

Following PR #1242, I noticed that in PR #1176 I used incorrect math mode syntax that is now being displayed thanks to PR #1242 showing it. Offending syntax (I must have been tired)

```
$ git grep ":math:\\$"
src/pyhf/contrib/viz/brazil.py:        tests (:obj:`list` or :obj:`array`): The :math:$\\mathrm{CL}_{s}$ values
src/pyhf/contrib/viz/brazil.py:        test_size (:obj:`float`): The size, :math:$\alpha$, of the test.
```

This PR fixes that by using proper syntax.

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-fix-math-mode-for-contrib/_generated/pyhf.contrib.viz.brazil.plot_results.html#pyhf.contrib.viz.brazil.plot_results


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use correct Sphinx math mode syntax for contrib.viz.brazil.plot_results docstring
```
