### PR TITLE
docs: Explicitly give version number in JOSS paper

### DIFF
--- a/docs/JOSS/paper.md
+++ b/docs/JOSS/paper.md
@@ -46,6 +46,7 @@ By taking advantage of tensor calculations, `pyhf` outperforms the traditional `
 `pyhf`'s default computational backend is built from NumPy and SciPy, and supports TensorFlow, PyTorch, and JAX as alternative backend choices.
 These alternative backends support hardware acceleration on GPUs, and in the case of JAX JIT compilation, as well as auto-differentiation allowing for calculating the full gradient of the likelihood function &mdash; all contributing to speeding up fits.
 The source code for `pyhf` has been archived on Zenodo with the linked DOI: [@pyhf_zenodo]
+At the time of writing this paper the most recent release of `pyhf` is [`v0.5.4`](https://doi.org/10.5281/zenodo.4318533).
 
 ## Impact on Physics
 

--- a/docs/JOSS/paper.md
+++ b/docs/JOSS/paper.md
@@ -45,7 +45,7 @@ Through adoption of open source "tensor" computational Python libraries, `pyhf` 
 By taking advantage of tensor calculations, `pyhf` outperforms the traditional `C++` implementation of `HistFactory` on data from real LHC analyses.
 `pyhf`'s default computational backend is built from NumPy and SciPy, and supports TensorFlow, PyTorch, and JAX as alternative backend choices.
 These alternative backends support hardware acceleration on GPUs, and in the case of JAX JIT compilation, as well as auto-differentiation allowing for calculating the full gradient of the likelihood function &mdash; all contributing to speeding up fits.
-The source code for `pyhf` has been archived on Zenodo with the linked DOI: [@pyhf_zenodo]
+The source code for `pyhf` has been archived on Zenodo with the linked DOI: [@pyhf_zenodo].
 At the time of writing this paper the most recent release of `pyhf` is [`v0.5.4`](https://doi.org/10.5281/zenodo.4318533).
 
 ## Impact on Physics


### PR DESCRIPTION
# Description

Following review, it has been requested that [the release number of `pyhf` available at the time of writing be stated in the text of the JOSS paper itself](https://github.com/openjournals/joss-reviews/issues/2823#issuecomment-769311767). This PR adds in the following text:

> At the time of writing this paper the most recent release of `pyhf` is [`v0.5.4`](https://doi.org/10.5281/zenodo.4318533).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Explicitly state the release of pyhf at time of writing JOSS paper is v0.5.4
   - Link to pyhf v0.5.4 Zenodo archive
* Amend PR #1089
```
