### PR TITLE
test: Test lower bounds of dependencies

### DIFF
--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -1,0 +1,34 @@
+name: Minimum supported dependencies
+
+on:
+  push:
+  # Run daily at 0:01 UTC
+  schedule:
+  - cron:  '1 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  test:
+
+    runs-on: ${{ matrix.os }}
+    os: [ubuntu-latest]
+    python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --no-cache-dir --requirement lower-bound-requirements.txt
+        python -m pip install --quiet --no-cache-dir --editable .[test]
+        python -m pip list
+    - name: Test with pytest
+      run: |
+        python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+    - name: Test Contrib module with pytest
+      run: |
+        python -m pytest -r sx tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -1,8 +1,6 @@
 name: Minimum supported dependencies
 
-# REMOVE THE ON PUSH
 on:
-  push:
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -1,5 +1,6 @@
 name: Minimum supported dependencies
 
+# REMOVE THE ON PUSH
 on:
   push:
   # Run daily at 0:01 UTC

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -15,7 +15,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        # minimum supported Python
+        python-version: [3.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -29,6 +29,3 @@ jobs:
     - name: Test with pytest
       run: |
         python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
-    - name: Test Contrib module with pytest
-      run: |
-        python -m pytest -r sx tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -12,8 +12,10 @@ jobs:
   test:
 
     runs-on: ${{ matrix.os }}
-    os: [ubuntu-latest]
-    python-version: [3.8]
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
       exclude: ^validation/|\.dtd$|\.json$|\.xml$
     - id: mixed-line-ending
     - id: requirements-txt-fixer
+      exclude: lower-bound-requirements.txt
     - id: trailing-whitespace
       # exclude generated files
       exclude: ^validation/|\.dtd$|\.xml$

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 prune *
 graft src
 include LICENSE
+exclude lower-bound-requirements.txt
 
 global-exclude __pycache__ *.py[cod] .*

--- a/lower-bound-requirements.txt
+++ b/lower-bound-requirements.txt
@@ -1,0 +1,20 @@
+# core
+scipy==1.4.0
+click==7.0.0
+tqdm==4.56.0
+jsonschema==3.2.0
+jsonpatch==1.23.0
+pyyaml==5.1.0
+# xmlio
+uproot3==3.14.0
+uproot==4.0.0
+# minuit
+iminuit==2.1.0
+# tensorflow
+tensorflow==2.2.0
+tensorflow-probability==0.10.0
+# torch
+torch==1.2.0
+# jax
+jax==0.2.4
+jaxlib==0.1.56

--- a/lower-bound-requirements.txt
+++ b/lower-bound-requirements.txt
@@ -1,5 +1,5 @@
 # core
-scipy==1.4.0
+scipy==1.4.1
 click==7.0.0
 tqdm==4.56.0
 jsonschema==3.2.0

--- a/lower-bound-requirements.txt
+++ b/lower-bound-requirements.txt
@@ -1,5 +1,5 @@
 # core
-scipy==1.4.1
+scipy==1.4.1  # c.f. Issue #1001
 click==7.0.0
 tqdm==4.56.0
 jsonschema==3.2.0
@@ -11,8 +11,8 @@ uproot==4.0.0
 # minuit
 iminuit==2.1.0
 # tensorflow
-tensorflow==2.2.0
-tensorflow-probability==0.10.0
+tensorflow==2.2.0  # c.f. Issue #1001
+tensorflow-probability==0.10.1
 # torch
 torch==1.2.0
 # jax

--- a/lower-bound-requirements.txt
+++ b/lower-bound-requirements.txt
@@ -11,10 +11,10 @@ uproot==4.0.0
 # minuit
 iminuit==2.1.0
 # tensorflow
-tensorflow==2.2.0  # c.f. PR #1001
-tensorflow-probability==0.10.1
+# tensorflow==2.2.0  # c.f. PR #1001
+# tensorflow-probability==0.10.1
 # torch
 torch==1.8.0
 # jax
-jax==0.2.4
-jaxlib==0.1.56
+# jax==0.2.4
+# jaxlib==0.1.56

--- a/lower-bound-requirements.txt
+++ b/lower-bound-requirements.txt
@@ -16,5 +16,5 @@ iminuit==2.1.0
 # torch
 torch==1.8.0
 # jax
-# jax==0.2.4
-# jaxlib==0.1.56
+jax==0.2.4
+jaxlib==0.1.56

--- a/lower-bound-requirements.txt
+++ b/lower-bound-requirements.txt
@@ -16,5 +16,5 @@ iminuit==2.1.0
 # torch
 torch==1.8.0
 # jax
-jax==0.2.5
-jaxlib==0.1.59
+jax==0.2.8
+jaxlib==0.1.58

--- a/lower-bound-requirements.txt
+++ b/lower-bound-requirements.txt
@@ -1,5 +1,5 @@
 # core
-scipy==1.4.1  # c.f. Issue #1001
+scipy==1.4.1  # c.f. PR #1001
 click==7.0.0
 tqdm==4.56.0
 jsonschema==3.2.0
@@ -11,7 +11,7 @@ uproot==4.0.0
 # minuit
 iminuit==2.1.0
 # tensorflow
-tensorflow==2.2.0  # c.f. Issue #1001
+tensorflow==2.2.0  # c.f. PR #1001
 tensorflow-probability==0.10.1
 # torch
 torch==1.2.0

--- a/lower-bound-requirements.txt
+++ b/lower-bound-requirements.txt
@@ -16,5 +16,5 @@ iminuit==2.1.0
 # torch
 torch==1.8.0
 # jax
-jax==0.2.4
-jaxlib==0.1.56
+jax==0.2.5
+jaxlib==0.1.59

--- a/lower-bound-requirements.txt
+++ b/lower-bound-requirements.txt
@@ -6,7 +6,7 @@ jsonschema==3.2.0
 jsonpatch==1.23.0
 pyyaml==5.1.0
 # xmlio
-uproot3==3.14.0
+uproot3==3.14.1
 uproot==4.0.0
 # minuit
 iminuit==2.1.0

--- a/lower-bound-requirements.txt
+++ b/lower-bound-requirements.txt
@@ -14,7 +14,7 @@ iminuit==2.1.0
 tensorflow==2.2.0  # c.f. PR #1001
 tensorflow-probability==0.10.1
 # torch
-torch==1.2.0
+torch==1.8.0
 # jax
 jax==0.2.4
 jaxlib==0.1.56

--- a/lower-bound-requirements.txt
+++ b/lower-bound-requirements.txt
@@ -11,7 +11,7 @@ uproot==4.0.0
 # minuit
 iminuit==2.1.0
 # tensorflow
-# tensorflow==2.2.0  # c.f. PR #1001
+tensorflow==2.2.0  # c.f. PR #1001
 # tensorflow-probability==0.10.1
 # torch
 torch==1.8.0

--- a/lower-bound-requirements.txt
+++ b/lower-bound-requirements.txt
@@ -11,7 +11,7 @@ uproot==4.0.0
 # minuit
 iminuit==2.1.0
 # tensorflow
-tensorflow==2.2.0  # c.f. PR #1001
+tensorflow==2.2.1  # c.f. PR #1001
 # tensorflow-probability==0.10.1
 # torch
 torch==1.8.0

--- a/lower-bound-requirements.txt
+++ b/lower-bound-requirements.txt
@@ -12,7 +12,7 @@ uproot==4.0.0
 iminuit==2.1.0
 # tensorflow
 tensorflow==2.2.1  # c.f. PR #1001
-# tensorflow-probability==0.10.1
+tensorflow-probability==0.10.1
 # torch
 torch==1.8.0
 # jax

--- a/lower-bound-requirements.txt
+++ b/lower-bound-requirements.txt
@@ -12,7 +12,7 @@ uproot==4.0.0
 iminuit==2.1.0
 # tensorflow
 tensorflow==2.2.1  # c.f. PR #1001
-tensorflow-probability==0.10.1
+tensorflow-probability==0.10.0
 # torch
 torch==1.8.0
 # jax

--- a/lower-bound-requirements.txt
+++ b/lower-bound-requirements.txt
@@ -12,7 +12,7 @@ uproot==4.0.0
 iminuit==2.1.0
 # tensorflow
 tensorflow==2.2.1  # c.f. PR #1001
-tensorflow-probability==0.10.0
+tensorflow-probability==0.10.1
 # torch
 torch==1.8.0
 # jax

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ extras_require = {
     'shellcomplete': ['click_completion'],
     'tensorflow': [
         'tensorflow~=2.2.1',  # TensorFlow minor releases are as volatile as major
-        'tensorflow-probability~=0.10.1',
+        'tensorflow-probability~=0.10.0',
     ],
     'torch': ['torch~=1.8'],
     'jax': ['jax~=0.2.8', 'jaxlib~=0.1.58'],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ extras_require = {
     'shellcomplete': ['click_completion'],
     'tensorflow': [
         'tensorflow~=2.2.1',  # TensorFlow minor releases are as volatile as major
-        'tensorflow-probability~=0.10.0',
+        'tensorflow-probability~=0.10.1',
     ],
     'torch': ['torch~=1.8'],
     'jax': ['jax~=0.2.8', 'jaxlib~=0.1.58'],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ extras_require = {
     'shellcomplete': ['click_completion'],
     'tensorflow': [
         'tensorflow~=2.2.0',  # TensorFlow minor releases are as volatile as major
-        'tensorflow-probability~=0.10.0',
+        'tensorflow-probability~=0.10.1',
     ],
     'torch': ['torch~=1.8'],
     'jax': ['jax~=0.2.4', 'jaxlib~=0.1.56'],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ extras_require = {
         'tensorflow-probability~=0.10.1',
     ],
     'torch': ['torch~=1.8'],
-    'jax': ['jax~=0.2.4', 'jaxlib~=0.1.56'],
+    'jax': ['jax~=0.2.8', 'jaxlib~=0.1.58'],
     'xmlio': [
         'uproot3~=3.14',
         'uproot~=4.0',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 extras_require = {
     'shellcomplete': ['click_completion'],
     'tensorflow': [
-        'tensorflow~=2.2.0',  # TensorFlow minor releases are as volatile as major
+        'tensorflow~=2.2.1',  # TensorFlow minor releases are as volatile as major
         'tensorflow-probability~=0.10.1',
     ],
     'torch': ['torch~=1.8'],

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require = {
     'torch': ['torch~=1.8'],
     'jax': ['jax~=0.2.8', 'jaxlib~=0.1.58'],
     'xmlio': [
-        'uproot3~=3.14',
+        'uproot3>=3.14.1',
         'uproot~=4.0',
     ],  # uproot3 required until writing to ROOT supported in uproot4
     'minuit': ['iminuit~=2.1,<2.4'],  # iminuit v2.4.0 behavior needs to be understood


### PR DESCRIPTION
# Description

Resolves #1350

To ensure that the lower bound of all dependencies are still sufficient for the API used, add a test that installs from a `lower-bound-requirements.txt`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing (CI failing for known reasons)
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Test lowest version of dependencies specified in setup.cfg and setup.py
   - Add lower-bound-requirements.txt with lowest versions pinned
   - Add lower-bound-requirements.yml GHA nightly workflow to test lower-bound-requirements.txt versions on test suite
* Update lower bounds of extra dependencies in setup.py to reflect their actual lowest bounds
```
