### PR TITLE
docs: Add talks and use citations from 2020

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ config.rst
 .pytest_cache
 htmlcov
 .benchmarks
+
+# text editors
+.vscode/

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -1,17 +1,6 @@
 % NB: entries with same author-title-year are not picked up:
 %     https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/117
 
-@unpublished{Feickert_SciPy2020,
-  title  = {{pyhf: a pure Python statistical fitting library with tensors and autograd}},
-  author = {Matthew Feickert},
-  year   = {2020},
-  month  = {July},
-  day    = {7},
-  note   = {19th Python in Science Conference (SciPy 2020)},
-  doi    = {10.25080/Majora-342d178e-023},
-  url    = {http://conference.scipy.org/proceedings/scipy2020/slides.html},
-}
-
 @unpublished{Feickert_20201103,
   title  = {{pyhf: pure-Python implementation of HistFactory with tensors and automatic differentiation}},
   author = {Matthew Feickert},
@@ -21,6 +10,17 @@
   note   = {Tools for High Energy Physics and Cosmology 2020 Workshop},
   doi    = {10.5281/zenodo.4246056},
   url    = {https://indico.cern.ch/event/955391/contributions/4075505/},
+}
+
+@unpublished{Feickert_SciPy2020,
+  title  = {{pyhf: a pure Python statistical fitting library with tensors and autograd}},
+  author = {Matthew Feickert},
+  year   = {2020},
+  month  = {July},
+  day    = {7},
+  note   = {19th Python in Science Conference (SciPy 2020)},
+  doi    = {10.25080/Majora-342d178e-023},
+  url    = {http://conference.scipy.org/proceedings/scipy2020/slides.html},
 }
 
 @unpublished{Heinrich20191119,

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -13,14 +13,14 @@
 }
 
 @unpublished{Feickert_20201103,
-  title  = {{pyhf: a pure Python statistical fitting library with tensors and autograd}},
+  title  = {{pyhf: pure-Python implementation of HistFactory with tensors and automatic differentiation}},
   author = {Matthew Feickert},
   year   = {2020},
-  month  = {July},
+  month  = {Nov},
   day    = {7},
-  note   = {19th Python in Science Conference (SciPy 2020)},
-  doi    = {10.25080/Majora-342d178e-023},
-  url    = {http://conference.scipy.org/proceedings/scipy2020/slides.html},
+  note   = {Tools for High Energy Physics and Cosmology 2020 Workshop},
+  doi    = {10.5281/zenodo.4246056},
+  url    = {https://indico.cern.ch/event/955391/contributions/4075505/},
 }
 
 @unpublished{Heinrich20191119,

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -1,8 +1,18 @@
 % NB: entries with same author-title-year are not picked up:
 %     https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/117
 
-
 @unpublished{Feickert_SciPy2020,
+  title  = {{pyhf: a pure Python statistical fitting library with tensors and autograd}},
+  author = {Matthew Feickert},
+  year   = {2020},
+  month  = {July},
+  day    = {7},
+  note   = {19th Python in Science Conference (SciPy 2020)},
+  doi    = {10.25080/Majora-342d178e-023},
+  url    = {http://conference.scipy.org/proceedings/scipy2020/slides.html},
+}
+
+@unpublished{Feickert_20201103,
   title  = {{pyhf: a pure Python statistical fitting library with tensors and autograd}},
   author = {Matthew Feickert},
   year   = {2020},

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -1,6 +1,18 @@
 % NB: entries with same author-title-year are not picked up:
 %     https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/117
 
+
+@unpublished{Feickert_SciPy2020,
+  title  = {{pyhf: a pure Python statistical fitting library with tensors and autograd}},
+  author = {Matthew Feickert},
+  year   = {2020},
+  month  = {July},
+  day    = {7},
+  note   = {19th Python in Science Conference (SciPy 2020)},
+  doi    = {10.25080/Majora-342d178e-023},
+  url    = {http://conference.scipy.org/proceedings/scipy2020/slides.html},
+}
+
 @unpublished{Heinrich20191119,
   title  = {{Likelihoods associated with statistical fits used in searches for new physics on HEPData and use of RECAST}},
   author = {Lukas Heinrich},

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,15 @@
+% 2020-12-15
+@inproceedings{Alguero:2020buz,
+    author = {Alguero, Ga\"el and Heisig, Jan and Khosa, Charanjit K. and Kraml, Sabine and Kulkarni, Suchita and Lessa, Andre and Neuhuber, Philipp and Reyes-Gonz\'alez, Humberto and Waltenberger, Wolfgang and Wongel, Alicia},
+    title = "{New developments in SModelS}",
+    booktitle = "{Tools for High Energy Physics and Cosmology}",
+    eprint = "2012.08192",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    month = "12",
+    year = "2020"
+}
+
 % 2020-11-16
 @article{Feickert:2020chep2019,
     author = "Feickert, Matthew and Heinrich, Lukas and Stark, Giordon",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -34,6 +34,15 @@
     journal = ""
 }
 
+% 2020-08-14
+@Booklet{ATLAS-CONF-2020-046,
+    author         = "{ATLAS Collaboration}",
+    title          = "{Search for new phenomena in events with two opposite-charge leptons, jets and missing transverse momentum in \(pp\) collisions at \(\sqrt{s} = 13\,\text{TeV}\) with the ATLAS detector}",
+    howpublished   = "{ATLAS-CONF-2020-046}",
+    url            = "https://cds.cern.ch/record/2728056",
+    year           = "2020",
+}
+
 % 2020-06-20
 @article{Krupa:2020bwg,
     author = "Krupa, Jeffrey and others",


### PR DESCRIPTION
# Description

* Resolves #1253
* Resolves #920

Add use citations

- [Search for new phenomena in events with two opposite-charge leptons, jets and missing transverse momentum in p p collisions at √s = 13 TeV with the ATLAS detector](https://inspirehep.net/literature/1811757) (ATLAS-CONF-2020-046)
- [New developments in SModelS](https://inspirehep.net/literature/1836682)

and talks

- [TOOLS 2020 workshop talk](https://indico.cern.ch/event/955391/contributions/4075505/)
- [SciPy 2020 talk](https://github.com/matthewfeickert/talk-SciPy-2020)

ReadTheDocs build: 
- https://pyhf.readthedocs.io/en/docs-add-end-2020-citations/citations.html
- https://pyhf.readthedocs.io/en/docs-add-end-2020-citations/outreach.html#presentations

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citations from 2020
   - ATLAS-CONF-2020-046 (https://inspirehep.net/literature/1811757)
   - New developments in SModelS (https://inspirehep.net/literature/1836682)
* Add talks on pyhf from 2020
   - SciPy 2020 (https://doi.org/10.25080/Majora-342d178e-023)
   - TOOLS 2020 (https://indico.cern.ch/event/955391/contributions/4075505/)
* Add VS Code workspace settings to gitignore
```
