### PR TITLE
feat: Solver options for scipy

### DIFF
--- a/src/pyhf/optimize/opt_scipy.py
+++ b/src/pyhf/optimize/opt_scipy.py
@@ -9,7 +9,7 @@ class scipy_optimizer(OptimizerMixin):
     Optimizer that uses :func:`scipy.optimize.minimize`.
     """
 
-    __slots__ = ['name', 'tolerance']
+    __slots__ = ['name', 'tolerance', 'solver_options']
 
     def __init__(self, *args, **kwargs):
         """
@@ -19,9 +19,13 @@ class scipy_optimizer(OptimizerMixin):
 
         Args:
             tolerance (:obj:`float`): tolerance for termination. See specific optimizer for detailed meaning. Default is None.
+            solver_options (:obj:`dict`): additional solver options. See
+                :func:`scipy.optimize.show_options` for additional options of
+                optimization solvers.
         """
         self.name = 'scipy'
         self.tolerance = kwargs.pop('tolerance', None)
+        self.solver_options = kwargs.pop('solver_options', {})
         super().__init__(*args, **kwargs)
 
     def _get_minimizer(
@@ -47,6 +51,9 @@ class scipy_optimizer(OptimizerMixin):
             verbose (:obj:`bool`): print verbose output during minimization. Default is off.
             method (:obj:`str`): minimization routine. Default is 'SLSQP'.
             tolerance (:obj:`float`): tolerance for termination. See specific optimizer for detailed meaning. Default is None.
+            solver_options (:obj:`dict`): additional solver options. See
+                :func:`scipy.optimize.show_options` for additional options of
+                optimization solvers.
 
         Returns:
             fitresult (scipy.optimize.OptimizeResult): the fit result
@@ -55,6 +62,7 @@ class scipy_optimizer(OptimizerMixin):
         verbose = options.pop('verbose', self.verbose)
         method = options.pop('method', 'SLSQP')
         tolerance = options.pop('tolerance', self.tolerance)
+        solver_options = options.pop('solver_options', self.solver_options)
         if options:
             raise exceptions.Unsupported(
                 f"Unsupported options were passed in: {list(options.keys())}."
@@ -79,5 +87,5 @@ class scipy_optimizer(OptimizerMixin):
             bounds=bounds,
             constraints=constraints,
             tol=tolerance,
-            options=dict(maxiter=maxiter, disp=bool(verbose)),
+            options=dict(maxiter=maxiter, disp=bool(verbose), **solver_options),
         )


### PR DESCRIPTION
# Pull Request Description

This adds in the functionality to pass through solver options to the chosen method for the scipy minimizer. See https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.show_options.html for more details.

It should be useful to help with debugging minimization by being able to tweak some of the handles available for the given method chosen for minimization (e.g. SLSQP). This should help understand issues like #876.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add solver_options kwarg to opt_scipy for extra configurability
* Add tests for solver_options
```
