### PR TITLE
build: Drop support for Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         exclude:
-          - os: macos-latest
-            python-version: 3.6
           - os: macos-latest
             python-version: 3.7
 

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -15,10 +15,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         exclude:
-          - os: macos-latest
-            python-version: 3.6
           - os: macos-latest
             python-version: 3.7
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     rev: v2.10.0
     hooks:
     - id: pyupgrade
-      args: ["--py36-plus"]
+      args: ["--py37-plus"]
 -   repo: https://github.com/nbQA-dev/nbQA
     rev: 0.5.7
     hooks:

--- a/codemeta.json
+++ b/codemeta.json
@@ -126,5 +126,5 @@
     "keywords": "physics fitting numpy scipy tensorflow pytorch jax",
     "developmentStatus": "4 - Beta",
     "applicationCategory": "Scientific/Engineering, Scientific/Engineering :: Physics",
-    "programmingLanguage": "Python 3, Python 3.6, Python 3.7, Python 3.8"
+    "programmingLanguage": "Python 3, Python 3.7, Python 3.8"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py37', 'py38']
 skip-string-normalization = true
 include = '\.pyi?$'
 exclude = '''
@@ -71,4 +71,4 @@ black = 1
 pyupgrade = 1
 
 [tool.nbqa.addopts]
-pyupgrade = ["--py36-plus"]
+pyupgrade = ["--py37-plus"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Physics
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
@@ -33,7 +32,7 @@ package_dir =
     = src
 packages = find:
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     scipy~=1.4  # requires numpy, which is required by pyhf and tensorflow
     click~=7.0  # for console scripts

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -545,7 +545,7 @@ def test_init_pars_sync_fixed_values_minuit(mocker):
     minuit = mocker.patch.object(getattr(opt_minuit, 'iminuit'), 'Minuit')
     minimizer = opt._get_minimizer(None, [9, 9, 9], [(0, 10)] * 3, fixed_vals=[(0, 1)])
     assert minuit.called
-    # python 3.6 does not have ::args attribute on ::call_args
+    # python 3.7 does not have ::args attribute on ::call_args
     # assert minuit.call_args.args[1] == [1, 9, 9]
     assert minuit.call_args[0][1] == [1, 9, 9]
     assert minimizer.fixed == [True, False, False]

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -563,12 +563,8 @@ def test_patchset_download(datadir, script_runner, archive):
     command = f'pyhf contrib download --verbose --force https://www.fail.org/record/resource/1234567 {datadir.join("likelihoods").strpath}'
     ret = script_runner.run(*shlex.split(command))
     assert not ret.success
-    # TODO: https://github.com/scikit-hep/pyhf/issues/1075
-    # Python 3.6 has different return error than 3.7, 3.8
     assert (
-        "ssl.CertificateError: hostname 'www.fail.org' doesn't match"
-        or "certificate verify failed: Hostname mismatch, certificate is not valid for 'www.fail.org'."
-        in ret.stderr
+        "SSLCertificateError" and "hostname 'www.fail.org' doesn't match" in ret.stderr
     )
 
 


### PR DESCRIPTION
# Description

Resolves #1075 

Drop support for Python 3.6. Require Python 3.7+ for `pyhf` installation and remove all Python 3.6 specific code.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Require Python 3.7+ for installation
* Remove Python 3.6 from testing in CI
* Remove Python 3.6 specific code from the codebase and metadata
```
