### PR TITLE
docs: Add docstrings to _ModelConfig methods

### DIFF
--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -276,6 +276,20 @@ class _ModelConfig(_ChannelSummaryMixin):
         return init
 
     def suggested_bounds(self):
+        """
+        Return suggested parameter bounds for the model.
+
+        Returns:
+            :obj:`list`: Suggested bounds on model parameters.
+
+        Example:
+            >>> import pyhf
+            >>> model = pyhf.simplemodels.hepdata_like(
+            ...     signal_data=[12.0, 11.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0]
+            ... )
+            >>> model.config.suggested_bounds()
+            [(0, 10), (1e-10, 10.0), (1e-10, 10.0)]
+        """
         bounds = []
         for name in self.par_order:
             bounds = bounds + self.par_map[name]['paramset'].suggested_bounds

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -374,7 +374,7 @@ class _ModelConfig(_ChannelSummaryMixin):
             >>> model = pyhf.simplemodels.hepdata_like(
             ...     signal_data=[12.0, 11.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0]
             ... )
-            >>> model.config.param_set("mu")
+            >>> model.config.set_poi("mu")
             >>> model.config.poi_name
             'mu'
         """

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -256,6 +256,20 @@ class _ModelConfig(_ChannelSummaryMixin):
         self.nmaindata = sum(self.channel_nbins.values())
 
     def suggested_init(self):
+        """
+        Return suggested initial parameter values for the model.
+
+        Returns:
+            :obj:`list`: Suggested initial model parameters.
+
+        Example:
+            >>> import pyhf
+            >>> model = pyhf.simplemodels.hepdata_like(
+            ...     signal_data=[12.0, 11.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0]
+            ... )
+            >>> model.config.suggested_init()
+            [1.0, 1.0, 1.0]
+        """
         init = []
         for name in self.par_order:
             init = init + self.par_map[name]['paramset'].suggested_init
@@ -278,7 +292,8 @@ class _ModelConfig(_ChannelSummaryMixin):
         Identify the fixed parameters in the model.
 
         Returns:
-            List: A list of booleans, ``True`` for fixed and ``False`` for not fixed.
+            :obj:`list`: A list of booleans, ``True`` for fixed and ``False``
+            for not fixed.
 
         Something like the following to build ``fixed_vals`` appropriately:
 

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -205,7 +205,22 @@ def _nominal_and_modifiers_from_spec(config, spec):
 
 
 class _ModelConfig(_ChannelSummaryMixin):
+    """
+    Configuration for the :class:`~pyhf.pdf.Model`.
+
+    .. note::
+
+        :class:`_ModelConfig` should not be called directly.
+        It should instead by accessed through the :obj:`config` attribute
+        of :class:`~pyhf.pdf.Model`.
+
+    """
+
     def __init__(self, spec, **config_kwargs):
+        """
+        Args:
+            spec (:obj:`jsonable`): The HistFactory JSON specification.
+        """
         super().__init__(channels=spec['channels'])
         _required_paramsets = _paramset_requirements_from_modelspec(
             spec, self.channel_nbins
@@ -265,7 +280,7 @@ class _ModelConfig(_ChannelSummaryMixin):
         Returns:
             List: A list of booleans, ``True`` for fixed and ``False`` for not fixed.
 
-        Something like the following to build fixed_vals appropriately:
+        Something like the following to build ``fixed_vals`` appropriately:
 
         .. code:: python
 

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -296,9 +296,39 @@ class _ModelConfig(_ChannelSummaryMixin):
         return bounds
 
     def par_slice(self, name):
+        """
+        The slice of the model parameter tensor corresponding to the model
+        parameter ``name``.
+
+        Returns:
+            :obj:`slice`: Slice of the model parameter tensor.
+
+        Example:
+            >>> import pyhf
+            >>> model = pyhf.simplemodels.hepdata_like(
+            ...     signal_data=[12.0, 11.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0]
+            ... )
+            >>> model.config.par_slice("uncorr_bkguncrt")
+            slice(1, 3, None)
+        """
         return self.par_map[name]['slice']
 
     def param_set(self, name):
+        """
+        The :class:`~pyhf.parameters.paramset` for the model parameter ``name``.
+
+        Returns:
+            :obj:`~pyhf.parameters.paramsets`: Corresponding :obj:`paramset`.
+
+        Example:
+            >>> import pyhf
+            >>> model = pyhf.simplemodels.hepdata_like(
+            ...     signal_data=[12.0, 11.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0]
+            ... )
+            >>> param_set = model.config.param_set("uncorr_bkguncrt")
+            >>> param_set.pdf_type
+            'poisson'
+        """
         return self.par_map[name]['paramset']
 
     def suggested_fixed(self):
@@ -309,12 +339,20 @@ class _ModelConfig(_ChannelSummaryMixin):
             :obj:`list`: A list of booleans, ``True`` for fixed and ``False``
             for not fixed.
 
+        Example:
+            >>> import pyhf
+            >>> model = pyhf.simplemodels.hepdata_like(
+            ...     signal_data=[12.0, 11.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0]
+            ... )
+            >>> model.config.suggested_fixed()
+            [False, False, False]
+
         Something like the following to build ``fixed_vals`` appropriately:
 
         .. code:: python
 
-            fixed_pars = pdf.config.suggested_fixed()
-            inits = pdf.config.suggested_init()
+            fixed_pars = model.config.suggested_fixed()
+            inits = model.config.suggested_init()
             fixed_vals = [
                 (index, init)
                 for index, (init, is_fixed) in enumerate(zip(inits, fixed_pars))
@@ -328,6 +366,18 @@ class _ModelConfig(_ChannelSummaryMixin):
         return fixed
 
     def set_poi(self, name):
+        """
+        Set the model parameter of interest to be model parameter ``name``.
+
+        Example:
+            >>> import pyhf
+            >>> model = pyhf.simplemodels.hepdata_like(
+            ...     signal_data=[12.0, 11.0], bkg_data=[50.0, 52.0], bkg_uncerts=[3.0, 7.0]
+            ... )
+            >>> model.config.param_set("mu")
+            >>> model.config.poi_name
+            'mu'
+        """
         if name not in [x for x, _ in self.modifiers]:
             raise exceptions.InvalidModel(
                 f"The parameter of interest '{name:s}' cannot be fit as it is not declared in the model specification."


### PR DESCRIPTION
# Description

To satisfy `pydocstyle` in PR #1403 docstrings need to be added to `pyhf.pdf._ModelConfig`, so these are added here.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add docstrings and examples to pyhf.pdf._ModelConfig and its methods
```
