### PR TITLE
docs: Update ATLAS 3G tt 2L citation

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -83,7 +83,8 @@
     primaryClass = "hep-ex",
     reportNumber = "CERN-EP-2020-243",
     month = "2",
-    year = "2021"
+    year = "2021",
+    journal = ""
 }
 
 % 2020-06-20

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -76,7 +76,7 @@
 
 % 2020-08-14
 @article{Aad:2021hjy,
-    author         = "{ATLAS Collaboration}",
+    author = "{ATLAS Collaboration}",
     title = "{Search for new phenomena in events with two opposite-charge leptons, jets and missing transverse momentum in $pp$ collisions at $\sqrt{s} = 13$ TeV with the ATLAS detector}",
     eprint = "2102.01444",
     archivePrefix = "arXiv",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -75,12 +75,16 @@
 }
 
 % 2020-08-14
-@Booklet{ATLAS-CONF-2020-046,
-    author         = "{ATLAS Collaboration}",
-    title          = "{Search for new phenomena in events with two opposite-charge leptons, jets and missing transverse momentum in \(pp\) collisions at \(\sqrt{s} = 13\,\text{TeV}\) with the ATLAS detector}",
-    howpublished   = "{ATLAS-CONF-2020-046}",
-    url            = "https://cds.cern.ch/record/2728056",
-    year           = "2020",
+@article{Aad:2021hjy,
+    author = "Aad, Georges and others",
+    collaboration = "ATLAS",
+    title = "{Search for new phenomena in events with two opposite-charge leptons, jets and missing transverse momentum in $pp$ collisions at $\sqrt{s} = 13$ TeV with the ATLAS detector}",
+    eprint = "2102.01444",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    reportNumber = "CERN-EP-2020-243",
+    month = "2",
+    year = "2021"
 }
 
 % 2020-06-20

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -76,8 +76,7 @@
 
 % 2020-08-14
 @article{Aad:2021hjy,
-    author = "Aad, Georges and others",
-    collaboration = "ATLAS",
+    author         = "{ATLAS Collaboration}",
     title = "{Search for new phenomena in events with two opposite-charge leptons, jets and missing transverse momentum in $pp$ collisions at $\sqrt{s} = 13$ TeV with the ATLAS detector}",
     eprint = "2102.01444",
     archivePrefix = "arXiv",


### PR DESCRIPTION
# Pull Request Description

Citation initially referred to CONF note that's now superseded by the paper. Likely better to cite the paper on arXiv.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Update 3G tt 2L CONF note that is superseded by paper
   - c.f. https://inspirehep.net/literature/1844425
```
