### PR TITLE
refactor: Use torch APIs for ravel, tile, and outer tensorlib methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ extras_require = {
         'tensorflow~=2.2.0',  # TensorFlow minor releases are as volatile as major
         'tensorflow-probability~=0.10.0',
     ],
-    'torch': ['torch~=1.2'],
+    'torch': ['torch~=1.8'],
     'jax': ['jax~=0.2.4', 'jaxlib~=0.1.56'],
     'xmlio': [
         'uproot3~=3.14',

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -146,6 +146,28 @@ class pytorch_backend:
         return tensor_in.tile(repeats)
 
     def outer(self, tensor_in_1, tensor_in_2):
+        """
+        Outer product of the input tensors.
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend("pytorch")
+            >>> a = pyhf.tensorlib.astensor([1.0, 2.0, 3.0])
+            >>> b = pyhf.tensorlib.astensor([1.0, 2.0, 3.0, 4.0])
+            >>> pyhf.tensorlib.outer(a, b)
+            >>> pyhf.tensorlib.outer(a, b)
+            tensor([[ 1.,  2.,  3.,  4.],
+                    [ 2.,  4.,  6.,  8.],
+                    [ 3.,  6.,  9., 12.]])
+
+        Args:
+            tensor_in_1 (:obj:`tensor`): 1-D input tensor.
+            tensor_in_2 (:obj:`tensor`): 1-D input tensor.
+
+        Returns:
+            PyTorch tensor: The outer product.
+        """
         return torch.outer(tensor_in_1, tensor_in_2)
 
     def astensor(self, tensor_in, dtype='float'):

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -156,7 +156,6 @@ class pytorch_backend:
             >>> a = pyhf.tensorlib.astensor([1.0, 2.0, 3.0])
             >>> b = pyhf.tensorlib.astensor([1.0, 2.0, 3.0, 4.0])
             >>> pyhf.tensorlib.outer(a, b)
-            >>> pyhf.tensorlib.outer(a, b)
             tensor([[ 1.,  2.,  3.,  4.],
                     [ 2.,  4.,  6.,  8.],
                     [ 3.,  6.,  9., 12.]])

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -209,7 +209,7 @@ class pytorch_backend:
         Returns:
             `torch.Tensor`: A flattened array.
         """
-        return tensor.view(-1)
+        return torch.ravel(tensor)
 
     def sum(self, tensor_in, axis=None):
         return (

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -143,7 +143,7 @@ class pytorch_backend:
         Returns:
             PyTorch tensor: The tensor with repeated axes
         """
-        return tensor_in.repeat(repeats)
+        return tensor_in.tile(repeats)
 
     def outer(self, tensor_in_1, tensor_in_2):
         return torch.ger(tensor_in_1, tensor_in_2)

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -146,7 +146,7 @@ class pytorch_backend:
         return tensor_in.tile(repeats)
 
     def outer(self, tensor_in_1, tensor_in_2):
-        return torch.ger(tensor_in_1, tensor_in_2)
+        return torch.outer(tensor_in_1, tensor_in_2)
 
     def astensor(self, tensor_in, dtype='float'):
         """


### PR DESCRIPTION
# Description

Resolves #1349 

Adopt the `torch` API for `ravel`, `tile`, and `outer` for easier comparisons across backends as the [PyTorch `v1.8.0` release notes](https://github.com/pytorch/pytorch/releases/tag/v1.8.0) comment

> New functions (most of them to improve numpy compatibility)

Note that in the case of `outer` the `v1.8.0` docs note that for [`torch.ger`](https://pytorch.org/docs/1.8.0/generated/torch.ger.html) (the current function)

> This function is deprecated and will be removed in a future PyTorch release. Use `torch.outer()` instead.


As a result also bump the minimum compatible release number of PyTorch to `1.8` so that these APIs exist.

# Checklist Before Requesting Reviewer

- [x] Tests are passing (CI is failing for known reasons)
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use torch.ravel, torch.tile, torch.outer for PyTorch backend tensorlib methods
   - https://pytorch.org/docs/1.8.0/generated/torch.ravel.html
   - https://pytorch.org/docs/1.8.0/generated/torch.tile.html
   - https://pytorch.org/docs/1.8.0/generated/torch.outer.html
* Set minimum compatible PyTorch release to v1.8 to ensure APIs
```
