### PR TITLE
docs: Update software citation URL to Zenodo DOI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -289,7 +289,8 @@ the preferred BibTeX entry for citation of ``pyhf`` includes both the
      title = "{pyhf: v0.6.1}",
      version = {0.6.1},
      doi = {10.5281/zenodo.1169739},
-     url = {https://github.com/scikit-hep/pyhf},
+     url = {https://doi.org/10.5281/zenodo.1169739},
+     note = {https://github.com/scikit-hep/pyhf/releases/tag/v0.6.1}
    }
 
    @article{pyhf_joss,

--- a/docs/release-notes/v0.6.0.rst
+++ b/docs/release-notes/v0.6.0.rst
@@ -99,7 +99,8 @@ CLI API
      title = "{pyhf: v0.6.0}",
      version = {0.6.0},
      doi = {10.5281/zenodo.1169739},
-     url = {https://github.com/scikit-hep/pyhf},
+     url = {https://doi.org/10.5281/zenodo.1169739},
+     note = {https://github.com/scikit-hep/pyhf/releases/tag/v0.6.0}
    }
 
    @article{pyhf_joss,

--- a/src/pyhf/data/citation.bib
+++ b/src/pyhf/data/citation.bib
@@ -3,7 +3,8 @@
   title = "{pyhf: v0.6.1}",
   version = {0.6.1},
   doi = {10.5281/zenodo.1169739},
-  url = {https://github.com/scikit-hep/pyhf},
+  url = {https://doi.org/10.5281/zenodo.1169739},
+  note = {https://github.com/scikit-hep/pyhf/releases/tag/v0.6.1}
 }
 
 @article{pyhf_joss,

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -142,7 +142,7 @@ def citation(oneline=False):
 
         >>> import pyhf
         >>> pyhf.utils.citation(oneline=True)
-        '@software{pyhf,  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark},  title = "{pyhf: v0.6.1}",  version = {0.6.1},  doi = {10.5281/zenodo.1169739},  url = {https://doi.org/10.5281/zenodo.1169739}, note = {https://github.com/scikit-hep/pyhf/releases/tag/v0.6.1}}@article{pyhf_joss,  doi = {10.21105/joss.02823},  url = {https://doi.org/10.21105/joss.02823},  year = {2021},  publisher = {The Open Journal},  volume = {6},  number = {58},  pages = {2823},  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark and Kyle Cranmer},  title = {pyhf: pure-Python implementation of HistFactory statistical models},  journal = {Journal of Open Source Software}}'
+        '@software{pyhf,  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark},  title = "{pyhf: v0.6.1}",  version = {0.6.1},  doi = {10.5281/zenodo.1169739},  url = {https://doi.org/10.5281/zenodo.1169739},  note = {https://github.com/scikit-hep/pyhf/releases/tag/v0.6.1}}@article{pyhf_joss,  doi = {10.21105/joss.02823},  url = {https://doi.org/10.21105/joss.02823},  year = {2021},  publisher = {The Open Journal},  volume = {6},  number = {58},  pages = {2823},  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark and Kyle Cranmer},  title = {pyhf: pure-Python implementation of HistFactory statistical models},  journal = {Journal of Open Source Software}}'
 
     Keyword Args:
         oneline (:obj:`bool`): Whether to provide citation with new lines (default) or as a one-liner.

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -142,7 +142,7 @@ def citation(oneline=False):
 
         >>> import pyhf
         >>> pyhf.utils.citation(oneline=True)
-        '@software{pyhf,  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark},  title = "{pyhf: v0.6.1}",  version = {0.6.1},  doi = {10.5281/zenodo.1169739},  url = {https://github.com/scikit-hep/pyhf},}@article{pyhf_joss,  doi = {10.21105/joss.02823},  url = {https://doi.org/10.21105/joss.02823},  year = {2021},  publisher = {The Open Journal},  volume = {6},  number = {58},  pages = {2823},  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark and Kyle Cranmer},  title = {pyhf: pure-Python implementation of HistFactory statistical models},  journal = {Journal of Open Source Software}}'
+        '@software{pyhf,  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark},  title = "{pyhf: v0.6.1}",  version = {0.6.1},  doi = {10.5281/zenodo.1169739},  url = {https://doi.org/10.5281/zenodo.1169739}, note = {https://github.com/scikit-hep/pyhf/releases/tag/v0.6.1}}@article{pyhf_joss,  doi = {10.21105/joss.02823},  url = {https://doi.org/10.21105/joss.02823},  year = {2021},  publisher = {The Open Journal},  volume = {6},  number = {58},  pages = {2823},  author = {Lukas Heinrich and Matthew Feickert and Giordon Stark and Kyle Cranmer},  title = {pyhf: pure-Python implementation of HistFactory statistical models},  journal = {Journal of Open Source Software}}'
 
     Keyword Args:
         oneline (:obj:`bool`): Whether to provide citation with new lines (default) or as a one-liner.


### PR DESCRIPTION
# Description

Resolves #1423 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update the 'url' field in the requested software citation to be the Zenodo DOI URL
* Add a 'note' field that has the GitHub release URL
```
