### PR TITLE
docs: Add use citation from MadAnalysis 5 workshop

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,4 @@
+% 2021-01-06
 @article{Fuks:2021wpe,
     author = "Araz, Jack Y. and others",
     title = "{Proceedings of the second MadAnalysis~5 workshop on LHC recasting in Korea}",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,17 @@
+@article{Fuks:2021wpe,
+    author = "Araz, Jack Y. and others",
+    title = "{Proceedings of the second MadAnalysis~5 workshop on LHC recasting in Korea}",
+    eprint = "2101.02245",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    doi = "10.1142/S0217732321020016",
+    journal = "Mod. Phys. Lett. A",
+    volume = "36",
+    number = "01",
+    pages = "2102001",
+    year = "2021"
+}
+
 % 2020-12-15
 @inproceedings{Alguero:2020buz,
     author = {Alguero, Ga\"el and Heisig, Jan and Khosa, Charanjit K. and Kraml, Sabine and Kulkarni, Suchita and Lessa, Andre and Neuhuber, Philipp and Reyes-Gonz\'alez, Humberto and Waltenberger, Wolfgang and Wongel, Alicia},


### PR DESCRIPTION
# Description

Resolves #1296 

Add use citation from the [Proceedings of the second MadAnalysis 5 workshop on LHC recasting in Korea](https://inspirehep.net/literature/1839663).

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-add-madanalysis5-citation/citations.html#use-in-publications

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from Proceedings of the second MadAnalysis 5 workshop on LHC recasting in Korea
   - c.f. https://inspirehep.net/literature/1839663
```