### PR TITLE
ci: Run docs CI on push events only from PR merges

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,6 @@
 name: Docs
 
 on:
-  # push:
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Docs
 
 on:
-  push:
+  # push:
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,9 @@
 name: Docs
 
 on:
+  push:
+    branches:
+    - master
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
# Description

When people are testing on their own branches we can often run into the situation where RTD hits the concurrency limit and delays each subsequent build of the docs by 5 minutes. This PR won't ~~fully~~ fix that, but we don't need to build the docs on every push, so only have the docs get build by the CI on `push` events if pushing to `master`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing (CI is failing for known reasons)
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Only build the docs on 'push' events if push is to master
   - In the case of the pyhf dev workflow these push events happen during merges of PRs
```