### PR TITLE
docs: Use more flexible BibTeX syntax for Zenodo DOI

### DIFF
--- a/src/pyhf/data/citation.bib
+++ b/src/pyhf/data/citation.bib
@@ -1,5 +1,5 @@
 @software{pyhf,
-  author = "{Lukas Heinrich and Matthew Feickert and Giordon Stark}",
+  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark},
   title = "{pyhf: v0.6.0}",
   version = {0.6.0},
   doi = {10.5281/zenodo.1169739},

--- a/src/pyhf/data/citation.bib
+++ b/src/pyhf/data/citation.bib
@@ -1,5 +1,5 @@
 @software{pyhf,
-  author = "{Heinrich, Lukas and Feickert, Matthew and Stark, Giordon}",
+  author = "{Lukas Heinrich and Matthew Feickert and Giordon Stark}",
   title = "{pyhf: v0.6.0}",
   version = {0.6.0},
   doi = {10.5281/zenodo.1169739},

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -142,7 +142,7 @@ def citation(oneline=False):
 
         >>> import pyhf
         >>> pyhf.utils.citation(True)
-        '@software{pyhf,  author = "{Heinrich, Lukas and Feickert, Matthew and Stark, Giordon}",  title = "{pyhf: v0.6.0}",  version = {0.6.0},  doi = {10.5281/zenodo.1169739},  url = {https://github.com/scikit-hep/pyhf},}@article{pyhf_joss,  doi = {10.21105/joss.02823},  url = {https://doi.org/10.21105/joss.02823},  year = {2021},  publisher = {The Open Journal},  volume = {6},  number = {58},  pages = {2823},  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark and Kyle Cranmer},  title = {pyhf: pure-Python implementation of HistFactory statistical models},  journal = {Journal of Open Source Software}}'
+        '@software{pyhf,  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark},  title = "{pyhf: v0.6.0}",  version = {0.6.0},  doi = {10.5281/zenodo.1169739},  url = {https://github.com/scikit-hep/pyhf},}@article{pyhf_joss,  doi = {10.21105/joss.02823},  url = {https://doi.org/10.21105/joss.02823},  year = {2021},  publisher = {The Open Journal},  volume = {6},  number = {58},  pages = {2823},  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark and Kyle Cranmer},  title = {pyhf: pure-Python implementation of HistFactory statistical models},  journal = {Journal of Open Source Software}}'
 
     Keyword Args:
         oneline (:obj:`bool`): Whether to provide citation with new lines (default) or as a one-liner.


### PR DESCRIPTION
# Description

Resolves #1321

Use author field of

```bibtex
@software{pyhf,
  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark},
  title = "{pyhf: v0.6.0}",
  version = {0.6.0},
  doi = {10.5281/zenodo.1169739},
  url = {https://github.com/scikit-hep/pyhf},
}
```

allowing BibTeX to render author names more natively for different BibTeX styles

![alt_render](https://user-images.githubusercontent.com/5142394/108158152-f230cb00-70a9-11eb-88ee-e120c672063d.png)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use more flexible syntax in the BibTeX author field for the Zenodo citation
   - Allows BibTeX to change formatting of names to fit the BibTeX style
```
