### PR TITLE
docs: Widen the content box of docs

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,3 +1,9 @@
+/* 1200px for slightly wider for most monitors */
+.wy-nav-content {
+    max-width: 1200px !important;
+}
+
+/* version warning badge */
 #dev-version {
   display: none;
 }
@@ -37,3 +43,4 @@ p.version-warning a {
 p.version-warning a:hover {
   border-bottom-style: solid;
 }
+/* -------------------------- */


### PR DESCRIPTION
# Pull Request Description

Docs are currently 800px max-width. Changing this to 1200px is a bit better for readability on most PC monitors.

https://pyhf.readthedocs.io/en/docs-widercontent/

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Change doc content width from 800px to 1200px
```
