### PR TITLE
docs: Add learn notebook on using calculators

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,6 +2,8 @@
 #
 
 # You can set these variables from the command line.
+# W: Turn warnings into errors
+# n: Run in nit-picky mode
 SPHINXOPTS    = -W --keep-going #-n
 SPHINXBUILD   = sphinx-build
 PAPER         =

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W --keep-going #-n
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/docs/examples/notebooks/learn/UsingCalculators.ipynb
+++ b/docs/examples/notebooks/learn/UsingCalculators.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/examples/notebooks/learn/UsingCalculators.ipynb
+++ b/docs/examples/notebooks/learn/UsingCalculators.ipynb
@@ -1,17 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy\n",
-    "\n",
-    "numpy.random.seed(0)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -28,9 +17,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pyhf\n",
     "import numpy as np\n",
+    "import pyhf\n",
     "\n",
+    "np.random.seed(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "model = pyhf.simplemodels.hepdata_like([6], [9], [3])\n",
     "data = [9] + model.config.auxdata"
    ]
@@ -382,5 +380,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/examples/notebooks/learn/UsingCalculators.ipynb
+++ b/docs/examples/notebooks/learn/UsingCalculators.ipynb
@@ -143,7 +143,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "From these distributions, we can ask for the p-value of the test statistic and use this to calculate the \"modified\" p-value, $\\mathrm{CL}_\\mathrm{s}$."
+    "From these distributions, we can ask for the $p$-value of the test statistic and use this to calculate the $\\mathrm{CL}_\\mathrm{s}$ &mdash; a \"modified\" $p$-value."
    ]
   },
   {
@@ -175,7 +175,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In a similar procedure, we can do the same thing for the expected $\\mathrm{CL}_\\mathrm{s}$ values as well. First we need to get the expected value of the test statistic at each $\\pm\\sigma$ and then ask for the expected p-value associated with each value of the test statistic."
+    "In a similar procedure, we can do the same thing for the expected $\\mathrm{CL}_\\mathrm{s}$ values as well. First we need to get the expected value of the test statistic at each $\\pm\\sigma$ and then ask for the expected $p$-value associated with each value of the test statistic."
    ]
   },
   {
@@ -302,7 +302,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "From these distributions, we can ask for the p-value of the test statistic and use this to calculate the \"modified\" p-value, $\\mathrm{CL}_\\mathrm{s}$."
+    "From these distributions, we can ask for the $p$-value of the test statistic and use this to calculate the $\\mathrm{CL}_\\mathrm{s}$."
    ]
   },
   {
@@ -334,7 +334,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In a similar procedure, we can do the same thing for the expected $\\mathrm{CL}_\\mathrm{s}$ values as well. First we need to get the expected value of the test statistic at each $\\pm\\sigma$ and then ask for the expected p-value associated with each value of the test statistic."
+    "In a similar procedure, we can do the same thing for the expected $\\mathrm{CL}_\\mathrm{s}$ values as well. First we need to get the expected value of the test statistic at each $\\pm\\sigma$ and then ask for the expected $p$-value associated with each value of the test statistic."
    ]
   },
   {

--- a/docs/examples/notebooks/learn/UsingCalculators.ipynb
+++ b/docs/examples/notebooks/learn/UsingCalculators.ipynb
@@ -210,7 +210,8 @@
    "source": [
     "### Toy-Based\n",
     "\n",
-    "_\"Oh no, surely this must be trickier!\"_ you exclaim. Due to the way the calculator API is designed, the calculator abstracts away a lot of the differences between various strategies, such that it returns what you want, regardless of whether you doing asymptotics or toy-based testing.\n",
+    "Due to the way the calculator API is designed, the calculator abstracts away a lot of the differences between various strategies, such that it returns what you want, regardless of whether you doing asymptotics or toy-based testing.\n",
+    "It hopefully delivers a simple but powerful API for you!\n",
     "\n",
     "Let's create a toy-based calculator and \"throw\" 500 toys."
    ]

--- a/docs/examples/notebooks/learn/UsingCalculators.ipynb
+++ b/docs/examples/notebooks/learn/UsingCalculators.ipynb
@@ -8,6 +8,7 @@
    "source": [
     "from IPython.display import display, Math\n",
     "import numpy\n",
+    "\n",
     "numpy.random.seed(0)"
    ]
   },
@@ -30,8 +31,9 @@
    "source": [
     "import pyhf\n",
     "import numpy as np\n",
+    "\n",
     "model = pyhf.simplemodels.hepdata_like([6], [9], [3])\n",
-    "data  = [9] + model.config.auxdata"
+    "data = [9] + model.config.auxdata"
    ]
   },
   {
@@ -125,7 +127,7 @@
     }
    ],
    "source": [
-    "teststat = calc.teststatistic(poi_test = 1.0)\n",
+    "teststat = calc.teststatistic(poi_test=1.0)\n",
     "display(Math(rf'\\tilde{{q}}_\\mu = {teststat}'))"
    ]
   },
@@ -142,7 +144,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sb_dist, b_dist = calc.distributions(poi_test = 1.0)"
+    "sb_dist, b_dist = calc.distributions(poi_test=1.0)"
    ]
   },
   {
@@ -200,7 +202,11 @@
     "p_s = p_sb / p_b\n",
     "display(Math(rf'\\mathrm{{CL}}_\\mathrm{{sb}} = {p_sb}'))\n",
     "display(Math(rf'\\mathrm{{CL}}_\\mathrm{{b}} = {p_b}'))\n",
-    "display(Math(rf'\\mathrm{{CL}}_\\mathrm{{s}} = \\frac{{\\mathrm{{CL}}_\\mathrm{{sb}}}}{{\\mathrm{{CL}}_\\mathrm{{b}}}} = {p_s}'))"
+    "display(\n",
+    "    Math(\n",
+    "        rf'\\mathrm{{CL}}_\\mathrm{{s}} = \\frac{{\\mathrm{{CL}}_\\mathrm{{sb}}}}{{\\mathrm{{CL}}_\\mathrm{{b}}}} = {p_s}'\n",
+    "    )\n",
+    ")"
    ]
   },
   {
@@ -232,7 +238,7 @@
    ],
    "source": [
     "teststat_expected = [b_dist.expected_value(i) for i in [2, 1, 0, -1, -2]]\n",
-    "p_expected = [sb_dist.pvalue(t)/b_dist.pvalue(t) for t in teststat_expected]\n",
+    "p_expected = [sb_dist.pvalue(t) / b_dist.pvalue(t) for t in teststat_expected]\n",
     "p_expected"
    ]
   },
@@ -282,7 +288,7 @@
     }
    ],
    "source": [
-    "teststat = calc.teststatistic(poi_test = 1.0)\n",
+    "teststat = calc.teststatistic(poi_test=1.0)\n",
     "display(Math(rf'\\tilde{{q}}_\\mu = {teststat}'))"
    ]
   },
@@ -332,7 +338,7 @@
     }
    ],
    "source": [
-    "sb_dist, b_dist = calc.distributions(poi_test = 1.0)"
+    "sb_dist, b_dist = calc.distributions(poi_test=1.0)"
    ]
   },
   {
@@ -390,7 +396,11 @@
     "p_s = p_sb / p_b\n",
     "display(Math(rf'\\mathrm{{CL}}_\\mathrm{{sb}} = {p_sb}'))\n",
     "display(Math(rf'\\mathrm{{CL}}_\\mathrm{{b}} = {p_b}'))\n",
-    "display(Math(rf'\\mathrm{{CL}}_\\mathrm{{s}} = \\frac{{\\mathrm{{CL}}_\\mathrm{{sb}}}}{{\\mathrm{{CL}}_\\mathrm{{b}}}} = {p_s}'))"
+    "display(\n",
+    "    Math(\n",
+    "        rf'\\mathrm{{CL}}_\\mathrm{{s}} = \\frac{{\\mathrm{{CL}}_\\mathrm{{sb}}}}{{\\mathrm{{CL}}_\\mathrm{{b}}}} = {p_s}'\n",
+    "    )\n",
+    ")"
    ]
   },
   {
@@ -418,7 +428,7 @@
    ],
    "source": [
     "teststat_expected = [b_dist.expected_value(i) for i in [2, 1, 0, -1, -2]]\n",
-    "p_expected = [sb_dist.pvalue(t)/b_dist.pvalue(t) for t in teststat_expected]\n",
+    "p_expected = [sb_dist.pvalue(t) / b_dist.pvalue(t) for t in teststat_expected]\n",
     "p_expected"
    ]
   }

--- a/docs/examples/notebooks/learn/UsingCalculators.ipynb
+++ b/docs/examples/notebooks/learn/UsingCalculators.ipynb
@@ -104,7 +104,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now from this, we want to perform the fit and compute the value of the test statistic from which we can get our p-values:"
+    "Now from this, we want to perform the fit and compute the value of the test statistic from which we can get our $p$-values:"
    ]
   },
   {

--- a/docs/examples/notebooks/learn/UsingCalculators.ipynb
+++ b/docs/examples/notebooks/learn/UsingCalculators.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "One low-level functionality of `pyhf` when it comes to statistical fits is the idea of a calculator to evaluate with `asymptotics` or `toybased` hypothesis testing.\n",
     "\n",
-    "This notebook will introduce very quickly what these calculators are meant to do and how they are used internally in the code. First, we'll set up a simple model for demonstration and then show how the calculators come into play."
+    "This notebook will introduce very quickly what these calculators are meant to do and how they are used internally in the code. We'll set up a simple model for demonstration and then show how the calculators come into play."
    ]
   },
   {
@@ -72,7 +72,7 @@
     "Under the hood, the hypothesis test computes *test statistics* (such as $q_\\mu, \\tilde{q}_\\mu$) and uses *calculators* in order to \n",
     "assess how likely the computed test statistic value is under various hypotheses. The goal is to provide a consistent API that understands how you wish to perform your hypothesis test.\n",
     "\n",
-    "First, let's look at the `asymptotics` calculator and then do the same thing for the `toybased`."
+    "Let's look at the `asymptotics` calculator and then do the same thing for the `toybased`."
    ]
   },
   {
@@ -177,7 +177,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In a similar procedure, we can do the same thing for the expected $\\mathrm{CL}_\\mathrm{s}$ values as well. First we need to get the expected value of the test statistic at each $\\pm\\sigma$ and then ask for the expected $p$-value associated with each value of the test statistic."
+    "In a similar procedure, we can do the same thing for the expected $\\mathrm{CL}_\\mathrm{s}$ values as well. We need to get the expected value of the test statistic at each $\\pm\\sigma$ and then ask for the expected $p$-value associated with each value of the test statistic."
    ]
   },
   {
@@ -212,7 +212,7 @@
    "source": [
     "### Toy-Based\n",
     "\n",
-    "The calculator API is designed, the calculator abstracts away a lot of the differences between various strategies, such that it returns what you want, regardless of whether you doing asymptotics or toy-based testing. It hopefully delivers a simple but powerful API for you!\n",
+    "The calculator API abstracts away a lot of the differences between various strategies, such that it returns what you want, regardless of whether you choose to perform asymptotics or toy-based testing. It hopefully delivers a simple but powerful API for you!\n",
     "\n",
     "Let's create a toy-based calculator and \"throw\" 500 toys."
    ]
@@ -338,7 +338,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In a similar procedure, we can do the same thing for the expected $\\mathrm{CL}_\\mathrm{s}$ values as well. First we need to get the expected value of the test statistic at each $\\pm\\sigma$ and then ask for the expected $p$-value associated with each value of the test statistic."
+    "In a similar procedure, we can do the same thing for the expected $\\mathrm{CL}_\\mathrm{s}$ values as well. We need to get the expected value of the test statistic at each $\\pm\\sigma$ and then ask for the expected $p$-value associated with each value of the test statistic."
    ]
   },
   {

--- a/docs/examples/notebooks/learn/UsingCalculators.ipynb
+++ b/docs/examples/notebooks/learn/UsingCalculators.ipynb
@@ -1,0 +1,447 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import display, Math\n",
+    "import numpy\n",
+    "numpy.random.seed(0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using Calculators\n",
+    "\n",
+    "One low-level functionality of `pyhf` when it comes to statistical fits is the idea of a calculator to evaluate with `asymptotics` or `toybased` hypothesis testing.\n",
+    "\n",
+    "This notebook will introduce very quickly what these calculators are meant to do and how they are used internally in the code. First, we'll set up a simple model for demonstration and then show how the calculators come into play."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyhf\n",
+    "import numpy as np\n",
+    "model = pyhf.simplemodels.hepdata_like([6], [9], [3])\n",
+    "data  = [9] + model.config.auxdata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The high-level API\n",
+    "\n",
+    "If the only thing you are interested in is the hypothesis test result you can\n",
+    "just run the high-level API to get it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CLs_obs = 0.1677886052335611\n",
+      "CLs_exp = [array(0.0159689), array(0.05465771), array(0.16778861), array(0.41863467), array(0.74964133)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "CLs_obs, CLs_exp = pyhf.infer.hypotest(1.0, data, model, return_expected_set=True)\n",
+    "print(f'CLs_obs = {CLs_obs}')\n",
+    "print(f'CLs_exp = {CLs_exp}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The low-level API\n",
+    "\n",
+    "Under the hood, the hypothesis test computes *test statistics* (such as $q_\\mu, \\tilde{q}_\\mu$) and uses *calculators* in order to \n",
+    "assess how likely the computed test statistic value is under various hypotheses. The goal is to provide a consistent API that understands how you wish to perform your hypothesis test.\n",
+    "\n",
+    "First, let's look at the `asymptotics` calculator and then do the same thing for the `toybased`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Asymptotics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, let's create the calculator for asymptotics using the $\\tilde{q}_\\mu$ test statistic."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calc = pyhf.infer.calculators.AsymptoticCalculator(data, model, test_stat='qtilde')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now from this, we want to perform the fit and compute the value of the test statistic from which we can get our p-values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\tilde{q}_\\mu = 0.0$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "teststat = calc.teststatistic(poi_test = 1.0)\n",
+    "display(Math(rf'\\tilde{{q}}_\\mu = {teststat}'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to this, we can ask the calculator for the distributions of the test statistic for the background-only and signal+background hypotheses:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sb_dist, b_dist = calc.distributions(poi_test = 1.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "From these distributions, we can ask for the p-value of the test statistic and use this to calculate the \"modified\" p-value, $\\mathrm{CL}_\\mathrm{s}$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\mathrm{CL}_\\mathrm{sb} = 0.08389430261678055$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\mathrm{CL}_\\mathrm{b} = 0.5$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\mathrm{CL}_\\mathrm{s} = \\frac{\\mathrm{CL}_\\mathrm{sb}}{\\mathrm{CL}_\\mathrm{b}} = 0.1677886052335611$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "p_sb = sb_dist.pvalue(teststat)\n",
+    "p_b = b_dist.pvalue(teststat)\n",
+    "p_s = p_sb / p_b\n",
+    "display(Math(rf'\\mathrm{{CL}}_\\mathrm{{sb}} = {p_sb}'))\n",
+    "display(Math(rf'\\mathrm{{CL}}_\\mathrm{{b}} = {p_b}'))\n",
+    "display(Math(rf'\\mathrm{{CL}}_\\mathrm{{s}} = \\frac{{\\mathrm{{CL}}_\\mathrm{{sb}}}}{{\\mathrm{{CL}}_\\mathrm{{b}}}} = {p_s}'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In a similar procedure, we can do the same thing for the expected $\\mathrm{CL}_\\mathrm{s}$ values as well. First we need to get the expected value of the test statistic at each $\\pm\\sigma$ and then ask for the expected p-value associated with each value of the test statistic."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0.01596890401598493,\n",
+       " 0.05465770873260968,\n",
+       " 0.1677886052335611,\n",
+       " 0.4186346709326618,\n",
+       " 0.7496413276864433]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "teststat_expected = [b_dist.expected_value(i) for i in [2, 1, 0, -1, -2]]\n",
+    "p_expected = [sb_dist.pvalue(t)/b_dist.pvalue(t) for t in teststat_expected]\n",
+    "p_expected"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Toy-Based\n",
+    "\n",
+    "_\"Oh no, surely this must be trickier!\"_ you exclaim. Due to the way the calculator API is designed, the calculator abstracts away a lot of the differences between various strategies, such that it returns what you want, regardless of whether you doing asymptotics or toy-based testing.\n",
+    "\n",
+    "Let's create a toy-based calculator and \"throw\" 500 toys."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calc = pyhf.infer.calculators.ToyCalculator(data, model, test_stat='qtilde', ntoys=500)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And like before, we'll ask for the test statistic. Unlike the asymptotics case where we compute the asimov dataset and perform a series of fits; here we are just evaluating the test statistic for the observed data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\tilde{q}_\\mu = 1.902590865638981$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "teststat = calc.teststatistic(poi_test = 1.0)\n",
+    "display(Math(rf'\\tilde{{q}}_\\mu = {teststat}'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(1.90259087)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "inits = model.config.suggested_init()\n",
+    "bounds = model.config.suggested_bounds()\n",
+    "fixeds = model.config.suggested_fixed()\n",
+    "pyhf.infer.test_statistics.qmu_tilde(1.0, data, model, inits, bounds, fixeds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So now the next thing to do is get our distributions. This is where, in the case of toys, we fit each and every single toy that we've randomly sampled from our model.\n",
+    "\n",
+    "Note, again, that the API for the calculator is the same as in the asymptotics case."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                    \r"
+     ]
+    }
+   ],
+   "source": [
+    "sb_dist, b_dist = calc.distributions(poi_test = 1.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "From these distributions, we can ask for the p-value of the test statistic and use this to calculate the \"modified\" p-value, $\\mathrm{CL}_\\mathrm{s}$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\mathrm{CL}_\\mathrm{sb} = 0.084$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\mathrm{CL}_\\mathrm{b} = 0.52$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\mathrm{CL}_\\mathrm{s} = \\frac{\\mathrm{CL}_\\mathrm{sb}}{\\mathrm{CL}_\\mathrm{b}} = 0.16153846153846155$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "p_sb = sb_dist.pvalue(teststat)\n",
+    "p_b = b_dist.pvalue(teststat)\n",
+    "p_s = p_sb / p_b\n",
+    "display(Math(rf'\\mathrm{{CL}}_\\mathrm{{sb}} = {p_sb}'))\n",
+    "display(Math(rf'\\mathrm{{CL}}_\\mathrm{{b}} = {p_b}'))\n",
+    "display(Math(rf'\\mathrm{{CL}}_\\mathrm{{s}} = \\frac{{\\mathrm{{CL}}_\\mathrm{{sb}}}}{{\\mathrm{{CL}}_\\mathrm{{b}}}} = {p_s}'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In a similar procedure, we can do the same thing for the expected $\\mathrm{CL}_\\mathrm{s}$ values as well. First we need to get the expected value of the test statistic at each $\\pm\\sigma$ and then ask for the expected p-value associated with each value of the test statistic."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0.0, 0.047058823529411764, 0.15, 0.3758865248226951, 1.0]"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "teststat_expected = [b_dist.expected_value(i) for i in [2, 1, 0, -1, -2]]\n",
+    "p_expected = [sb_dist.pvalue(t)/b_dist.pvalue(t) for t in teststat_expected]\n",
+    "p_expected"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/examples/notebooks/learn/UsingCalculators.ipynb
+++ b/docs/examples/notebooks/learn/UsingCalculators.ipynb
@@ -6,7 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from IPython.display import display, Math\n",
     "import numpy\n",
     "\n",
     "numpy.random.seed(0)"
@@ -114,21 +113,16 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\tilde{q}_\\mu = 0.0$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "qtilde = 0.0\n"
+     ]
     }
    ],
    "source": [
     "teststat = calc.teststatistic(poi_test=1.0)\n",
-    "display(Math(rf'\\tilde{{q}}_\\mu = {teststat}'))"
+    "print(f'qtilde = {teststat}')"
    ]
   },
   {
@@ -160,53 +154,23 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\mathrm{CL}_\\mathrm{sb} = 0.08389430261678055$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\mathrm{CL}_\\mathrm{b} = 0.5$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\mathrm{CL}_\\mathrm{s} = \\frac{\\mathrm{CL}_\\mathrm{sb}}{\\mathrm{CL}_\\mathrm{b}} = 0.1677886052335611$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CL_sb = 0.08389430261678055\n",
+      "CL_b = 0.5\n",
+      "CL_s = CL_sb / CL_b = 0.1677886052335611\n"
+     ]
     }
    ],
    "source": [
     "p_sb = sb_dist.pvalue(teststat)\n",
     "p_b = b_dist.pvalue(teststat)\n",
     "p_s = p_sb / p_b\n",
-    "display(Math(rf'\\mathrm{{CL}}_\\mathrm{{sb}} = {p_sb}'))\n",
-    "display(Math(rf'\\mathrm{{CL}}_\\mathrm{{b}} = {p_b}'))\n",
-    "display(\n",
-    "    Math(\n",
-    "        rf'\\mathrm{{CL}}_\\mathrm{{s}} = \\frac{{\\mathrm{{CL}}_\\mathrm{{sb}}}}{{\\mathrm{{CL}}_\\mathrm{{b}}}} = {p_s}'\n",
-    "    )\n",
-    ")"
+    "\n",
+    "print(f'CL_sb = {p_sb}')\n",
+    "print(f'CL_b = {p_b}')\n",
+    "print(f'CL_s = CL_sb / CL_b = {p_s}')"
    ]
   },
   {
@@ -275,21 +239,16 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\tilde{q}_\\mu = 1.902590865638981$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "qtilde = 1.902590865638981\n"
+     ]
     }
    ],
    "source": [
     "teststat = calc.teststatistic(poi_test=1.0)\n",
-    "display(Math(rf'\\tilde{{q}}_\\mu = {teststat}'))"
+    "print(f'qtilde = {teststat}')"
    ]
   },
   {
@@ -354,53 +313,23 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\mathrm{CL}_\\mathrm{sb} = 0.084$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\mathrm{CL}_\\mathrm{b} = 0.52$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/latex": [
-       "$\\displaystyle \\mathrm{CL}_\\mathrm{s} = \\frac{\\mathrm{CL}_\\mathrm{sb}}{\\mathrm{CL}_\\mathrm{b}} = 0.16153846153846155$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Math object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CL_sb = 0.084\n",
+      "CL_b = 0.52\n",
+      "CL_s = CL_sb / CL_b = 0.16153846153846155\n"
+     ]
     }
    ],
    "source": [
     "p_sb = sb_dist.pvalue(teststat)\n",
     "p_b = b_dist.pvalue(teststat)\n",
     "p_s = p_sb / p_b\n",
-    "display(Math(rf'\\mathrm{{CL}}_\\mathrm{{sb}} = {p_sb}'))\n",
-    "display(Math(rf'\\mathrm{{CL}}_\\mathrm{{b}} = {p_b}'))\n",
-    "display(\n",
-    "    Math(\n",
-    "        rf'\\mathrm{{CL}}_\\mathrm{{s}} = \\frac{{\\mathrm{{CL}}_\\mathrm{{sb}}}}{{\\mathrm{{CL}}_\\mathrm{{b}}}} = {p_s}'\n",
-    "    )\n",
-    ")"
+    "\n",
+    "print(f'CL_sb = {p_sb}')\n",
+    "print(f'CL_b = {p_b}')\n",
+    "print(f'CL_s = CL_sb / CL_b = {p_s}')"
    ]
   },
   {

--- a/docs/examples/notebooks/learn/UsingCalculators.ipynb
+++ b/docs/examples/notebooks/learn/UsingCalculators.ipynb
@@ -95,7 +95,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "calc = pyhf.infer.calculators.AsymptoticCalculator(data, model, test_stat='qtilde')"
+    "asymp_calc = pyhf.infer.calculators.AsymptoticCalculator(\n",
+    "    data, model, test_stat='qtilde'\n",
+    ")"
    ]
   },
   {
@@ -119,7 +121,7 @@
     }
    ],
    "source": [
-    "teststat = calc.teststatistic(poi_test=1.0)\n",
+    "teststat = asymp_calc.teststatistic(poi_test=1.0)\n",
     "print(f'qtilde = {teststat}')"
    ]
   },
@@ -136,7 +138,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sb_dist, b_dist = calc.distributions(poi_test=1.0)"
+    "sb_dist, b_dist = asymp_calc.distributions(poi_test=1.0)"
    ]
   },
   {
@@ -210,8 +212,7 @@
    "source": [
     "### Toy-Based\n",
     "\n",
-    "Due to the way the calculator API is designed, the calculator abstracts away a lot of the differences between various strategies, such that it returns what you want, regardless of whether you doing asymptotics or toy-based testing.\n",
-    "It hopefully delivers a simple but powerful API for you!\n",
+    "The calculator API is designed, the calculator abstracts away a lot of the differences between various strategies, such that it returns what you want, regardless of whether you doing asymptotics or toy-based testing. It hopefully delivers a simple but powerful API for you!\n",
     "\n",
     "Let's create a toy-based calculator and \"throw\" 500 toys."
    ]
@@ -222,14 +223,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "calc = pyhf.infer.calculators.ToyCalculator(data, model, test_stat='qtilde', ntoys=500)"
+    "toy_calc = pyhf.infer.calculators.ToyCalculator(\n",
+    "    data, model, test_stat='qtilde', ntoys=500\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And like before, we'll ask for the test statistic. Unlike the asymptotics case where we compute the asimov dataset and perform a series of fits; here we are just evaluating the test statistic for the observed data."
+    "Like before, we'll ask for the test statistic. Unlike the asymptotics case, where we compute the Asimov dataset and perform a series of fits, here we are just evaluating the test statistic for the observed data."
    ]
   },
   {
@@ -246,7 +249,7 @@
     }
    ],
    "source": [
-    "teststat = calc.teststatistic(poi_test=1.0)\n",
+    "teststat = toy_calc.teststatistic(poi_test=1.0)\n",
     "print(f'qtilde = {teststat}')"
    ]
   },
@@ -296,7 +299,7 @@
     }
    ],
    "source": [
-    "sb_dist, b_dist = calc.distributions(poi_test=1.0)"
+    "sb_dist, b_dist = toy_calc.distributions(poi_test=1.0)"
    ]
   },
   {

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -76,3 +76,9 @@ def test_learn_tensorizinginterpolations(common_kwargs):
     pm.execute_notebook(
         'docs/examples/notebooks/learn/TensorizingInterpolations.ipynb', **common_kwargs
     )
+
+
+def test_learn_using_calculators(common_kwargs):
+    pm.execute_notebook(
+        "docs/examples/notebooks/learn/UsingCalculators.ipynb", **common_kwargs
+    )


### PR DESCRIPTION
# Description

This is the last thing from #709 that we don't have in `pyhf` by now.

Render: https://pyhf.readthedocs.io/en/docs-usingcalculators/examples/notebooks/learn/UsingCalculators.html

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add learn notebook on using calculators (asymptotics, toy-based)
   - Add notebook to notebook tests
* Update Sphinx Makefile to correctly raise warnings as errors
   - c.f. https://www.sphinx-doc.org/en/master/man/sphinx-build.html
   - Amends PR #1257

Co-authored-by: Lukas Heinrich <lukas.heinrich@gmail.com>
```