### PR TITLE
chore: Use newer setuptools_scm for versioning

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,10 +3,6 @@ current_version = 0.6.1
 commit = True
 tag = True
 
-[bumpversion:file:setup.cfg]
-
-[bumpversion:file:src/pyhf/version.py]
-
 [bumpversion:file:src/pyhf/utils.py]
 
 [bumpversion:file:README.rst]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -43,6 +45,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -69,6 +73,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -94,6 +100,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -119,6 +127,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
+        with:
+          fetch-depth: 0
       - name: Prepare
         id: prep
         run: |

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+src/pyhf/version.py
 MANIFEST
 build
 dist

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,8 +19,7 @@ from pathlib import Path
 import sys
 from pkg_resources import get_distribution
 
-sys.path.insert(0, str(Path('../src').resolve()))
-sys.path.insert(1, str(Path('./exts').resolve()))
+sys.path.insert(0, str(Path('./exts').resolve()))
 
 
 def setup(app):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,10 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["wheel", "setuptools>=30.3.0", "attrs>=17.1", "setuptools_scm"]
+requires = ["wheel", "setuptools>=30.3.0", "attrs>=17.1", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "src/pyhf/version.py"
 
 [tool.black]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "src/pyhf/version.py"
+local_scheme = "no-local-version"
 
 [tool.black]
 line-length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = pyhf
-version = 0.6.1
 description = pure-Python HistFactory implementation with tensors and autodiff
 long_description = file: README.rst
 long_description_content_type = text/x-rst
@@ -28,8 +27,6 @@ classifiers =
 
 [options]
 setup_requires =
-    setuptools_scm>=1.15.0
-    setuptools_scm_git_archive>=1.0
 package_dir =
     = src
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ classifiers =
     Programming Language :: Python :: Implementation :: CPython
 
 [options]
-setup_requires =
 package_dir =
     = src
 packages = find:

--- a/src/pyhf/__init__.py
+++ b/src/pyhf/__init__.py
@@ -1,6 +1,6 @@
 from .tensor import BackendRetriever as tensor
 from .optimize import OptimizerRetriever as optimize
-from .version import __version__
+from .version import version as __version__
 from .exceptions import InvalidBackend, InvalidOptimizer, Unsupported
 from . import events
 

--- a/src/pyhf/cli/cli.py
+++ b/src/pyhf/cli/cli.py
@@ -3,7 +3,7 @@ import logging
 
 import click
 
-from ..version import __version__
+from .. import __version__
 from . import rootio, spec, infer, patchset, complete
 from ..contrib import cli as contrib
 from .. import utils

--- a/src/pyhf/version.py
+++ b/src/pyhf/version.py
@@ -1,5 +1,0 @@
-"""Define pyhf version information."""
-
-# Use semantic versioning (https://semver.org/)
-# The version number is controlled through bumpversion.cfg
-__version__ = '0.6.1'

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -8,7 +8,7 @@ def model_setup(backend):
     np.random.seed(0)
     n_bins = 100
     # TODO: Simplify after pyhf v0.6.2 released
-    if tuple(int(part) for part in pyhf.__version__.split(".")) < (0, 6, 2):
+    if tuple(int(part) for part in pyhf.__version__.split(".")[:3]) < (0, 6, 2):
         model = pyhf.simplemodels.hepdata_like(
             [10] * n_bins, [50] * n_bins, [1] * n_bins
         )
@@ -211,7 +211,7 @@ def test_pdf_batched_deprecated_api(backend):
 
 # TODO: Remove skipif after pyhf v0.6.2 released
 @pytest.mark.skipif(
-    tuple(int(part) for part in pyhf.__version__.split(".")) < (0, 6, 2),
+    tuple(int(part) for part in pyhf.__version__.split(".")[:3]) < (0, 6, 2),
     reason="requires pyhf v0.6.2+",
 )
 def test_pdf_batched(backend):


### PR DESCRIPTION
# Pull Request Description

This bumps us up to a more modern version of `setuptools_scm` that supports `pyproject.toml` and will inject the right version at build time (via PEP517/8) as well as generate the corresponding `version.py` for us at build time.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Update to a modern version of setuptools_scm to support pyproject-based Python packages
   - Use local_scheme = "no-local-version" to continue uploading to TestPyPI
   - c.f. https://github.com/pypa/setuptools_scm/blob/v6.0.1/README.rst#version-number-construction
* Remove src/pyhf/version.py in favor of generating at build time
   - Remove setup.cfg and src/pyhf/version.py from bump2version control
* Set fetch depth:0 in CI to get full history and tags to generate version number
   - c.f. https://github.com/scikit-hep/pyhf/issues/1465
```
