### PR TITLE
docs: Correct typos in v0.6.0 release notes

### DIFF
--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -11,7 +11,7 @@ Important Notes
   Perhaps most relevant is the changes to the :func:`pyhf.infer.hypotest` API, which now
   uses a ``calctype`` argument to differentiate between using an asymptotic calculator
   or a toy calculator, and a ``test_stat`` kwarg to specify which test statistic
-  the calculator should use, with ``'qtilde'``, coresponding to
+  the calculator should use, with ``'qtilde'``, corresponding to
   :func:`pyhf.infer.test_statistics.qmu_tilde`, now the default option.
   It also relies more heavily on using kwargs to pass options through to the optimizer.
 * Support for the discovery test statistic, :math:`q_{0}`, has now been added through

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -20,13 +20,13 @@ Important Notes
   :func:`pyhf.infer.calculators.ToyCalculator` API.
   Please see the corresponding `example notebook`_ for more detailed exploration
   of the API.
-* The ``minuit`` extra, ``python -m pip install pyhf[minuit]``, now uses and requries
+* The ``minuit`` extra, ``python -m pip install pyhf[minuit]``, now uses and requires
   the |iminuit docs|_ ``v2.X`` release series and API.
   Note that ``iminuit`` ``v2.X`` can result in slight differences in minimization
   results from ``iminuit`` ``v1.X``.
 * The documentation will now be versioned with releases on ReadTheDocs.
   Please use `pyhf.readthedocs.io`_ to access the documentation for the latest
-  stable realease of ``pyhf``.
+  stable release of ``pyhf``.
 * ``pyhf`` is transtioning away from Stack Overflow to `GitHub Discussions`_ for
   resolving user questions not covered in the documentation.
   Please check the `GitHub Discussions`_ page to search for discussions addressing
@@ -60,7 +60,7 @@ Python API
   ``tensorlib.ravel`` API.
 * The :func:`pyhf.infer.calculators.ToyCalculator` API has been added to support
   pseudoexperiments (toys).
-* The emperical test statistic distribution API has been added to help support the
+* The empirical test statistic distribution API has been added to help support the
   ``ToyCalculator`` API.
 * Add a ``tolerance`` kwarg to the optimizer API to set a ``float`` value as a
   tolerance for termination of the fit.
@@ -79,12 +79,12 @@ Python API
   :func:`pyhf.infer.test_statistics.qmu_tilde`.
 * The return type of :math:`p`-value like functions is now a 0-dimensional ``tensor``
   (with shape ``()``) instead of a ``float``.
-  This is required to support end-to-end automatic differenation in future releases.
+  This is required to support end-to-end automatic differentiation in future releases.
 
 CLI API
 ~~~~~~~
 
-* The CLI API now suppoerts a ``--citation`` or ``--cite`` option to print the
+* The CLI API now supports a ``--citation`` or ``--cite`` option to print the
   preferred BibTeX entry for citation of the version of ``pyhf`` installed.
 
 .. code-block:: shell


### PR DESCRIPTION
# Description

Corrects typos in PR #1314. @matthewfeickert needs to get a spell checker for VS Code that works in .rst files.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Correct spelling errors and typos in the v0.6.0 release notes
   - Amends PR #1314 
```
