### PR TITLE
docs: Add Symmetry Magazine article on likelihood publication

### DIFF
--- a/docs/bib/media.bib
+++ b/docs/bib/media.bib
@@ -1,3 +1,13 @@
+@article{Symmetry_magazine_2021,
+  title   = {{ATLAS releases 'full orchestra' of analysis instruments}},
+  author  = {Stephanie Melchor},
+  journal = {Symmetry Magazine},
+  year    = {2021},
+  month   = {January},
+  day     = {14},
+  url     = {https://www.symmetrymagazine.org/article/atlas-releases-full-orchestra-of-analysis-instruments},
+}
+
 @article{CERN_News_2019,
   title   = {{New open release allows theorists to explore LHC data in a new way}},
   author  = {Katarina Anthony},


### PR DESCRIPTION
# Description

Resolves #1262 

Adds ["ATLAS releases ‘full orchestra’ of analysis instruments" Symmetry Magazine article](https://www.symmetrymagazine.org/article/atlas-releases-full-orchestra-of-analysis-instruments) to "In the Media" section in the docs.

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-add-symmetry-magazine-article/outreach.html#in-the-media

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add Symmetry Magazine article on likelihood publication using pyhf to docs
   - c.f. https://www.symmetrymagazine.org/article/atlas-releases-full-orchestra-of-analysis-instruments
```