### PR TITLE
fix: Restrict iminuit to compatible releases below 2.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ extras_require = {
         'uproot3~=3.14',
         'uproot~=4.0',
     ],  # uproot3 required until writing to ROOT supported in uproot4
-    'minuit': ['iminuit~=2.1'],
+    'minuit': ['iminuit~=2.1,<2.4'],
 }
 extras_require['backends'] = sorted(
     set(

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ extras_require = {
         'uproot3~=3.14',
         'uproot~=4.0',
     ],  # uproot3 required until writing to ROOT supported in uproot4
-    'minuit': ['iminuit~=2.1,<2.4'],
+    'minuit': ['iminuit~=2.1,<2.4'],  # iminuit v2.4.0 behavior needs to be understood
 }
 extras_require['backends'] = sorted(
     set(


### PR DESCRIPTION
# Description

Temporary resolution to Issue #1305 

In the interest of getting `v0.6.0` released in a timely manner, bound `iminuit` releases to be below `v2.4.0` until the behavior in PR #1306 can be better understood. Aim to have this understood and acted on  for [`pyhf` `v0.6.1`](https://github.com/scikit-hep/pyhf/projects/14).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Restrict iminuit to compatible releases below v2.4.0
   - c.f. https://github.com/scikit-hep/pyhf/issues/1305
```
