### PR TITLE
chore: Use tmpdir fixture over datadir in pyhf contrib download tests

### DIFF
--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -549,18 +549,18 @@ def test_patchset_download(tmpdir, script_runner, archive):
     assert ret.success
 
     # Run with all optional flags
-    command = f'pyhf contrib download --verbose --force {archive} {datadir.join("likelihoods").strpath}'
+    command = f'pyhf contrib download --verbose --force {archive} {tmpdir.join("likelihoods").strpath}'
     ret = script_runner.run(*shlex.split(command))
     assert ret.success
 
-    command = f'pyhf contrib download --verbose https://www.fail.org/record/resource/1234567 {datadir.join("likelihoods").strpath}'
+    command = f'pyhf contrib download --verbose https://www.fail.org/record/resource/1234567 {tmpdir.join("likelihoods").strpath}'
     ret = script_runner.run(*shlex.split(command))
     assert not ret.success
     assert (
         "pyhf.exceptions.InvalidArchiveHost: www.fail.org is not an approved archive host"
         in ret.stderr
     )
-    command = f'pyhf contrib download --verbose --force https://www.fail.org/record/resource/1234567 {datadir.join("likelihoods").strpath}'
+    command = f'pyhf contrib download --verbose --force https://www.fail.org/record/resource/1234567 {tmpdir.join("likelihoods").strpath}'
     ret = script_runner.run(*shlex.split(command))
     assert not ret.success
     assert (

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -543,8 +543,8 @@ def test_workspace_digest(tmpdir, script_runner, algorithms, do_json):
         "https://doi.org/10.17182/hepdata.89408.v1/r2",
     ],
 )
-def test_patchset_download(datadir, script_runner, archive):
-    command = f'pyhf contrib download {archive} {datadir.join("likelihoods").strpath}'
+def test_patchset_download(tmpdir, script_runner, archive):
+    command = f'pyhf contrib download {archive} {tmpdir.join("likelihoods").strpath}'
     ret = script_runner.run(*shlex.split(command))
     assert ret.success
 


### PR DESCRIPTION
# Description

As brought up in Issue #1485, the `test_patchset_download` tests don't actually need to use the `datadir` fixture, so for clarity use the `tmpdir` fixture.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use tmpdir fixture instead of datadir fixture in test_patchset_download as datadir is not explicitly needed
   - The tests are easier to understand when fixtures are used in situations that use their intended features
```
