### PR TITLE
fix: Retain continuous approximation of Poisson in torch v1.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ extras_require = {
         'tensorflow~=2.2.0',  # TensorFlow minor releases are as volatile as major
         'tensorflow-probability~=0.10.0',
     ],
-    'torch': ['torch~=1.8'],
+    'torch': ['torch~=1.2'],
     'jax': ['jax~=0.2.4', 'jaxlib~=0.1.56'],
     'xmlio': [
         'uproot3~=3.14',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ extras_require = {
         'tensorflow~=2.2.0',  # TensorFlow minor releases are as volatile as major
         'tensorflow-probability~=0.10.0',
     ],
-    'torch': ['torch~=1.2'],
+    'torch': ['torch~=1.8'],
     'jax': ['jax~=0.2.4', 'jaxlib~=0.1.56'],
     'xmlio': [
         'uproot3~=3.14',

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -350,6 +350,10 @@ class pytorch_backend:
         return torch.exp(torch.distributions.Poisson(lam).log_prob(n))
 
     def normal_logpdf(self, x, mu, sigma):
+        x = self.astensor(x)
+        mu = self.astensor(mu)
+        sigma = self.astensor(sigma)
+
         normal = torch.distributions.Normal(mu, sigma)
         return normal.log_prob(x)
 
@@ -379,6 +383,10 @@ class pytorch_backend:
         Returns:
             PyTorch FloatTensor: Value of Normal(x|mu, sigma)
         """
+        x = self.astensor(x)
+        mu = self.astensor(mu)
+        sigma = self.astensor(sigma)
+
         normal = torch.distributions.Normal(mu, sigma)
         return self.exp(normal.log_prob(x))
 

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -319,7 +319,8 @@ class pytorch_backend:
         return torch.einsum(subscripts, operands)
 
     def poisson_logpdf(self, n, lam):
-        return torch.distributions.Poisson(lam).log_prob(n)
+        # validate_args=True disallows continuous approximation
+        return torch.distributions.Poisson(lam, validate_args=False).log_prob(n)
 
     def poisson(self, n, lam):
         r"""
@@ -347,7 +348,10 @@ class pytorch_backend:
         Returns:
             PyTorch FloatTensor: Value of the continuous approximation to Poisson(n|lam)
         """
-        return torch.exp(torch.distributions.Poisson(lam).log_prob(n))
+        # validate_args=True disallows continuous approximation
+        return torch.exp(
+            torch.distributions.Poisson(lam, validate_args=False).log_prob(n)
+        )
 
     def normal_logpdf(self, x, mu, sigma):
         x = self.astensor(x)
@@ -441,7 +445,8 @@ class pytorch_backend:
             PyTorch Poisson distribution: The Poisson distribution class
 
         """
-        return torch.distributions.Poisson(rate)
+        # validate_args=True disallows continuous approximation
+        return torch.distributions.Poisson(rate, validate_args=False)
 
     def normal_dist(self, mu, sigma):
         r"""

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -343,9 +343,11 @@ def test_pdf_calculations(backend):
         )
 
     # Ensure continuous approximation is valid
-    assert tb.tolist(
-        tb.poisson(tb.astensor([0.5, 1.1, 1.5]), tb.astensor(1.0))
-    ) == pytest.approx([0.4151074974205947, 0.3515379040027489, 0.2767383316137298])
+    values = tb.astensor([0.5, 1.1, 1.5])
+    rates = tb.astensor(1.0)
+    assert tb.tolist(tb.poisson(values, rates)) == pytest.approx(
+        [0.4151074974205947, 0.3515379040027489, 0.2767383316137298]
+    )
 
 
 def test_boolean_mask(backend):

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -325,11 +325,9 @@ def test_pdf_calculations(backend):
     )
 
     # Ensure continuous approximation is valid
-    values = tb.astensor([0.5, 1.1, 1.5])
-    rates = tb.astensor(1.0)
-    assert tb.tolist(tb.poisson(values, rates)) == pytest.approx(
-        [0.4151074974205947, 0.3515379040027489, 0.2767383316137298]
-    )
+    assert tb.tolist(
+        tb.poisson(n=tb.astensor([0.5, 1.1, 1.5]), lam=tb.astensor(1.0))
+    ) == pytest.approx([0.4151074974205947, 0.3515379040027489, 0.2767383316137298])
 
 
 def test_boolean_mask(backend):

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -292,6 +292,7 @@ def test_pdf_calculations(backend):
     ) == pytest.approx([0.4151074974205947, 0.3515379040027489, 0.2767383316137298])
 
 
+# validate_args in torch.distributions raises ValueError not nan
 @pytest.mark.only_pytorch
 @pytest.mark.only_pytorch64
 def test_pdf_calculations_pytorch(backend):

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -312,35 +312,17 @@ def test_pdf_calculations(backend):
             nan_ok=True,
         )
     # poisson(lambda=0) is not defined, should return NaN
-    if tb.name == "pytorch":
-        with pytest.raises(ValueError):
-            _ = tb.poisson(tb.astensor([0]), tb.astensor([0]))
-        with pytest.raises(ValueError):
-            _ = tb.poisson(tb.astensor([1]), tb.astensor([0]))
-        assert tb.tolist(
-            tb.poisson(tb.astensor([0, 1]), tb.astensor([1, 1]))
-        ) == pytest.approx([0.3678794503211975, 0.3678794503211975])
-        with pytest.raises(ValueError):
-            _ = tb.poisson_logpdf(tb.astensor([0]), tb.astensor([0]))
-        with pytest.raises(ValueError):
-            _ = tb.poisson_logpdf(tb.astensor([1]), tb.astensor([0]))
-        assert tb.tolist(
-            tb.poisson_logpdf(tb.astensor([0, 1]), tb.astensor([1, 1]))
-        ) == pytest.approx(
-            np.log([0.3678794503211975, 0.3678794503211975]).tolist(),
-        )
-    else:
-        assert tb.tolist(
-            tb.poisson(tb.astensor([0, 0, 1, 1]), tb.astensor([0, 1, 0, 1]))
-        ) == pytest.approx(
-            [np.nan, 0.3678794503211975, 0.0, 0.3678794503211975], nan_ok=True
-        )
-        assert tb.tolist(
-            tb.poisson_logpdf(tb.astensor([0, 0, 1, 1]), tb.astensor([0, 1, 0, 1]))
-        ) == pytest.approx(
-            np.log([np.nan, 0.3678794503211975, 0.0, 0.3678794503211975]).tolist(),
-            nan_ok=True,
-        )
+    assert tb.tolist(
+        tb.poisson(tb.astensor([0, 0, 1, 1]), tb.astensor([0, 1, 0, 1]))
+    ) == pytest.approx(
+        [np.nan, 0.3678794503211975, 0.0, 0.3678794503211975], nan_ok=True
+    )
+    assert tb.tolist(
+        tb.poisson_logpdf(tb.astensor([0, 0, 1, 1]), tb.astensor([0, 1, 0, 1]))
+    ) == pytest.approx(
+        np.log([np.nan, 0.3678794503211975, 0.0, 0.3678794503211975]).tolist(),
+        nan_ok=True,
+    )
 
     # Ensure continuous approximation is valid
     values = tb.astensor([0.5, 1.1, 1.5])

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -252,37 +252,95 @@ def test_pdf_calculations(backend):
     assert tb.tolist(tb.normal_cdf(tb.astensor([0.8]))) == pytest.approx(
         [0.7881446014166034], 1e-07
     )
-    assert tb.tolist(
-        tb.normal_logpdf(
-            tb.astensor([0, 0, 1, 1, 0, 0, 1, 1]),
-            tb.astensor([0, 1, 0, 1, 0, 1, 0, 1]),
-            tb.astensor([0, 0, 0, 0, 1, 1, 1, 1]),
+    if tb.name == "pytorch":
+        with pytest.raises(ValueError):
+            _ = tb.normal_logpdf(
+                tb.astensor([0]),
+                tb.astensor([0]),
+                tb.astensor([0]),
+            )
+        with pytest.raises(ValueError):
+            _ = tb.normal_logpdf(
+                tb.astensor([0]),
+                tb.astensor([1]),
+                tb.astensor([0]),
+            )
+        with pytest.raises(ValueError):
+            _ = tb.normal_logpdf(
+                tb.astensor([1]),
+                tb.astensor([0]),
+                tb.astensor([0]),
+            )
+        with pytest.raises(ValueError):
+            _ = tb.normal_logpdf(
+                tb.astensor([1]),
+                tb.astensor([1]),
+                tb.astensor([0]),
+            )
+        assert tb.tolist(
+            tb.normal_logpdf(
+                tb.astensor([0, 0, 1, 1]),
+                tb.astensor([0, 1, 0, 1]),
+                tb.astensor([1, 1, 1, 1]),
+            )
+        ) == pytest.approx(
+            [
+                -0.91893853,
+                -1.41893853,
+                -1.41893853,
+                -0.91893853,
+            ],
         )
-    ) == pytest.approx(
-        [
-            np.nan,
-            np.nan,
-            np.nan,
-            np.nan,
-            -0.91893853,
-            -1.41893853,
-            -1.41893853,
-            -0.91893853,
-        ],
-        nan_ok=True,
-    )
+    else:
+        assert tb.tolist(
+            tb.normal_logpdf(
+                tb.astensor([0, 0, 1, 1, 0, 0, 1, 1]),
+                tb.astensor([0, 1, 0, 1, 0, 1, 0, 1]),
+                tb.astensor([0, 0, 0, 0, 1, 1, 1, 1]),
+            )
+        ) == pytest.approx(
+            [
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+                -0.91893853,
+                -1.41893853,
+                -1.41893853,
+                -0.91893853,
+            ],
+            nan_ok=True,
+        )
     # poisson(lambda=0) is not defined, should return NaN
-    assert tb.tolist(
-        tb.poisson(tb.astensor([0, 0, 1, 1]), tb.astensor([0, 1, 0, 1]))
-    ) == pytest.approx(
-        [np.nan, 0.3678794503211975, 0.0, 0.3678794503211975], nan_ok=True
-    )
-    assert tb.tolist(
-        tb.poisson_logpdf(tb.astensor([0, 0, 1, 1]), tb.astensor([0, 1, 0, 1]))
-    ) == pytest.approx(
-        np.log([np.nan, 0.3678794503211975, 0.0, 0.3678794503211975]).tolist(),
-        nan_ok=True,
-    )
+    if tb.name == "pytorch":
+        with pytest.raises(ValueError):
+            _ = tb.poisson(tb.astensor([0]), tb.astensor([0]))
+        with pytest.raises(ValueError):
+            _ = tb.poisson(tb.astensor([1]), tb.astensor([0]))
+        assert tb.tolist(
+            tb.poisson(tb.astensor([0, 1]), tb.astensor([1, 1]))
+        ) == pytest.approx([0.3678794503211975, 0.3678794503211975])
+        with pytest.raises(ValueError):
+            _ = tb.poisson_logpdf(tb.astensor([0]), tb.astensor([0]))
+        with pytest.raises(ValueError):
+            _ = tb.poisson_logpdf(tb.astensor([1]), tb.astensor([0]))
+        assert tb.tolist(
+            tb.poisson_logpdf(tb.astensor([0, 1]), tb.astensor([1, 1]))
+        ) == pytest.approx(
+            np.log([0.3678794503211975, 0.3678794503211975]).tolist(),
+        )
+    else:
+        assert tb.tolist(
+            tb.poisson(tb.astensor([0, 0, 1, 1]), tb.astensor([0, 1, 0, 1]))
+        ) == pytest.approx(
+            [np.nan, 0.3678794503211975, 0.0, 0.3678794503211975], nan_ok=True
+        )
+        assert tb.tolist(
+            tb.poisson_logpdf(tb.astensor([0, 0, 1, 1]), tb.astensor([0, 1, 0, 1]))
+        ) == pytest.approx(
+            np.log([np.nan, 0.3678794503211975, 0.0, 0.3678794503211975]).tolist(),
+            nan_ok=True,
+        )
 
     # Ensure continuous approximation is valid
     assert tb.tolist(


### PR DESCRIPTION
# Description

Resolves #1348 

To retain the continuous approximation of the Poisson, set `validate_args=False` in instantiations of the `torch.distributions.Poisson` class.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add validate_args=False to instantiations of the torch.distributions.Poisson class in PyTorch backend to allow for the continuous approximation of the Poisson distribution in torch v1.8+
* Ensure tensor value arguments for torch.distributions.Normal
* Check that ValueErrors are raised by PyTorch v1.8+ when the validations of validate_args are violated
```
