### PR TITLE
fix: Don't use exact assert for test_probability.py

### DIFF
--- a/tests/test_probability.py
+++ b/tests/test_probability.py
@@ -56,8 +56,10 @@ def test_joint(backend):
     tb, _ = backend
     p1 = probability.Poisson(tb.astensor([10.0])).log_prob(tb.astensor(2.0))
     p2 = probability.Poisson(tb.astensor([10.0])).log_prob(tb.astensor(3.0))
-    assert tb.tolist(probability.Simultaneous._joint_logpdf([p1, p2])) == tb.tolist(
-        p1 + p2
+    assert np.allclose(
+        tb.tolist(probability.Simultaneous._joint_logpdf([p1, p2])),
+        tb.tolist(p1 + p2),
+        atol=1e-12,
     )
 
 

--- a/tests/test_probability.py
+++ b/tests/test_probability.py
@@ -72,9 +72,6 @@ def test_independent(backend):
     assert tb.tolist(probability.Simultaneous._joint_logpdf([p1, p2]))[0] == tb.tolist(
         result
     )
-    assert tb.tolist(probability.Simultaneous._joint_logpdf([p1, p2]))[0] == tb.tolist(
-        result
-    )
 
 
 def test_simultaneous_list_ducktype():

--- a/tests/test_probability.py
+++ b/tests/test_probability.py
@@ -69,8 +69,10 @@ def test_independent(backend):
 
     p1 = probability.Poisson(tb.astensor([10.0])).log_prob(tb.astensor(2.0))
     p2 = probability.Poisson(tb.astensor([10.0])).log_prob(tb.astensor(3.0))
-    assert tb.tolist(probability.Simultaneous._joint_logpdf([p1, p2]))[0] == tb.tolist(
-        result
+    assert np.allclose(
+        tb.tolist(probability.Simultaneous._joint_logpdf([p1, p2]))[0],
+        tb.tolist(result),
+        atol=1e-12,
     )
 
 


### PR DESCRIPTION
# Description

* Resolves #1251
* Required for PR #1232
* Addresses https://github.com/google/jax/issues/5386

To avoid the issues with floating point comparison out to 15 decimal places that started surfacing with the release of [`jaxlib` `v0.1.58`](https://pypi.org/project/jaxlib/0.1.58/) don't use exact `assert`s for floating point comparison in `test_probability.py`. `atol=1e-12` was chosen as that is well beyond the floating point precision that should matter for comparion here, but not up to the `1e-15` or so that caused the difference.

Also remove redundant test added by mistake in PR #582 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use np.allclose with an absolute tolerance of 1e-12 instead of exact assert to compare floating point values in test_probability.py
   - Applies to tests test_joint and test_independent
* Remove redundant test added by mistake in PR #582
```