### PR TITLE
chore: Trial pip in-tree-build before release in pip 21.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[test]
+        python -m pip install --use-feature=in-tree-build --ignore-installed --upgrade -quiet --no-cache-dir -e .[test]
         python -m pip list
     - name: Test with pytest
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --use-feature=in-tree-build install --ignore-installed --upgrade .[test]
+        python -m pip --use-feature=in-tree-build install --ignore-installed --upgrade --editable .[test]
     - name: List installed Python packages
       run: |
         python -m pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --use-feature=in-tree-build install --ignore-installed --upgrade --quiet --no-cache-dir --editable .[test]
+        python -m pip --no-cache-dir --quiet --use-feature=in-tree-build install --ignore-installed --upgrade --editable .[test]
         python -m pip list
     - name: Test with pytest
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --use-feature=in-tree-build install --ignore-installed --upgrade --editable .[test]
+        python -m pip --use-feature=in-tree-build install --upgrade --editable .[test]
     - name: List installed Python packages
       run: |
         python -m pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet --use-feature=in-tree-build install --ignore-installed --upgrade --editable .[test]
+        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
+        python -m pip --no-cache-dir --use-feature=in-tree-build install --ignore-installed --upgrade .[test]
+    - name: List installed Python packages
+      run: |
         python -m pip list
     - name: Test with pytest
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --use-feature=in-tree-build install --ignore-installed --upgrade .[test]
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip --use-feature=in-tree-build install --ignore-installed --upgrade .[test]
     - name: List installed Python packages
       run: |
         python -m pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --use-feature=in-tree-build install --upgrade --editable .[test]
+        python -m pip install --upgrade --editable .[test]
     - name: List installed Python packages
       run: |
         python -m pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --use-feature=in-tree-build --ignore-installed --upgrade -quiet --no-cache-dir -e .[test]
+        python -m pip --use-feature=in-tree-build install --ignore-installed --upgrade --quiet --no-cache-dir --editable .[test]
         python -m pip list
     - name: Test with pytest
       run: |

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[test]
+        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade --editable .[test]
         python -m pip uninstall --yes scipy
         python -m pip install --upgrade cython
         python -m pip install --upgrade git+git://github.com/scipy/scipy.git
@@ -50,7 +50,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[test]
+        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade --editable .[test]
         python -m pip uninstall --yes iminuit
         python -m pip install --upgrade cython
         python -m pip install --upgrade git+git://github.com/scikit-hep/iminuit.git
@@ -76,7 +76,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[test]
+        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade --editable .[test]
         python -m pip uninstall --yes uproot3
         python -m pip install --upgrade git+git://github.com/scikit-hep/uproot3.git
         python -m pip list
@@ -101,7 +101,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[test]
+        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade --editable .[test]
         python -m pip uninstall --yes uproot
         python -m pip install --upgrade git+git://github.com/scikit-hep/uproot4.git
         python -m pip list
@@ -126,7 +126,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[test]
+        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade --editable .[test]
         python -m pip uninstall --yes pytest
         python -m pip install --upgrade git+git://github.com/pytest-dev/pytest.git
         python -m pip list

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -23,11 +23,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
+        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[test]
         python -m pip uninstall --yes scipy
-        python -m pip install --upgrade --no-cache-dir cython
-        python -m pip install --upgrade --no-cache-dir git+git://github.com/scipy/scipy.git
+        python -m pip --no-cache-dir install --upgrade cython
+        python -m pip --no-cache-dir install --upgrade git+git://github.com/scipy/scipy.git
         python -m pip list
     - name: Test with pytest
       run: |
@@ -49,11 +49,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
+        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[test]
         python -m pip uninstall --yes iminuit
-        python -m pip install --upgrade --no-cache-dir cython
-        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/iminuit.git
+        python -m pip --no-cache-dir install --upgrade cython
+        python -m pip --no-cache-dir install --upgrade git+git://github.com/scikit-hep/iminuit.git
         python -m pip list
     - name: Test with pytest
       run: |
@@ -75,10 +75,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
+        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[test]
         python -m pip uninstall --yes uproot3
-        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/uproot3.git
+        python -m pip --no-cache-dir install --upgrade git+git://github.com/scikit-hep/uproot3.git
         python -m pip list
     - name: Test with pytest
       run: |
@@ -100,10 +100,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
+        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[test]
         python -m pip uninstall --yes uproot
-        python -m pip install --upgrade --no-cache-dir git+git://github.com/scikit-hep/uproot4.git
+        python -m pip --no-cache-dir install --upgrade git+git://github.com/scikit-hep/uproot4.git
         python -m pip list
     - name: Test with pytest
       run: |
@@ -125,10 +125,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[test]
+        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
+        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[test]
         python -m pip uninstall --yes pytest
-        python -m pip install --upgrade --no-cache-dir git+git://github.com/pytest-dev/pytest.git
+        python -m pip --no-cache-dir install --upgrade git+git://github.com/pytest-dev/pytest.git
         python -m pip list
     - name: Test with pytest
       run: |

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -23,11 +23,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[test]
         python -m pip uninstall --yes scipy
-        python -m pip --no-cache-dir install --upgrade cython
-        python -m pip --no-cache-dir install --upgrade git+git://github.com/scipy/scipy.git
+        python -m pip install --upgrade cython
+        python -m pip install --upgrade git+git://github.com/scipy/scipy.git
         python -m pip list
     - name: Test with pytest
       run: |
@@ -49,11 +49,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[test]
         python -m pip uninstall --yes iminuit
-        python -m pip --no-cache-dir install --upgrade cython
-        python -m pip --no-cache-dir install --upgrade git+git://github.com/scikit-hep/iminuit.git
+        python -m pip install --upgrade cython
+        python -m pip install --upgrade git+git://github.com/scikit-hep/iminuit.git
         python -m pip list
     - name: Test with pytest
       run: |
@@ -75,10 +75,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[test]
         python -m pip uninstall --yes uproot3
-        python -m pip --no-cache-dir install --upgrade git+git://github.com/scikit-hep/uproot3.git
+        python -m pip install --upgrade git+git://github.com/scikit-hep/uproot3.git
         python -m pip list
     - name: Test with pytest
       run: |
@@ -100,10 +100,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[test]
         python -m pip uninstall --yes uproot
-        python -m pip --no-cache-dir install --upgrade git+git://github.com/scikit-hep/uproot4.git
+        python -m pip install --upgrade git+git://github.com/scikit-hep/uproot4.git
         python -m pip list
     - name: Test with pytest
       run: |
@@ -125,10 +125,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[test]
         python -m pip uninstall --yes pytest
-        python -m pip --no-cache-dir install --upgrade git+git://github.com/pytest-dev/pytest.git
+        python -m pip install --upgrade git+git://github.com/pytest-dev/pytest.git
         python -m pip list
     - name: Test with pytest
       run: |

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade --editable .[test]
+        python -m pip --no-cache-dir --quiet install --upgrade --editable .[test]
         python -m pip uninstall --yes scipy
         python -m pip install --upgrade cython
         python -m pip install --upgrade git+git://github.com/scipy/scipy.git
@@ -50,7 +50,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade --editable .[test]
+        python -m pip --no-cache-dir --quiet install --upgrade --editable .[test]
         python -m pip uninstall --yes iminuit
         python -m pip install --upgrade cython
         python -m pip install --upgrade git+git://github.com/scikit-hep/iminuit.git
@@ -76,7 +76,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade --editable .[test]
+        python -m pip --no-cache-dir --quiet install --upgrade --editable .[test]
         python -m pip uninstall --yes uproot3
         python -m pip install --upgrade git+git://github.com/scikit-hep/uproot3.git
         python -m pip list
@@ -101,7 +101,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade --editable .[test]
+        python -m pip --no-cache-dir --quiet install --upgrade --editable .[test]
         python -m pip uninstall --yes uproot
         python -m pip install --upgrade git+git://github.com/scikit-hep/uproot4.git
         python -m pip list
@@ -126,7 +126,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade --editable .[test]
+        python -m pip --no-cache-dir --quiet install --upgrade --editable .[test]
         python -m pip uninstall --yes pytest
         python -m pip install --upgrade git+git://github.com/pytest-dev/pytest.git
         python -m pip list

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,8 +25,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[docs,test]
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip --quiet install --ignore-installed --upgrade .[docs,test]
         python -m pip list
         sudo apt-get update
         sudo apt-get -qq install pandoc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install --ignore-installed --upgrade .[docs,test]
+        python -m pip --quiet install --upgrade .[docs,test]
         python -m pip list
         sudo apt-get update
         sudo apt-get -qq install pandoc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install --upgrade .[docs,test]
+        python -m pip --quiet --use-feature=in-tree-build install --upgrade .[docs,test]
         python -m pip list
         sudo apt-get update
         sudo apt-get -qq install pandoc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,8 +25,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --quiet --no-cache-dir --ignore-installed --upgrade .[docs,test]
+        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
+        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[docs,test]
         python -m pip list
         sudo apt-get update
         sudo apt-get -qq install pandoc

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,8 +18,8 @@ jobs:
         python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[lint]
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip --quiet install --ignore-installed --upgrade .[lint]
         python -m pip list
     - name: Lint with flake8
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install --ignore-installed --upgrade .[lint]
+        python -m pip --quiet install --upgrade .[lint]
         python -m pip list
     - name: Lint with flake8
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,8 +18,8 @@ jobs:
         python-version: 3.8
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed -U -q --no-cache-dir -e .[lint]
+        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
+        python -m pip --no-cache-dir --quiet install --ignore-installed --upgrade .[lint]
         python -m pip list
     - name: Lint with flake8
       run: |

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -24,10 +24,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies and force lowest bound
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --quiet --no-cache-dir --requirement lower-bound-requirements.txt
-        python -m pip install --quiet --no-cache-dir --editable .[test]
-        python -m pip install --no-cache-dir --upgrade --requirement lower-bound-requirements.txt
+        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
+        python -m pip --no-cache-dir --quiet install --requirement lower-bound-requirements.txt
+        python -m pip --no-cache-dir --quiet install .[test]
+        python -m pip --no-cache-dir --quiet install --requirement lower-bound-requirements.txt
         python -m pip list
     - name: Test with pytest
       run: |

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -24,10 +24,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies and force lowest bound
       run: |
-        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --requirement lower-bound-requirements.txt
         python -m pip --no-cache-dir --quiet install .[test]
-        python -m pip --no-cache-dir --quiet install --requirement lower-bound-requirements.txt
+        python -m pip install --requirement lower-bound-requirements.txt
         python -m pip list
     - name: Test with pytest
       run: |

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --requirement lower-bound-requirements.txt
-        python -m pip --no-cache-dir --quiet install .[test]
+        python -m pip --no-cache-dir --quiet install --editable .[test]
         python -m pip install --requirement lower-bound-requirements.txt
         python -m pip list
     - name: Test with pytest

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -22,8 +22,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[complete]
+        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
+        python -m pip --no-cache-dir --quiet install --upgrade .[complete]
         python -m pip list
     - name: Test example notebooks
       run: |

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -22,8 +22,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade .[complete]
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip --quiet install --upgrade .[complete]
         python -m pip list
     - name: Test example notebooks
       run: |

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install --upgrade .[complete]
+        python -m pip --quiet install --upgrade --editable .[complete]
         python -m pip list
     - name: Test example notebooks
       run: |

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -24,8 +24,8 @@ jobs:
         python-version: 3.8
     - name: Install python-build, check-manifest, and twine
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install build check-manifest twine
+        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
+        python -m pip --no-cache-dir install build check-manifest twine
     - name: Check MANIFEST
       run: |
         check-manifest

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -24,8 +24,8 @@ jobs:
         python-version: 3.8
     - name: Install python-build, check-manifest, and twine
       run: |
-        python -m pip --no-cache-dir install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir install build check-manifest twine
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install build check-manifest twine
     - name: Check MANIFEST
       run: |
         check-manifest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ We recommend first reading the "[Developing](https://scikit-hep.org/pyhf/develop
 You can install the development environment (which includes a number of extra) libraries and all others needed to run the tests via `pip`:
 
 ```bash
-python -m pip install --ignore-installed -U -e .[complete]
+python -m pip install --upgrade --editable .[complete]
 ```
 
 To make the PR process much smoother we also strongly recommend that you setup the Git pre-commit hook for [Black](https://github.com/psf/black) by running

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -11,7 +11,7 @@ and install all necessary packages for development
 
 .. code-block:: console
 
-    python -m pip install --ignore-installed -U -e .[complete]
+    python -m pip install --upgrade --editable .[complete]
 
 Then setup the Git pre-commit hook for `Black <https://github.com/psf/black>`__  by running
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -72,35 +72,35 @@ Install latest development version from `GitHub <https://github.com/scikit-hep/p
 
 .. code-block:: console
 
-    python -m pip install --ignore-installed -U "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf"
+    python -m pip install --upgrade "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf"
 
 ... with TensorFlow backend
 +++++++++++++++++++++++++++
 
 .. code-block:: console
 
-    python -m pip install --ignore-installed -U "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf[tensorflow]"
+    python -m pip install --upgrade "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf[tensorflow]"
 
 ... with PyTorch backend
 ++++++++++++++++++++++++
 
 .. code-block:: console
 
-    python -m pip install --ignore-installed -U "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf[torch]"
+    python -m pip install --upgrade "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf[torch]"
 
 ... with JAX backend
 ++++++++++++++++++++++
 
 .. code-block:: console
 
-    python -m pip install --ignore-installed -U "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf[jax]"
+    python -m pip install --upgrade "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf[jax]"
 
 ... with all backends
 +++++++++++++++++++++
 
 .. code-block:: console
 
-    python -m pip install --ignore-installed -U "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf[backends]"
+    python -m pip install --upgrade "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf[backends]"
 
 
 ... with xml import/export functionality
@@ -108,10 +108,10 @@ Install latest development version from `GitHub <https://github.com/scikit-hep/p
 
 .. code-block:: console
 
-    python -m pip install --ignore-installed -U "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf[xmlio]"
+    python -m pip install --upgrade "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf[xmlio]"
 
 
 Updating :code:`pyhf`
 ---------------------
 
-Rerun the installation command. As the upgrade flag, :code:`-U`, is used then the libraries will be updated.
+Rerun the installation command. As the upgrade flag (:code:`-U`, :code:`--upgrade`) is used then the libraries will be updated.


### PR DESCRIPTION
# Description

From the current docs build there is a warning from `pip`

```
  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
```

This PR adds in the `pip` option `--use-feature=in-tree-build` to the docs workflow (only needed to test in one place, not all of our `pip` installs but do need a non `--editable` install to get the warning) to test this feature change in advance as requested.

c.f. https://github.com/pypa/pip/issues/7555 for further details

Also revise `pip` options to simplify workflow and make more readable.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Trial upcoming pip release build in-place functionality by adding '--use-feature=in-tree-build' option in docs workflow
   - c.f. https://github.com/pypa/pip/issues/7555
   - Warning requires a non --editable install, so trial option in docs instead of CI workflow
* Remove optional pip flags that aren't needed for success to improve workflow readability
* Remove --ignore-installed from suggested flags in install docs
```
