### PR TITLE
docs: Add v0.6.0 release notes

### DIFF
--- a/docs/governance/ROADMAP.rst
+++ b/docs/governance/ROADMAP.rst
@@ -69,7 +69,7 @@ Roadmap
    -  |check| Write submission to `JOSS <https://joss.theoj.org/>`__ (Issue
       #502) and write submission to
       `pyOpenSci <https://www.pyopensci.org/>`__ [2019-Q4 → 2020-Q2]
-   -  |uncheck| Contribute to `IRIS-HEP Analysis Systems
+   -  |check| Contribute to `IRIS-HEP Analysis Systems
       Milestones <https://docs.google.com/spreadsheets/d/1VKpHlQWXu_p8AUv5E5H_BzqF_i7hh2Z-Id0XPwNHu8o/edit#gid=1864915304>`__
       "`Initial roadmap for ecosystem
       coherency <https://github.com/iris-hep/project-milestones/issues/8>`__"
@@ -105,7 +105,7 @@ Roadmap
    -  |check| Add sampling with toys (PR #558) [2019-Q3]
    -  |uncheck| Make general modeling choices (e.g., Issue #293) [2019-Q4 →
       2020-Q1]
-   -  |uncheck| Add "discovery" test stats (p0) (PR #520) [2019-Q4 → 2020-Q1]
+   -  |check| Add "discovery" test stats (p0) (PR #520) [2019-Q4 → 2020-Q1]
    -  |uncheck| Add better Model creation [2019-Q4 → 2020-Q1]
    -  |check| Add background model support (Issues #514, #946) [2019-Q4 → 2020-Q1]
    -  |check| Develop interface for the optimizers similar to tensor/backend

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -2,5 +2,6 @@
 Release Notes
 =============
 
+.. include:: release-notes/v0.6.0.rst
 .. include:: release-notes/v0.5.4.rst
 .. include:: release-notes/v0.5.3.rst

--- a/docs/release-notes/v0.5.3.rst
+++ b/docs/release-notes/v0.5.3.rst
@@ -31,6 +31,8 @@ CLI API
 Contributors
 ------------
 
+``v0.5.3`` benefited from contributions from:
+
 * Karthikeyan Singaravelan
 
 .. |release v0.5.3| replace:: ``v0.5.3``

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -8,14 +8,16 @@ Important Notes
 
 * Please note this release has **API breaking changes** and carefully read these
   notes while updating your code to the ``v0.6.0`` API.
-  Perhaps most relevant is the changes to the |hypotest API|_ API now uses a
-  ``calctype`` argument to differentiate between using an asymptotic calculator
+  Perhaps most relevant is the changes to the :func:`pyhf.infer.hypotest` API now
+  uses a ``calctype`` argument to differentiate between using an asymptotic calculator
   or a toy calculator, and a ``test_stat`` kwarg to specify which test statistic
-  to use.
+  the calculator should use, with ``'qtilde'``, coresponding to
+  :func:`pyhf.infer.test_statistics.qmu_tilde`, now the default option.
   It also relies more heavily on using kwargs to pass options through to the optimizer.
 * Support for the discovery test statistic, :math:`q_{0}`, has now been added through
-  the |q0 API|_ API.
-* Support for pseudoexperiments (toys) has been added through the |ToyCalculator API|_.
+  the :func:`pyhf.infer.test_statistics.q0` API.
+* Support for pseudoexperiments (toys) has been added through the
+  :func:`pyhf.infer.calculators.ToyCalculator`.
   Please see the corresponding `example notebook`_ for more detailed exploration
   of the API.
 * The ``minuit`` extra, ``python -m pip install pyhf[minuit]``, now uses and requries
@@ -38,9 +40,14 @@ Fixes
 
 * Correct bug on pyhf contrib
 * writexml: float-like values used
-* Model.spec: was missing attribute needed to build new models from existing ones
-* p-values reported based on their quantiles, instead of interpolating test statistics and converting to p-values
-* uproot3/4 namespace collisions
+* ``Model.spec`` now supports build new models from existing models.
+* :math:`p`-values are now reported based on their quantiles, instead of interpolating
+  test statistics and converting to :math:`p`-values.
+* Namespace collisions between ``uproot3`` and ``uproot``/``uproot4`` have been fixed.
+* The ``normsys`` modifier now uses the ``code4`` interpolation method by default.
+* The ``histosys`` modifier now uses the ``code4p`` interpolation method by default.
+
+* qtilde test statistic is now the default
 
 Features
 --------
@@ -48,8 +55,10 @@ Features
 Python API
 ~~~~~~~~~~
 
-* The ``tensorlib`` API now supports a ``tensorlib.to_numpy`` and ``tensorlib.ravel`` API.
-* The |ToyCalculator API|_ API has been added to support pseudoexperiments (toys).
+* The ``tensorlib`` API now supports a ``tensorlib.to_numpy`` and
+  ``tensorlib.ravel`` API.
+* The :func:`pyhf.infer.calculators.ToyCalculator` API has been added to support
+  pseudoexperiments (toys).
 * The emperical test statistic distribution API has been added to help support the
   ``ToyCalculator`` API.
 * Add a ``tolerance`` kwarg to the optimizer API to set a ``float`` value as a
@@ -59,9 +68,9 @@ Python API
 * Add the ``pyhf.utils.citation`` API to get a ``str`` of the preferred BibTeX entry
   for citation of the version of ``pyhf`` installed.
   See the example for the CLI API for more information.
-* The |hypotest API|_ API now uses a ``calctype`` argument to differentiate between
-  using an asymptotic calculator or a toy calculator, and a ``test_stat`` kwarg to
-  specify which test statistic to use.
+* The :func:`pyhf.infer.hypotest` API now uses a ``calctype`` argument to differentiate
+  between using an asymptotic calculator or a toy calculator, and a ``test_stat`` kwarg
+  to specify which test statistic to use.
   It also relies more heavily on using kwargs to pass options through to the optimizer.
 * The return type of :math:`p`-value like functions is now a 0-dimensional ``tensor``
   (with shape ``()``) instead of a ``float``.
@@ -108,15 +117,6 @@ Contributors
 
 .. |release v0.6.0| replace:: ``v0.6.0``
 .. _`release v0.6.0`: https://github.com/scikit-hep/pyhf/releases/tag/v0.6.0
-
-.. |hypotest API| replace:: ``pyhf.infer.hypotest``
-.. _`hypotest API`: https://pyhf.readthedocs.io/en/v0.6.0/_generated/pyhf.infer.hypotest.html
-
-.. |q0 API| replace:: ``pyhf.infer.test_statistics.q0``
-.. _`q0 API`: https://pyhf.readthedocs.io/en/v0.6.0/_generated/pyhf.infer.test_statistics.q0.html
-
-.. |ToyCalculator API| replace:: ``pyhf.infer.calculators.ToyCalculator``
-.. _`ToyCalculator API`: https://pyhf.readthedocs.io/en/v0.6.0/_generated/pyhf.infer.calculators.ToyCalculator.html
 
 .. _`example notebook`: https://pyhf.readthedocs.io/en/latest/examples/notebooks/toys.html
 

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -40,10 +40,11 @@ Fixes
 
 * Fix bug where all extras triggered warning for installation of the ``contrib`` extra.
 * ``float``-like values are used in division for :func:`pyhf.writexml`.
-* ``Model.spec`` now supports build new models from existing models.
+* ``Model.spec`` now supports building new models from existing models.
 * :math:`p`-values are now reported based on their quantiles, instead of interpolating
   test statistics and converting to :math:`p`-values.
-* Namespace collisions between ``uproot3`` and ``uproot``/``uproot4`` have been fixed.
+* Namespace collisions between ``uproot3`` and ``uproot``/``uproot4`` have been fixed
+  for the ``xmlio`` extra.
 * The ``normsys`` modifier now uses the ``code4`` interpolation method by default.
 * The ``histosys`` modifier now uses the ``code4p`` interpolation method by default.
 
@@ -61,8 +62,9 @@ Python API
   ``ToyCalculator`` API.
 * Add a ``tolerance`` kwarg to the optimizer API to set a ``float`` value as a
   tolerance for termination of the fit.
-* The ``minuit`` optimizer now can return correlations of the fitted parameters
-  through use of the ``return_correlation`` Boolean kwarg.
+* The :func:`pyhf.optimize.opt_minuit.minuit_optimizer` optimizer now can return
+  correlations of the fitted parameters through use of the ``return_correlation``
+  Boolean kwarg.
 * Add the ``pyhf.utils.citation`` API to get a ``str`` of the preferred BibTeX entry
   for citation of the version of ``pyhf`` installed.
   See the example for the CLI API for more information.

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -6,9 +6,14 @@ This is a minor release from ``v0.5.4`` → ``v0.6.0``.
 Important Notes
 ---------------
 
+* Please note this release has **API breaking changes** and carefully read these
+  notes while updating your code to the ``v0.6.0`` API.
+  Perhaps most relevant is the changes to the |hypotest API|_ API now uses a
+  ``test_stat`` kwarg to specify which test statistic to use and relies more
+  heavily on using kwargs to pass options through to the optimizer.
+* Support for the discovery test statistic, :math:`q_{0}`, has now been added through
+  the |q0 API|_ API.
 * toys
-* API breaking change
-* Discovery test stat
 * new requirements for ``iminuit`` and ``uproot``
 * Transitioning away from Stack Overflow to GitHub Discussions
 * Versioned docs --- don't go to ``master`` docs unless you want unstable
@@ -58,8 +63,15 @@ CLI API
      journal = {Journal of Open Source Software}
    }
 
+Changes
+-------
+
+* The hypotest API has changed since v0.5.4 and that this should be largely highlighted.
+
 Contributors
 ------------
+
+``v0.6.0`` benefited from contributions from:
 
 * Pradyumna Rahul K
 * Eric Schanet
@@ -67,3 +79,9 @@ Contributors
 
 .. |release v0.6.0| replace:: ``v0.6.0``
 .. _`release v0.6.0`: https://github.com/scikit-hep/pyhf/releases/tag/v0.6.0
+
+.. |hypotest API| replace:: ``pyhf.infer.hypotest``
+.. _`hypotest API`: https://pyhf.readthedocs.io/en/v0.6.0/_generated/pyhf.infer.hypotest.html
+
+.. |q0 API| replace:: ``pyhf.infer.test_statistics.q0``
+.. _`q0 API`: https://pyhf.readthedocs.io/en/v0.6.0/_generated/pyhf.infer.test_statistics.q0.html

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -17,7 +17,7 @@ Important Notes
 * Support for the discovery test statistic, :math:`q_{0}`, has now been added through
   the :func:`pyhf.infer.test_statistics.q0` API.
 * Support for pseudoexperiments (toys) has been added through the
-  :func:`pyhf.infer.calculators.ToyCalculator`.
+  :func:`pyhf.infer.calculators.ToyCalculator` API.
   Please see the corresponding `example notebook`_ for more detailed exploration
   of the API.
 * The ``minuit`` extra, ``python -m pip install pyhf[minuit]``, now uses and requries

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -38,16 +38,14 @@ Important Notes
 Fixes
 -----
 
-* Correct bug on pyhf contrib
-* writexml: float-like values used
+* Fix bug where all extras triggered warning for installation of the ``contrib`` extra.
+* ``float``-like values are used in division for :func:`pyhf.writexml`.
 * ``Model.spec`` now supports build new models from existing models.
 * :math:`p`-values are now reported based on their quantiles, instead of interpolating
   test statistics and converting to :math:`p`-values.
 * Namespace collisions between ``uproot3`` and ``uproot``/``uproot4`` have been fixed.
 * The ``normsys`` modifier now uses the ``code4`` interpolation method by default.
 * The ``histosys`` modifier now uses the ``code4p`` interpolation method by default.
-
-* qtilde test statistic is now the default
 
 Features
 --------
@@ -72,6 +70,9 @@ Python API
   between using an asymptotic calculator or a toy calculator, and a ``test_stat`` kwarg
   to specify which test statistic to use.
   It also relies more heavily on using kwargs to pass options through to the optimizer.
+* The default ``test_stat`` kwarg for :func:`pyhf.infer.hypotest` and the calculator
+  APIs is ``'qtilde'``, which corresponds to the alternative test statistic
+  :func:`pyhf.infer.test_statistics.qmu_tilde`.
 * The return type of :math:`p`-value like functions is now a 0-dimensional ``tensor``
   (with shape ``()``) instead of a ``float``.
   This is required to support end-to-end automatic differenation in future releases.
@@ -111,6 +112,8 @@ Contributors
 
 ``v0.6.0`` benefited from contributions from:
 
+* Alexander Held
+* Marco Gorelli
 * Pradyumna Rahul K
 * Eric Schanet
 * Henry Schreiner

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -9,11 +9,16 @@ Important Notes
 * Please note this release has **API breaking changes** and carefully read these
   notes while updating your code to the ``v0.6.0`` API.
   Perhaps most relevant is the changes to the |hypotest API|_ API now uses a
-  ``test_stat`` kwarg to specify which test statistic to use and relies more
-  heavily on using kwargs to pass options through to the optimizer.
+  ``calctype`` argument to differentiate between using an asymptotic calculator
+  or a toy calculator, and a ``test_stat`` kwarg to specify which test statistic
+  to use.
+  It also relies more heavily on using kwargs to pass options through to the optimizer.
 * Support for the discovery test statistic, :math:`q_{0}`, has now been added through
   the |q0 API|_ API.
-* toys
+* Support for pseudoexperiments (toys) has been added through the |ToyCalculator API|_.
+  Please see the corresponding `example notebook`_ for more detailed exploration
+  of the API.
+
 * new requirements for ``iminuit`` and ``uproot``
 * Transitioning away from Stack Overflow to GitHub Discussions
 * Versioned docs --- don't go to ``master`` docs unless you want unstable
@@ -88,6 +93,11 @@ Contributors
 
 .. |q0 API| replace:: ``pyhf.infer.test_statistics.q0``
 .. _`q0 API`: https://pyhf.readthedocs.io/en/v0.6.0/_generated/pyhf.infer.test_statistics.q0.html
+
+.. |ToyCalculator API| replace:: ``pyhf.infer.calculators.ToyCalculator``
+.. _`ToyCalculator API`: https://pyhf.readthedocs.io/en/v0.6.0/_generated/pyhf.infer.calculators.ToyCalculator.html
+
+.. _`example notebook`: https://pyhf.readthedocs.io/en/latest/examples/notebooks/toys.html
 
 .. |JOSS DOI| image:: https://joss.theoj.org/papers/10.21105/joss.02823/status.svg
    :target: https://doi.org/10.21105/joss.02823

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -18,8 +18,10 @@ Important Notes
 * Support for pseudoexperiments (toys) has been added through the |ToyCalculator API|_.
   Please see the corresponding `example notebook`_ for more detailed exploration
   of the API.
-
-* new requirements for ``iminuit`` and ``uproot``
+* The ``minuit`` extra, ``python -m pip install pyhf[minuit]``, now uses and requries
+  the |iminuit docs|_ ``v2.X`` release series and API.
+  Note that ``iminuit`` ``v2.X`` can result in slight differences in minimization
+  results from ``iminuit`` ``v1.X``.
 * The documentation will now be versioned with releases at ReadTheDocs.
   Please use `pyhf.readthedocs.io`_ to access the documentation for the latest
   stable realease of ``pyhf``.
@@ -103,6 +105,9 @@ Contributors
 .. _`ToyCalculator API`: https://pyhf.readthedocs.io/en/v0.6.0/_generated/pyhf.infer.calculators.ToyCalculator.html
 
 .. _`example notebook`: https://pyhf.readthedocs.io/en/latest/examples/notebooks/toys.html
+
+.. |iminuit docs| replace:: ``iminuit``
+.. _`iminuit docs`: https://iminuit.readthedocs.io/
 
 .. _`pyhf.readthedocs.io`: https://pyhf.readthedocs.io/
 

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -8,7 +8,7 @@ Important Notes
 
 * Please note this release has **API breaking changes** and carefully read these
   notes while updating your code to the ``v0.6.0`` API.
-  Perhaps most relevant is the changes to the :func:`pyhf.infer.hypotest` API now
+  Perhaps most relevant is the changes to the :func:`pyhf.infer.hypotest` API, which now
   uses a ``calctype`` argument to differentiate between using an asymptotic calculator
   or a toy calculator, and a ``test_stat`` kwarg to specify which test statistic
   the calculator should use, with ``'qtilde'``, coresponding to
@@ -24,7 +24,7 @@ Important Notes
   the |iminuit docs|_ ``v2.X`` release series and API.
   Note that ``iminuit`` ``v2.X`` can result in slight differences in minimization
   results from ``iminuit`` ``v1.X``.
-* The documentation will now be versioned with releases at ReadTheDocs.
+* The documentation will now be versioned with releases on ReadTheDocs.
   Please use `pyhf.readthedocs.io`_ to access the documentation for the latest
   stable realease of ``pyhf``.
 * ``pyhf`` is transtioning away from Stack Overflow to `GitHub Discussions`_ for

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -48,13 +48,24 @@ Features
 Python API
 ~~~~~~~~~~
 
-* tensorlib.to_numpy, tensorlib.ravel
-* toy calculator
-* empirical test statistic distribution
-* get current citation
-* optimizer tolerance
-* return correlations (minuit)
-* test statistic specified by string instead of using `qtilde=True`, use `test_stat="qtilde"`
+* The ``tensorlib`` API now supports a ``tensorlib.to_numpy`` and ``tensorlib.ravel`` API.
+* The |ToyCalculator API|_ API has been added to support pseudoexperiments (toys).
+* The emperical test statistic distribution API has been added to help support the
+  ``ToyCalculator`` API.
+* Add a ``tolerance`` kwarg to the optimizer API to set a ``float`` value as a
+  tolerance for termination of the fit.
+* The ``minuit`` optimizer now can return correlations of the fitted parameters
+  through use of the ``return_correlation`` Boolean kwarg.
+* Add the ``pyhf.utils.citation`` API to get a ``str`` of the preferred BibTeX entry
+  for citation of the version of ``pyhf`` installed.
+  See the example for the CLI API for more information.
+* The |hypotest API|_ API now uses a ``calctype`` argument to differentiate between
+  using an asymptotic calculator or a toy calculator, and a ``test_stat`` kwarg to
+  specify which test statistic to use.
+  It also relies more heavily on using kwargs to pass options through to the optimizer.
+* The return type of :math:`p`-value like functions is now a 0-dimensional ``tensor``
+  (with shape ``()``) instead of a ``float``.
+  This is required to support end-to-end automatic differenation in future releases.
 
 CLI API
 ~~~~~~~
@@ -85,17 +96,6 @@ CLI API
      title = {pyhf: pure-Python implementation of HistFactory statistical models},
      journal = {Journal of Open Source Software}
    }
-
-Changes
--------
-
-* The |hypotest API|_ API now uses a ``calctype`` argument to differentiate between
-  using an asymptotic calculator or a toy calculator, and a ``test_stat`` kwarg to
-  specify which test statistic to use.
-  It also relies more heavily on using kwargs to pass options through to the optimizer.
-* The return type of :math:`p`-value like functions is now a 0-dimensional ``tensor``
-  (with shape ``()``) instead of a ``float``.
-  This is required to support end-to-end automatic differenation in future releases.
 
 Contributors
 ------------

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -17,6 +17,9 @@ Important Notes
 * new requirements for ``iminuit`` and ``uproot``
 * Transitioning away from Stack Overflow to GitHub Discussions
 * Versioned docs --- don't go to ``master`` docs unless you want unstable
+* ``pyhf`` has published a paper in the Journal of Open Source Software. |JOSS DOI|
+  Please make sure to include the paper reference in all citations of ``pyhf``, as
+  documented in the `Use and Citations`_ section of the documentation.
 
 Fixes
 -----
@@ -85,3 +88,8 @@ Contributors
 
 .. |q0 API| replace:: ``pyhf.infer.test_statistics.q0``
 .. _`q0 API`: https://pyhf.readthedocs.io/en/v0.6.0/_generated/pyhf.infer.test_statistics.q0.html
+
+.. |JOSS DOI| image:: https://joss.theoj.org/papers/10.21105/joss.02823/status.svg
+   :target: https://doi.org/10.21105/joss.02823
+
+.. _`Use and Citations`: https://pyhf.readthedocs.io/en/latest/citations.html

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -20,8 +20,13 @@ Important Notes
   of the API.
 
 * new requirements for ``iminuit`` and ``uproot``
-* Transitioning away from Stack Overflow to GitHub Discussions
-* Versioned docs --- don't go to ``master`` docs unless you want unstable
+* The documentation will now be versioned with releases at ReadTheDocs.
+  Please use `pyhf.readthedocs.io`_ to access the documentation for the latest
+  stable realease of ``pyhf``.
+* ``pyhf`` is transtioning away from Stak Overflow to `GitHub Discussions`_ for
+  resolving user questions not covered in the documentation.
+  Please check the `GitHub Discussions`_ page to search for discussions addressing
+  your questions and to open up a new discussion if your question is not covered.
 * ``pyhf`` has published a paper in the Journal of Open Source Software. |JOSS DOI|
   Please make sure to include the paper reference in all citations of ``pyhf``, as
   documented in the `Use and Citations`_ section of the documentation.
@@ -98,6 +103,10 @@ Contributors
 .. _`ToyCalculator API`: https://pyhf.readthedocs.io/en/v0.6.0/_generated/pyhf.infer.calculators.ToyCalculator.html
 
 .. _`example notebook`: https://pyhf.readthedocs.io/en/latest/examples/notebooks/toys.html
+
+.. _`pyhf.readthedocs.io`: https://pyhf.readthedocs.io/
+
+.. _`GitHub Discussions`: https://github.com/scikit-hep/pyhf/discussions
 
 .. |JOSS DOI| image:: https://joss.theoj.org/papers/10.21105/joss.02823/status.svg
    :target: https://doi.org/10.21105/joss.02823

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -1,0 +1,34 @@
+|release v0.6.0|_
+=================
+
+This is a minor release from ``v0.5.4`` → ``v0.6.0``.
+
+Fixes
+-----
+
+* Blah
+* Blah
+
+Features
+--------
+
+Python API
+~~~~~~~~~~
+
+* Blah
+* Blah
+
+CLI API
+~~~~~~~
+
+* Blah
+* Blah
+
+Contributors
+------------
+
+* Blah
+* Blah
+
+.. |release v0.6.0| replace:: ``v0.6.0``
+.. _`release v0.6.0`: https://github.com/scikit-hep/pyhf/releases/tag/v0.6.0

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -45,8 +45,10 @@ Fixes
   test statistics and converting to :math:`p`-values.
 * Namespace collisions between ``uproot3`` and ``uproot``/``uproot4`` have been fixed
   for the ``xmlio`` extra.
-* The ``normsys`` modifier now uses the ``code4`` interpolation method by default.
-* The ``histosys`` modifier now uses the ``code4p`` interpolation method by default.
+* The ``normsys`` modifier now uses the :mod:`pyhf.interpolators.code4` interpolation
+  method by default.
+* The ``histosys`` modifier now uses the :mod:`pyhf.interpolators.code4p` interpolation
+  method by default.
 
 Features
 --------

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -3,11 +3,21 @@
 
 This is a minor release from ``v0.5.4`` → ``v0.6.0``.
 
+Important Notes
+---------------
+
+* toys
+* API breaking change
+* Discovery test stat
+* new requirements for ``iminuit`` and ``uproot``
+* Transitioning away from Stack Overflow to GitHub Discussions
+* Versioned docs --- don't go to ``master`` docs unless you want unstable
+
 Fixes
 -----
 
 * Blah
-* Blah
+* Correct bug on pyhf contrib
 
 Features
 --------
@@ -24,11 +34,36 @@ CLI API
 * Blah
 * Blah
 
+.. code-block:: shell
+
+   $ pyhf --citation
+   @software{pyhf,
+     author = "{Heinrich, Lukas and Feickert, Matthew and Stark, Giordon}",
+     title = "{pyhf: v0.6.0}",
+     version = {0.6.0},
+     doi = {10.5281/zenodo.1169739},
+     url = {https://github.com/scikit-hep/pyhf},
+   }
+
+   @article{pyhf_joss,
+     doi = {10.21105/joss.02823},
+     url = {https://doi.org/10.21105/joss.02823},
+     year = {2021},
+     publisher = {The Open Journal},
+     volume = {6},
+     number = {58},
+     pages = {2823},
+     author = {Lukas Heinrich and Matthew Feickert and Giordon Stark and Kyle Cranmer},
+     title = {pyhf: pure-Python implementation of HistFactory statistical models},
+     journal = {Journal of Open Source Software}
+   }
+
 Contributors
 ------------
 
-* Blah
-* Blah
+* Pradyumna Rahul K
+* Eric Schanet
+* Henry Schreiner
 
 .. |release v0.6.0| replace:: ``v0.6.0``
 .. _`release v0.6.0`: https://github.com/scikit-hep/pyhf/releases/tag/v0.6.0

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -36,8 +36,11 @@ Important Notes
 Fixes
 -----
 
-* Blah
 * Correct bug on pyhf contrib
+* writexml: float-like values used
+* Model.spec: was missing attribute needed to build new models from existing ones
+* p-values reported based on their quantiles, instead of interpolating test statistics and converting to p-values
+* uproot3/4 namespace collisions
 
 Features
 --------
@@ -45,14 +48,19 @@ Features
 Python API
 ~~~~~~~~~~
 
-* Blah
-* Blah
+* tensorlib.to_numpy, tensorlib.ravel
+* toy calculator
+* empirical test statistic distribution
+* get current citation
+* optimizer tolerance
+* return correlations (minuit)
+* test statistic specified by string instead of using `qtilde=True`, use `test_stat="qtilde"`
 
 CLI API
 ~~~~~~~
 
-* Blah
-* Blah
+* The CLI API now suppoerts a ``--citation`` or ``--cite`` option to print the
+  preferred BibTeX entry for citation of the version of ``pyhf`` installed.
 
 .. code-block:: shell
 
@@ -81,7 +89,13 @@ CLI API
 Changes
 -------
 
-* The hypotest API has changed since v0.5.4 and that this should be largely highlighted.
+* The |hypotest API|_ API now uses a ``calctype`` argument to differentiate between
+  using an asymptotic calculator or a toy calculator, and a ``test_stat`` kwarg to
+  specify which test statistic to use.
+  It also relies more heavily on using kwargs to pass options through to the optimizer.
+* The return type of :math:`p`-value like functions is now a 0-dimensional ``tensor``
+  (with shape ``()``) instead of a ``float``.
+  This is required to support end-to-end automatic differenation in future releases.
 
 Contributors
 ------------

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -27,7 +27,7 @@ Important Notes
 * The documentation will now be versioned with releases at ReadTheDocs.
   Please use `pyhf.readthedocs.io`_ to access the documentation for the latest
   stable realease of ``pyhf``.
-* ``pyhf`` is transtioning away from Stak Overflow to `GitHub Discussions`_ for
+* ``pyhf`` is transtioning away from Stack Overflow to `GitHub Discussions`_ for
   resolving user questions not covered in the documentation.
   Please check the `GitHub Discussions`_ page to search for discussions addressing
   your questions and to open up a new discussion if your question is not covered.


### PR DESCRIPTION
# Description

- Resolves #1270 
- Resolves #1303

Add release notes for release v0.6.0

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-add-v0.6.0-release-notes/

- [ROADMAP](https://pyhf.readthedocs.io/en/docs-add-v0.6.0-release-notes/governance/ROADMAP.html)
- [release notes](https://pyhf.readthedocs.io/en/docs-add-v0.6.0-release-notes/release-notes.html)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add release notes for v0.6.0
* Update ROADMAP to note discovery test statistic support added
```
