### PR TITLE
docs: Add use citations for QCD instantons and charged lepton flavor violation

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -7,7 +7,8 @@
     primaryClass = "hep-ph",
     reportNumber = "LA-UR-21-20531",
     month = "2",
-    year = "2021"
+    year = "2021",
+    journal = ""
 }
 
 % 2021-01-06

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,15 @@
+% 2021-02-11
+@article{Cirigliano:2021img,
+    author = "Cirigliano, Vincenzo and Fuyuto, Kaori and Lee, Christopher and Mereghetti, Emanuele and Yan, Bin",
+    title = "{Charged Lepton Flavor Violation at the EIC}",
+    eprint = "2102.06176",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "LA-UR-21-20531",
+    month = "2",
+    year = "2021"
+}
+
 % 2021-01-06
 @article{Fuks:2021wpe,
     author = "Araz, Jack Y. and others",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -13,6 +13,18 @@
     year = "2021"
 }
 
+% 2020-12-16
+@inproceedings{Amoroso:2020zrz,
+    author = "Amoroso, Simone and Kar, Deepak and Schott, Matthias",
+    title = "{How to discover QCD Instantons at the LHC}",
+    booktitle = "{Topological Effects in the Standard Model: Instantons, Sphalerons and Beyond at LHC}",
+    eprint = "2012.09120",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    month = "12",
+    year = "2020"
+}
+
 % 2020-12-15
 @inproceedings{Alguero:2020buz,
     author = {Alguero, Ga\"el and Heisig, Jan and Khosa, Charanjit K. and Kraml, Sabine and Kulkarni, Suchita and Lessa, Andre and Neuhuber, Philipp and Reyes-Gonz\'alez, Humberto and Waltenberger, Wolfgang and Wongel, Alicia},


### PR DESCRIPTION
# Description

Resolves #1328

Add citations  to the [Use and Citations page](https://scikit-hep.org/pyhf/citations.html) for:
- [How to discover QCD Instantons at the LHC](https://inspirehep.net/literature/1836890) (arXiv: 2012.09120)
- [Charged Lepton Flavor Violation at the EIC](https://inspirehep.net/literature/1846026) (arXiv: 2102.06176)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'How to discover QCD Instantons at the LHC'
   - c.f. https://inspirehep.net/literature/1836890
* Add use citation from 'Charged Lepton Flavor Violation at the EIC'
   - c.f. https://inspirehep.net/literature/1846026
```
