### PR TITLE
docs: Build docs with sphinx-build via Sphinx Makefile

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,9 @@ jobs:
     - name: Test and build docs
       run: |
         python -m doctest README.rst
-        python setup.py build_sphinx
+        pushd docs
+        make html
+        popd
         touch docs/_build/html/.nojekyll
     - name: Check schemas are copied over
       run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,13 +52,6 @@ where = src
 console_scripts =
     pyhf = pyhf.cli:cli
 
-[build_sphinx]
-project = pyhf
-source-dir = docs
-build-dir = docs/_build
-all-files = 1
-warning-is-error = 1
-
 [flake8]
 # E203: whitespace before ':'
 # E402: module level import not at top of file


### PR DESCRIPTION
# Description

Resolves #1256

Use Sphinx's Makefile to build the docs using `sphinx-build` via `make html`. 

https://github.com/scikit-hep/pyhf/blob/fd8fdf3c280604c173f6229837baab3616abe8c3/docs/Makefile#L54-L58

This deprecates the previously used method of using [Sphinx's `setuptools` integration](https://www.sphinx-doc.org/en/master/usage/advanced/setuptools.html).

This also more closely resembles the [ReadTheDocs procedure](https://docs.readthedocs.io/en/stable/builds.html)

> When we build your Sphinx documentation, we run `sphinx-build -b <format> . _build/<format>`. We also create pdf’s and ePub’s automatically based on your project.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Build the docs using the html Make target from Sphinx's Makefile
   - Sphinx Make targets all invoke sphinx-build
   - Deprecate pattern `python setup.py <command>`
* Remove build_sphinx info for setuptools from setup.cfg as deprecated
```