### PR TITLE
feat: Add 'contrib' extra to Docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get -qq -y update && \
     rm -rf /var/lib/apt/lists/* && \
     cd /code && \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
-    python -m pip install --no-cache-dir .[xmlio] && \
+    python -m pip install --no-cache-dir .[xmlio,contrib] && \
     python -m pip list
 
 FROM base

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,7 @@ FROM ${BASE_IMAGE} as base
 FROM base as builder
 COPY . /code
 # hadolint ignore=DL3003
+# hadolint ignore=SC2102
 RUN apt-get -qq -y update && \
     apt-get -qq -y install --no-install-recommends \
         git && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,8 +4,7 @@ FROM ${BASE_IMAGE} as base
 
 FROM base as builder
 COPY . /code
-# hadolint ignore=DL3003
-# hadolint ignore=SC2102
+# hadolint ignore=DL3003,SC2102
 RUN apt-get -qq -y update && \
     apt-get -qq -y install --no-install-recommends \
         git && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get -qq -y update && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/* && \
     cd /code && \
-    python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
-    python -m pip install --no-cache-dir .[xmlio,contrib] && \
+    python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
+    python -m pip --no-cache-dir install .[xmlio,contrib] && \
     python -m pip list
 
 FROM base

--- a/docker/gpu/Dockerfile
+++ b/docker/gpu/Dockerfile
@@ -14,7 +14,7 @@ COPY . /code
 COPY ./docker/gpu/install_backend.sh /code/install_backend.sh
 WORKDIR /code
 ARG BACKEND=tensorflow
-RUN python3 -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
+RUN python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     /bin/bash install_backend.sh ${BACKEND} && \
     python3 -m pip list
 


### PR DESCRIPTION
# Description

Resolves #1478 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add 'contrib' extra to Docker images so that 'pyhf contrib download' can be used
* Ignore hadolint SC2102 as [xmlio,contrib] is valid for pip
* Move --no-cache-dir flag to indicate it is a top level pip command
```
