### PR TITLE
docs: Add release notes to website

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@
    api
    citations
    governance/ROADMAP
+   release-notes
    contributors
 
 .. raw:: html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@
    api
    citations
    governance/ROADMAP
-   release-notes/index
+   release-notes
    contributors
 
 .. raw:: html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@
    api
    citations
    governance/ROADMAP
-   release-notes
+   release-notes/index
    contributors
 
 .. raw:: html

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -83,6 +83,11 @@ CLI API
 * pyhf combine now allows for merging channels: ``pyhf combine --merge-channels --join <join option>``
 * Added utility to download archived pyhf pallets (workspaces + patchsets) to contrib module: ``pyhf contrib download``
 
+Contributors
+------------
+
+* Karthikeyan Singaravelan
+
 .. |release v0.5.4| replace:: ``v0.5.4``
 .. _`release v0.5.4`: https://github.com/scikit-hep/pyhf/releases/tag/v0.5.4
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -5,7 +5,7 @@ Release Notes
 |release v0.5.4|_
 =================
 
-This is a patch release from v0.5.3 → v0.5.4.
+This is a patch release from ``v0.5.3`` → ``v0.5.4``.
 
 Fixes
 -----
@@ -56,7 +56,7 @@ this is resolved in ``v0.5.4`` with the requirement of ``uproot3``
 |release v0.5.3|_
 =================
 
-This is a patch release from v0.5.2 → v0.5.3.
+This is a patch release from ``v0.5.2`` → ``v0.5.3``.
 
 Fixes
 -----

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,13 +1,14 @@
+=============
 Release Notes
 =============
 
 |release v0.5.4|_
------------------
+=================
 
 This is a patch release from v0.5.3 → v0.5.4.
 
 Fixes
-~~~~~
+-----
 
 * Require ``uproot3`` instead of ``uproot`` ``v3.X`` releases to avoid conflicts when
   ``uproot4`` is installed in an environment with ``uproot`` ``v3.X`` installed and
@@ -52,6 +53,38 @@ this is resolved in ``v0.5.4`` with the requirement of ``uproot3``
    uproot3-methods 0.10.0
    uproot4         4.0.0
 
+|release v0.5.3|_
+=================
+
+This is a patch release from v0.5.2 → v0.5.3.
+
+Fixes
+-----
+
+* Workspaces are now immutable
+* ShapeFactor support added to XML reading and writing
+* An error is raised if a fit initialization parameter is outside of its bounds
+  (preventing hypotest with POI outside of bounds)
+
+Features
+--------
+
+Python API
+~~~~~~~~~~
+
+* Inverting hypothesis tests to get upper limits now has an API with
+  ``pyhf.infer.intervals.upperlimit``
+* Building workspaces from a model and data added with ``pyhf.workspace.build``
+
+CLI API
+~~~~~~~
+
+* Added CLI API for ``pyhf.infer.fit``: ``pyhf fit``
+* pyhf combine now allows for merging channels: ``pyhf combine --merge-channels --join <join option>``
+* Added utility to download archived pyhf pallets (workspaces + patchsets) to contrib module: ``pyhf contrib download``
 
 .. |release v0.5.4| replace:: ``v0.5.4``
 .. _`release v0.5.4`: https://github.com/scikit-hep/pyhf/releases/tag/v0.5.4
+
+.. |release v0.5.3| replace:: ``v0.5.3``
+.. _`release v0.5.3`: https://github.com/scikit-hep/pyhf/releases/tag/v0.5.3

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -4,7 +4,53 @@ Release Notes
 |release v0.5.4|_
 -----------------
 
-Hi.
+This is a patch release from v0.5.3 → v0.5.4.
+
+Fixes
+~~~~~
+
+* Require ``uproot3`` instead of ``uproot`` ``v3.X`` releases to avoid conflicts when
+  ``uproot4`` is installed in an environment with ``uproot`` ``v3.X`` installed and
+  namespace conflicts with ``uproot-methods``.
+  Adoption of ``uproot3`` in ``v0.5.4`` will ensure ``v0.5.4`` works far into the future
+  if XML and ROOT I/O through uproot is required.
+
+**Example:**
+
+Without the ``v0.5.4`` patch release there is a regression in using ``uproot`` ``v3.X``
+and ``uproot4`` in the same environment (which was swiftly identified and patched by the
+fantastic ``uproot`` team)
+
+.. code-block:: shell
+
+   $ python -m pip install "pyhf[xmlio]<0.5.4"
+   $ python -m pip list | grep "pyhf\|uproot"
+   pyhf           0.5.3
+   uproot         3.13.1
+   uproot-methods 0.8.0
+   $ python -m pip install uproot4
+   $ python -m pip list | grep "pyhf\|uproot"
+   pyhf           0.5.3
+   uproot         4.0.0
+   uproot-methods 0.8.0
+   uproot4        4.0.0
+
+this is resolved in ``v0.5.4`` with the requirement of ``uproot3``
+
+.. code-block:: shell
+
+   $ python -m pip install "pyhf[xmlio]>=0.5.4"
+   $ python -m pip list | grep "pyhf\|uproot"
+   pyhf            0.5.4
+   uproot3         3.14.1
+   uproot3-methods 0.10.0
+   $ python -m pip install uproot4 # or uproot
+   $ python -m pip list | grep "pyhf\|uproot"
+   pyhf            0.5.4
+   uproot          4.0.0
+   uproot3         3.14.1
+   uproot3-methods 0.10.0
+   uproot4         4.0.0
 
 
 .. |release v0.5.4| replace:: ``v0.5.4``

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,0 +1,11 @@
+Release Notes
+=============
+
+|release v0.5.4|_
+-----------------
+
+Hi.
+
+
+.. |release v0.5.4| replace:: ``v0.5.4``
+.. _`release v0.5.4`: https://github.com/scikit-hep/pyhf/releases/tag/v0.5.4

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,0 +1,6 @@
+=============
+Release Notes
+=============
+
+.. include:: release-notes/v0.5.4.rst
+.. include:: release-notes/v0.5.3.rst

--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -1,6 +1,0 @@
-=============
-Release Notes
-=============
-
-.. include:: v0.5.4.rst
-.. include:: v0.5.3.rst

--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -1,0 +1,6 @@
+=============
+Release Notes
+=============
+
+.. include:: v0.5.4.rst
+.. include:: v0.5.3.rst

--- a/docs/release-notes/v0.5.3.rst
+++ b/docs/release-notes/v0.5.3.rst
@@ -1,0 +1,37 @@
+|release v0.5.3|_
+=================
+
+This is a patch release from ``v0.5.2`` → ``v0.5.3``.
+
+Fixes
+-----
+
+* Workspaces are now immutable
+* ShapeFactor support added to XML reading and writing
+* An error is raised if a fit initialization parameter is outside of its bounds
+  (preventing hypotest with POI outside of bounds)
+
+Features
+--------
+
+Python API
+~~~~~~~~~~
+
+* Inverting hypothesis tests to get upper limits now has an API with
+  ``pyhf.infer.intervals.upperlimit``
+* Building workspaces from a model and data added with ``pyhf.workspace.build``
+
+CLI API
+~~~~~~~
+
+* Added CLI API for ``pyhf.infer.fit``: ``pyhf fit``
+* pyhf combine now allows for merging channels: ``pyhf combine --merge-channels --join <join option>``
+* Added utility to download archived pyhf pallets (workspaces + patchsets) to contrib module: ``pyhf contrib download``
+
+Contributors
+------------
+
+* Karthikeyan Singaravelan
+
+.. |release v0.5.3| replace:: ``v0.5.3``
+.. _`release v0.5.3`: https://github.com/scikit-hep/pyhf/releases/tag/v0.5.3

--- a/docs/release-notes/v0.5.4.rst
+++ b/docs/release-notes/v0.5.4.rst
@@ -1,7 +1,3 @@
-=============
-Release Notes
-=============
-
 |release v0.5.4|_
 =================
 
@@ -53,43 +49,5 @@ this is resolved in ``v0.5.4`` with the requirement of ``uproot3``
    uproot3-methods 0.10.0
    uproot4         4.0.0
 
-|release v0.5.3|_
-=================
-
-This is a patch release from ``v0.5.2`` → ``v0.5.3``.
-
-Fixes
------
-
-* Workspaces are now immutable
-* ShapeFactor support added to XML reading and writing
-* An error is raised if a fit initialization parameter is outside of its bounds
-  (preventing hypotest with POI outside of bounds)
-
-Features
---------
-
-Python API
-~~~~~~~~~~
-
-* Inverting hypothesis tests to get upper limits now has an API with
-  ``pyhf.infer.intervals.upperlimit``
-* Building workspaces from a model and data added with ``pyhf.workspace.build``
-
-CLI API
-~~~~~~~
-
-* Added CLI API for ``pyhf.infer.fit``: ``pyhf fit``
-* pyhf combine now allows for merging channels: ``pyhf combine --merge-channels --join <join option>``
-* Added utility to download archived pyhf pallets (workspaces + patchsets) to contrib module: ``pyhf contrib download``
-
-Contributors
-------------
-
-* Karthikeyan Singaravelan
-
 .. |release v0.5.4| replace:: ``v0.5.4``
 .. _`release v0.5.4`: https://github.com/scikit-hep/pyhf/releases/tag/v0.5.4
-
-.. |release v0.5.3| replace:: ``v0.5.3``
-.. _`release v0.5.3`: https://github.com/scikit-hep/pyhf/releases/tag/v0.5.3


### PR DESCRIPTION
# Description

As the docs are going to start being versioned in releases with `v0.6.0` then we should also make sure release notes are available on the website as well.

A follow up PR can add `v0.6.0` release notes being drafted in Issue #1303 for the time being.

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-add-release-notes/release-notes.html

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add release notes page to docs website
   - Add v0.5.3 and v0.5.4 release notes from GitHub
```
