### PR TITLE
ci: Upload coverage to Codecov in flagged stages for complete coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,16 +34,23 @@ jobs:
     - name: Test with pytest
       run: |
         python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
-    - name: Test Contrib module with pytest
-      run: |
-        python -m pytest -r sx tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
-    - name: Report coverage with Codecov
+    - name: Report core project coverage with Codecov
       if: github.event_name == 'push' && matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         flags: unittests
+    - name: Test Contrib module with pytest
+      run: |
+        python -m pytest -r sx tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
+    - name: Report contrib coverage with Codecov
+      if: github.event_name == 'push' && matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest'
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        flags: contrib
     - name: Run benchmarks
       if: github.event_name == 'schedule' && matrix.python-version == 3.8
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
     - name: Test with pytest
       run: |
         python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+    - name: Test Contrib module with pytest
+      run: |
+        python -m pytest -r sx tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
     - name: Report coverage with Codecov
       if: github.event_name == 'push' && matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v1
@@ -41,9 +44,6 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         flags: unittests
-    - name: Test Contrib module with pytest
-      run: |
-        python -m pytest -r sx tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
     - name: Run benchmarks
       if: github.event_name == 'schedule' && matrix.python-version == 3.8
       run: |


### PR DESCRIPTION
# Description

First noted in PR #1377, this allows for running the main tests, uploading the coverage to Codecov with a "unittests" flag, then running the tests for the contrib module, and uploading the new coverage report with these tests **added** to the main tests with a "contrib" flag.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Upload coverage reports to Codecov in staged runs with different flags to allow for iterative reporting
   - Allows for testing contrib module separately buy adding the coverage to the final report
   - c.f. https://docs.codecov.io/docs/flags
```
