### PR TITLE
docs: Add and apply blacken-docs as a pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,11 @@ repos:
     rev: 20.8b1
     hooks:
     - id: black
+-   repo: https://github.com/asottile/blacken-docs
+    rev: v1.10.0
+    hooks:
+    - id: blacken-docs
+      additional_dependencies: [black==20.8b1]
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.4
     hooks:

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Hello World
 
 This is how you use the ``pyhf`` Python API to build a statistical model and run basic inference:
 
-.. code:: python
+.. code:: pycon
 
    >>> import pyhf
    >>> model = pyhf.simplemodels.hepdata_like(signal_data=[12.0, 11.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0])
@@ -48,7 +48,7 @@ This is how you use the ``pyhf`` Python API to build a statistical model and run
 
 Alternatively the statistical model and observational data can be read from its serialized JSON representation (see next section).
 
-.. code:: python
+.. code:: pycon
 
    >>> import pyhf
    >>> import requests

--- a/README.rst
+++ b/README.rst
@@ -39,10 +39,14 @@ This is how you use the ``pyhf`` Python API to build a statistical model and run
 .. code:: pycon
 
    >>> import pyhf
-   >>> model = pyhf.simplemodels.hepdata_like(signal_data=[12.0, 11.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0])
+   >>> model = pyhf.simplemodels.hepdata_like(
+   ...     signal_data=[12.0, 11.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0]
+   ... )
    >>> data = [51, 48] + model.config.auxdata
    >>> test_mu = 1.0
-   >>> CLs_obs, CLs_exp = pyhf.infer.hypotest(test_mu, data, model, test_stat="qtilde", return_expected=True)
+   >>> CLs_obs, CLs_exp = pyhf.infer.hypotest(
+   ...     test_mu, data, model, test_stat="qtilde", return_expected=True
+   ... )
    >>> print(f"Observed: {CLs_obs}, Expected: {CLs_exp}")
    Observed: 0.05251497423736956, Expected: 0.06445320535890459
 
@@ -52,11 +56,13 @@ Alternatively the statistical model and observational data can be read from its 
 
    >>> import pyhf
    >>> import requests
-   >>> wspace = pyhf.Workspace(requests.get('https://git.io/JJYDE').json())
+   >>> wspace = pyhf.Workspace(requests.get("https://git.io/JJYDE").json())
    >>> model = wspace.model()
    >>> data = wspace.data(model)
    >>> test_mu = 1.0
-   >>> CLs_obs, CLs_exp = pyhf.infer.hypotest(test_mu, data, model, test_stat="qtilde", return_expected=True)
+   >>> CLs_obs, CLs_exp = pyhf.infer.hypotest(
+   ...     test_mu, data, model, test_stat="qtilde", return_expected=True
+   ... )
    >>> print(f"Observed: {CLs_obs}, Expected: {CLs_exp}")
    Observed: 0.3599840922126626, Expected: 0.3599840922126626
 

--- a/docs/babel.rst
+++ b/docs/babel.rst
@@ -35,18 +35,19 @@ Typically, ``prefix = 'FitConfig'`` and ``measurementName = 'NormalMeasurement'`
 .. code:: python
 
   from configManager import configMgr
+
   # ...
-  configMgr.analysisName = '3b_tag21.2.27-1_RW_ExpSyst_36100_multibin_bkg'
-  configMgr.histCacheFile = f'cache/{configMgr.analysisName:s}.root'
+  configMgr.analysisName = "3b_tag21.2.27-1_RW_ExpSyst_36100_multibin_bkg"
+  configMgr.histCacheFile = f"cache/{configMgr.analysisName:s}.root"
   # ...
   fitConfig = configMgr.addFitConfig("Excl")
   # ...
-  channel = fitConfig.addChannel("cuts", ['SR_0L'], 1, 0.5, 1.5)
+  channel = fitConfig.addChannel("cuts", ["SR_0L"], 1, 0.5, 1.5)
   # ...
-  meas1=fitConfig.addMeasurement(name="DefaultMeasurement",lumi=1.0,lumiErr=0.029)
+  meas1 = fitConfig.addMeasurement(name="DefaultMeasurement", lumi=1.0, lumiErr=0.029)
   meas1.addPOI("mu_SIG1")
   # ...
-  meas2=fitConfig.addMeasurement(name="DefaultMeasurement",lumi=1.0,lumiErr=0.029)
+  meas2 = fitConfig.addMeasurement(name="DefaultMeasurement", lumi=1.0, lumiErr=0.029)
   meas2.addPOI("mu_SIG2")
 
 Then, you expect the following files to be made:

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -44,7 +44,7 @@ available by the ``datadir`` fixture. Therefore, one can do:
 .. code-block:: python
 
     def test_patchset(datadir):
-        data_file = open(datadir.join('test.txt'))
+        data_file = open(datadir.join("test.txt"))
         ...
 
 which will load the copy of ``text.txt`` in the temporary directory. This also

--- a/docs/likelihood.rst
+++ b/docs/likelihood.rst
@@ -27,9 +27,10 @@ check that it conforms to the provided workspace specification as follows:
 .. code:: python
 
    import json, requests, jsonschema
-   workspace = json.load(open('/path/to/analysis_workspace.json'))
+
+   workspace = json.load(open("/path/to/analysis_workspace.json"))
    # if no exception is raised, it found and parsed the schema
-   schema = requests.get('https://scikit-hep.org/pyhf/schemas/1.0.0/workspace.json').json()
+   schema = requests.get("https://scikit-hep.org/pyhf/schemas/1.0.0/workspace.json").json()
    # If no exception is raised by validate(), the instance is valid.
    jsonschema.validate(instance=workspace, schema=schema)
 


### PR DESCRIPTION
# Description

Apply Anthony Sottile's [`blacken-docs`](https://github.com/asottile/blacken-docs) as a pre-commit hook to all docs files in the codebase. HT to @kratsg for making me aware! :)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add blacken-docs as a pre-commit hook
   - c.f. https://github.com/asottile/blacken-docs
* Apply blackend-docs to RST and Markdown files in the codebase
   - Use 'pycon' formatting in codeblocks with REPL markers (>>>)
```
