### PR TITLE
fix: Check parameter shapes for pdf API calls

### DIFF
--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -848,7 +848,7 @@ class Model:
         # Verify parameter shapes
         if pars.shape[-1] != self.config.npars:
             raise exceptions.InvalidPdfParameters(
-                f'eval failed as pars has len {pars.shape[-1]} but {self.config.npars} was expected'
+                f"Evaluation failed as parameters have length {pars.shape[-1]} but model requires {self.config.npars}."
             )
 
         return self.make_pdf(pars)[1].expected_data()
@@ -881,10 +881,10 @@ class Model:
         # Verify parameter shapes
         if pars.shape[-1] != self.config.npars:
             raise exceptions.InvalidPdfParameters(
-                f'eval failed as pars has len {pars.shape[-1]} but {self.config.npars} was expected'
+                f"Evaluation failed as parameters have length {pars.shape[-1]} but model requires {self.config.npars}."
             )
 
-        return self.make_pdf(pars)[0].expected_data()
+        return self.main_model._expected_data_unchecked(pars)
 
     def expected_data(self, pars, include_auxdata=True):
         """
@@ -902,11 +902,11 @@ class Model:
         # Verify parameter shapes
         if pars.shape[-1] != self.config.npars:
             raise exceptions.InvalidPdfParameters(
-                f'eval failed as pars has len {pars.shape[-1]} but {self.config.npars} was expected'
+                f"Evaluation failed as parameters have length {pars.shape[-1]} but model requires {self.config.npars}."
             )
 
         if not include_auxdata:
-            return self.make_pdf(pars)[0].expected_data()
+            return self.main_model._expected_data_unchecked(pars)
         return self.make_pdf(pars).expected_data()
 
     def constraint_logpdf(self, auxdata, pars):

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -625,7 +625,7 @@ class _MainModel:
         return True
 
     def make_pdf(self, pars):
-        lambdas_data = self.expected_data(pars)
+        lambdas_data = self._expected_data_unchecked(pars)
         return prob.Independent(prob.Poisson(lambdas_data))
 
     def logpdf(self, maindata, pars):
@@ -672,41 +672,15 @@ class _MainModel:
 
         return deltas, factors
 
-    def expected_data(self, pars, return_by_sample=False):
+    def _expected_data_unchecked(self, pars, return_by_sample=False):
         """
-        Compute the expected rates for given values of parameters.
+        Compute the expected rates for given values of parameters without
+        input validation. For internal use in performance-critical paths.
 
-        For a single channel single sample, we compute:
-
-            Pois(d | fac(pars) * (delta(pars) + nom) ) * Gaus(a | pars[is_gaus], sigmas) * Pois(a * cfac | pars[is_poi] * cfac)
-
-        where:
-            - delta(pars) is the result of an apply(pars) of combined modifiers
-              with 'addition' op_code
-            - factor(pars) is the result of apply(pars) of combined modifiers
-              with 'multiplication' op_code
-            - pars[is_gaus] are the subset of parameters that are constrained by
-              gauss (with sigmas accordingly, some of which are computed by
-              modifiers)
-            - pars[is_pois] are the poissons and their rates (they come with
-              their own additional factors unrelated to factor(pars) which are
-              also computed by the finalize() of the modifier)
-
-        So in the end we only make 3 calls to pdfs
-
-            1. The pdf of data and modified rates
-            2. All Gaussian constraint as one call
-            3. All Poisson constraints as one call
-
+        See :meth:`expected_data` for full documentation.
         """
         tensorlib, _ = get_backend()
         pars = tensorlib.astensor(pars)
-        # Verify parameter shapes
-        if pars.shape[-1] != self.config.npars:
-            raise exceptions.InvalidPdfParameters(
-                f"Evaluation failed as parameters have length {pars.shape[-1]} but model requires {self.config.npars}."
-            )
-
         deltas, factors = self.modifications(pars)
 
         allsum = tensorlib.concatenate(deltas + [self.nominal_rates])
@@ -737,6 +711,41 @@ class _MainModel:
         if self.batch_size is None:
             return newresults[0]
         return newresults
+
+    def expected_data(self, pars, return_by_sample=False):
+        """
+        Compute the expected rates for given values of parameters.
+
+        For a single channel single sample, we compute:
+
+            Pois(d | fac(pars) * (delta(pars) + nom) ) * Gaus(a | pars[is_gaus], sigmas) * Pois(a * cfac | pars[is_poi] * cfac)
+
+        where:
+            - delta(pars) is the result of an apply(pars) of combined modifiers
+              with 'addition' op_code
+            - factor(pars) is the result of apply(pars) of combined modifiers
+              with 'multiplication' op_code
+            - pars[is_gaus] are the subset of parameters that are constrained by
+              gauss (with sigmas accordingly, some of which are computed by
+              modifiers)
+            - pars[is_pois] are the poissons and their rates (they come with
+              their own additional factors unrelated to factor(pars) which are
+              also computed by the finalize() of the modifier)
+
+        So in the end we only make 3 calls to pdfs
+
+            1. The pdf of data and modified rates
+            2. All Gaussian constraint as one call
+            3. All Poisson constraints as one call
+
+        """
+        tensorlib, _ = get_backend()
+        pars = tensorlib.astensor(pars)
+        if pars.shape[-1] != self.config.npars:
+            raise exceptions.InvalidPdfParameters(
+                f"Evaluation failed as parameters have length {pars.shape[-1]} but model requires {self.config.npars}."
+            )
+        return self._expected_data_unchecked(pars, return_by_sample)
 
 
 class Model:

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -742,9 +742,8 @@ class _MainModel:
         tensorlib, _ = get_backend()
         pars = tensorlib.astensor(pars)
         if pars.shape[-1] != self.config.npars:
-            raise exceptions.InvalidPdfParameters(
-                f"Evaluation failed as parameters have length {pars.shape[-1]} but model requires {self.config.npars}."
-            )
+            msg = f"Evaluation failed as parameters have length {pars.shape[-1]} but model requires {self.config.npars}."
+            raise exceptions.InvalidPdfParameters(msg)
         return self._expected_data_unchecked(pars, return_by_sample)
 
 
@@ -847,9 +846,8 @@ class Model:
         pars = tensorlib.astensor(pars)
         # Verify parameter shapes
         if pars.shape[-1] != self.config.npars:
-            raise exceptions.InvalidPdfParameters(
-                f"Evaluation failed as parameters have length {pars.shape[-1]} but model requires {self.config.npars}."
-            )
+            msg = f"Evaluation failed as parameters have length {pars.shape[-1]} but model requires {self.config.npars}."
+            raise exceptions.InvalidPdfParameters(msg)
 
         return self.make_pdf(pars)[1].expected_data()
 
@@ -880,9 +878,8 @@ class Model:
         pars = tensorlib.astensor(pars)
         # Verify parameter shapes
         if pars.shape[-1] != self.config.npars:
-            raise exceptions.InvalidPdfParameters(
-                f"Evaluation failed as parameters have length {pars.shape[-1]} but model requires {self.config.npars}."
-            )
+            msg = f"Evaluation failed as parameters have length {pars.shape[-1]} but model requires {self.config.npars}."
+            raise exceptions.InvalidPdfParameters(msg)
 
         return self.main_model._expected_data_unchecked(pars)
 
@@ -901,9 +898,8 @@ class Model:
         pars = tensorlib.astensor(pars)
         # Verify parameter shapes
         if pars.shape[-1] != self.config.npars:
-            raise exceptions.InvalidPdfParameters(
-                f"Evaluation failed as parameters have length {pars.shape[-1]} but model requires {self.config.npars}."
-            )
+            msg = f"Evaluation failed as parameters have length {pars.shape[-1]} but model requires {self.config.npars}."
+            raise exceptions.InvalidPdfParameters(msg)
 
         if not include_auxdata:
             return self.main_model._expected_data_unchecked(pars)

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -701,6 +701,12 @@ class _MainModel:
         """
         tensorlib, _ = get_backend()
         pars = tensorlib.astensor(pars)
+        # Verify parameter shapes
+        if pars.shape[-1] != self.config.npars:
+            raise exceptions.InvalidPdfParameters(
+                f"Evaluation failed as parameters have length {pars.shape[-1]} but model requires {self.config.npars}."
+            )
+
         deltas, factors = self.modifications(pars)
 
         allsum = tensorlib.concatenate(deltas + [self.nominal_rates])
@@ -830,6 +836,12 @@ class Model:
         """
         tensorlib, _ = get_backend()
         pars = tensorlib.astensor(pars)
+        # Verify parameter shapes
+        if pars.shape[-1] != self.config.npars:
+            raise exceptions.InvalidPdfParameters(
+                f'eval failed as pars has len {pars.shape[-1]} but {self.config.npars} was expected'
+            )
+
         return self.make_pdf(pars)[1].expected_data()
 
     def modifications(self, pars):
@@ -857,6 +869,12 @@ class Model:
         """
         tensorlib, _ = get_backend()
         pars = tensorlib.astensor(pars)
+        # Verify parameter shapes
+        if pars.shape[-1] != self.config.npars:
+            raise exceptions.InvalidPdfParameters(
+                f'eval failed as pars has len {pars.shape[-1]} but {self.config.npars} was expected'
+            )
+
         return self.make_pdf(pars)[0].expected_data()
 
     def expected_data(self, pars, include_auxdata=True):
@@ -872,6 +890,12 @@ class Model:
         """
         tensorlib, _ = get_backend()
         pars = tensorlib.astensor(pars)
+        # Verify parameter shapes
+        if pars.shape[-1] != self.config.npars:
+            raise exceptions.InvalidPdfParameters(
+                f'eval failed as pars has len {pars.shape[-1]} but {self.config.npars} was expected'
+            )
+
         if not include_auxdata:
             return self.make_pdf(pars)[0].expected_data()
         return self.make_pdf(pars).expected_data()

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1379,11 +1379,15 @@ def test_pdf_invalid_parameter_shapes(backend):
     #  - b/c uncorrelated, we have 1 par per bin for shapesys (so nbins)
     #  - actual data + aux data = 2 * nbins
     assert pdf.expected_actualdata(pars).shape[-1] == nbins
+    assert pdf.main_model.expected_data(pars).shape[-1] == nbins
     assert pdf.expected_auxdata(pars).shape[-1] == nbins
     assert pdf.expected_data(pars).shape[-1] == 2 * nbins
 
     with pytest.raises(pyhf.exceptions.InvalidPdfParameters):
         pdf.expected_actualdata(pars[: nbins - 1])
+
+    with pytest.raises(pyhf.exceptions.InvalidPdfParameters):
+        pdf.main_model.expected_data(pars[: nbins - 1])
 
     with pytest.raises(pyhf.exceptions.InvalidPdfParameters):
         pdf.expected_auxdata(pars[: nbins - 1])
@@ -1393,6 +1397,9 @@ def test_pdf_invalid_parameter_shapes(backend):
 
     with pytest.raises(pyhf.exceptions.InvalidPdfParameters):
         pdf.expected_actualdata(pars + [pars[-1]])
+
+    with pytest.raises(pyhf.exceptions.InvalidPdfParameters):
+        pdf.main_model.expected_data(pars + [pars[-1]])
 
     with pytest.raises(pyhf.exceptions.InvalidPdfParameters):
         pdf.expected_auxdata(pars + [pars[-1]])

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1362,3 +1362,40 @@ def test_multi_component_poi():
         match=r"The parameter 'mu' contains multiple components and is not currently supported as parameter of interest.",
     ):
         pyhf.Workspace(spec).model()
+
+
+def test_pdf_invalid_parameter_shapes(backend):
+    nbins = np.random.randint(2, 10)
+
+    signal = np.random.random(nbins).tolist()
+    bkg = np.random.random(nbins).tolist()
+    bkg_uncrt = np.sqrt(bkg).tolist()
+    pdf = pyhf.simplemodels.uncorrelated_background(signal, bkg, bkg_uncrt)
+
+    pars = pdf.config.suggested_init()
+
+    # NB:
+    #  - nbins is shape of actual data
+    #  - b/c uncorrelated, we have 1 par per bin for shapesys (so nbins)
+    #  - actual data + aux data = 2 * nbins
+    assert pdf.expected_actualdata(pars).shape[-1] == nbins
+    assert pdf.expected_auxdata(pars).shape[-1] == nbins
+    assert pdf.expected_data(pars).shape[-1] == 2 * nbins
+
+    with pytest.raises(pyhf.exceptions.InvalidPdfParameters):
+        pdf.expected_actualdata(pars[: nbins - 1])
+
+    with pytest.raises(pyhf.exceptions.InvalidPdfParameters):
+        pdf.expected_auxdata(pars[: nbins - 1])
+
+    with pytest.raises(pyhf.exceptions.InvalidPdfParameters):
+        pdf.expected_data(pars[: nbins - 1])
+
+    with pytest.raises(pyhf.exceptions.InvalidPdfParameters):
+        pdf.expected_actualdata(pars + [pars[-1]])
+
+    with pytest.raises(pyhf.exceptions.InvalidPdfParameters):
+        pdf.expected_auxdata(pars + [pars[-1]])
+
+    with pytest.raises(pyhf.exceptions.InvalidPdfParameters):
+        pdf.expected_data(pars + [pars[-1]])


### PR DESCRIPTION
# Pull Request Description

Resolves #1459. Check that `expected_data`, `expected_auxdata`, and `expected_actualdata` are being called with the right shape for `pars` (the parameters) before evaluating. This is usually caught by lower-level code, however the error is not as user-friendly.

A quick note: it is ok to add `if/raise` in these API calls as they're not meant to be "fast" in our code -- but this could potentially be a problem if we need to allow for autodiff capabilities. For now, we're only enforcing that `logpdf()` calls are the performant ones.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add checks on input parameter shapes for the pdf API calls to expected_auxdata,
expected_actualdata, and expected_data.
* Add tests for parameter shape checks to properly raise exceptions.InvalidPdfParameters
```
