### PR TITLE
ci: Drop GESIS from Binder trigger

### DIFF
--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -16,5 +16,4 @@ jobs:
       run: |
         # Use Binder build API to trigger repo2docker to build image on Google Cloud, GESIS Notebooks, and Turing Institute Binder Federation clusters
         bash binder/trigger_binder.sh https://gke.mybinder.org/build/gh/scikit-hep/pyhf/master
-        bash binder/trigger_binder.sh https://gesis.mybinder.org/build/gh/scikit-hep/pyhf/master
         bash binder/trigger_binder.sh https://turing.mybinder.org/build/gh/scikit-hep/pyhf/master

--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -14,6 +14,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Trigger Binder build
       run: |
-        # Use Binder build API to trigger repo2docker to build image on Google Cloud, GESIS Notebooks, and Turing Institute Binder Federation clusters
+        # Use Binder build API to trigger repo2docker to build image on Google Cloud, and Turing Institute Binder Federation clusters
         bash binder/trigger_binder.sh https://gke.mybinder.org/build/gh/scikit-hep/pyhf/master
         bash binder/trigger_binder.sh https://turing.mybinder.org/build/gh/scikit-hep/pyhf/master

--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -14,6 +14,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Trigger Binder build
       run: |
-        # Use Binder build API to trigger repo2docker to build image on Google Cloud, and Turing Institute Binder Federation clusters
+        # Use Binder build API to trigger repo2docker to build image on Google Cloud and Turing Institute Binder Federation clusters
         bash binder/trigger_binder.sh https://gke.mybinder.org/build/gh/scikit-hep/pyhf/master
         bash binder/trigger_binder.sh https://turing.mybinder.org/build/gh/scikit-hep/pyhf/master


### PR DESCRIPTION
# Description

GESIS notebooks are failing, so drop the endpoint.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove GESIS Notebooks endpoint from Binder triggers to keep workflow from failing
```
