### PR TITLE
build: Revise MANIFEST.in strategy to properly use prune

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -63,6 +63,8 @@ jobs:
         echo "python-build named built distribution: ${wheel_name}"
     - name: Verify the distribution
       run: twine check dist/*
+    - name: List contents of sdist
+      run: tar --list --file dist/pyhf-*.tar.gz
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master
       if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pyhf'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 prune **
 graft src
+
 include setup.py
 include setup.cfg
 include LICENSE

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,5 @@ include README.rst
 include pyproject.toml
 include MANIFEST.in
 include AUTHORS
-exclude lower-bound-requirements.txt
 
 global-exclude __pycache__ *.py[cod]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ graft src
 include LICENSE
 exclude lower-bound-requirements.txt
 
-global-exclude __pycache__ *.py[cod] .*
+global-exclude __pycache__ *.py[cod]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ graft src
 include LICENSE
 exclude lower-bound-requirements.txt
 
-global-exclude __pycache__ *.py[cod]
+global-exclude __pycache__ *.py[cod] .*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,10 @@
 prune **
 graft src
 include LICENSE
+include README.rst
+include pyproject.toml
+include MANIFEST.in
+include AUTHORS
 exclude lower-bound-requirements.txt
 
 global-exclude __pycache__ *.py[cod]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
 prune **
 graft src
+include setup.py
+include setup.cfg
 include LICENSE
 include README.rst
 include pyproject.toml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 prune *
 graft src
 include LICENSE
+include AUTHORS
 exclude lower-bound-requirements.txt
 
 global-exclude __pycache__ *.py[cod]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
-prune *
+prune **
 graft src
 include LICENSE
 exclude lower-bound-requirements.txt
 
-global-exclude __pycache__ *.py[cod] .*
+global-exclude __pycache__ *.py[cod]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 prune *
 graft src
 include LICENSE
-include AUTHORS
 exclude lower-bound-requirements.txt
 
-global-exclude __pycache__ *.py[cod]
+global-exclude __pycache__ *.py[cod] .*


### PR DESCRIPTION
# Description

Based on notes from https://github.com/scikit-build/scikit-build/issues/537, the `.* ` in 

https://github.com/scikit-hep/pyhf/blob/2c681a68df801f7b368c37cecdbdb4da996e5483/MANIFEST.in#L6

added in an attempt to exclude dotfiles (c.f. PR #791) is not actually needed (I think given the `prune *`) and appears to be causing trouble (?) in some other cases (c.f. https://github.com/scikit-build/scikit-build/issues/537). In an effort to avoid problems, this PR removes the `.*` from the global exclude and adds the `AUTHORS` file (as I noticed it wasn't there and doesn't hurt).

**Edit:**

As it seems that `prune *` wasn't doing what we _thought_ it was, additionally also use `prune **` pattern and then manually include the files that the [PyPA notes are automatically added to an `sdist`](https://packaging.python.org/guides/using-manifest-in/#how-files-are-included-in-an-sdist) (but which we remove with `prune **` which clobbers everything). Also ads a step to the CI that lists out the contents of the `sdist` `tar.gz`, so it should be a lot easier to spot check in the future.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove global exclude of dotfiles from MANIFEST.in to avoid potential problems with build systems
   - c.f. https://github.com/scikit-build/scikit-build/issues/537
* Use `prune **` to remove all files from the sdist
   - c.f. https://packaging.python.org/guides/using-manifest-in/#manifest-in-commands
   - "Setuptools also has undocumented support for ** matching zero or more characters including forward slash, backslash, and colon."
* Manually include all "default" files for a sdist in MANIFEST.in
   - c.f. https://packaging.python.org/guides/using-manifest-in/#how-files-are-included-in-an-sdist
* Include AUTHORS in MANIFEST.in
* Add list of sdist contents to package publishing CI
   - Allow for easier checking of the sdist contents in CI logs
```
