### PR TITLE
fix: Make p-value-like values 0-d tensors

### DIFF
--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -295,7 +295,7 @@ class AsymptoticCalculator:
             >>> mu_test = 1.0
             >>> asymptotic_calculator = pyhf.infer.calculators.AsymptoticCalculator(data, model, test_stat="qtilde")
             >>> asymptotic_calculator.teststatistic(mu_test)
-            0.14043184405388176
+            array(0.14043184)
 
         Args:
             poi_test (:obj:`float` or :obj:`tensor`): The value for the parameter of interest.
@@ -379,7 +379,7 @@ class AsymptoticCalculator:
             >>> sig_plus_bkg_dist, bkg_dist = asymptotic_calculator.distributions(mu_test)
             >>> CLsb, CLb, CLs = asymptotic_calculator.pvalues(q_tilde, sig_plus_bkg_dist, bkg_dist)
             >>> CLsb, CLb, CLs
-            (array(0.02332502), array(0.4441594), 0.05251497423736956)
+            (array(0.02332502), array(0.4441594), array(0.05251497))
 
         Args:
             teststat (:obj:`tensor`): The test statistic.
@@ -424,7 +424,7 @@ class AsymptoticCalculator:
             >>> sig_plus_bkg_dist, bkg_dist = asymptotic_calculator.distributions(mu_test)
             >>> CLsb_exp_band, CLb_exp_band, CLs_exp_band = asymptotic_calculator.expected_pvalues(sig_plus_bkg_dist, bkg_dist)
             >>> CLs_exp_band
-            [0.0026062609501074576, 0.01382005356161206, 0.06445320535890459, 0.23525643861460702, 0.573036205919389]
+            [array(0.00260626), array(0.01382005), array(0.06445321), array(0.23525644), array(0.57303621)]
 
         Args:
             sig_plus_bkg_distribution (~pyhf.infer.calculators.AsymptoticTestStatDistribution):

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -527,7 +527,7 @@ class EmpiricalDistribution:
 
         """
         tensorlib, _ = get_backend()
-        return (
+        return tensorlib.astensor(
             tensorlib.sum(
                 tensorlib.where(
                     self.samples >= value, tensorlib.astensor(1), tensorlib.astensor(0)
@@ -769,9 +769,11 @@ class ToyCalculator:
             corresponding to the :math:`\mathrm{CL}_{s+b}`,
             :math:`\mathrm{CL}_{b}`, and :math:`\mathrm{CL}_{s}`.
         """
+        tensorlib, _ = get_backend()
+
         CLsb = sig_plus_bkg_distribution.pvalue(teststat)
         CLb = bkg_only_distribution.pvalue(teststat)
-        CLs = CLsb / CLb
+        CLs = tensorlib.astensor(CLsb / CLb)
         return CLsb, CLb, CLs
 
     def expected_pvalues(self, sig_plus_bkg_distribution, bkg_only_distribution):

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -355,7 +355,7 @@ class AsymptoticCalculator:
             teststat = tensorlib.conditional(
                 (sqrtqmu_v < self.sqrtqmuA_v), _true_case, _false_case
             )
-        return teststat
+        return tensorlib.astensor(teststat)
 
     def pvalues(self, teststat, sig_plus_bkg_distribution, bkg_only_distribution):
         r"""

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -817,7 +817,7 @@ class ToyCalculator:
         tb, _ = get_backend()
         pvalues = [
             self.pvalues(
-                tb.astensor(test_stat),
+                test_stat,
                 sig_plus_bkg_distribution,
                 bkg_only_distribution,
             )

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -393,9 +393,11 @@ class AsymptoticCalculator:
             corresponding to the :math:`\mathrm{CL}_{s+b}`,
             :math:`\mathrm{CL}_{b}`, and :math:`\mathrm{CL}_{s}`.
         """
+        tensorlib, _ = get_backend()
+
         CLsb = sig_plus_bkg_distribution.pvalue(teststat)
         CLb = bkg_only_distribution.pvalue(teststat)
-        CLs = CLsb / CLb
+        CLs = tensorlib.astensor(CLsb / CLb)
         return CLsb, CLb, CLs
 
     def expected_pvalues(self, sig_plus_bkg_distribution, bkg_only_distribution):

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -132,7 +132,7 @@ class AsymptoticTestStatDistribution:
             value (:obj:`float`): The test statistic value.
 
         Returns:
-            Float: The integrated probability to observe a value at least as large as the observed one.
+            Tensor: The integrated probability to observe a value at least as large as the observed one.
 
         """
         tensorlib, _ = get_backend()
@@ -301,7 +301,7 @@ class AsymptoticCalculator:
             poi_test (:obj:`float` or :obj:`tensor`): The value for the parameter of interest.
 
         Returns:
-            Float: The value of the test statistic.
+            Tensor: The value of the test statistic.
 
         """
         tensorlib, _ = get_backend()
@@ -389,7 +389,7 @@ class AsymptoticCalculator:
               The distribution for the background-only hypothesis.
 
         Returns:
-            Tuple (:obj:`float`): The :math:`p`-values for the test statistic
+            Tuple (:obj:`tensor`): The :math:`p`-values for the test statistic
             corresponding to the :math:`\mathrm{CL}_{s+b}`,
             :math:`\mathrm{CL}_{b}`, and :math:`\mathrm{CL}_{s}`.
         """
@@ -433,7 +433,7 @@ class AsymptoticCalculator:
               The distribution for the background-only hypothesis.
 
         Returns:
-            Tuple (:obj:`float`): The :math:`p`-values for the test statistic
+            Tuple (:obj:`tensor`): The :math:`p`-values for the test statistic
             corresponding to the :math:`\mathrm{CL}_{s+b}`,
             :math:`\mathrm{CL}_{b}`, and :math:`\mathrm{CL}_{s}`.
         """
@@ -523,7 +523,7 @@ class EmpiricalDistribution:
             value (:obj:`float`): The test statistic value.
 
         Returns:
-            Float: The integrated probability to observe a value at least as large as the observed one.
+            Tensor: The integrated probability to observe a value at least as large as the observed one.
 
         """
         tensorlib, _ = get_backend()
@@ -765,7 +765,7 @@ class ToyCalculator:
               The distribution for the background-only hypothesis.
 
         Returns:
-            Tuple (:obj:`float`): The :math:`p`-values for the test statistic
+            Tuple (:obj:`tensor`): The :math:`p`-values for the test statistic
             corresponding to the :math:`\mathrm{CL}_{s+b}`,
             :math:`\mathrm{CL}_{b}`, and :math:`\mathrm{CL}_{s}`.
         """
@@ -810,7 +810,7 @@ class ToyCalculator:
               The distribution for the background-only hypothesis.
 
         Returns:
-            Tuple (:obj:`float`): The :math:`p`-values for the test statistic
+            Tuple (:obj:`tensor`): The :math:`p`-values for the test statistic
             corresponding to the :math:`\mathrm{CL}_{s+b}`,
             :math:`\mathrm{CL}_{b}`, and :math:`\mathrm{CL}_{s}`.
         """
@@ -862,7 +862,7 @@ class ToyCalculator:
             poi_test (:obj:`float` or :obj:`tensor`): The value for the parameter of interest.
 
         Returns:
-            Float: The value of the test statistic.
+            Tensor: The value of the test statistic.
 
         """
         teststat_func = utils.get_test_stat(self.test_stat)

--- a/src/pyhf/infer/utils.py
+++ b/src/pyhf/infer/utils.py
@@ -33,7 +33,7 @@ def create_calculator(calctype, *args, **kwargs):
         ... )
         >>> qmu_sig, qmu_bkg = toy_calculator.distributions(mu_test)
         >>> qmu_sig.pvalue(mu_test), qmu_bkg.pvalue(mu_test)
-        (0.14, 0.76)
+        (array(0.14), array(0.76))
 
     Args:
         calctype (:obj:`str`): The calculator to create. Choose either


### PR DESCRIPTION
# Description

Resolves #1268

Ensure all p-value-like values and test statistics are given as 0-d tensors and harmonize returns types across calculator types.

ReadTheDocs build: https://pyhf.readthedocs.io/en/fix-ensure-p-value-like-return-type/
- [`pyhf.infer.calculators.AsymptoticCalculator`](https://pyhf.readthedocs.io/en/fix-ensure-p-value-like-return-type/_generated/pyhf.infer.calculators.AsymptoticCalculator.html)
- [`pyhf.infer.calculators.ToyCalculator`](https://pyhf.readthedocs.io/en/fix-ensure-p-value-like-return-type/_generated/pyhf.infer.calculators.ToyCalculator.html)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Ensure p-value-like values and test statistics are all 0-d tensors for consistent return type
   - Update docstrings
* Harmonize return types from asymptotic and toy calculators
```
