### PR TITLE
ci: Update PyPI publish GitHub Action to v1.4.2

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master
       if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pyhf'
-      uses: pypa/gh-action-pypi-publish@v1.3.1
+      uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -72,6 +72,6 @@ jobs:
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == 'scikit-hep/pyhf'
-      uses: pypa/gh-action-pypi-publish@v1.3.1
+      uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
# Description

Following the release of [`pypa/gh-action-pypi-publish` `v1.4.2`](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.4.2) update for reasons listed in the release notes.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update pypa/gh-action-pypi-publish to v1.4.2 for newer pip and stability
   - c.f. https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.4.2
```
