### PR TITLE
fix: Do not configure logging in contrib.utils

### DIFF
--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -6,7 +6,6 @@ from io import BytesIO
 import logging
 from .. import exceptions
 
-logging.basicConfig()
 log = logging.getLogger(__name__)
 
 __all__ = ["download"]


### PR DESCRIPTION
# Description

Fixes #1455. This is the equivalent of #866, which fixed #865.

`pyhf.contrib.utils` sets up logging, thereby preventing users who import that module from configuring logging themselves after the import. This removes the logging setup, which is only needed for the CLI (and done there).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove the logging configuration in contrib.utils as it interferes with custom logging users may want to set up
```