### PR TITLE
docs: Correct TestPyPI install instructions

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -71,8 +71,9 @@ from PyPI, and then upgrading ``pyhf`` to a dev release from TestPyPI.
   when installing.
   PyPI will still be the default package index ``pip`` will attempt to install
   from for all dependencies, but if a package has a release on TestPyPI that
-  has a higher release or dev release number the package will be installed from
-  TestPyPI instead.
+  is a more recent release then the package will be installed from TestPyPI instead.
+  Note that dev releases are considered pre-releases, so ``v0.1.2`` is a "newer"
+  release than ``v0.1.2.dev3``.
 
 Publishing
 ----------

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -72,8 +72,8 @@ from PyPI, and then upgrading ``pyhf`` to a dev release from TestPyPI
   PyPI will still be the default package index ``pip`` will attempt to install
   from for all dependencies, but if a package has a release on TestPyPI that
   is a more recent release then the package will be installed from TestPyPI instead.
-  Note that dev releases are considered pre-releases, so ``v0.1.2`` is a "newer"
-  release than ``v0.1.2.dev3``.
+  Note that dev releases are considered pre-releases, so ``0.1.2`` is a "newer"
+  release than ``0.1.2.dev3``.
 
 Publishing
 ----------

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -58,7 +58,7 @@ TestPyPI
 ``master`` to `TestPyPI <https://test.pypi.org/project/pyhf/>`__.
 In addition, installation of the latest test release from TestPyPI can be tested
 by first installing ``pyhf`` normally, to ensure all dependencies are installed
-from PyPI, and then upgrading ``pyhf`` to a dev release from TestPyPI.
+from PyPI, and then upgrading ``pyhf`` to a dev release from TestPyPI
 
 .. code-block:: bash
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -61,7 +61,8 @@ with
 
 .. code-block:: bash
 
-  python -m pip install --extra-index-url https://test.pypi.org/simple/ --pre pyhf
+  python -m pip install pyhf
+  python -m pip install --upgrade --extra-index-url https://test.pypi.org/simple/ --pre pyhf
 
 .. note::
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -57,7 +57,8 @@ TestPyPI
 ``pyhf`` tests packaging and distributing by publishing each commit to
 ``master`` to `TestPyPI <https://test.pypi.org/project/pyhf/>`__.
 In addition, installation of the latest test release from TestPyPI can be tested
-with
+by first installing ``pyhf`` normally, to ensure all dependencies are installed
+from PyPI, and then upgrading ``pyhf`` to a dev release from TestPyPI.
 
 .. code-block:: bash
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -68,9 +68,11 @@ from PyPI, and then upgrading ``pyhf`` to a dev release from TestPyPI.
 .. note::
 
   This adds TestPyPI as `an additional package index to search <https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-extra-index-url>`__
-  when installing ``pyhf`` specifically.
+  when installing.
   PyPI will still be the default package index ``pip`` will attempt to install
-  from for all dependencies.
+  from for all dependencies, but if a package has a release on TestPyPI that
+  has a higher release or dev release number the package will be installed from
+  TestPyPI instead.
 
 Publishing
 ----------


### PR DESCRIPTION
# Description

The instructions on how to install a dev release from TestPyPI are not actually correct (@matthewfeickert got it a little bit wrong in PR #859 :grimacing:). This PR corrects those instructions and tries to clarifying things more.

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-correct-testpypi-install-instructions/development.html#testpypi

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Note to first install library from PyPI and then upgrade to TestPyPI
   - If library dependencies have releases on TestPyPI ensures installed from PyPI
* Clarify the package index hierarchy checked during install
```
