### PR TITLE
docs: Add use citation from ATLAS SUSY 3L+compressed combination paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -7,7 +7,8 @@
     primaryClass = "hep-ex",
     reportNumber = "CERN-EP-2021-059",
     month = "6",
-    year = "2021"
+    year = "2021",
+    journal = ""
 }
 
 % 2021-05-12

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,5 +1,5 @@
 % 2021-06-03
-@article{Aad:2021ajl,
+@article{ATLAS:SUSY-3L-compressed-combination,
     author = "ATLAS Collaboration",
     title = "{Search for chargino--neutralino pair production in final states with three leptons and missing transverse momentum in $\sqrt{s} = 13$ TeV $pp$ collisions with the ATLAS detector}",
     eprint = "2106.01676",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,14 @@
+@article{Aad:2021ajl,
+    author = "ATLAS Collaboration",
+    title = "{Search for chargino--neutralino pair production in final states with three leptons and missing transverse momentum in $\sqrt{s} = 13$ TeV $pp$ collisions with the ATLAS detector}",
+    eprint = "2106.01676",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    reportNumber = "CERN-EP-2021-059",
+    month = "6",
+    year = "2021"
+}
+
 % 2021-05-12
 @inproceedings{Dattola:2021cmw,
     author = "Belle II Collaboration",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,4 @@
+% 2021-06-03
 @article{Aad:2021ajl,
     author = "ATLAS Collaboration",
     title = "{Search for chargino--neutralino pair production in final states with three leptons and missing transverse momentum in $\sqrt{s} = 13$ TeV $pp$ collisions with the ATLAS detector}",


### PR DESCRIPTION
# Description

Resolves #1482 

Add use citation from [Search for chargino--neutralino pair production in final states with three leptons and missing transverse momentum in s√=13 TeV pp collisions with the ATLAS detector](https://inspirehep.net/literature/1866951) by the ATLAS Collaboration! :rocket: 

This is the third citation from ATLAS following the paper https://doi.org/10.1007/JHEP04(2021)165 and the PUB note.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Search for chargino--neutralino pair production in final states with three leptons and missing transverse momentum in s√=13 TeV pp collisions with the ATLAS detector'
   - c.f. https://inspirehep.net/literature/1866951
   - Third citation from ATLAS
```