### PR TITLE
docs: Add CPython implementation and Python 3 only metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Physics
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: Implementation :: CPython
 
 [options]
 setup_requires =


### PR DESCRIPTION
# Description

Add PyPI metadata for Python 3 only and CPython implementation. 

Influence came from [`pyupgrade`'s `setup.cfg`](https://github.com/asottile/pyupgrade/blob/49b8cba72e2222451be96402428d771f0b6fe1ea/setup.cfg#L12-L21).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add metadata for Python3 only and CPython implementation to setup.cfg
```
