### PR TITLE
ci: Publish Docker images to GitHub Container Registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Docker Images
 
 on:
   push:
-    branches:
-    - master
-    tags:
-    - v*
+    # branches:
+    # - master
+    # tags:
+    # - v*
   pull_request:
     branches:
     - master
@@ -35,7 +35,7 @@ jobs:
             VERSION=pr-${{ github.event.number }}
           fi
           TAGS="${DOCKER_IMAGE}:${VERSION}"
-          TAGS="$TAGS,${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          TAGS="$TAGS,${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8},ghcr.io/${DOCKER_IMAGE}:test"
           if [ "${{ github.event_name }}" = "release" ]; then
             TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable,ghcr.io/${DOCKER_IMAGE}:latest-stable"
           fi
@@ -100,7 +100,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on master, so check the push event is actually coming from master
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pyhf'
+        # if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pyhf'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,6 +55,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Test build
         id: docker_build_test
         uses: docker/build-push-action@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Docker Images
 
 on:
   push:
-    # branches:
-    # - master
-    # tags:
-    # - v*
+    branches:
+    - master
+    tags:
+    - v*
   pull_request:
     branches:
     - master
@@ -35,7 +35,7 @@ jobs:
             VERSION=pr-${{ github.event.number }}
           fi
           TAGS="${DOCKER_IMAGE}:${VERSION}"
-          TAGS="$TAGS,${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8},ghcr.io/${{github.repository}}:test"
+          TAGS="$TAGS,${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
           if [ "${{ github.event_name }}" = "release" ]; then
             TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable,ghcr.io/${{github.repository}}:latest-stable"
           fi
@@ -100,7 +100,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on master, so check the push event is actually coming from master
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pyhf'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pyhf'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
           TAGS="${DOCKER_IMAGE}:${VERSION}"
           TAGS="$TAGS,${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
           if [ "${{ github.event_name }}" = "release" ]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable,ghcr.io/${{github.repository}}:latest-stable"
+            TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable,ghcr.io/${{github.repository}}:latest-stable,ghcr.io/${{github.repository}}:${GITHUB_REF#refs/tags/}"
           fi
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
           TAGS="${DOCKER_IMAGE}:${VERSION}"
           TAGS="$TAGS,${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
           if [ "${{ github.event_name }}" = "release" ]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable"
+            TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable,ghcr.io/${DOCKER_IMAGE}:latest-stable"
           fi
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
@@ -106,7 +106,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          tags: pyhf/pyhf:latest
+          tags: pyhf/pyhf:latest,ghcr.io/pyhf/pyhf:latest
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,9 +35,9 @@ jobs:
             VERSION=pr-${{ github.event.number }}
           fi
           TAGS="${DOCKER_IMAGE}:${VERSION}"
-          TAGS="$TAGS,${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8},ghcr.io/${DOCKER_IMAGE}:test"
+          TAGS="$TAGS,${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8},ghcr.io/${{github.repository}}:test"
           if [ "${{ github.event_name }}" = "release" ]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable,ghcr.io/${DOCKER_IMAGE}:latest-stable"
+            TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable,ghcr.io/${{github.repository}}:latest-stable"
           fi
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
@@ -106,7 +106,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          tags: pyhf/pyhf:latest,ghcr.io/pyhf/pyhf:latest
+          tags: pyhf/pyhf:latest,ghcr.io/${{github.repository}}:latest
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}


### PR DESCRIPTION
# Description

Resolves #1443 

Publish Docker images to the [GitHub Container Registry](https://github.blog/2020-09-01-introducing-github-container-registry/) in addition to Docker Hub.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [ ] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Publish Docker images to the GitHub Container Registry in addition to Docker Hub
   - c.f. https://github.com/orgs/scikit-hep/packages/container/package/pyhf
```
