### PR TITLE
chore: Use _version.py to follow setuptools_scm recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-src/pyhf/version.py
+src/pyhf/_version.py
 MANIFEST
 build
 dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["wheel", "setuptools>=30.3.0", "attrs>=17.1", "setuptools_scm[toml]>
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-write_to = "src/pyhf/version.py"
+write_to = "src/pyhf/_version.py"
 local_scheme = "no-local-version"
 
 [tool.black]

--- a/src/pyhf/__init__.py
+++ b/src/pyhf/__init__.py
@@ -1,6 +1,6 @@
 from .tensor import BackendRetriever as tensor
 from .optimize import OptimizerRetriever as optimize
-from .version import version as __version__
+from ._version import version as __version__
 from .exceptions import InvalidBackend, InvalidOptimizer, Unsupported
 from . import events
 


### PR DESCRIPTION
# Description

Following https://github.com/pypa/setuptools_scm/pull/576 change the generated version file (c.f. PR #1450) to be named `_version.py`

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Renames generated version file from version.py to _version.py following setuptools_scm recommendations
   - c.f. https://github.com/pypa/setuptools_scm/pull/576
   - Avoids publishing the contents of "version.py" as externally visible API
* Amends PR #1450
```
