### PR TITLE
docs: Add record for published ATLAS likelihoods from November 2020

### DIFF
--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -1,4 +1,4 @@
-@misc{1831992,
+@misc{ins1831992,
     title = "{Search for trilepton resonances from chargino and neutralino pair production in $\sqrt{s}$ = 13 TeV $pp$ collisions with the ATLAS detector}",
     doi = "10.17182/hepdata.99806",
     url = "https://doi.org/10.17182/hepdata.99806",

--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -1,3 +1,12 @@
+@misc{1831992,
+    title = "{Search for trilepton resonances from chargino and neutralino pair production in $\sqrt{s}$ = 13 TeV $pp$ collisions with the ATLAS detector}",
+    doi = "10.17182/hepdata.99806",
+    url = "https://doi.org/10.17182/hepdata.99806",
+    year = "2020",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
 @misc{ins1831504,
     title = "{Search for displaced leptons in $\sqrt{s} = 13$ TeV $pp$ collisions with the ATLAS detector}",
     doi = "10.17182/hepdata.98796",

--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -1,4 +1,13 @@
-@misc {ins1754675,
+@misc{ins1831504,
+    title = "{Search for displaced leptons in $\sqrt{s} = 13$ TeV $pp$ collisions with the ATLAS detector}",
+    doi = "10.17182/hepdata.98796",
+    url = "https://doi.org/10.17182/hepdata.98796",
+    year = "2020",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
+@misc{ins1754675,
     title = "{Search for squarks and gluinos in final states with same-sign leptons and jets using 139 fb$^{-1}$ of data collected with the ATLAS detector}",
     doi = "10.17182/hepdata.91214.v3",
     url = "https://doi.org/10.17182/hepdata.91214.v3",
@@ -7,7 +16,7 @@
     collaboration = "ATLAS",
 }
 
-@misc {ins1755298,
+@misc{ins1755298,
     title = "{Search for direct production of electroweakinos in final states with one lepton, missing transverse momentum and a Higgs boson decaying into two $b$-jets in (pp) collisions at $\sqrt{s}=13$ TeV with the ATLAS detector}",
     doi = "10.17182/hepdata.90607.v2",
     url = "https://doi.org/10.17182/hepdata.90607.v2",


### PR DESCRIPTION
# Description

Add records of HEPData published likelihoods for

- [Search for displaced leptons in $\sqrt{s} = 13$ TeV $pp$ collisions with the ATLAS detector](https://doi.org/10.17182/hepdata.98796)
- [Search for trilepton resonances from chargino and neutralino pair production in $\sqrt{s}$ = 13 TeV $pp$ collisions with the ATLAS detector](https://doi.org/10.17182/hepdata.99806)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add ATLAS displaced leptons HEPData record
   - c.f. https://doi.org/10.17182/hepdata.98796
* Add ATLAS trilepton resonances from chargino and neutralino HEPData record
   - c.f. https://doi.org/10.17182/hepdata.99806
```
