### PR TITLE
fix: Set precision for ones and zeros through dtype arg

### DIFF
--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -242,7 +242,7 @@ class jax_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                "Invalid dtype: dtype must be float, int, or bool.", exc_info=True
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.", exc_info=True
             )
             raise
 
@@ -253,7 +253,7 @@ class jax_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                "Invalid dtype: dtype must be float, int, or bool.", exc_info=True
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.", exc_info=True
             )
             raise
 

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -242,7 +242,8 @@ class jax_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.", exc_info=True
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.",
+                exc_info=True,
             )
             raise
 
@@ -253,7 +254,8 @@ class jax_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.", exc_info=True
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.",
+                exc_info=True,
             )
             raise
 

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -197,7 +197,7 @@ class jax_backend:
     def isfinite(self, tensor):
         return jnp.isfinite(tensor)
 
-    def astensor(self, tensor_in, dtype='float'):
+    def astensor(self, tensor_in, dtype="float"):
         """
         Convert to a JAX ndarray.
 
@@ -237,11 +237,27 @@ class jax_backend:
     def abs(self, tensor):
         return jnp.abs(tensor)
 
-    def ones(self, shape):
-        return jnp.ones(shape)
+    def ones(self, shape, dtype="float"):
+        try:
+            dtype = self.dtypemap[dtype]
+        except KeyError:
+            log.error(
+                "Invalid dtype: dtype must be float, int, or bool.", exc_info=True
+            )
+            raise
 
-    def zeros(self, shape):
-        return jnp.zeros(shape)
+        return jnp.ones(shape, dtype=dtype)
+
+    def zeros(self, shape, dtype="float"):
+        try:
+            dtype = self.dtypemap[dtype]
+        except KeyError:
+            log.error(
+                "Invalid dtype: dtype must be float, int, or bool.", exc_info=True
+            )
+            raise
+
+        return jnp.zeros(shape, dtype=dtype)
 
     def power(self, tensor_in_1, tensor_in_2):
         return jnp.power(tensor_in_1, tensor_in_2)

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -227,7 +227,7 @@ class numpy_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                "Invalid dtype: dtype must be float, int, or bool.", exc_info=True
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.", exc_info=True
             )
             raise
 
@@ -238,7 +238,7 @@ class numpy_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                "Invalid dtype: dtype must be float, int, or bool.", exc_info=True
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.", exc_info=True
             )
             raise
 

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -227,7 +227,8 @@ class numpy_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.", exc_info=True
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.",
+                exc_info=True,
             )
             raise
 
@@ -238,7 +239,8 @@ class numpy_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.", exc_info=True
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.",
+                exc_info=True,
             )
             raise
 

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -222,11 +222,27 @@ class numpy_backend:
     def abs(self, tensor):
         return np.abs(tensor)
 
-    def ones(self, shape):
-        return np.ones(shape)
+    def ones(self, shape, dtype="float"):
+        try:
+            dtype = self.dtypemap[dtype]
+        except KeyError:
+            log.error(
+                "Invalid dtype: dtype must be float, int, or bool.", exc_info=True
+            )
+            raise
 
-    def zeros(self, shape):
-        return np.zeros(shape)
+        return np.ones(shape, dtype=dtype)
+
+    def zeros(self, shape, dtype="float"):
+        try:
+            dtype = self.dtypemap[dtype]
+        except KeyError:
+            log.error(
+                "Invalid dtype: dtype must be float, int, or bool.", exc_info=True
+            )
+            raise
+
+        return np.zeros(shape, dtype=dtype)
 
     def power(self, tensor_in_1, tensor_in_2):
         return np.power(tensor_in_1, tensor_in_2)

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -245,11 +245,27 @@ class pytorch_backend:
     def abs(self, tensor):
         return torch.abs(tensor)
 
-    def ones(self, shape):
-        return torch.ones(shape, dtype=self.dtypemap['float'])
+    def ones(self, shape, dtype="float"):
+        try:
+            dtype = self.dtypemap[dtype]
+        except KeyError:
+            log.error(
+                "Invalid dtype: dtype must be float, int, or bool.", exc_info=True
+            )
+            raise
 
-    def zeros(self, shape):
-        return torch.zeros(shape, dtype=self.dtypemap['float'])
+        return torch.ones(shape, dtype=dtype)
+
+    def zeros(self, shape, dtype="float"):
+        try:
+            dtype = self.dtypemap[dtype]
+        except KeyError:
+            log.error(
+                "Invalid dtype: dtype must be float, int, or bool.", exc_info=True
+            )
+            raise
+
+        return torch.zeros(shape, dtype=dtype)
 
     def power(self, tensor_in_1, tensor_in_2):
         return torch.pow(tensor_in_1, tensor_in_2)

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -250,7 +250,8 @@ class pytorch_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.", exc_info=True
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.",
+                exc_info=True,
             )
             raise
 
@@ -261,7 +262,8 @@ class pytorch_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.", exc_info=True
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.",
+                exc_info=True,
             )
             raise
 

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -250,7 +250,7 @@ class pytorch_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                "Invalid dtype: dtype must be float, int, or bool.", exc_info=True
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.", exc_info=True
             )
             raise
 
@@ -261,7 +261,7 @@ class pytorch_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                "Invalid dtype: dtype must be float, int, or bool.", exc_info=True
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.", exc_info=True
             )
             raise
 

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -245,7 +245,7 @@ class tensorflow_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                "Invalid dtype: dtype must be float, int, or bool.", exc_info=True
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.", exc_info=True
             )
             raise
 
@@ -256,7 +256,7 @@ class tensorflow_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                "Invalid dtype: dtype must be float, int, or bool.", exc_info=True
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.", exc_info=True
             )
             raise
 

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -240,11 +240,27 @@ class tensorflow_backend:
     def abs(self, tensor):
         return tf.abs(tensor)
 
-    def ones(self, shape):
-        return tf.ones(shape, dtype=self.dtypemap['float'])
+    def ones(self, shape, dtype="float"):
+        try:
+            dtype = self.dtypemap[dtype]
+        except KeyError:
+            log.error(
+                "Invalid dtype: dtype must be float, int, or bool.", exc_info=True
+            )
+            raise
 
-    def zeros(self, shape):
-        return tf.zeros(shape, dtype=self.dtypemap['float'])
+        return tf.ones(shape, dtype=dtype)
+
+    def zeros(self, shape, dtype="float"):
+        try:
+            dtype = self.dtypemap[dtype]
+        except KeyError:
+            log.error(
+                "Invalid dtype: dtype must be float, int, or bool.", exc_info=True
+            )
+            raise
+
+        return tf.zeros(shape, dtype=dtype)
 
     def power(self, tensor_in_1, tensor_in_2):
         return tf.pow(tensor_in_1, tensor_in_2)

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -245,7 +245,8 @@ class tensorflow_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.", exc_info=True
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.",
+                exc_info=True,
             )
             raise
 
@@ -256,7 +257,8 @@ class tensorflow_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.", exc_info=True
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.",
+                exc_info=True,
             )
             raise
 

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -119,6 +119,7 @@ def test_minimize(tensorlib, precision, optimizer, do_grad, do_stitch):
             rtol = 7e-05
         if 'no_grad-minuit-jax-32b' in identifier:
             rtol = 4e-02
+        # NB: ubuntu and macos give different results for 32b
         if "do_grad-scipy-jax-32b" in identifier:
             rtol = 5e-03
         if "do_grad-minuit-jax-32b" in identifier:

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -120,7 +120,7 @@ def test_minimize(tensorlib, precision, optimizer, do_grad, do_stitch):
         if 'no_grad-minuit-jax-32b' in identifier:
             rtol = 4e-02
         if "do_grad-scipy-jax-32b" in identifier:
-            rtol = 4e-03
+            rtol = 5e-03
         if "do_grad-minuit-jax-32b" in identifier:
             rtol = 5e-03
 

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -120,7 +120,7 @@ def test_minimize(tensorlib, precision, optimizer, do_grad, do_stitch):
         if 'no_grad-minuit-jax-32b' in identifier:
             rtol = 4e-02
         if "do_grad-scipy-jax-32b" in identifier:
-            rtol = 2e-03
+            rtol = 3e-03
         if "do_grad-minuit-jax-32b" in identifier:
             rtol = 5e-03
 

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -75,13 +75,13 @@ def test_minimize(tensorlib, precision, optimizer, do_grad, do_stitch):
             # do grad, scipy, 32b
             'do_grad-scipy-pytorch-32b': [0.49993881583213806, 1.0001085996627808],
             'do_grad-scipy-tensorflow-32b': [0.4999384582042694, 1.0001084804534912],
-            'do_grad-scipy-jax-32b': [0.4999389052391052, 1.0001085996627808],
+            'do_grad-scipy-jax-32b': [0.4978247582912445, 1.0006263256072998],
             # do grad, scipy, 64b
             'do_grad-scipy-pytorch-64b': [0.49998837853531425, 0.9999696648069287],
             'do_grad-scipy-tensorflow-64b': [0.4999883785353142, 0.9999696648069278],
             'do_grad-scipy-jax-64b': [0.49998837853531414, 0.9999696648069285],
             # no grad, minuit, 32b - not very consistent for pytorch
-            'no_grad-minuit-numpy-32b': [0.49622172117233276, 1.0007264614105225],
+            'no_grad-minuit-numpy-32b': [0.7465415000915527, 0.8796938061714172],
             #    nb: macos gives different numerics than CI
             # 'no_grad-minuit-pytorch-32b': [0.7465415000915527, 0.8796938061714172],
             'no_grad-minuit-pytorch-32b': [0.9684963226318359, 0.9171305894851685],

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -119,7 +119,9 @@ def test_minimize(tensorlib, precision, optimizer, do_grad, do_stitch):
             rtol = 7e-05
         if 'no_grad-minuit-jax-32b' in identifier:
             rtol = 4e-02
-        if 'do_grad-minuit-jax-32b' in identifier:
+        if "do_grad-scipy-jax-32b" in identifier:
+            rtol = 5e-03
+        if "do_grad-minuit-jax-32b" in identifier:
             rtol = 5e-03
 
         # check fitted parameters

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -120,7 +120,7 @@ def test_minimize(tensorlib, precision, optimizer, do_grad, do_stitch):
         if 'no_grad-minuit-jax-32b' in identifier:
             rtol = 4e-02
         if "do_grad-scipy-jax-32b" in identifier:
-            rtol = 3e-03
+            rtol = 4e-03
         if "do_grad-minuit-jax-32b" in identifier:
             rtol = 5e-03
 

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -120,7 +120,7 @@ def test_minimize(tensorlib, precision, optimizer, do_grad, do_stitch):
         if 'no_grad-minuit-jax-32b' in identifier:
             rtol = 4e-02
         if "do_grad-scipy-jax-32b" in identifier:
-            rtol = 1e-03
+            rtol = 2e-03
         if "do_grad-minuit-jax-32b" in identifier:
             rtol = 5e-03
 

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -120,7 +120,7 @@ def test_minimize(tensorlib, precision, optimizer, do_grad, do_stitch):
         if 'no_grad-minuit-jax-32b' in identifier:
             rtol = 4e-02
         if "do_grad-scipy-jax-32b" in identifier:
-            rtol = 5e-03
+            rtol = 1e-03
         if "do_grad-minuit-jax-32b" in identifier:
             rtol = 5e-03
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -14,6 +14,20 @@ def test_astensor_dtype(backend, caplog):
             assert 'Invalid dtype' in caplog.text
 
 
+def test_ones_dtype(backend, caplog):
+    with caplog.at_level(logging.INFO, "pyhf.tensor"):
+        with pytest.raises(KeyError):
+            assert pyhf.tensorlib.ones([1, 2, 3], dtype="long")
+            assert "Invalid dtype" in caplog.text
+
+
+def test_zeros_dtype(backend, caplog):
+    with caplog.at_level(logging.INFO, "pyhf.tensor"):
+        with pytest.raises(KeyError):
+            assert pyhf.tensorlib.zeros([1, 2, 3], dtype="long")
+            assert "Invalid dtype" in caplog.text
+
+
 def test_simple_tensor_ops(backend):
     tb = pyhf.tensorlib
     assert tb.tolist(tb.astensor([1, 2, 3]) + tb.astensor([4, 5, 6])) == [5, 7, 9]


### PR DESCRIPTION
# Description

- Resolves #1368 
- Resolves #1145

As this is fixing and so changing the `dtype` that is being set from `64b` to `32b` then this is also going to mean corrections of tests.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add dtype arg to tensorlib .ones and .zeros to set precision
   - Ensures that precision set at tensorlib set time is propagated
   - Default to the value of the tensor backend dtypemap
* Add test_tensor tests to cover invalid dtype to .ones and .zeros
* Update test_optim to use 32b values
```
