### PR TITLE
fix: Remove trailing spaces in parameter names

### DIFF
--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -266,7 +266,7 @@ def process_measurements(toplvl, other_parameter_configs=None):
         result = {
             'name': x.attrib['Name'],
             'config': {
-                'poi': x.findall('POI')[0].text,
+                'poi': x.findall('POI')[0].text.strip(),
                 'parameters': [
                     {
                         'name': 'lumi',
@@ -289,7 +289,7 @@ def process_measurements(toplvl, other_parameter_configs=None):
 
             # might be specifying multiple parameters in the same ParamSetting
             if param.text:
-                for param_name in param.text.split(' '):
+                for param_name in param.text.strip().split(' '):
                     param_name = utils.remove_prefix(param_name, 'alpha_')
                     if param_name.startswith('gamma_') and re.search(
                         r'^gamma_.+_\d+$', param_name

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -149,6 +149,30 @@ def test_import_measurements():
 
 
 @pytest.mark.parametrize("const", ['False', 'True'])
+def test_spaces_in_measurement_config(const):
+    toplvl = ET.Element("Combination")
+    meas = ET.Element(
+        "Measurement",
+        Name='NormalMeasurement',
+        Lumi=str(1.0),
+        LumiRelErr=str(0.017),
+        ExportOnly=str(True),
+    )
+    poiel = ET.Element('POI')
+    poiel.text = 'mu_SIG ' #space
+    meas.append(poiel)
+
+    setting = ET.Element('ParamSetting', Const=const)
+    setting.text = ' '.join(['Lumi', 'alpha_mu_both']) + ' ' #spacces
+    meas.append(setting)
+
+    toplvl.append(meas)
+
+    meas_json = pyhf.readxml.process_measurements(toplvl)[0]
+    assert meas_json['config']['poi'] == 'mu_SIG'
+    assert [x['name'] for x in meas_json['config']['parameters']] == ['lumi','mu_both']
+    
+@pytest.mark.parametrize("const", ['False', 'True'])
 def test_import_measurement_gamma_bins(const):
     toplvl = ET.Element("Combination")
     meas = ET.Element(

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -159,19 +159,20 @@ def test_spaces_in_measurement_config(const):
         ExportOnly=str(True),
     )
     poiel = ET.Element('POI')
-    poiel.text = 'mu_SIG ' #space
+    poiel.text = 'mu_SIG '  # space
     meas.append(poiel)
 
     setting = ET.Element('ParamSetting', Const=const)
-    setting.text = ' '.join(['Lumi', 'alpha_mu_both']) + ' ' #spacces
+    setting.text = ' '.join(['Lumi', 'alpha_mu_both']) + ' '  # spacces
     meas.append(setting)
 
     toplvl.append(meas)
 
     meas_json = pyhf.readxml.process_measurements(toplvl)[0]
     assert meas_json['config']['poi'] == 'mu_SIG'
-    assert [x['name'] for x in meas_json['config']['parameters']] == ['lumi','mu_both']
-    
+    assert [x['name'] for x in meas_json['config']['parameters']] == ['lumi', 'mu_both']
+
+
 @pytest.mark.parametrize("const", ['False', 'True'])
 def test_import_measurement_gamma_bins(const):
     toplvl = ET.Element("Combination")


### PR DESCRIPTION
# Description

Resolves #1389 

resolves  space issue  https://github.com/scikit-hep/pyhf/issues/1389 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Strip trailing spaces from parameter names
   - Normalizes parameter name string and makes robust to space differences
* Add test for trailing spaces functioning properly 
```