### PR TITLE
fix: Make wheel naming indicate wheels are not Python 2 compatible

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -21,3 +21,4 @@ Contributors include:
 - Marco Gorelli
 - Pradyumna Rahul K
 - Eric Schanet
+- Henry Schreiner

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,9 +25,6 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
-[bdist_wheel]
-universal = 1
-
 [options]
 setup_requires =
     setuptools_scm>=1.15.0


### PR DESCRIPTION
The universal setting means that it gets a py2.py3 tag, which is not true. This should already get the correct, `py3` only tag without any extra settings. (the Requires-Python metadata setting is set correctly, so no harm, just not needed)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove universal wheel setting as pyhf is Python 3 only
   - Fixes py2.py3 tag naming scheme for wheels
* Add Henry Schreiner to list of contributors   
```
