### PR TITLE
fix: Remove load option from Docker workflow publish steps

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -104,7 +104,6 @@ jobs:
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
-          load: true
           push: true
 
       - name: Build and publish to registry with release tag
@@ -119,5 +118,4 @@ jobs:
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
-          load: true
           push: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Docker Images
 
 on:
   push:
-    # branches:
-    # - master
-    # tags:
-    # - v*
+    branches:
+    - master
+    tags:
+    - v*
   pull_request:
     branches:
     - master
@@ -93,7 +93,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on master, so check the push event is actually coming from master
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pyhf'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pyhf'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Docker Images
 
 on:
   push:
-    branches:
-    - master
-    tags:
-    - v*
+    # branches:
+    # - master
+    # tags:
+    # - v*
   pull_request:
     branches:
     - master
@@ -93,7 +93,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on master, so check the push event is actually coming from master
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pyhf'
+        # if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pyhf'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
# Description

Fix for PR #1441 in which `load` and `push` can not be used simultaneously for the `docker/build-push-action@v2` action. So remove `load` as the image isn't needed locally.

> ### <a name="push"></a> Push the build result to a registry (--push)
> 
> Shorthand for [`--output=type=registry`](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#registry). Will automatically push the
> build result to registry.
> 
> ### <a name="load"></a> Load the single-platform build result to `docker images` (--load)
> 
> Shorthand for [`--output=type=docker`](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#docker). Will automatically load the
> single-platform build result to `docker images`.


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove load from docker/build-push-action@v2 action publish steps
   - load and push can not be used in the same step
   - load option: Shorthand for --output=type=docker
* Amends PR #1441
```
