### PR TITLE
docs: Update CONTRIBUTING.md to disincentivize 'drive by PRs'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ To get started fork the repo.
 
 Making Issues is very helpful to the project &mdash; they help the dev team form the development roadmap and are where most important discussion takes place.
 If you have suggestions, questions that you can't find answers to on the [documentation website](https://scikit-hep.org/pyhf/) or on the [GitHub Discussions](https://github.com/scikit-hep/pyhf/discussions), or have found a bug please [open an Issue](https://github.com/scikit-hep/pyhf/issues/new/choose)!
+The `pyhf` dev team wants to encourage contributions and community involvement in the project and also avoid low quality PRs that don't actually fix an issue or contribute towards the current roadmap.
 
 ## Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,6 @@ To get started fork the repo.
 
 Making Issues is very helpful to the project &mdash; they help the dev team form the development roadmap and are where most important discussion takes place.
 If you have suggestions, questions that you can't find answers to on the [documentation website](https://scikit-hep.org/pyhf/) or on the [GitHub Discussions](https://github.com/scikit-hep/pyhf/discussions), or have found a bug please [open an Issue](https://github.com/scikit-hep/pyhf/issues/new/choose)!
-The `pyhf` dev team wants to encourage contributions and community involvement in the project and also avoid low quality PRs that don't actually fix an issue or contribute towards the current roadmap.
 
 ## Pull Requests
 
@@ -15,6 +14,8 @@ The `pyhf` dev team wants to encourage contributions and community involvement i
 
 Unless your Pull Request is an obvious 1 line fix, please first [open an Issue](https://github.com/scikit-hep/pyhf/issues/new/choose) to discuss your PR with the dev team.
 The Issue allows for discussion on the usefulness and scope of the PR to be publicly discussed and also allows for the PR to then be focused on the code review.
+The `pyhf` dev team wants to encourage contributions and community involvement in the project and also avoid low quality PRs that don't actually fix an issue or contribute towards the current roadmap.
+PRs that don't follow these guidelines might be rejected.
 
 ### Good Examples
 


### PR DESCRIPTION
# Description

Add clarifying language to `CONTRIBUTING.md` to emphasize the importance of communication with the dev team when opening up a PR. This helps to establish a policy of avoiding "drive by PRs".

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Clarify in CONTRIBUTING.md that contribution PRs should involve communication with the dev team
   - Goal is to improve PR experience and avoid noise
```
