### PR TITLE
docs: Update Zenodo BibTeX author field in citation in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -283,7 +283,7 @@ the preferred BibTeX entry for citation of ``pyhf`` includes both the
 .. code:: bibtex
 
    @software{pyhf,
-     author = "{Heinrich, Lukas and Feickert, Matthew and Stark, Giordon}",
+     author = {Lukas Heinrich and Matthew Feickert and Giordon Stark},
      title = "{pyhf: v0.6.0}",
      version = {0.6.0},
      doi = {10.5281/zenodo.1169739},

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -95,7 +95,7 @@ CLI API
 
    $ pyhf --citation
    @software{pyhf,
-     author = "{Heinrich, Lukas and Feickert, Matthew and Stark, Giordon}",
+     author = {Lukas Heinrich and Matthew Feickert and Giordon Stark},
      title = "{pyhf: v0.6.0}",
      version = {0.6.0},
      doi = {10.5281/zenodo.1169739},


### PR DESCRIPTION
# Description

@matthewfeickert was too quick on the trigger for PR #1322 and forgot to get the docs too. Doh! :(

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update the BibTeX author field for the Zenodo archive citation in the docs
   - Amends PR #1322
```
