### PR TITLE
docs: Add use citation for Artificial Proto-Modelling paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -39,6 +39,16 @@
     year = "2021"
 }
 
+@article{Waltenberger:2020ygp,
+    author = "Waltenberger, Wolfgang and Lessa, Andr\'e and Kraml, Sabine",
+    title = "{Artificial Proto-Modelling: Building Precursors of a Next Standard Model from Simplified Model Results}",
+    eprint = "2012.12246",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    month = "12",
+    year = "2020"
+}
+
 % 2020-12-16
 @inproceedings{Amoroso:2020zrz,
     author = "Amoroso, Simone and Kar, Deepak and Schott, Matthias",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -39,6 +39,7 @@
     year = "2021"
 }
 
+% 2020-12-22
 @article{Waltenberger:2020ygp,
     author = "Waltenberger, Wolfgang and Lessa, Andr\'e and Kraml, Sabine",
     title = "{Artificial Proto-Modelling: Building Precursors of a Next Standard Model from Simplified Model Results}",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -47,7 +47,8 @@
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
     month = "12",
-    year = "2020"
+    year = "2020",
+    journal = ""
 }
 
 % 2020-12-16


### PR DESCRIPTION
# Description

Resolves #1346 

Add use citation from [Artificial Proto-Modelling: Building Precursors of a Next Standard Model from Simplified Model Results](https://inspirehep.net/literature/1837822) by @WolfgangWaltenberger, @andlessa, and @sabinekraml :rocket: 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Artificial Proto-Modelling: Building Precursors of a Next Standard Model from Simplified Model Results'
   - c.f. https://inspirehep.net/literature/1837822
```
