### PR TITLE
docs: Add use citation from Belle II in Moriond EW 2021 contribution

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,16 @@
+% 2021-05-12
+
+@inproceedings{Dattola:2021cmw,
+    author = "Belle II Collaboration",
+    title = "{Search for $B^{+} \to K^{+} \nu \bar \nu$ decays with an inclusive tagging method at the Belle II experiment}",
+    booktitle = "{55th Rencontres de Moriond on Electroweak Interactions and Unified Theories}",
+    eprint = "2105.05754",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    month = "5",
+    year = "2021"
+}
+
 % 2021-04-26
 @article{Abudinen:2021emt,
     author = "Belle II Collaboration",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,5 +1,4 @@
 % 2021-05-12
-
 @inproceedings{Dattola:2021cmw,
     author = "Belle II Collaboration",
     title = "{Search for $B^{+} \to K^{+} \nu \bar \nu$ decays with an inclusive tagging method at the Belle II experiment}",


### PR DESCRIPTION
# Description

Add `pyhf` use citation from [Search for B⁺→ K⁺νν̅ decays using an inclusive tagging method at Belle II](https://inspirehep.net/literature/1863052) by the Belle II Collaboration in a contribution to the 2021 EW session of the 55th Rencontres de Moriond.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR


```
* Add use citation from Belle II in Moriond EW 2021 contribution on B⁺→ K⁺νν̅ search
   - Contribution title: 'Search for B⁺→ K⁺νν̅ decays using an inclusive tagging method at Belle II'
   - c.f. https://inspirehep.net/literature/1863052
```