### PR TITLE
ci: Add custom commit message for pre-commit.ci autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,7 @@
-repos:
+ci:
+  autoupdate_commit_msg: "chore: [pre-commit.ci] pre-commit autoupdate"
 
+repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       exclude: ^validation/|\.dtd$|\.xml$
 
 -   repo: https://github.com/psf/black
-    rev: 21.4b2
+    rev: 21.5b0
     hooks:
     - id: black
 
@@ -33,7 +33,7 @@ repos:
     rev: v1.10.0
     hooks:
     - id: blacken-docs
-      additional_dependencies: [black==21.4b2]
+      additional_dependencies: [black==21.5b0]
 
 -   repo: https://github.com/PyCQA/flake8
     rev: 3.9.1
@@ -50,6 +50,6 @@ repos:
     rev: 0.8.0
     hooks:
     - id: nbqa-black
-      additional_dependencies: [black==21.4b2]
+      additional_dependencies: [black==21.5b0]
     - id: nbqa-pyupgrade
       additional_dependencies: [pyupgrade==2.14.0]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     rev: v1.10.0
     hooks:
     - id: blacken-docs
-      additional_dependencies: [black==21.4b1]
+      additional_dependencies: [black==21.4b2]
 
 -   repo: https://github.com/PyCQA/flake8
     rev: 3.9.1
@@ -50,6 +50,6 @@ repos:
     rev: 0.8.0
     hooks:
     - id: nbqa-black
-      additional_dependencies: [black==21.4b1]
+      additional_dependencies: [black==21.4b2]
     - id: nbqa-pyupgrade
-      additional_dependencies: [pyupgrade==2.11.0]
+      additional_dependencies: [pyupgrade==2.14.0]

--- a/docs/examples/notebooks/binderexample/StatisticalAnalysis.ipynb
+++ b/docs/examples/notebooks/binderexample/StatisticalAnalysis.ipynb
@@ -2269,7 +2269,7 @@
     "ax2.set_title('nominal background-only µ = 0')\n",
     "plot(ax=ax2, **{k: background_only[v] for k, v in par_name_dict.items()})\n",
     "\n",
-    "ax3.set_title('best fit µ = {:.3g}'.format(best_fit[pdf.config.poi_index]))\n",
+    "ax3.set_title(f'best fit µ = {best_fit[pdf.config.poi_index]:.3g}')\n",
     "plot(ax=ax3, **{k: best_fit[v] for k, v in par_name_dict.items()});"
    ]
   },


### PR DESCRIPTION
# Description

Resolves #1431

Add custom pre-commit.ci autoupdate commit message that is in semantic PR style by prepending "chore:" to the default. Update the additional dependencies to match their top level pre-commit hook versions.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add custom pre-commit.ci autoupdate commit message that is in semantic PR style
   - c.f. https://pre-commit.ci/#configuration
* Update black pre-commit hook
   - github.com/psf/black: 21.4b2 → 21.5b0
* Update black and pyupgrade additional_dependencies to current versions
   - github.com/psf/black: 21.4b1 → 21.5b0
   - github.com/asottile/pyupgrade: v2.11.0 → v2.14.0
   - Apply Black to notebooks
```
