### PR TITLE
build: Update minimum required tqdm release to avoid repr crash

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,8 @@ python_requires = >=3.6
 install_requires =
     scipy~=1.4  # requires numpy, which is required by pyhf and tensorflow
     click~=7.0  # for console scripts
-    tqdm~=4.25  # for readxml
+    tqdm~=4.56  # for readxml
+
     jsonschema~=3.2  # for utils
     jsonpatch~=1.23
     pyyaml~=5.1  # for parsing CLI equal-delimited options

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ install_requires =
     scipy~=1.4  # requires numpy, which is required by pyhf and tensorflow
     click~=7.0  # for console scripts
     tqdm~=4.56  # for readxml
-
     jsonschema~=3.2  # for utils
     jsonpatch~=1.23
     pyyaml~=5.1  # for parsing CLI equal-delimited options


### PR DESCRIPTION
# Description

As https://github.com/tqdm/tqdm/issues/624 which @kratsg opened up has been resolved, take advantage of its resolution by picking up the release in which is it fixed, [`v4.56.1`](https://github.com/tqdm/tqdm/releases/tag/v4.56.1), by requiring a minimum compatible version of `tqdm` of `v4.56` in `setup.cfg`.

Example of it working now:
```python
>>> import tqdm
>>> import sys
>>> print(tqdm.__version__, sys.version, sys.platform)
4.56.1 3.8.6 (default, Jan  5 2021, 00:14:15) 
[GCC 9.3.0] linux
>>> a = tqdm.tqdm([], disable=True)
>>> print(a)
0it [00:00, ?it/s]
>>> str(a)
'0it [00:00, ?it/s]'
>>> dir(a)
['__bool__', '__class__', '__del__', '__delattr__', '__dict__', '__dir__', '__doc__', '__enter__', '__eq__', '__exit__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__iter__', '__le__', '__len__', '__lt__', '__module__', '__ne__', '__new__', '__nonzero__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_comparable', '_decr_instances', '_get_free_pos', '_instances', '_lock', 'clear', 'close', 'disable', 'display', 'external_write_mode', 'format_dict', 'format_interval', 'format_meter', 'format_num', 'format_sizeof', 'get_lock', 'iterable', 'leave', 'monitor', 'monitor_interval', 'moveto', 'n', 'pandas', 'pos', 'refresh', 'reset', 'set_description', 'set_description_str', 'set_lock', 'set_postfix', 'set_postfix_str', 'status_printer', 'total', 'unpause', 'update', 'wrapattr', 'write']
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update tqdm to require tqdm v4.56 as minimum to get tqdm.__repr__() crash fix
   - c.f. https://github.com/tqdm/tqdm/issues/624
   - Fix was released in tqdm v4.5.6.1, but minimum of v4.56 will pick this up
```
