### PR TITLE
docs: Add dropping of Python 3.6 support to v0.6.0 release notes

### DIFF
--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -14,6 +14,10 @@ Important Notes
   the calculator should use, with ``'qtilde'``, corresponding to
   :func:`pyhf.infer.test_statistics.qmu_tilde`, now the default option.
   It also relies more heavily on using kwargs to pass options through to the optimizer.
+* Following the recommendations of |NEP 29|_ ``pyhf`` ``v0.6.0`` drops support for
+  Python 3.6.
+  |PEP 494|_ also notes that Python 3.6 will be end of life in December 2021, so
+  ``pyhf`` is moving forward with a minimum required runtime of Python 3.7.
 * Support for the discovery test statistic, :math:`q_{0}`, has now been added through
   the :func:`pyhf.infer.test_statistics.q0` API.
 * Support for pseudoexperiments (toys) has been added through the

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -129,6 +129,12 @@ Contributors
 .. |release v0.6.0| replace:: ``v0.6.0``
 .. _`release v0.6.0`: https://github.com/scikit-hep/pyhf/releases/tag/v0.6.0
 
+.. |NEP 29| replace:: NEP 29 — Recommend Python and NumPy version support as a community policy standard
+.. _`NEP 29`: https://numpy.org/neps/nep-0029-deprecation_policy.html
+
+.. |PEP 494| replace:: PEP 494 -- Python 3.6 Release Schedule
+.. _`PEP 494`: https://www.python.org/dev/peps/pep-0494/
+
 .. _`example notebook`: https://pyhf.readthedocs.io/en/latest/examples/notebooks/toys.html
 
 .. |iminuit docs| replace:: ``iminuit``


### PR DESCRIPTION
# Description

Amend PR #1314 to mention that Python 3.6 support is dropped in v0.6.0.

ReadTheDocs build: https://pyhf.readthedocs.io/en/docs-add-drop-3.6-to-release-notes/release-notes.html

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Include dropping of support for Python 3.6 in the v0.6.0 release notes
   - Include motivation from NEP 29 and PEP 494
   - Amends PR #1314
```
