### PR TITLE
docs: Make 'Statement of Need' explicit section in JOSS paper

### DIFF
--- a/docs/JOSS/paper.md
+++ b/docs/JOSS/paper.md
@@ -40,6 +40,8 @@ The relationship between them is often formalised in a statistical model $f(\mat
 Given observed data, the likelihood $\mathcal{L}(\mathbf{\phi})$ then serves as the basis for inference on the parameters $\mathbf{\phi}$.
 For measurements based on binned data (histograms), the `HistFactory` family of statistical models [@Cranmer:1456844] has been widely used in both Standard Model measurements [@HIGG-2013-02] as well as searches for new physics [@ATLAS-CONF-2018-041].
 `pyhf` is a pure-Python implementation of the `HistFactory` model specification and implements a declarative, plain-text format for describing `HistFactory`-based likelihoods that is targeted for reinterpretation and long-term preservation in analysis data repositories such as HEPData [@Maguire:2017ypu].
+The source code for `pyhf` has been archived on Zenodo with the linked DOI: [@pyhf_zenodo].
+At the time of writing this paper the most recent release of `pyhf` is [`v0.5.4`](https://doi.org/10.5281/zenodo.4318533).
 
 # Statement of Need
 
@@ -47,8 +49,6 @@ Through adoption of open source "tensor" computational Python libraries, `pyhf` 
 By taking advantage of tensor calculations, `pyhf` outperforms the traditional `C++` implementation of `HistFactory` on data from real LHC analyses.
 `pyhf`'s default computational backend is built from NumPy and SciPy, and supports TensorFlow, PyTorch, and JAX as alternative backend choices.
 These alternative backends support hardware acceleration on GPUs, and in the case of JAX JIT compilation, as well as auto-differentiation allowing for calculating the full gradient of the likelihood function &mdash; all contributing to speeding up fits.
-The source code for `pyhf` has been archived on Zenodo with the linked DOI: [@pyhf_zenodo].
-At the time of writing this paper the most recent release of `pyhf` is [`v0.5.4`](https://doi.org/10.5281/zenodo.4318533).
 
 ## Impact on Physics
 

--- a/docs/JOSS/paper.md
+++ b/docs/JOSS/paper.md
@@ -41,6 +41,8 @@ Given observed data, the likelihood $\mathcal{L}(\mathbf{\phi})$ then serves as 
 For measurements based on binned data (histograms), the `HistFactory` family of statistical models [@Cranmer:1456844] has been widely used in both Standard Model measurements [@HIGG-2013-02] as well as searches for new physics [@ATLAS-CONF-2018-041].
 `pyhf` is a pure-Python implementation of the `HistFactory` model specification and implements a declarative, plain-text format for describing `HistFactory`-based likelihoods that is targeted for reinterpretation and long-term preservation in analysis data repositories such as HEPData [@Maguire:2017ypu].
 
+# Statement of Need
+
 Through adoption of open source "tensor" computational Python libraries, `pyhf` decreases the abstractions between a physicist performing an analysis and the statistical modeling without sacrificing computational speed.
 By taking advantage of tensor calculations, `pyhf` outperforms the traditional `C++` implementation of `HistFactory` on data from real LHC analyses.
 `pyhf`'s default computational backend is built from NumPy and SciPy, and supports TensorFlow, PyTorch, and JAX as alternative backend choices.

--- a/docs/JOSS/paper.md
+++ b/docs/JOSS/paper.md
@@ -41,7 +41,7 @@ Given observed data, the likelihood $\mathcal{L}(\mathbf{\phi})$ then serves as 
 For measurements based on binned data (histograms), the `HistFactory` family of statistical models [@Cranmer:1456844] has been widely used in both Standard Model measurements [@HIGG-2013-02] as well as searches for new physics [@ATLAS-CONF-2018-041].
 `pyhf` is a pure-Python implementation of the `HistFactory` model specification and implements a declarative, plain-text format for describing `HistFactory`-based likelihoods that is targeted for reinterpretation and long-term preservation in analysis data repositories such as HEPData [@Maguire:2017ypu].
 The source code for `pyhf` has been archived on Zenodo with the linked DOI: [@pyhf_zenodo].
-At the time of writing this paper the most recent release of `pyhf` is [`v0.5.4`](https://doi.org/10.5281/zenodo.4318533).
+At the time of writing this paper, the most recent release of `pyhf` is [`v0.5.4`](https://doi.org/10.5281/zenodo.4318533).
 
 # Statement of Need
 


### PR DESCRIPTION
# Description

As requested by the JOSS Editor in Chief for the review https://github.com/openjournals/joss-reviews/issues/2823, add a section for "Statement of Need". Additionally, move the information on the archival of the `pyhf` source code on Zenodo and the version used in the review out of "Statement of Need" and (back into) the end of "Summary" as this information doesn't belong with motivational text.

For posterity, related PRs to the JOSS paper revision are:

- PR #1089 
- PR #1280 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add 'Statement of Need' section heading to JOSS paper
   - c.f. https://github.com/openjournals/joss-reviews/issues/2823
* Move information on version and Zenodo archive back to 'Summary' section
```
