### PR TITLE
chore: Update Black to release v21.4b0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       exclude: ^validation/|\.dtd$|\.xml$
 
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.4b0
     hooks:
     - id: black
 
@@ -31,7 +31,7 @@ repos:
     rev: v1.10.0
     hooks:
     - id: blacken-docs
-      additional_dependencies: [black==20.8b1]
+      additional_dependencies: [black==21.4b0]
 
 -   repo: https://github.com/PyCQA/flake8
     rev: 3.9.1
@@ -39,7 +39,7 @@ repos:
     - id: flake8
 
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.12.0
+    rev: v2.13.0
     hooks:
     - id: pyupgrade
       args: ["--py37-plus"]
@@ -48,6 +48,6 @@ repos:
     rev: 0.7.0
     hooks:
     - id: nbqa-black
-      additional_dependencies: [black==20.8b1]
+      additional_dependencies: [black==21.4b0]
     - id: nbqa-pyupgrade
       additional_dependencies: [pyupgrade==2.11.0]

--- a/src/pyhf/patchset.py
+++ b/src/pyhf/patchset.py
@@ -38,27 +38,27 @@ class Patch(jsonpatch.JsonPatch):
 
     @property
     def metadata(self):
-        """ The metadata of the patch """
+        """The metadata of the patch"""
         return self._metadata
 
     @property
     def name(self):
-        """ The name of the patch """
+        """The name of the patch"""
         return self.metadata['name']
 
     @property
     def values(self):
-        """ The values of the associated labels for the patch """
+        """The values of the associated labels for the patch"""
         return tuple(self.metadata['values'])
 
     def __repr__(self):
-        """ Representation of the object """
+        """Representation of the object"""
         module = type(self).__module__
         qualname = type(self).__qualname__
         return f"<{module}.{qualname} object '{self.name}{self.values}' at {hex(id(self))}>"
 
     def __eq__(self, other):
-        """ Equality for subclass with new attributes """
+        """Equality for subclass with new attributes"""
         if not isinstance(other, Patch):
             return False
         return (
@@ -195,41 +195,41 @@ class PatchSet:
 
     @property
     def version(self):
-        """ The version of the PatchSet """
+        """The version of the PatchSet"""
         return self._version
 
     @property
     def metadata(self):
-        """ The metadata of the PatchSet """
+        """The metadata of the PatchSet"""
         return self._metadata
 
     @property
     def references(self):
-        """ The references in the PatchSet metadata """
+        """The references in the PatchSet metadata"""
         return self.metadata['references']
 
     @property
     def description(self):
-        """ The description in the PatchSet metadata """
+        """The description in the PatchSet metadata"""
         return self.metadata['description']
 
     @property
     def digests(self):
-        """ The digests in the PatchSet metadata """
+        """The digests in the PatchSet metadata"""
         return self.metadata['digests']
 
     @property
     def labels(self):
-        """ The labels in the PatchSet metadata """
+        """The labels in the PatchSet metadata"""
         return self.metadata['labels']
 
     @property
     def patches(self):
-        """ The patches in the PatchSet """
+        """The patches in the PatchSet"""
         return self._patches
 
     def __repr__(self):
-        """ Representation of the object """
+        """Representation of the object"""
         module = type(self).__module__
         qualname = type(self).__qualname__
         return f"<{module}.{qualname} object with {len(self.patches)} patch{'es' if len(self.patches) != 1 else ''} at {hex(id(self))}>"


### PR DESCRIPTION
# Description

Update Black to use release [`21.4b0`](https://github.com/psf/black/releases/tag/21.4b0).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update docstrings to use Black release v21.4b0 style
   - c.f. https://github.com/psf/black/releases/tag/21.4b0
* Update pre-commit hooks releases
   - github.com/psf/black: 20.8b1 → 21.4b0
   - github.com/asottile/pyupgrade: 2.12.0 → 2.13.0
```
