### PR TITLE
docs: Add CERN Courier article to media listing

### DIFF
--- a/docs/bib/media.bib
+++ b/docs/bib/media.bib
@@ -1,5 +1,5 @@
 @article{CERN-COURIER-61-3_May_2021,
-  title   = {{CERN Courier Volume 61, Number 3, May/June 2021}},
+  title   = {{LHC reinterpreters think long-term}},
   author  = {Sabine Kraml},
   journal = {CERN Courier Volume 61, Number 3, May/June 2021},
   year    = {2021},

--- a/docs/bib/media.bib
+++ b/docs/bib/media.bib
@@ -4,7 +4,8 @@
   journal = {CERN Courier Volume 61, Number 3, May/June 2021},
   year    = {2021},
   month   = {May},
-  url     = {https://cds.cern.ch/record/2765233},
+  url     = {https://cerncourier.com/wp-content/uploads/2021/04/CERNCourier2021MayJun-digitaledition.pdf},
+  note    = {https://cds.cern.ch/record/2765233}
 }
 
 @article{Symmetry_magazine_2021,

--- a/docs/bib/media.bib
+++ b/docs/bib/media.bib
@@ -4,7 +4,7 @@
   journal = {CERN Courier Volume 61, Number 3, May/June 2021},
   year    = {2021},
   month   = {May},
-  url     = {https://cerncourier.com/wp-content/uploads/2021/04/CERNCourier2021MayJun-digitaledition.pdf},
+  url     = {https://cerncourier.com/a/lhc-reinterpreters-think-long-term/},
   note    = {https://cds.cern.ch/record/2765233}
 }
 

--- a/docs/bib/media.bib
+++ b/docs/bib/media.bib
@@ -3,7 +3,8 @@
   author  = {Sabine Kraml},
   journal = {CERN Courier Volume 61, Number 3, May/June 2021},
   year    = {2021},
-  month   = {May},
+  month   = {April},
+  day     = {28},
   url     = {https://cerncourier.com/a/lhc-reinterpreters-think-long-term/},
   note    = {https://cds.cern.ch/record/2765233}
 }

--- a/docs/bib/media.bib
+++ b/docs/bib/media.bib
@@ -1,3 +1,12 @@
+@article{CERN-COURIER-61-3_May_2021,
+  title   = {{CERN Courier Volume 61, Number 3, May/June 2021}},
+  author  = {Sabine Kraml},
+  journal = {CERN Courier Volume 61, Number 3, May/June 2021},
+  year    = {2021},
+  month   = {May},
+  url     = {https://cds.cern.ch/record/2765233},
+}
+
 @article{Symmetry_magazine_2021,
   title   = {{ATLAS releases 'full orchestra' of analysis instruments}},
   author  = {Stephanie Melchor},


### PR DESCRIPTION
# Description

Add links in the "In the Media" section to the [May/June 2021 Issue](https://cds.cern.ch/record/2765233) of the CERN Courier that feature `pyhf` in the the article "LHC reinterpreters think long-term" (page 23) written by @sabinekraml (:raised_hands:).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add May/June 2021 Issue of the CERN Courier that features pyhf's role in open likelihood publishing and summary of the 6th LHC Reinterpretation Workshop to 'In the Media' section
   - c.f. https://cds.cern.ch/record/2765233
   - "LHC reinterpreters think long-term" article on page 23 written by Sabine Kraml
```
