### PR TITLE
chore: Update Black to release v21.4b1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       exclude: ^validation/|\.dtd$|\.xml$
 
 -   repo: https://github.com/psf/black
-    rev: 21.4b0
+    rev: 21.4b1
     hooks:
     - id: black
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     rev: v1.10.0
     hooks:
     - id: blacken-docs
-      additional_dependencies: [black==21.4b0]
+      additional_dependencies: [black==21.4b1]
 
 -   repo: https://github.com/PyCQA/flake8
     rev: 3.9.1
@@ -48,6 +48,6 @@ repos:
     rev: 0.7.0
     hooks:
     - id: nbqa-black
-      additional_dependencies: [black==21.4b0]
+      additional_dependencies: [black==21.4b1]
     - id: nbqa-pyupgrade
       additional_dependencies: [pyupgrade==2.11.0]


### PR DESCRIPTION
# Description

Update Black to use release [`21.4b1`](https://github.com/psf/black/releases/tag/21.4b1).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* c.f. https://github.com/psf/black/releases/tag/21.4b1
* Update pre-commit hooks releases
   - github.com/psf/black: 21.4b0 → 21.4b1
```
