### PR TITLE
fix: Stricter schema definitions for histosys and normsys

### DIFF
--- a/src/pyhf/schemas/1.0.0/defs.json
+++ b/src/pyhf/schemas/1.0.0/defs.json
@@ -107,7 +107,8 @@
                             "lo_data": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
                             "hi_data": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
                         },
-                        "required": ["lo_data", "hi_data"]
+                        "required": ["lo_data", "hi_data"],
+                        "additionalProperties": false
                     }
                 },
                 "required": ["name", "type", "data"],
@@ -144,7 +145,8 @@
                             "lo": { "type": "number" },
                             "hi": { "type": "number"}
                         },
-                        "required": ["lo", "hi"]
+                        "required": ["lo", "hi"],
+                        "additionalProperties": false
                     }
                 },
                 "required": ["name", "type", "data"],
@@ -190,6 +192,7 @@
             "operation": {
                 "type": "object",
                 "required": [ "op", "path" ],
+                "additionalProperties": false,
                 "allOf": [ { "$ref": "#/definitions/jsonpatch/path" } ],
                 "oneOf": [
                     {
@@ -281,10 +284,12 @@
                             "name": { "type": "string", "pattern": "^[a-zA-Z0-9_]+$" },
                             "values": { "type": "array", "items": { "type": "number" } }
                         },
-                        "required": ["name", "values"]
+                        "required": ["name", "values"],
+                        "additionalProperties": true
                     }
                 },
-                "required": ["metadata", "patch"]
+                "required": ["metadata", "patch"],
+                "additionalProperties": false
             },
             "metadata": {
                 "type": "object",
@@ -298,7 +303,8 @@
                     "description": { "type": "string" },
                     "references": { "$ref": "#/definitions/patchset/references" }
                 },
-                "required": ["references", "digests", "labels", "description"]
+                "required": ["references", "digests", "labels", "description"],
+                "additionalProperties": true
             }
         }
     }

--- a/src/pyhf/schemas/1.0.0/defs.json
+++ b/src/pyhf/schemas/1.0.0/defs.json
@@ -192,7 +192,6 @@
             "operation": {
                 "type": "object",
                 "required": [ "op", "path" ],
-                "additionalProperties": false,
                 "allOf": [ { "$ref": "#/definitions/jsonpatch/path" } ],
                 "oneOf": [
                     {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -377,6 +377,60 @@ def test_parameters_normfactor_bad_attribute(bad_parameter):
         pyhf.Model(spec, poi_name='mypoi')
 
 
+def test_histosys_additional_properties():
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {
+                        'name': 'sample',
+                        'data': [10.0],
+                        'modifiers': [
+                            {
+                                'name': 'histosys',
+                                'type': 'histosys',
+                                'data': {
+                                    'hi_data': [1.0],
+                                    'lo_data': [0.5],
+                                    'foo': 2.0,
+                                },
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    with pytest.raises(pyhf.exceptions.InvalidSpecification):
+        pyhf.Model(spec)
+
+
+def test_normsys_additional_properties():
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {
+                        'name': 'sample',
+                        'data': [10.0],
+                        'modifiers': [
+                            {
+                                'name': 'normsys',
+                                'type': 'normsys',
+                                'data': {'hi': 1.0, 'lo': 0.5, 'foo': 2.0},
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    with pytest.raises(pyhf.exceptions.InvalidSpecification):
+        pyhf.Model(spec)
+
+
 @pytest.mark.parametrize(
     'patch',
     [


### PR DESCRIPTION
# Pull Request Description

Resolves #1387. Histosys and Normsys should be stricter about not allowing additional properties in the `data` object in the schema.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Teach the schema to not allow additional properties for histosys and normsys
* Be more explicit about the patchset/jsonpatch metadata information (that we do allow additionalProperties)
* Add tests to check that additionalProperties for for histosys and normsys result in an invalid spec
```
