### PR TITLE
chore: Add default virtual environment on PATH for Docker image

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,8 @@ jobs:
     - name: Lint with Black
       run: |
         black --check --diff --verbose .
+
     - name: Lint Dockerfile
-      uses: brpaz/hadolint-action@v1.1.0
+      uses: hadolint/hadolint-action@v1.5.0
       with:
-        dockerfile: "docker/Dockerfile"
+        dockerfile: docker/Dockerfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,8 @@ ARG BASE_IMAGE=python:3.8-slim
 FROM ${BASE_IMAGE} as base
 
 FROM base as builder
+# Set PATH to pickup virtual environment by default
+ENV PATH=/usr/local/venv/bin:"${PATH}"
 COPY . /code
 # hadolint ignore=DL3003,SC2102
 RUN apt-get -qq -y update && \
@@ -11,17 +13,19 @@ RUN apt-get -qq -y update && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/* && \
+    python -m venv /usr/local/venv && \
     cd /code && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     python -m pip --no-cache-dir install .[xmlio,contrib] && \
     python -m pip list
 
 FROM base
+ENV PATH=/usr/local/venv/bin:"${PATH}"
 RUN apt-get -qq -y update && \
     apt-get -qq -y install --no-install-recommends \
         curl && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=builder /usr/local /usr/local
-ENTRYPOINT ["/usr/local/bin/pyhf"]
+COPY --from=builder /usr/local/venv /usr/local/venv
+ENTRYPOINT ["/usr/local/venv/bin/pyhf"]


### PR DESCRIPTION
# Description

Create a default virtual environment and place it on `PATH` so that it is active and used to install all libraries. Then, just `COPY` the virtual environment from the builder image instead of all of `/usr/local/` reducing the amount of files copied to _only_ the necessary files.

This has the added benefit of symlinking the installed `python3` to the `virtualenv` PATH, so the equivalent of

```
ln -s $(command -v python3) /usr/local/venv/bin/python
```

This approach was recommended by Anthony Sottile in his YouTube video "[how to get pip for deadsnakes / docker pythons (intermediate) anthony explains 293](https://youtu.be/2Hg5-Hrsa6w)". Thanks Anthony!


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add a venv virtual environment to PATH
   - Adding venv also symlinks the python doing the installing to the virtual environment's python
      -  e.g. `ls -l $(which python)` shows `/usr/local/venv/bin/python -> /usr/local/bin/python`
   - Thanks to Anthony Sottile for recommending this approach
   - c.f. https://youtu.be/2Hg5-Hrsa6w
   - c.f. https://github.com/pyhf/cuda-images/pull/3
* Update hadolint GitHub Action to hadolint/hadolint-action@v1.5.0
```