### PR TITLE
WIP: getting suggested_init without user config overrides

### DIFF
--- a/src/pyhf/parameters/paramsets.py
+++ b/src/pyhf/parameters/paramsets.py
@@ -26,6 +26,10 @@ class paramset:
                 f'misconfigured parameter set {self.name}. Scalar but N>1 parameters.'
             )
 
+    @property
+    def maximal_pars(self):
+        return self.suggested_init
+
 
 class unconstrained(paramset):
     def __init__(self, **kwargs):
@@ -54,6 +58,10 @@ class constrained_by_normal(constrained_paramset):
         except AttributeError:
             return [1.0] * self.n_parameters
 
+    @property
+    def maximal_pars(self):
+        return [0.0] * self.n_parameters
+
 
 class constrained_by_poisson(constrained_paramset):
     def __init__(self, **kwargs):
@@ -71,3 +79,7 @@ class constrained_by_poisson(constrained_paramset):
             ).tolist()
         except AttributeError:
             raise RuntimeError('need to know rate factor to compu')
+
+    @property
+    def maximal_pars(self):
+        return [1.0] * self.n_parameters


### PR DESCRIPTION
# Description

Just a quick idea. Normally, the `suggested_init` will often provide information about the default parameter settings, however this doesn't necessarily work when a user overrides these inits. This provides a way to get an init that does not necessarily depend on the user configs. Just an idea.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
- [ ] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR
