### PR TITLE
docs: Add commas to infer.mle.fixed_poi_fit docstring for clarity

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -19,3 +19,4 @@ Contributors include:
 - Alexander Held
 - Karthikeyan Singaravelan
 - Marco Gorelli
+- Pradyumna Rahul K

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -132,7 +132,7 @@ def fixed_poi_fit(
     This is done by minimizing the objective function of :func:`~pyhf.infer.mle.twice_nll`
     of the model parameters given the observed data, for a given fixed value of :math:`\mu`.
     This is used to produce the constrained maximal likelihood for the given :math:`\mu`
-    :math:`L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}\right)` in the profile
+    ,:math:`L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}\right)`, in the profile
     likelihood ratio in Equation (7) in :xref:`arXiv:1007.1727`
 
     .. math::

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -131,8 +131,8 @@ def fixed_poi_fit(
     Run a maximum likelihood fit with the POI value fixed.
     This is done by minimizing the objective function of :func:`~pyhf.infer.mle.twice_nll`
     of the model parameters given the observed data, for a given fixed value of :math:`\mu`.
-    This is used to produce the constrained maximal likelihood for the given :math:`\mu`
-    ,:math:`L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}\right)`, in the profile
+    This is used to produce the constrained maximal likelihood for the given :math:`\mu`,
+    :math:`L\left(\mu, \hat{\hat{\boldsymbol{\theta}}}\right)`, in the profile
     likelihood ratio in Equation (7) in :xref:`arXiv:1007.1727`
 
     .. math::


### PR DESCRIPTION
# Description

Resolves #1234 

As mentioned in the issue, there was a readability problem with the following lines:
https://github.com/scikit-hep/pyhf/blob/fd7930cce36cbc3a2d0ee1828f060d7382129579/src/pyhf/infer/mle.py#L134-L135

I have added the comma around the constrained maximal likelihood as mentioned in the issue.

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-build-docs-docfix-1nformed/_generated/pyhf.infer.mle.fixed_poi_fit.html

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add commas around constrained maximal likelihood for reading clarity
* Add Pradyumna to list of contributors
```
