### PR TITLE
docs: Redirect questions to GitHub Discussions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ To get started fork the repo.
 ## Issues
 
 Making Issues is very helpful to the project &mdash; they help the dev team form the development roadmap and are where most important discussion takes place.
-If you have suggestions, questions that you can't find answers to on the [documentation website](https://scikit-hep.org/pyhf/) or in the [GitHub Discussions](https://github.com/scikit-hep/pyhf/discussions), or have found a bug please [open an Issue](https://github.com/scikit-hep/pyhf/issues/new/choose)!
+If you have suggestions, questions that you can't find answers to on the [documentation website](https://scikit-hep.org/pyhf/) or on the [GitHub Discussions](https://github.com/scikit-hep/pyhf/discussions), or have found a bug please [open an Issue](https://github.com/scikit-hep/pyhf/issues/new/choose)!
 
 ## Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ To get started fork the repo.
 ## Issues
 
 Making Issues is very helpful to the project &mdash; they help the dev team form the development roadmap and are where most important discussion takes place.
-If you have suggestions, questions that you can't find answers to on the [documentation website](https://scikit-hep.org/pyhf/) or in the [Github discussions](https://github.com/scikit-hep/pyhf/discussions), or have found a bug please [open an Issue](https://github.com/scikit-hep/pyhf/issues/new/choose)!
+If you have suggestions, questions that you can't find answers to on the [documentation website](https://scikit-hep.org/pyhf/) or in the [GitHub Discussions](https://github.com/scikit-hep/pyhf/discussions), or have found a bug please [open an Issue](https://github.com/scikit-hep/pyhf/issues/new/choose)!
 
 ## Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ To get started fork the repo.
 ## Issues
 
 Making Issues is very helpful to the project &mdash; they help the dev team form the development roadmap and are where most important discussion takes place.
-If you have suggestions, questions that you can't find answers to on the [documentation website](https://scikit-hep.org/pyhf/) or on the [Stack Overflow tag](https://stackoverflow.com/questions/tagged/pyhf), or have found a bug please [open an Issue](https://github.com/scikit-hep/pyhf/issues/new/choose)!
+If you have suggestions, questions that you can't find answers to on the [documentation website](https://scikit-hep.org/pyhf/) or in the [Github discussions](https://github.com/scikit-hep/pyhf/discussions), or have found a bug please [open an Issue](https://github.com/scikit-hep/pyhf/issues/new/choose)!
 
 ## Pull Requests
 

--- a/README.rst
+++ b/README.rst
@@ -262,7 +262,7 @@ Questions
 
 If you have a question about the use of ``pyhf`` not covered in `the
 documentation <https://scikit-hep.org/pyhf/>`__, please ask a question
-on `GitHub Discussions <https://github.com/scikit-hep/pyhf/discussions>`__.
+on the `GitHub Discussions <https://github.com/scikit-hep/pyhf/discussions>`__.
 
 If you believe you have found a bug in ``pyhf``, please report it in the
 `GitHub

--- a/README.rst
+++ b/README.rst
@@ -262,7 +262,7 @@ Questions
 
 If you have a question about the use of ``pyhf`` not covered in `the
 documentation <https://scikit-hep.org/pyhf/>`__, please ask a question
-on `Github Discussions <https://github.com/scikit-hep/pyhf/discussions>`__.
+on `GitHub Discussions <https://github.com/scikit-hep/pyhf/discussions>`__.
 
 If you believe you have found a bug in ``pyhf``, please report it in the
 `GitHub

--- a/README.rst
+++ b/README.rst
@@ -262,15 +262,7 @@ Questions
 
 If you have a question about the use of ``pyhf`` not covered in `the
 documentation <https://scikit-hep.org/pyhf/>`__, please ask a question
-on `Stack Overflow <https://stackoverflow.com/questions/tagged/pyhf>`__
-with the ``[pyhf]`` tag, which the ``pyhf`` dev team
-`watches <https://stackoverflow.com/questions/tagged/pyhf?sort=Newest&filters=NoAcceptedAnswer&edited=true>`__.
-
-.. image:: https://cdn.sstatic.net/Sites/stackoverflow/company/img/logos/so/so-logo.png
-   :alt: Stack Overflow pyhf tag
-   :width: 50 %
-   :target: https://stackoverflow.com/questions/tagged/pyhf
-   :align: center
+on `Github Discussions <https://github.com/scikit-hep/pyhf/discussions>`__.
 
 If you believe you have found a bug in ``pyhf``, please report it in the
 `GitHub

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ intersphinx_mapping = {
     'uproot': ('https://uproot.readthedocs.io/en/latest/', None),
 }
 
-# Github repo
+# GitHub repo
 issues_github_path = 'scikit-hep/pyhf'
 
 # Generate the API documentation when building

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -20,3 +20,4 @@ Contributors include:
 - Karthikeyan Singaravelan
 - Marco Gorelli
 - Pradyumna Rahul K
+- Eric Schanet

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -8,7 +8,7 @@ Questions
 
 Where can I ask questions about ``pyhf`` use?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If you have a question about the use of ``pyhf`` not covered in the `documentation <https://scikit-hep.org/pyhf/>`__, please ask a question on `Github Discussions <https://github.com/scikit-hep/pyhf/discussions>`__.
+If you have a question about the use of ``pyhf`` not covered in the `documentation <https://scikit-hep.org/pyhf/>`__, please ask a question on `GitHub Discussions <https://github.com/scikit-hep/pyhf/discussions>`__.
 
 If you believe you have found a bug in ``pyhf``, please report it in the `GitHub Issues <https://github.com/scikit-hep/pyhf/issues/new?template=Bug-Report.md&labels=bug&title=Bug+Report+:+Title+Here>`__.
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -8,7 +8,7 @@ Questions
 
 Where can I ask questions about ``pyhf`` use?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If you have a question about the use of ``pyhf`` not covered in the `documentation <https://scikit-hep.org/pyhf/>`__, please ask a question on `GitHub Discussions <https://github.com/scikit-hep/pyhf/discussions>`__.
+If you have a question about the use of ``pyhf`` not covered in the `documentation <https://scikit-hep.org/pyhf/>`__, please ask a question on the `GitHub Discussions <https://github.com/scikit-hep/pyhf/discussions>`__.
 
 If you believe you have found a bug in ``pyhf``, please report it in the `GitHub Issues <https://github.com/scikit-hep/pyhf/issues/new?template=Bug-Report.md&labels=bug&title=Bug+Report+:+Title+Here>`__.
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -8,15 +8,7 @@ Questions
 
 Where can I ask questions about ``pyhf`` use?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If you have a question about the use of ``pyhf`` not covered in the `documentation <https://scikit-hep.org/pyhf/>`__, please ask a question on `Stack Overflow <https://stackoverflow.com/questions/tagged/pyhf>`__ with the ``[pyhf]`` tag, which the ``pyhf`` dev team `watches <https://stackoverflow.com/questions/tagged/pyhf?sort=Newest&filters=NoAcceptedAnswer&edited=true>`__.
-
-.. raw:: html
-
-  <p align="center">
-  <a href="https://stackoverflow.com/questions/tagged/pyhf">
-  <img src="https://cdn.sstatic.net/Sites/stackoverflow/company/img/logos/so/so-logo.png" alt="Stack Overflow pyhf tag" width="50%"/>
-  </a>
-  </p>
+If you have a question about the use of ``pyhf`` not covered in the `documentation <https://scikit-hep.org/pyhf/>`__, please ask a question on `Github Discussions <https://github.com/scikit-hep/pyhf/discussions>`__.
 
 If you believe you have found a bug in ``pyhf``, please report it in the `GitHub Issues <https://github.com/scikit-hep/pyhf/issues/new?template=Bug-Report.md&labels=bug&title=Bug+Report+:+Title+Here>`__.
 


### PR DESCRIPTION
# Description

Fixes  #1269, by replacing links to the `pyhf` stackoverflow tag with links to the Github Discussions page of the project.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

ReadTheDocs build: https://pyhf.readthedocs.io/en/trigger-docs-github-discussion/

- https://pyhf.readthedocs.io/en/trigger-docs-github-discussion/#questions
- https://pyhf.readthedocs.io/en/trigger-docs-github-discussion/faq.html#where-can-i-ask-questions-about-pyhf-use

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Deprecate Stack Overflow in favor of GitHub Discussions for community use questions
* Add Eric Schanet to list of contributors
```