### PR TITLE
docs: Clarify and harmonize docstrings for fit parameters

### DIFF
--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -44,7 +44,8 @@ def hypotest(
         data (Number or Tensor): The data considered
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``
         init_pars (:obj:`tensor` of :obj:`float`): The starting values of the model parameters for minimization.
-        par_bounds (:obj:`tensor`): The parameter value bounds to be used for minimization
+        par_bounds (:obj:`tensor` of shape Nx2): The extrema of values the model parameters
+            are allowed to reach in the fit.
         fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to the value
             ``init_pars`` value during minimization.
         calctype (:obj:`str`): The calculator to create. Choose either 'asymptotics' (default) or 'toybased'.

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -43,7 +43,7 @@ def hypotest(
         poi_test (Number or Tensor): The value of the parameter of interest (POI)
         data (Number or Tensor): The data considered
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``
-        init_pars (:obj:`tensor`): The initial parameter values to be used for minimization
+        init_pars (:obj:`tensor` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`tensor`): The parameter value bounds to be used for minimization
         fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to the value
             ``init_pars`` value during minimization.

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -44,8 +44,9 @@ def hypotest(
         data (Number or Tensor): The data considered
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``
         init_pars (:obj:`tensor` of :obj:`float`): The starting values of the model parameters for minimization.
-        par_bounds (:obj:`tensor` of shape Nx2): The extrema of values the model parameters
+        par_bounds (:obj:`tensor`): The extrema of values the model parameters
             are allowed to reach in the fit.
+            The shape should be ``(n, 2)`` for ``n`` model parameters.
         fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to its starting
             value during minimization.
         calctype (:obj:`str`): The calculator to create. Choose either 'asymptotics' (default) or 'toybased'.

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -46,8 +46,8 @@ def hypotest(
         init_pars (:obj:`tensor` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`tensor` of shape Nx2): The extrema of values the model parameters
             are allowed to reach in the fit.
-        fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to the value
-            ``init_pars`` value during minimization.
+        fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to its starting
+            value during minimization.
         calctype (:obj:`str`): The calculator to create. Choose either 'asymptotics' (default) or 'toybased'.
         return_tail_probs (:obj:`bool`): Bool for returning :math:`\mathrm{CL}_{s+b}` and :math:`\mathrm{CL}_{b}`
         return_expected (:obj:`bool`): Bool for returning :math:`\mathrm{CL}_{\mathrm{exp}}`

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -45,7 +45,8 @@ def hypotest(
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``
         init_pars (:obj:`tensor`): The initial parameter values to be used for minimization
         par_bounds (:obj:`tensor`): The parameter value bounds to be used for minimization
-        fixed_params (:obj:`tensor`): Whether to fix the parameter to the init_pars value during minimization
+        fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to the value
+            ``init_pars`` value during minimization.
         calctype (:obj:`str`): The calculator to create. Choose either 'asymptotics' (default) or 'toybased'.
         return_tail_probs (:obj:`bool`): Bool for returning :math:`\mathrm{CL}_{s+b}` and :math:`\mathrm{CL}_{b}`
         return_expected (:obj:`bool`): Bool for returning :math:`\mathrm{CL}_{\mathrm{exp}}`

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -39,8 +39,9 @@ def generate_asimov_data(asimov_mu, data, pdf, init_pars, par_bounds, fixed_para
         data (:obj:`tensor`): The observed data.
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``.
         init_pars (:obj:`tensor` of :obj:`float`): The starting values of the model parameters for minimization.
-        par_bounds (:obj:`tensor` of shape Nx2): The extrema of values the model parameters
+        par_bounds (:obj:`tensor`): The extrema of values the model parameters
             are allowed to reach in the fit.
+            The shape should be ``(n, 2)`` for ``n`` model parameters.
         fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to its starting
             value during minimization.
 
@@ -195,8 +196,9 @@ class AsymptoticCalculator:
             data (:obj:`tensor`): The observed data.
             pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``.
             init_pars (:obj:`tensor` of :obj:`float`): The starting values of the model parameters for minimization.
-            par_bounds (:obj:`tensor` of shape Nx2): The extrema of values the model parameters
+            par_bounds (:obj:`tensor`): The extrema of values the model parameters
                 are allowed to reach in the fit.
+                The shape should be ``(n, 2)`` for ``n`` model parameters.
             fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to its starting
                 value during minimization.
             test_stat (:obj:`str`): The test statistic to use as a numerical summary of the
@@ -622,8 +624,9 @@ class ToyCalculator:
             data (:obj:`tensor`): The observed data.
             pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``.
             init_pars (:obj:`tensor` of :obj:`float`): The starting values of the model parameters for minimization.
-            par_bounds (:obj:`tensor` of shape Nx2): The extrema of values the model parameters
+            par_bounds (:obj:`tensor`): The extrema of values the model parameters
                 are allowed to reach in the fit.
+                The shape should be ``(n, 2)`` for ``n`` model parameters.
             fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to its starting
                 value during minimization.
             test_stat (:obj:`str`): The test statistic to use as a numerical summary of the

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -39,7 +39,8 @@ def generate_asimov_data(asimov_mu, data, pdf, init_pars, par_bounds, fixed_para
         data (:obj:`tensor`): The observed data.
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``.
         init_pars (:obj:`tensor` of :obj:`float`): The starting values of the model parameters for minimization.
-        par_bounds (:obj:`tensor`): The parameter value bounds to be used for fitting.
+        par_bounds (:obj:`tensor` of shape Nx2): The extrema of values the model parameters
+            are allowed to reach in the fit.
         fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to the value
             ``init_pars`` value during minimization.
 
@@ -194,7 +195,8 @@ class AsymptoticCalculator:
             data (:obj:`tensor`): The observed data.
             pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``.
             init_pars (:obj:`tensor` of :obj:`float`): The starting values of the model parameters for minimization.
-            par_bounds (:obj:`tensor`): The parameter value bounds to be used for fitting.
+            par_bounds (:obj:`tensor` of shape Nx2): The extrema of values the model parameters
+                are allowed to reach in the fit.
             fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to the value
                 ``init_pars`` value during minimization.
             test_stat (:obj:`str`): The test statistic to use as a numerical summary of the
@@ -620,7 +622,8 @@ class ToyCalculator:
             data (:obj:`tensor`): The observed data.
             pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``.
             init_pars (:obj:`tensor` of :obj:`float`): The starting values of the model parameters for minimization.
-            par_bounds (:obj:`tensor`): The parameter value bounds to be used for fitting.
+            par_bounds (:obj:`tensor` of shape Nx2): The extrema of values the model parameters
+                are allowed to reach in the fit.
             fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to the value
                 ``init_pars`` value during minimization.
             test_stat (:obj:`str`): The test statistic to use as a numerical summary of the

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -38,7 +38,7 @@ def generate_asimov_data(asimov_mu, data, pdf, init_pars, par_bounds, fixed_para
         asimov_mu (:obj:`float`): The value for the parameter of interest to be used.
         data (:obj:`tensor`): The observed data.
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``.
-        init_pars (:obj:`tensor`): The initial parameter values to be used for fitting.
+        init_pars (:obj:`tensor` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`tensor`): The parameter value bounds to be used for fitting.
         fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to the value
             ``init_pars`` value during minimization.
@@ -193,7 +193,7 @@ class AsymptoticCalculator:
         Args:
             data (:obj:`tensor`): The observed data.
             pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``.
-            init_pars (:obj:`tensor`): The initial parameter values to be used for fitting.
+            init_pars (:obj:`tensor` of :obj:`float`): The starting values of the model parameters for minimization.
             par_bounds (:obj:`tensor`): The parameter value bounds to be used for fitting.
             fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to the value
                 ``init_pars`` value during minimization.
@@ -619,7 +619,7 @@ class ToyCalculator:
         Args:
             data (:obj:`tensor`): The observed data.
             pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``.
-            init_pars (:obj:`tensor`): The initial parameter values to be used for fitting.
+            init_pars (:obj:`tensor` of :obj:`float`): The starting values of the model parameters for minimization.
             par_bounds (:obj:`tensor`): The parameter value bounds to be used for fitting.
             fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to the value
                 ``init_pars`` value during minimization.

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -40,7 +40,8 @@ def generate_asimov_data(asimov_mu, data, pdf, init_pars, par_bounds, fixed_para
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``.
         init_pars (:obj:`tensor`): The initial parameter values to be used for fitting.
         par_bounds (:obj:`tensor`): The parameter value bounds to be used for fitting.
-        fixed_params (:obj:`tensor`): Parameters to be held constant in the fit.
+        fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to the value
+            ``init_pars`` value during minimization.
 
     Returns:
         Tensor: The Asimov dataset.
@@ -194,8 +195,8 @@ class AsymptoticCalculator:
             pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``.
             init_pars (:obj:`tensor`): The initial parameter values to be used for fitting.
             par_bounds (:obj:`tensor`): The parameter value bounds to be used for fitting.
-            fixed_params (:obj:`tensor`): Whether to fix the parameter to the init_pars value
-              during minimization.
+            fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to the value
+                ``init_pars`` value during minimization.
             test_stat (:obj:`str`): The test statistic to use as a numerical summary of the
               data: ``'qtilde'``, ``'q'``, or ``'q0'``.
 
@@ -620,8 +621,8 @@ class ToyCalculator:
             pdf (~pyhf.pdf.Model): The statistical model adhering to the schema ``model.json``.
             init_pars (:obj:`tensor`): The initial parameter values to be used for fitting.
             par_bounds (:obj:`tensor`): The parameter value bounds to be used for fitting.
-            fixed_params (:obj:`tensor`): Whether to fix the parameter to the init_pars value
-              during minimization.
+            fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to the value
+                ``init_pars`` value during minimization.
             test_stat (:obj:`str`): The test statistic to use as a numerical summary of the
               data: ``'qtilde'``, ``'q'``, or ``'q0'``.
               ``'qtilde'`` (default) performs the calculation using the alternative test statistic,

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -41,8 +41,8 @@ def generate_asimov_data(asimov_mu, data, pdf, init_pars, par_bounds, fixed_para
         init_pars (:obj:`tensor` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`tensor` of shape Nx2): The extrema of values the model parameters
             are allowed to reach in the fit.
-        fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to the value
-            ``init_pars`` value during minimization.
+        fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to its starting
+            value during minimization.
 
     Returns:
         Tensor: The Asimov dataset.
@@ -197,8 +197,8 @@ class AsymptoticCalculator:
             init_pars (:obj:`tensor` of :obj:`float`): The starting values of the model parameters for minimization.
             par_bounds (:obj:`tensor` of shape Nx2): The extrema of values the model parameters
                 are allowed to reach in the fit.
-            fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to the value
-                ``init_pars`` value during minimization.
+            fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to its starting
+                value during minimization.
             test_stat (:obj:`str`): The test statistic to use as a numerical summary of the
               data: ``'qtilde'``, ``'q'``, or ``'q0'``.
 
@@ -624,8 +624,8 @@ class ToyCalculator:
             init_pars (:obj:`tensor` of :obj:`float`): The starting values of the model parameters for minimization.
             par_bounds (:obj:`tensor` of shape Nx2): The extrema of values the model parameters
                 are allowed to reach in the fit.
-            fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to the value
-                ``init_pars`` value during minimization.
+            fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to its starting
+                value during minimization.
             test_stat (:obj:`str`): The test statistic to use as a numerical summary of the
               data: ``'qtilde'``, ``'q'``, or ``'q0'``.
               ``'qtilde'`` (default) performs the calculation using the alternative test statistic,

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -98,7 +98,8 @@ def fit(data, pdf, init_pars=None, par_bounds=None, fixed_params=None, **kwargs)
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
         init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
         par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
-        fixed_params (:obj:`list`): Parameters to be held constant in the fit.
+        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
+            ``init_pars`` value during minimization.
         kwargs: Keyword arguments passed through to the optimizer API
 
     Returns:
@@ -169,7 +170,8 @@ def fixed_poi_fit(
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
         init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
         par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
-        fixed_params (:obj:`list`): Parameters to be held constant in the fit.
+        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
+            ``init_pars`` value during minimization.
         kwargs: Keyword arguments passed through to the optimizer API
 
     Returns:

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -99,8 +99,8 @@ def fit(data, pdf, init_pars=None, par_bounds=None, fixed_params=None, **kwargs)
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
             are allowed to reach in the fit.
-        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
-            ``init_pars`` value during minimization.
+        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
+            value during minimization.
         kwargs: Keyword arguments passed through to the optimizer API
 
     Returns:
@@ -172,8 +172,8 @@ def fixed_poi_fit(
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
             are allowed to reach in the fit.
-        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
-            ``init_pars`` value during minimization.
+        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
+            value during minimization.
         kwargs: Keyword arguments passed through to the optimizer API
 
     Returns:

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -99,6 +99,7 @@ def fit(data, pdf, init_pars=None, par_bounds=None, fixed_params=None, **kwargs)
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
             are allowed to reach in the fit.
+            The shape should be ``(n, 2)`` for ``n`` model parameters.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
             value during minimization.
         kwargs: Keyword arguments passed through to the optimizer API
@@ -172,6 +173,7 @@ def fixed_poi_fit(
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
             are allowed to reach in the fit.
+            The shape should be ``(n, 2)`` for ``n`` model parameters.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
             value during minimization.
         kwargs: Keyword arguments passed through to the optimizer API

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -97,7 +97,8 @@ def fit(data, pdf, init_pars=None, par_bounds=None, fixed_params=None, **kwargs)
         data (:obj:`tensor`): The data
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
-        par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
+        par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
+            are allowed to reach in the fit.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
             ``init_pars`` value during minimization.
         kwargs: Keyword arguments passed through to the optimizer API
@@ -169,7 +170,8 @@ def fixed_poi_fit(
         data: The data
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
-        par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
+        par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
+            are allowed to reach in the fit.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
             ``init_pars`` value during minimization.
         kwargs: Keyword arguments passed through to the optimizer API

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -96,7 +96,7 @@ def fit(data, pdf, init_pars=None, par_bounds=None, fixed_params=None, **kwargs)
     Args:
         data (:obj:`tensor`): The data
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
-        init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
+        init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
             ``init_pars`` value during minimization.
@@ -168,7 +168,7 @@ def fixed_poi_fit(
     Args:
         data: The data
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
-        init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
+        init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
             ``init_pars`` value during minimization.

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -95,8 +95,8 @@ def qmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
             are allowed to reach in the fit.
-        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
-            ``init_pars`` value during minimization.
+        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
+            value during minimization.
 
     Returns:
         Float: The calculated test statistic, :math:`q_{\mu}`
@@ -163,8 +163,8 @@ def qmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
             are allowed to reach in the fit.
-        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
-            ``init_pars`` value during minimization.
+        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
+            value during minimization.
 
     Returns:
         Float: The calculated test statistic, :math:`\tilde{q}_{\mu}`
@@ -220,8 +220,8 @@ def tmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
             are allowed to reach in the fit.
-        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
-            ``init_pars`` value during minimization.
+        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
+            value during minimization.
 
     Returns:
         Float: The calculated test statistic, :math:`t_{\mu}`
@@ -282,8 +282,8 @@ def tmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
             are allowed to reach in the fit.
-        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
-            ``init_pars`` value during minimization.
+        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
+            value during minimization.
 
     Returns:
         Float: The calculated test statistic, :math:`\tilde{t}_{\mu}`
@@ -337,8 +337,8 @@ def q0(mu, data, pdf, init_pars, par_bounds, fixed_params):
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
             are allowed to reach in the fit.
-        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
-            ``init_pars`` value during minimization.
+        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
+            value during minimization.
 
     Returns:
         Float: The calculated test statistic, :math:`q_{0}`

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -95,6 +95,7 @@ def qmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
             are allowed to reach in the fit.
+            The shape should be ``(n, 2)`` for ``n`` model parameters.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
             value during minimization.
 
@@ -163,6 +164,7 @@ def qmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
             are allowed to reach in the fit.
+            The shape should be ``(n, 2)`` for ``n`` model parameters.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
             value during minimization.
 
@@ -220,6 +222,7 @@ def tmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
             are allowed to reach in the fit.
+            The shape should be ``(n, 2)`` for ``n`` model parameters.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
             value during minimization.
 
@@ -282,6 +285,7 @@ def tmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
             are allowed to reach in the fit.
+            The shape should be ``(n, 2)`` for ``n`` model parameters.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
             value during minimization.
 
@@ -337,6 +341,7 @@ def q0(mu, data, pdf, init_pars, par_bounds, fixed_params):
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
             are allowed to reach in the fit.
+            The shape should be ``(n, 2)`` for ``n`` model parameters.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
             value during minimization.
 

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -93,7 +93,8 @@ def qmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
         data (Tensor): The data to be considered
         pdf (~pyhf.pdf.Model): The HistFactory statistical model used in the likelihood ratio calculation
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
-        par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
+        par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
+            are allowed to reach in the fit.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
             ``init_pars`` value during minimization.
 
@@ -160,7 +161,8 @@ def qmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
         data (:obj:`tensor`): The data to be considered
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
-        par_bounds (:obj:`list` of `list`\s or `tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
+        par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
+            are allowed to reach in the fit.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
             ``init_pars`` value during minimization.
 
@@ -216,7 +218,8 @@ def tmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
         data (Tensor): The data to be considered
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
-        par_bounds (:obj:`list` of `list`\s or `tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
+        par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
+            are allowed to reach in the fit.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
             ``init_pars`` value during minimization.
 
@@ -277,7 +280,8 @@ def tmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
         data (:obj:`tensor`): The data to be considered
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
-        par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
+        par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
+            are allowed to reach in the fit.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
             ``init_pars`` value during minimization.
 
@@ -331,7 +335,8 @@ def q0(mu, data, pdf, init_pars, par_bounds, fixed_params):
         data (Tensor): The data to be considered
         pdf (~pyhf.pdf.Model): The HistFactory statistical model used in the likelihood ratio calculation
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
-        par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
+        par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
+            are allowed to reach in the fit.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
             ``init_pars`` value during minimization.
 

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -92,7 +92,7 @@ def qmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
         mu (Number or Tensor): The signal strength parameter
         data (Tensor): The data to be considered
         pdf (~pyhf.pdf.Model): The HistFactory statistical model used in the likelihood ratio calculation
-        init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
+        init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
             ``init_pars`` value during minimization.
@@ -159,7 +159,7 @@ def qmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
         mu (Number or Tensor): The signal strength parameter
         data (:obj:`tensor`): The data to be considered
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
-        init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
+        init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of `list`\s or `tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
             ``init_pars`` value during minimization.
@@ -215,7 +215,7 @@ def tmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
         mu (Number or Tensor): The signal strength parameter
         data (Tensor): The data to be considered
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
-        init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
+        init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of `list`\s or `tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
             ``init_pars`` value during minimization.
@@ -276,7 +276,7 @@ def tmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
         mu (Number or Tensor): The signal strength parameter
         data (:obj:`tensor`): The data to be considered
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
-        init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
+        init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
             ``init_pars`` value during minimization.
@@ -330,7 +330,7 @@ def q0(mu, data, pdf, init_pars, par_bounds, fixed_params):
         mu (Number or Tensor): The signal strength parameter (must be set to zero)
         data (Tensor): The data to be considered
         pdf (~pyhf.pdf.Model): The HistFactory statistical model used in the likelihood ratio calculation
-        init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
+        init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
             ``init_pars`` value during minimization.

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -94,7 +94,8 @@ def qmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
         pdf (~pyhf.pdf.Model): The HistFactory statistical model used in the likelihood ratio calculation
         init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
         par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
-        fixed_params (:obj:`list`): Parameters held constant in the fit
+        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
+            ``init_pars`` value during minimization.
 
     Returns:
         Float: The calculated test statistic, :math:`q_{\mu}`
@@ -160,7 +161,8 @@ def qmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
         init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
         par_bounds (:obj:`list` of `list`\s or `tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
-        fixed_params (:obj:`list`): Parameters held constant in the fit
+        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
+            ``init_pars`` value during minimization.
 
     Returns:
         Float: The calculated test statistic, :math:`\tilde{q}_{\mu}`
@@ -215,7 +217,8 @@ def tmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
         init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
         par_bounds (:obj:`list` of `list`\s or `tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
-        fixed_params (:obj:`list`): Parameters held constant in the fit
+        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
+            ``init_pars`` value during minimization.
 
     Returns:
         Float: The calculated test statistic, :math:`t_{\mu}`
@@ -275,7 +278,8 @@ def tmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
         init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
         par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
-        fixed_params (:obj:`list`): Parameters held constant in the fit
+        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
+            ``init_pars`` value during minimization.
 
     Returns:
         Float: The calculated test statistic, :math:`\tilde{t}_{\mu}`
@@ -328,7 +332,8 @@ def q0(mu, data, pdf, init_pars, par_bounds, fixed_params):
         pdf (~pyhf.pdf.Model): The HistFactory statistical model used in the likelihood ratio calculation
         init_pars (:obj:`list`): Values to initialize the model parameters at for the fit
         par_bounds (:obj:`list` of :obj:`list`\s or :obj:`tuple`\s): The extrema of values the model parameters are allowed to reach in the fit
-        fixed_params (:obj:`list`): Parameters held constant in the fit
+        fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to the value
+            ``init_pars`` value during minimization.
 
     Returns:
         Float: The calculated test statistic, :math:`q_{0}`

--- a/src/pyhf/optimize/common.py
+++ b/src/pyhf/optimize/common.py
@@ -76,7 +76,8 @@ def shim(
         data (:obj:`list`): observed data
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
-        par_bounds (:obj:`list`): parameter boundaries
+        par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
+            are allowed to reach in the fit.
         fixed_vals (:obj:`list`): fixed parameter values
 
     .. note::

--- a/src/pyhf/optimize/common.py
+++ b/src/pyhf/optimize/common.py
@@ -75,7 +75,7 @@ def shim(
         objective (:obj:`func`): objective function
         data (:obj:`list`): observed data
         pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
-        init_pars (:obj:`list`): initial parameters
+        init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list`): parameter boundaries
         fixed_vals (:obj:`list`): fixed parameter values
 

--- a/src/pyhf/optimize/common.py
+++ b/src/pyhf/optimize/common.py
@@ -78,7 +78,8 @@ def shim(
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
             are allowed to reach in the fit.
-        fixed_vals (:obj:`list`): fixed parameter values
+        fixed_vals (:obj:`list` of :obj:`list`/:obj:`tuple`): The pairs of index and constant value for a constant
+            model parameter during minimization. Set to ``None`` to allow all parameters to float.
 
     .. note::
 

--- a/src/pyhf/optimize/common.py
+++ b/src/pyhf/optimize/common.py
@@ -78,6 +78,7 @@ def shim(
         init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
         par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
             are allowed to reach in the fit.
+            The shape should be ``(n, 2)`` for ``n`` model parameters.
         fixed_vals (:obj:`list` of :obj:`list`/:obj:`tuple`): The pairs of index and constant value for a constant
             model parameter during minimization. Set to ``None`` to allow all parameters to float.
 

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -121,7 +121,7 @@ class OptimizerMixin:
             objective (:obj:`func`): objective function
             data (:obj:`list`): observed data
             pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
-            init_pars (:obj:`list`): initial parameters
+            init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
             par_bounds (:obj:`list`): parameter boundaries
             fixed_vals (:obj:`list`): fixed parameter values
             return_fitted_val (:obj:`bool`): Return bestfit value of the objective. Default is off (``False``).

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -122,7 +122,8 @@ class OptimizerMixin:
             data (:obj:`list`): observed data
             pdf (~pyhf.pdf.Model): The statistical model adhering to the schema model.json
             init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
-            par_bounds (:obj:`list`): parameter boundaries
+            par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
+                are allowed to reach in the fit.
             fixed_vals (:obj:`list`): fixed parameter values
             return_fitted_val (:obj:`bool`): Return bestfit value of the objective. Default is off (``False``).
             return_result_obj (:obj:`bool`): Return :class:`scipy.optimize.OptimizeResult`. Default is off (``False``).

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -124,7 +124,8 @@ class OptimizerMixin:
             init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
             par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
                 are allowed to reach in the fit.
-            fixed_vals (:obj:`list`): fixed parameter values
+            fixed_vals (:obj:`list` of :obj:`list`/:obj:`tuple`): The pairs of index and constant value for a constant
+                model parameter during minimization. Set to ``None`` to allow all parameters to float.
             return_fitted_val (:obj:`bool`): Return bestfit value of the objective. Default is off (``False``).
             return_result_obj (:obj:`bool`): Return :class:`scipy.optimize.OptimizeResult`. Default is off (``False``).
             return_uncertainties (:obj:`bool`): Return uncertainties on the fitted parameters. Default is off (``False``).

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -124,6 +124,7 @@ class OptimizerMixin:
             init_pars (:obj:`list` of :obj:`float`): The starting values of the model parameters for minimization.
             par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
                 are allowed to reach in the fit.
+                The shape should be ``(n, 2)`` for ``n`` model parameters.
             fixed_vals (:obj:`list` of :obj:`list`/:obj:`tuple`): The pairs of index and constant value for a constant
                 model parameter during minimization. Set to ``None`` to allow all parameters to float.
             return_fitted_val (:obj:`bool`): Return bestfit value of the objective. Default is off (``False``).


### PR DESCRIPTION
# Pull Request Description

This clarifies a lot of the docstrings and makes them slightly more verbose and appropriate for the corresponding function. This was initially raised due to confusino about the `fixed_params` docstrings which wasn't explicit about what that list or tensor should/could be.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Clarify docstrings for fit parameters: init_pars, par_bounds, fixed_params, and fixed_vals
```
