### PR TITLE
fix: Correct JAX tensor type in docstring

### DIFF
--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -340,7 +340,7 @@ class jax_backend:
             tensor (Tensor): Tensor object
 
         Returns:
-            `jax.interpreters.xla._DeviceArray`: A flattened array.
+            `jaxlib.xla_extension.DeviceArray`: A flattened array.
         """
         return jnp.ravel(tensor)
 

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -210,7 +210,7 @@ class jax_backend:
             DeviceArray([[1., 2., 3.],
                          [4., 5., 6.]], dtype=float64)
             >>> type(tensor)
-            <class 'jax.interpreters.xla._DeviceArray'>
+            <class 'jaxlib.xla_extension.DeviceArray'>
 
         Args:
             tensor_in (Number or Tensor): Tensor object

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -216,7 +216,7 @@ class jax_backend:
             tensor_in (Number or Tensor): Tensor object
 
         Returns:
-            `jax.interpreters.xla._DeviceArray`: A multi-dimensional, fixed-size homogenous array.
+            `jaxlib.xla_extension.DeviceArray`: A multi-dimensional, fixed-size homogenous array.
         """
         try:
             dtype = self.dtypemap[dtype]


### PR DESCRIPTION
# Description

Update JAX tensor type to `jaxlib.xla_extension.DeviceArray` that was introduced in `jax` `v0.2.11`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update JAX tensor type to jaxlib.xla_extension.DeviceArray in docs
   - Changed in JAX v0.2.11
```
