### PR TITLE
chore: Use module level __dir__ to restrict public API views

### DIFF
--- a/src/pyhf/__init__.py
+++ b/src/pyhf/__init__.py
@@ -159,21 +159,21 @@ from .patchset import PatchSet
 
 __all__ = [
     "Model",
-    "Workspace",
     "PatchSet",
-    "infer",
-    "utils",
-    "modifiers",
-    "simplemodels",
+    "Workspace",
     "__version__",
-    "tensorlib",
-    "optimzier",
-    "get_backend",
-    "set_backend",
     "exceptions",
+    "get_backend",
+    "infer",
     "interpolators",
+    "modifiers",
     "optimize",
+    "optimzier",
+    "set_backend",
+    "simplemodels",
     "tensor",
+    "tensorlib",
+    "utils",
 ]
 
 

--- a/src/pyhf/__init__.py
+++ b/src/pyhf/__init__.py
@@ -167,12 +167,17 @@ __all__ = [
     "infer",
     "interpolators",
     "modifiers",
-    "optimzier",
+    "optimizer",
+    "parameters",
+    "patchset",
+    "pdf",
+    "probability",
     "set_backend",
     "simplemodels",
     "tensor",
     "tensorlib",
     "utils",
+    "workspace",
 ]
 
 

--- a/src/pyhf/__init__.py
+++ b/src/pyhf/__init__.py
@@ -158,12 +158,24 @@ from . import infer
 from .patchset import PatchSet
 
 __all__ = [
-    'Model',
-    'Workspace',
-    'PatchSet',
-    'infer',
-    'utils',
-    'modifiers',
-    'simplemodels',
-    '__version__',
+    "Model",
+    "Workspace",
+    "PatchSet",
+    "infer",
+    "utils",
+    "modifiers",
+    "simplemodels",
+    "__version__",
+    "tensorlib",
+    "optimzier",
+    "get_backend",
+    "set_backend",
+    "exceptions",
+    "interpolators",
+    "optimize",
+    "tensor",
 ]
+
+
+def __dir__():
+    return __all__

--- a/src/pyhf/__init__.py
+++ b/src/pyhf/__init__.py
@@ -167,7 +167,6 @@ __all__ = [
     "infer",
     "interpolators",
     "modifiers",
-    "optimize",
     "optimzier",
     "set_backend",
     "simplemodels",

--- a/src/pyhf/cli/__init__.py
+++ b/src/pyhf/cli/__init__.py
@@ -7,3 +7,7 @@ from .complete import cli as complete
 from ..contrib import cli as contrib
 
 __all__ = ['cli', 'rootio', 'spec', 'infer', 'complete', 'contrib']
+
+
+def __dir__():
+    return __all__

--- a/src/pyhf/constraints.py
+++ b/src/pyhf/constraints.py
@@ -3,6 +3,12 @@ from . import events
 from . import probability as prob
 from .parameters import ParamViewer
 
+__all__ = ["gaussian_constraint_combined", "poisson_constraint_combined"]
+
+
+def __dir__():
+    return __all__
+
 
 class gaussian_constraint_combined:
     def __init__(self, pdfconfig, batch_size=None):

--- a/src/pyhf/contrib/cli.py
+++ b/src/pyhf/contrib/cli.py
@@ -6,6 +6,12 @@ from pathlib import Path
 logging.basicConfig()
 log = logging.getLogger(__name__)
 
+__all__ = ["download"]
+
+
+def __dir__():
+    return __all__
+
 
 @click.group(name="contrib")
 def cli():

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -9,6 +9,13 @@ from .. import exceptions
 logging.basicConfig()
 log = logging.getLogger(__name__)
 
+__all__ = ["download"]
+
+
+def __dir__():
+    return __all__
+
+
 try:
     import requests
 

--- a/src/pyhf/contrib/viz/brazil.py
+++ b/src/pyhf/contrib/viz/brazil.py
@@ -4,6 +4,12 @@ from collections import namedtuple
 import matplotlib.pyplot as plt
 import numpy as np
 
+__all__ = ["plot_results"]
+
+
+def __dir__():
+    return __all__
+
 
 class BrazilBandCollection(
     namedtuple(

--- a/src/pyhf/contrib/viz/brazil.py
+++ b/src/pyhf/contrib/viz/brazil.py
@@ -4,7 +4,12 @@ from collections import namedtuple
 import matplotlib.pyplot as plt
 import numpy as np
 
-__all__ = ["plot_results"]
+__all__ = [
+    "BrazilBandCollection",
+    "plot_brazil_band",
+    "plot_cls_components",
+    "plot_results",
+]
 
 
 def __dir__():

--- a/src/pyhf/events.py
+++ b/src/pyhf/events.py
@@ -4,6 +4,21 @@ from functools import wraps
 __events = {}
 __disabled_events = set()
 
+__all__ = [
+    "Callables",
+    "WeakList",
+    "disable",
+    "enable",
+    "noop",
+    "register",
+    "subscribe",
+    "trigger",
+]
+
+
+def __dir__():
+    return __all__
+
 
 def noop(*args, **kwargs):
     pass

--- a/src/pyhf/exceptions/__init__.py
+++ b/src/pyhf/exceptions/__init__.py
@@ -1,5 +1,32 @@
 import sys
 
+__all__ = [
+    "FailedMinimization",
+    "ImportBackendError",
+    "InvalidArchiveHost",
+    "InvalidBackend",
+    "InvalidInterpCode",
+    "InvalidMeasurement",
+    "InvalidModel",
+    "InvalidModifier",
+    "InvalidNameReuse",
+    "InvalidOptimizer",
+    "InvalidPatchLookup",
+    "InvalidPatchSet",
+    "InvalidPdfData",
+    "InvalidPdfParameters",
+    "InvalidSpecification",
+    "InvalidTestStatistic",
+    "InvalidWorkspaceOperation",
+    "PatchSetVerificationError",
+    "UnspecifiedPOI",
+    "Unsupported",
+]
+
+
+def __dir__():
+    return __all__
+
 
 class Unsupported(Exception):
     """

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -194,4 +194,8 @@ def hypotest(
 
 from . import intervals  # noqa: F401
 
-__all__ = ["hypotest"]
+__all__ = ["hypotest", "calculators", "intervals", "mle", "test_statistics", "utils"]
+
+
+def __dir__():
+    return __all__

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -16,6 +16,18 @@ import logging
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "AsymptoticCalculator",
+    "AsymptoticTestStatDistribution",
+    "EmpiricalDistribution",
+    "ToyCalculator",
+    "generate_asimov_data",
+]
+
+
+def __dir__():
+    return __all__
+
 
 def generate_asimov_data(asimov_mu, data, pdf, init_pars, par_bounds, fixed_params):
     """

--- a/src/pyhf/infer/intervals.py
+++ b/src/pyhf/infer/intervals.py
@@ -3,6 +3,12 @@ from . import hypotest
 from .. import get_backend
 import numpy as np
 
+__all__ = ["upperlimit"]
+
+
+def __dir__():
+    return __all__
+
 
 def _interp(x, xp, fp):
     tb, _ = get_backend()

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -2,6 +2,12 @@
 from .. import get_backend
 from ..exceptions import UnspecifiedPOI
 
+__all__ = ["fit", "fixed_poi_fit", "twice_nll"]
+
+
+def __dir__():
+    return __all__
+
 
 def twice_nll(pars, data, pdf):
     r"""

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -6,6 +6,12 @@ import logging
 
 log = logging.getLogger(__name__)
 
+__all__ = ["q0", "qmu", "qmu_tilde", "tmu", "tmu_tilde"]
+
+
+def __dir__():
+    return __all__
+
 
 def _qmu_like(mu, data, pdf, init_pars, par_bounds, fixed_params):
     """

--- a/src/pyhf/infer/utils.py
+++ b/src/pyhf/infer/utils.py
@@ -8,6 +8,12 @@ import logging
 
 log = logging.getLogger(__name__)
 
+__all__ = ["create_calculator", "get_test_stat"]
+
+
+def __dir__():
+    return __all__
+
 
 def all_pois_floating(pdf, fixed_params):
     r"""

--- a/src/pyhf/interpolators/__init__.py
+++ b/src/pyhf/interpolators/__init__.py
@@ -43,3 +43,7 @@ def get(interpcode, do_tensorized_calc=True):
 
 
 __all__ = ['code0', 'code1', 'code2', 'code4', 'code4p']
+
+
+def __dir__():
+    return __all__

--- a/src/pyhf/modifiers/__init__.py
+++ b/src/pyhf/modifiers/__init__.py
@@ -192,21 +192,21 @@ combined = {
 }
 
 __all__ = [
-    'histosys',
-    'histosys_combined',
-    'lumi',
-    'lumi_combined',
-    'normfactor',
-    'normfactor_combined',
-    'normsys',
-    'normsys_combined',
-    'shapefactor',
-    'shapefactor_combined',
-    'shapesys',
-    'shapesys_combined',
-    'staterror',
-    'staterror_combined',
-    'combined',
+    "combined",
+    "histosys",
+    "histosys_combined",
+    "lumi",
+    "lumi_combined",
+    "normfactor",
+    "normfactor_combined",
+    "normsys",
+    "normsys_combined",
+    "shapefactor",
+    "shapefactor_combined",
+    "shapesys",
+    "shapesys_combined",
+    "staterror",
+    "staterror_combined",
 ]
 
 

--- a/src/pyhf/modifiers/__init__.py
+++ b/src/pyhf/modifiers/__init__.py
@@ -208,3 +208,7 @@ __all__ = [
     'staterror_combined',
     'combined',
 ]
+
+
+def __dir__():
+    return __all__

--- a/src/pyhf/parameters/__init__.py
+++ b/src/pyhf/parameters/__init__.py
@@ -15,3 +15,7 @@ __all__ = [
     'reduce_paramsets_requirements',
     'ParamViewer',
 ]
+
+
+def __dir__():
+    return __all__

--- a/src/pyhf/parameters/paramsets.py
+++ b/src/pyhf/parameters/paramsets.py
@@ -1,5 +1,17 @@
 from .. import default_backend
 
+__all__ = [
+    "constrained_by_normal",
+    "constrained_by_poisson",
+    "constrained_paramset",
+    "paramset",
+    "unconstrained",
+]
+
+
+def __dir__():
+    return __all__
+
 
 class paramset:
     def __init__(self, **kwargs):

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -4,6 +4,12 @@ from ..tensor.common import (
     _tensorviewer_from_sizes,
 )
 
+__all__ = ["ParamViewer"]
+
+
+def __dir__():
+    return __all__
+
 
 def _tensorviewer_from_parmap(par_map, batch_size):
     names, slices, _ = list(

--- a/src/pyhf/parameters/utils.py
+++ b/src/pyhf/parameters/utils.py
@@ -1,5 +1,11 @@
 from .. import exceptions
 
+__all__ = ["reduce_paramsets_requirements"]
+
+
+def __dir__():
+    return __all__
+
 
 def reduce_paramsets_requirements(paramsets_requirements, paramsets_user_configs):
     reduced_paramsets_requirements = {}

--- a/src/pyhf/patchset.py
+++ b/src/pyhf/patchset.py
@@ -9,6 +9,12 @@ from .workspace import Workspace
 
 log = logging.getLogger(__name__)
 
+__all__ = ["Patch", "PatchSet"]
+
+
+def __dir__():
+    return __all__
+
 
 class Patch(jsonpatch.JsonPatch):
     """

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -16,6 +16,12 @@ from .mixins import _ChannelSummaryMixin
 
 log = logging.getLogger(__name__)
 
+__all__ = ["Model", "_ModelConfig"]
+
+
+def __dir__():
+    return __all__
+
 
 def _paramset_requirements_from_channelspec(spec, channel_nbins):
     # bookkeep all requirements for paramsets we need to build

--- a/src/pyhf/probability.py
+++ b/src/pyhf/probability.py
@@ -1,6 +1,12 @@
 """The probability density function module."""
 from . import get_backend
 
+__all__ = ["Independent", "Normal", "Poisson", "Simultaneous"]
+
+
+def __dir__():
+    return __all__
+
 
 class _SimpleDistributionMixin:
     """The mixin class for distributions."""

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -13,6 +13,22 @@ log = logging.getLogger(__name__)
 
 __FILECACHE__ = {}
 
+__all__ = [
+    "clear_filecache",
+    "dedupe_parameters",
+    "extract_error",
+    "import_root_histogram",
+    "parse",
+    "process_channel",
+    "process_data",
+    "process_measurements",
+    "process_sample",
+]
+
+
+def __dir__():
+    return __all__
+
 
 def extract_error(hist):
     """

--- a/src/pyhf/simplemodels.py
+++ b/src/pyhf/simplemodels.py
@@ -1,5 +1,11 @@
 from . import Model
 
+__all__ = ["hepdata_like"]
+
+
+def __dir__():
+    return __all__
+
 
 def hepdata_like(signal_data, bkg_data, bkg_uncerts, batch_size=None):
     """

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -12,6 +12,20 @@ SCHEMA_CACHE = {}
 SCHEMA_BASE = "https://scikit-hep.org/pyhf/schemas/"
 SCHEMA_VERSION = '1.0.0'
 
+__all__ = [
+    "EqDelimStringParamType",
+    "citation",
+    "digest",
+    "load_schema",
+    "options_from_eqdelimstring",
+    "remove_prefix",
+    "validate",
+]
+
+
+def __dir__():
+    return __all__
+
 
 def load_schema(schema_id, version=None):
     global SCHEMA_CACHE

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -16,6 +16,12 @@ from .mixins import _ChannelSummaryMixin
 
 log = logging.getLogger(__name__)
 
+__all__ = ["Workspace"]
+
+
+def __dir__():
+    return __all__
+
 
 def _join_items(join, left_items, right_items, key='name', deep_merge_key=None):
     """

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -16,6 +16,20 @@ _ROOT_DATA_FILE = None
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    "build_channel",
+    "build_data",
+    "build_measurement",
+    "build_modifier",
+    "build_sample",
+    "indent",
+]
+
+
+def __dir__():
+    return __all__
+
+
 # 'spec' gets passed through all functions as NormFactor is a unique case of having
 # parameter configurations stored at the modifier-definition-spec level. This means
 # that build_modifier() needs access to the measurements. The call stack is:

--- a/tests/test_public_api_repr.py
+++ b/tests/test_public_api_repr.py
@@ -16,7 +16,6 @@ def test_top_level_public_api():
         "infer",
         "interpolators",
         "modifiers",
-        "optimize",
         "optimzier",
         "set_backend",
         "simplemodels",

--- a/tests/test_public_api_repr.py
+++ b/tests/test_public_api_repr.py
@@ -1,6 +1,8 @@
 import pyhf
 import pyhf.cli
 import pyhf.contrib.viz.brazil
+import pyhf.readxml
+import pyhf.writexml
 
 
 def test_top_level_public_api():
@@ -150,4 +152,90 @@ def test_modifiers_public_api():
         "shapesys_combined",
         "staterror",
         "staterror_combined",
+    ]
+
+
+def test_parameters_public_api():
+    assert dir(pyhf.parameters) == [
+        "ParamViewer",
+        "constrained_by_normal",
+        "constrained_by_poisson",
+        "paramset",
+        "reduce_paramsets_requirements",
+        "unconstrained",
+    ]
+
+
+def test_parameters_paramsets_public_api():
+    assert dir(pyhf.parameters.paramsets) == [
+        "constrained_by_normal",
+        "constrained_by_poisson",
+        "constrained_paramset",
+        "paramset",
+        "unconstrained",
+    ]
+
+
+def test_parameters_paramview_public_api():
+    assert dir(pyhf.parameters.paramview) == ["ParamViewer"]
+
+
+def test_parameters_utils_public_api():
+    assert dir(pyhf.parameters.utils) == ["reduce_paramsets_requirements"]
+
+
+def test_patchset_public_api():
+    assert dir(pyhf.patchset) == ["Patch", "PatchSet"]
+
+
+def test_pdf_public_api():
+    assert dir(pyhf.pdf) == ["Model", "_ModelConfig"]
+
+
+def test_probability_public_api():
+    assert dir(pyhf.probability) == ["Independent", "Normal", "Poisson", "Simultaneous"]
+
+
+def test_readxml_public_api():
+    assert dir(pyhf.readxml) == [
+        "clear_filecache",
+        "dedupe_parameters",
+        "extract_error",
+        "import_root_histogram",
+        "parse",
+        "process_channel",
+        "process_data",
+        "process_measurements",
+        "process_sample",
+    ]
+
+
+def test_simplemodels_public_api():
+    assert dir(pyhf.simplemodels) == ["hepdata_like"]
+
+
+def test_utils_public_api():
+    assert dir(pyhf.utils) == [
+        "EqDelimStringParamType",
+        "citation",
+        "digest",
+        "load_schema",
+        "options_from_eqdelimstring",
+        "remove_prefix",
+        "validate",
+    ]
+
+
+def test_workspace_public_api():
+    assert dir(pyhf.workspace) == ["Workspace"]
+
+
+def test_writexml_public_api():
+    assert dir(pyhf.writexml) == [
+        "build_channel",
+        "build_data",
+        "build_measurement",
+        "build_modifier",
+        "build_sample",
+        "indent",
     ]

--- a/tests/test_public_api_repr.py
+++ b/tests/test_public_api_repr.py
@@ -1,0 +1,153 @@
+import pyhf
+import pyhf.cli
+import pyhf.contrib.viz.brazil
+
+
+def test_top_level_public_api():
+    assert dir(pyhf) == [
+        "Model",
+        "PatchSet",
+        "Workspace",
+        "__version__",
+        "exceptions",
+        "get_backend",
+        "infer",
+        "interpolators",
+        "modifiers",
+        "optimize",
+        "optimzier",
+        "set_backend",
+        "simplemodels",
+        "tensor",
+        "tensorlib",
+        "utils",
+    ]
+
+
+def test_cli_public_api():
+    assert dir(pyhf.cli) == ["cli", "complete", "contrib", "infer", "rootio", "spec"]
+
+
+def test_constraints_public_api():
+    assert dir(pyhf.constraints) == [
+        "gaussian_constraint_combined",
+        "poisson_constraint_combined",
+    ]
+
+
+def test_cli_contrib_public_api():
+    assert dir(pyhf.cli.contrib) == ["download"]
+
+
+def test_contrib_viz_public_api():
+    assert dir(pyhf.contrib.viz.brazil) == [
+        "BrazilBandCollection",
+        "plot_brazil_band",
+        "plot_cls_components",
+        "plot_results",
+    ]
+
+
+def test_contrib_events_public_api():
+    assert dir(pyhf.events) == [
+        "Callables",
+        "WeakList",
+        "disable",
+        "enable",
+        "noop",
+        "register",
+        "subscribe",
+        "trigger",
+    ]
+
+
+def test_contrib_exceptions_public_api():
+    assert dir(pyhf.exceptions) == [
+        "FailedMinimization",
+        "ImportBackendError",
+        "InvalidArchiveHost",
+        "InvalidBackend",
+        "InvalidInterpCode",
+        "InvalidMeasurement",
+        "InvalidModel",
+        "InvalidModifier",
+        "InvalidNameReuse",
+        "InvalidOptimizer",
+        "InvalidPatchLookup",
+        "InvalidPatchSet",
+        "InvalidPdfData",
+        "InvalidPdfParameters",
+        "InvalidSpecification",
+        "InvalidTestStatistic",
+        "InvalidWorkspaceOperation",
+        "PatchSetVerificationError",
+        "UnspecifiedPOI",
+        "Unsupported",
+    ]
+
+
+def test_infer_public_api():
+    assert dir(pyhf.infer) == [
+        "calculators",
+        "hypotest",
+        "intervals",
+        "mle",
+        "test_statistics",
+        "utils",
+    ]
+
+
+def test_infer_calculators_public_api():
+    assert dir(pyhf.infer.calculators) == [
+        "AsymptoticCalculator",
+        "AsymptoticTestStatDistribution",
+        "EmpiricalDistribution",
+        "ToyCalculator",
+        "generate_asimov_data",
+    ]
+
+
+def test_infer_intervals_public_api():
+    assert dir(pyhf.infer.intervals) == ["upperlimit"]
+
+
+def test_infer_mle_public_api():
+    assert dir(pyhf.infer.mle) == ["fit", "fixed_poi_fit", "twice_nll"]
+
+
+def test_infer_test_statistics_public_api():
+    assert dir(pyhf.infer.test_statistics) == [
+        "q0",
+        "qmu",
+        "qmu_tilde",
+        "tmu",
+        "tmu_tilde",
+    ]
+
+
+def test_infer_utils_public_api():
+    assert dir(pyhf.infer.utils) == ["create_calculator", "get_test_stat"]
+
+
+def test_interpolators_public_api():
+    assert dir(pyhf.interpolators) == ["code0", "code1", "code2", "code4", "code4p"]
+
+
+def test_modifiers_public_api():
+    assert dir(pyhf.modifiers) == [
+        "combined",
+        "histosys",
+        "histosys_combined",
+        "lumi",
+        "lumi_combined",
+        "normfactor",
+        "normfactor_combined",
+        "normsys",
+        "normsys_combined",
+        "shapefactor",
+        "shapefactor_combined",
+        "shapesys",
+        "shapesys_combined",
+        "staterror",
+        "staterror_combined",
+    ]

--- a/tests/test_public_api_repr.py
+++ b/tests/test_public_api_repr.py
@@ -1,5 +1,6 @@
 import pyhf
 import pyhf.cli
+import pyhf.contrib.utils
 import pyhf.contrib.viz.brazil
 import pyhf.readxml
 import pyhf.writexml
@@ -38,6 +39,10 @@ def test_constraints_public_api():
 
 def test_cli_contrib_public_api():
     assert dir(pyhf.cli.contrib) == ["download"]
+
+
+def test_contrib_utils_public_api():
+    assert dir(pyhf.contrib.utils) == ["download"]
 
 
 def test_contrib_viz_public_api():

--- a/tests/test_public_api_repr.py
+++ b/tests/test_public_api_repr.py
@@ -17,12 +17,17 @@ def test_top_level_public_api():
         "infer",
         "interpolators",
         "modifiers",
-        "optimzier",
+        "optimizer",
+        "parameters",
+        "patchset",
+        "pdf",
+        "probability",
         "set_backend",
         "simplemodels",
         "tensor",
         "tensorlib",
         "utils",
+        "workspace",
     ]
 
 


### PR DESCRIPTION
# Description

Resolves #1402 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use module level __dir__ in combination with __all__ to restrict the public API import views to useful imports
* c.f. https://snarky.ca/lazy-importing-in-python-3-7/
```
