### PR TITLE
docs: Add utils.citation to Python API docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -197,7 +197,7 @@ Utilities
    validate
    options_from_eqdelimstring
    digest
-   pyhf.utils.citation
+   citation
 
 Contrib
 -------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -197,6 +197,7 @@ Utilities
    validate
    options_from_eqdelimstring
    digest
+   pyhf.utils.citation
 
 Contrib
 -------

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -141,7 +141,7 @@ def citation(oneline=False):
     Example:
 
         >>> import pyhf
-        >>> pyhf.utils.citation(True)
+        >>> pyhf.utils.citation(oneline=True)
         '@software{pyhf,  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark},  title = "{pyhf: v0.6.1}",  version = {0.6.1},  doi = {10.5281/zenodo.1169739},  url = {https://github.com/scikit-hep/pyhf},}@article{pyhf_joss,  doi = {10.21105/joss.02823},  url = {https://doi.org/10.21105/joss.02823},  year = {2021},  publisher = {The Open Journal},  volume = {6},  number = {58},  pages = {2823},  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark and Kyle Cranmer},  title = {pyhf: pure-Python implementation of HistFactory statistical models},  journal = {Journal of Open Source Software}}'
 
     Keyword Args:


### PR DESCRIPTION
# Description

Resolves #1315

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add pyhf.utils.citation to the Python API docs
* Add oneline arg to docstring example to make output format more clear
```
