### PR TITLE
docs: Add use citation from Belle II B⁺→ K⁺νν̅ decays search paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,14 @@
+% 2021-04-26
+@article{Abudinen:2021emt,
+    author = "Belle II Collaboration",
+    title = "{Search for $B^{+}\to K^{+}\nu\bar{\nu}$ decays using an inclusive tagging method at Belle II}",
+    eprint = "2104.12624",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    reportNumber = "Belle II Preprint 2021-001, KEK Preprint 2020-45",
+    month = "4",
+    year = "2021"
+}
 
 % 2021-04-25
 @article{Angelescu:2021lln,

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -7,7 +7,8 @@
     primaryClass = "hep-ex",
     reportNumber = "Belle II Preprint 2021-001, KEK Preprint 2020-45",
     month = "4",
-    year = "2021"
+    year = "2021",
+    journal = ""
 }
 
 % 2021-04-25


### PR DESCRIPTION
# Description

Add use citation from [Search for B⁺→ K⁺νν̅ decays using an inclusive tagging method at Belle II](https://inspirehep.net/literature/1860766) by the Belle II Collaboration! :rocket: 

This is the second paper by an experiment to cite `pyhf` (ATLAS was first with https://doi.org/10.1007/JHEP04(2021)165)!

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Search for B⁺→ K⁺νν̅ decays using an inclusive tagging method at Belle II'
   - c.f. https://inspirehep.net/literature/1860766
   - First use citation of pyhf in a paper by a non-LHC experiment
```
