### PR TITLE
feat: Use PyYAML's safe_load for better security

### DIFF
--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -55,7 +55,7 @@ def options_from_eqdelimstring(opts):
     document = '\n'.join(
         f"{opt.split('=', 1)[0]}: {opt.split('=', 1)[1]}" for opt in opts
     )
-    return yaml.full_load(document)
+    return yaml.safe_load(document)
 
 
 class EqDelimStringParamType(click.ParamType):

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -55,7 +55,7 @@ def options_from_eqdelimstring(opts):
     document = '\n'.join(
         f"{opt.split('=', 1)[0]}: {opt.split('=', 1)[1]}" for opt in opts
     )
-    return yaml.safe_load(document)
+    return yaml.full_load(document)
 
 
 class EqDelimStringParamType(click.ParamType):


### PR DESCRIPTION
# Description

In light of a discussion, motivated by PR #1378, with @alexander-held, @henryiii, and @jpivarski about the security risk of PyYAML, use `yaml.safe_load` over `yaml.full_load` in `pyhf.utils.options_from_eqdelimstring`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use yaml.safe_load over yaml.full_load in pyhf.utils.options_from_eqdelimstring
* Further safeguards against things like CVE-2020-14343
   - c.f. PR #1378
```
