### PR TITLE
fix: Update to mathjax3_config to support math rendering in Sphinx v4.x+

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -433,6 +433,7 @@ texinfo_documents = [
 #
 # texinfo_no_detailmenu = False
 
+# mathjax3_config = {
 mathjax_config = {
     'tex2jax': {'inlineMath': [['$', '$'], ['\\(', '\\)']]},
     'TeX': {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -435,8 +435,8 @@ texinfo_documents = [
 
 mathjax3_config = {
     'tex2jax': {'inlineMath': [['$', '$'], ['\\(', '\\)']]},
-    'TeX': {
-        'Macros': {
+    'tex': {
+        'macros': {
             'bm': ["\\boldsymbol{#1}", 1],  # \usepackage{bm}, see mathjax/MathJax#1219
             'HiFa': r'\texttt{HistFactory}',
             'Root': r'\texttt{ROOT}',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -433,8 +433,7 @@ texinfo_documents = [
 #
 # texinfo_no_detailmenu = False
 
-# mathjax3_config = {
-mathjax_config = {
+mathjax3_config = {
     'tex2jax': {'inlineMath': [['$', '$'], ['\\(', '\\)']]},
     'TeX': {
         'Macros': {

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras_require['docs'] = sorted(
         extras_require['xmlio']
         + extras_require['contrib']
         + [
-            'sphinx>=3.1.2',
+            'sphinx>=4.0.0',
             'sphinxcontrib-bibtex~=2.1',
             'sphinx-click',
             'sphinx_rtd_theme',


### PR DESCRIPTION
# Description

Sphinx v4.0 is out now and it appears that it requires [`mathjax3_config`](https://www.sphinx-doc.org/en/master/usage/extensions/math.html#confval-mathjax3_config) to be able to work as at the moment it is spitting out lots of 

```
WARNING: mathjax_config/mathjax2_config does not work for the current MathJax version, use mathjax3_config instead
```

in the docs builds.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update Sphinx config to use mathjax3_config
   - Used in Sphinx v4.x+
   - c.f. https://www.sphinx-doc.org/en/master/usage/extensions/math.html#confval-mathjax3_config
* Set lower bound of supported Sphinx to v4.0.0
```
