### PR TITLE
fix: Ensure tensorlib precision used throughout TensorFlow backend

### DIFF
--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -160,15 +160,12 @@ class tensorflow_backend:
             raise
 
     def outer(self, tensor_in_1, tensor_in_2):
+        dtype = self.dtypemap["float"]
         tensor_in_1 = (
-            tensor_in_1
-            if tensor_in_1.dtype != tf.bool
-            else tf.cast(tensor_in_1, tf.float32)
+            tensor_in_1 if tensor_in_1.dtype != tf.bool else tf.cast(tensor_in_1, dtype)
         )
         tensor_in_1 = (
-            tensor_in_1
-            if tensor_in_2.dtype != tf.bool
-            else tf.cast(tensor_in_2, tf.float32)
+            tensor_in_1 if tensor_in_2.dtype != tf.bool else tf.cast(tensor_in_2, dtype)
         )
         return tf.einsum('i,j->ij', tensor_in_1, tensor_in_2)
 

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -490,8 +490,7 @@ class tensorflow_backend:
         mu = self.astensor(mu)
         sigma = self.astensor(sigma)
 
-        normal = tfp.distributions.Normal(mu, sigma)
-        return normal.log_prob(x)
+        return tfp.distributions.Normal(mu, sigma).log_prob(x)
 
     def normal(self, x, mu, sigma):
         r"""
@@ -523,8 +522,7 @@ class tensorflow_backend:
         mu = self.astensor(mu)
         sigma = self.astensor(sigma)
 
-        normal = tfp.distributions.Normal(mu, sigma)
-        return normal.prob(x)
+        return tfp.distributions.Normal(mu, sigma).prob(x)
 
     def normal_cdf(self, x, mu=0.0, sigma=1):
         """
@@ -552,8 +550,7 @@ class tensorflow_backend:
         mu = self.astensor(mu)
         sigma = self.astensor(sigma)
 
-        normal = tfp.distributions.Normal(mu, sigma)
-        return normal.cdf(x)
+        return tfp.distributions.Normal(mu, sigma).cdf(x)
 
     def poisson_dist(self, rate):
         r"""

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -425,6 +425,8 @@ class tensorflow_backend:
         Returns:
             TensorFlow Tensor: Value of the continuous approximation to log(Poisson(n|lam))
         """
+        lam = self.astensor(lam)
+
         return tfp.distributions.Poisson(lam).log_prob(n)
 
     def poisson(self, n, lam):
@@ -454,6 +456,8 @@ class tensorflow_backend:
         Returns:
             TensorFlow Tensor: Value of the continuous approximation to Poisson(n|lam)
         """
+        lam = self.astensor(lam)
+
         return tf.exp(tfp.distributions.Poisson(lam).log_prob(n))
 
     def normal_logpdf(self, x, mu, sigma):
@@ -483,6 +487,9 @@ class tensorflow_backend:
         Returns:
             TensorFlow Tensor: Value of log(Normal(x|mu, sigma))
         """
+        mu = self.astensor(mu)
+        sigma = self.astensor(sigma)
+
         normal = tfp.distributions.Normal(mu, sigma)
         return normal.log_prob(x)
 
@@ -513,6 +520,9 @@ class tensorflow_backend:
         Returns:
             TensorFlow Tensor: Value of Normal(x|mu, sigma)
         """
+        mu = self.astensor(mu)
+        sigma = self.astensor(sigma)
+
         normal = tfp.distributions.Normal(mu, sigma)
         return normal.prob(x)
 
@@ -539,9 +549,10 @@ class tensorflow_backend:
         Returns:
             TensorFlow Tensor: The CDF
         """
-        normal = tfp.distributions.Normal(
-            self.astensor(mu, dtype='float'), self.astensor(sigma, dtype='float')
-        )
+        mu = self.astensor(mu)
+        sigma = self.astensor(sigma)
+
+        normal = tfp.distributions.Normal(mu, sigma)
         return normal.cdf(x)
 
     def poisson_dist(self, rate):
@@ -565,6 +576,8 @@ class tensorflow_backend:
             TensorFlow Probability Poisson distribution: The Poisson distribution class
 
         """
+        rate = self.astensor(rate)
+
         return tfp.distributions.Poisson(rate)
 
     def normal_dist(self, mu, sigma):
@@ -590,6 +603,9 @@ class tensorflow_backend:
             TensorFlow Probability Normal distribution: The Normal distribution class
 
         """
+        mu = self.astensor(mu)
+        sigma = self.astensor(sigma)
+
         return tfp.distributions.Normal(mu, sigma)
 
     def to_numpy(self, tensor_in):


### PR DESCRIPTION
# Description

While investigating Issue #1398, it was noticed that for `64b` precision for the TensorFlow backed the precision was not properly being used throughout. `tf.float32` was used as a default instead of the result of `self.dtypemap["float"]` and if TensorFlow Probability is given floats as parameters it will default to using `32b` precision, and so _requires_ that a tensor of the desired precision be given.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Ensure that the precision requested in the set_backend API is used throughout the TensorFlow backend calculations
   - Determine dtype from dtypemap
   - Ensure TensorFlow Probability operations are given a tensor of the correct precision
```
