### PR TITLE
docs: Add JOSS paper to preferred citation and DOI Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -275,9 +275,10 @@ announcements you can join the |pyhf-announcements mailing list|_.
 Citation
 --------
 
-As noted in `Use and
-Citations <https://scikit-hep.org/pyhf/citations.html>`__, the preferred
-BibTeX entries for citation of ``pyhf`` are:
+As noted in `Use and Citations <https://scikit-hep.org/pyhf/citations.html>`__,
+the preferred BibTeX entries for citation of ``pyhf`` includes both the `JOSS
+<https://joss.theoj.org/>`__ paper and the `Zenodo <https://zenodo.org/>`__
+archive:
 
 .. code:: bibtex
 

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@
 pure-python fitting/limit-setting/interval estimation HistFactory-style
 =======================================================================
 
-|GitHub Project| |DOI| |Scikit-HEP| |NSF Award Number|
+|GitHub Project| |DOI| |JOSS DOI| |Scikit-HEP| |NSF Award Number|
 
 |GitHub Actions Status: CI| |GitHub Actions Status: Docs| |GitHub Actions Status: Publish|
 |Docker Automated| |Code Coverage| |CodeFactor| |pre-commit.ci Status| |Code style: black|
@@ -313,6 +313,8 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
    :target: https://github.com/scikit-hep/pyhf
 .. |DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1169739.svg
    :target: https://doi.org/10.5281/zenodo.1169739
+.. |JOSS DOI| image:: https://joss.theoj.org/papers/10.21105/joss.02823/status.svg
+   :target: https://doi.org/10.21105/joss.02823
 .. |Scikit-HEP| image:: https://scikit-hep.org/assets/images/Scikit--HEP-Project-blue.svg
    :target: https://scikit-hep.org/
 .. |NSF Award Number| image:: https://img.shields.io/badge/NSF-1836650-blue.svg

--- a/README.rst
+++ b/README.rst
@@ -276,9 +276,9 @@ Citation
 --------
 
 As noted in `Use and Citations <https://scikit-hep.org/pyhf/citations.html>`__,
-the preferred BibTeX entries for citation of ``pyhf`` includes both the `JOSS
-<https://joss.theoj.org/>`__ paper and the `Zenodo <https://zenodo.org/>`__
-archive:
+the preferred BibTeX entries for citation of ``pyhf`` includes both the
+`Zenodo <https://zenodo.org/>`__ archive and the
+`JOSS <https://joss.theoj.org/>`__ paper:
 
 .. code:: bibtex
 

--- a/README.rst
+++ b/README.rst
@@ -277,7 +277,7 @@ Citation
 
 As noted in `Use and
 Citations <https://scikit-hep.org/pyhf/citations.html>`__, the preferred
-BibTeX entry for citation of ``pyhf`` is
+BibTeX entries for citation of ``pyhf`` are:
 
 .. code:: bibtex
 
@@ -288,6 +288,19 @@ BibTeX entry for citation of ``pyhf`` is
      doi = {10.5281/zenodo.1169739},
      url = {https://github.com/scikit-hep/pyhf},
    }
+
+   @article{pyhf_joss,
+     doi = {10.21105/joss.02823},
+     url = {https://doi.org/10.21105/joss.02823},
+     year = {2021},
+     publisher = {The Open Journal},
+     volume = {6},
+     number = {58},
+     pages = {2823},
+     author = {Lukas Heinrich and Matthew Feickert and Giordon Stark and Kyle Cranmer},
+     title = {pyhf: pure-Python implementation of HistFactory statistical models},
+     journal = {Journal of Open Source Software}
+   :
 
 Authors
 -------

--- a/README.rst
+++ b/README.rst
@@ -301,7 +301,7 @@ archive:
      author = {Lukas Heinrich and Matthew Feickert and Giordon Stark and Kyle Cranmer},
      title = {pyhf: pure-Python implementation of HistFactory statistical models},
      journal = {Journal of Open Source Software}
-   :
+   }
 
 Authors
 -------

--- a/README.rst
+++ b/README.rst
@@ -276,7 +276,7 @@ Citation
 --------
 
 As noted in `Use and Citations <https://scikit-hep.org/pyhf/citations.html>`__,
-the preferred BibTeX entries for citation of ``pyhf`` includes both the
+the preferred BibTeX entry for citation of ``pyhf`` includes both the
 `Zenodo <https://zenodo.org/>`__ archive and the
 `JOSS <https://joss.theoj.org/>`__ paper:
 

--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -9,7 +9,7 @@ Citation
 --------
 
 The preferred BibTeX entries for citation of ``pyhf`` includes both the  `Zenodo <https://zenodo.org/>`__
-and the `JOSS <https://joss.theoj.org/>`__ paper:
+archive and the `JOSS <https://joss.theoj.org/>`__ paper:
 
 .. literalinclude:: bib/preferred.bib
    :language: bibtex

--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -4,7 +4,7 @@ Use and Citations
 Citation
 --------
 
-The preferred BibTeX entry for citation of ``pyhf`` is
+The preferred BibTeX entries for citation of ``pyhf`` are
 
 .. literalinclude:: bib/preferred.bib
    :language: bibtex

--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -3,7 +3,7 @@ Use and Citations
 
 .. raw:: html
 
-   <p id="dev-version"><strong>Warning:</strong> This is a development version and should not be cited. The latest stable version is at <a href="https://pyhf.readthedocs.io/">ReadTheDocs</a>.</p>
+   <p id="dev-version"><strong>Warning:</strong> This is a development version and should not be cited. To find the specific version to cite, please go to <a href="https://pyhf.readthedocs.io/">ReadTheDocs</a>.</p>
 
 Citation
 --------

--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -4,7 +4,9 @@ Use and Citations
 Citation
 --------
 
-The preferred BibTeX entries for citation of ``pyhf`` are
+The preferred BibTeX entries for citation of ``pyhf`` includes both the `JOSS
+<https://joss.theoj.org/>`__ paper and the `Zenodo <https://zenodo.org/>`__
+archive:
 
 .. literalinclude:: bib/preferred.bib
    :language: bibtex

--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -8,7 +8,7 @@ Use and Citations
 Citation
 --------
 
-The preferred BibTeX entries for citation of ``pyhf`` includes both the  `Zenodo <https://zenodo.org/>`__
+The preferred BibTeX entry for citation of ``pyhf`` includes both the  `Zenodo <https://zenodo.org/>`__
 archive and the `JOSS <https://joss.theoj.org/>`__ paper:
 
 .. literalinclude:: bib/preferred.bib

--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -1,6 +1,10 @@
 Use and Citations
 =================
 
+.. raw:: html
+
+   <p id="dev-version"><strong>Warning:</strong> This is a development version and should not be cited. The latest stable version is at <a href="https://pyhf.readthedocs.io/">ReadTheDocs</a>.</p>
+
 Citation
 --------
 

--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -8,9 +8,8 @@ Use and Citations
 Citation
 --------
 
-The preferred BibTeX entries for citation of ``pyhf`` includes both the `JOSS
-<https://joss.theoj.org/>`__ paper and the `Zenodo <https://zenodo.org/>`__
-archive:
+The preferred BibTeX entries for citation of ``pyhf`` includes both the  `Zenodo <https://zenodo.org/>`__
+and the `JOSS <https://joss.theoj.org/>`__ paper:
 
 .. literalinclude:: bib/preferred.bib
    :language: bibtex

--- a/src/pyhf/data/citation.bib
+++ b/src/pyhf/data/citation.bib
@@ -5,3 +5,16 @@
   doi = {10.5281/zenodo.1169739},
   url = {https://github.com/scikit-hep/pyhf},
 }
+
+@article{pyhf_joss,
+  doi = {10.21105/joss.02823},
+  url = {https://doi.org/10.21105/joss.02823},
+  year = {2021},
+  publisher = {The Open Journal},
+  volume = {6},
+  number = {58},
+  pages = {2823},
+  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark and Kyle Cranmer},
+  title = {pyhf: pure-Python implementation of HistFactory statistical models},
+  journal = {Journal of Open Source Software}
+}

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -142,7 +142,7 @@ def citation(oneline=False):
 
         >>> import pyhf
         >>> pyhf.utils.citation(True)
-        '@software{pyhf,  author = "{Heinrich, Lukas and Feickert, Matthew and Stark, Giordon}",  title = "{pyhf: v0.5.4}",  version = {0.5.4},  doi = {10.5281/zenodo.1169739},  url = {https://github.com/scikit-hep/pyhf},}'
+        '@software{pyhf,  author = "{Heinrich, Lukas and Feickert, Matthew and Stark, Giordon}",  title = "{pyhf: v0.5.4}",  version = {0.5.4},  doi = {10.5281/zenodo.1169739},  url = {https://github.com/scikit-hep/pyhf},}@article{pyhf_joss,  doi = {10.21105/joss.02823},  url = {https://doi.org/10.21105/joss.02823},  year = {2021},  publisher = {The Open Journal},  volume = {6},  number = {58},  pages = {2823},  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark and Kyle Cranmer},  title = {pyhf: pure-Python implementation of HistFactory statistical models},  journal = {Journal of Open Source Software}}'
 
     Keyword Args:
         oneline (:obj:`bool`): Whether to provide citation with new lines (default) or as a one-liner.

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -33,6 +33,7 @@ def test_citation(script_runner, flag):
     elapsed = end - start
     assert ret.success
     assert ret.stdout.startswith('@software{pyhf,')
+    assert '@article{pyhf_joss,' in ret.stdout
     # ensure there's not \n\n at the end
     assert ret.stdout.endswith('}\n')
     # make sure it took less than a second


### PR DESCRIPTION
# Pull Request Description

JOSS is out! https://twitter.com/JOSS_TheOJ/status/1357410376124669952

[![DOI](https://joss.theoj.org/papers/10.21105/joss.02823/status.svg)](https://doi.org/10.21105/joss.02823)

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-addjossbadge/

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add JOSS paper BibTeX entry to preferred citation
* Add JOSS DOI badge to README
   - c.f. https://doi.org/10.21105/joss.02823
* Add test for JOSS paper in pyhf --cite output
```
