### PR TITLE
feat: Allow strings in patch values for patchset

### DIFF
--- a/src/pyhf/schemas/1.0.0/defs.json
+++ b/src/pyhf/schemas/1.0.0/defs.json
@@ -281,7 +281,12 @@
                         "type": "object",
                         "properties": {
                             "name": { "type": "string", "pattern": "^[a-zA-Z0-9_]+$" },
-                            "values": { "type": "array", "items": { "type": "number" } }
+                            "values": {
+                                "type": "array",
+                                "items": {
+                                    "anyOf": [{"type": "number"}, {"type": "string"}]
+                                }
+                            }
                         },
                         "required": ["name", "values"],
                         "additionalProperties": true

--- a/tests/test_patchset.py
+++ b/tests/test_patchset.py
@@ -25,7 +25,11 @@ def patch():
 
 @pytest.mark.parametrize(
     'patchset_file',
-    ['patchset_bad_empty_patches.json', 'patchset_bad_no_version.json'],
+    [
+        'patchset_bad_empty_patches.json',
+        'patchset_bad_no_version.json',
+        'patchset_bad_wrong_valuetype.json',
+    ],
 )
 def test_patchset_invalid_spec(datadir, patchset_file):
     patchsetspec = json.load(open(datadir.join(patchset_file)))
@@ -130,7 +134,9 @@ def test_patch_equality(patch):
 
 
 def test_patchset_get_string_values(datadir):
-    patchset = pyhf.PatchSet(json.load(open(datadir.join('patchset_good_stringvalues.json'))))
+    patchset = pyhf.PatchSet(
+        json.load(open(datadir.join('patchset_good_stringvalues.json')))
+    )
     assert patchset["Gtt_2100_5000_800"]
     assert patchset["Gbb_2200_5000_800"]
     assert patchset[[2100, 800, "Gtt"]]

--- a/tests/test_patchset.py
+++ b/tests/test_patchset.py
@@ -127,3 +127,11 @@ def test_patch_repr(patch):
 def test_patch_equality(patch):
     assert patch == patch
     assert patch != object()
+
+
+def test_patchset_get_string_values(datadir):
+    patchset = pyhf.PatchSet(json.load(open(datadir.join('patchset_good_stringvalues.json'))))
+    assert patchset["Gtt_2100_5000_800"]
+    assert patchset["Gbb_2200_5000_800"]
+    assert patchset[[2100, 800, "Gtt"]]
+    assert patchset[[2100, 800, "Gbb"]]

--- a/tests/test_patchset/patchset_bad_wrong_valuetype.json
+++ b/tests/test_patchset/patchset_bad_wrong_valuetype.json
@@ -1,0 +1,41 @@
+{
+    "metadata": {
+        "references": { "hepdata": "ins1234567" },
+        "description": "signal patchset for the SUSY Multi-b-jet analysis",
+        "digests": { "md5": "098f6bcd4621d373cade4e832627b4f6" },
+        "labels": ["mass_stop", "mass_neutralino"]
+    },
+    "patches": [
+        {
+            "metadata": {
+                "name": "Gtt_2100_5000_800",
+                "values": [2100, {"a": "b"}]
+            },
+            "patch": [
+                {
+                    "op": "add",
+                    "path": "/foo/0/bar",
+                    "value": {
+                        "foo": [1.0]
+                    }
+                }
+            ]
+        },
+        {
+            "metadata": {
+                "name": "Gtt_2200_5000_800",
+                "values": [2200, 5000]
+            },
+            "patch": [
+                {
+                    "op": "add",
+                    "path": "/foo/0/bar",
+                    "value": {
+                        "foo": [1.0]
+                    }
+                }
+            ]
+        }
+    ],
+    "version": "1.0.0"
+}

--- a/tests/test_patchset/patchset_good_stringvalues.json
+++ b/tests/test_patchset/patchset_good_stringvalues.json
@@ -1,0 +1,41 @@
+{
+    "metadata": {
+        "references": { "hepdata": "ins1234567" },
+        "description": "signal patchset for the SUSY Multi-b-jet analysis",
+        "digests": { "md5": "098f6bcd4621d373cade4e832627b4f6" },
+        "labels": ["mass_stop", "mass_neutralino", "decay"]
+    },
+    "patches": [
+        {
+            "metadata": {
+                "name": "Gtt_2100_5000_800",
+                "values": [2100, 800, "Gtt"]
+            },
+            "patch": [
+                {
+                    "op": "add",
+                    "path": "/foo/0/bar",
+                    "value": {
+                        "foo": [1.0]
+                    }
+                }
+            ]
+        },
+        {
+            "metadata": {
+                "name": "Gbb_2200_5000_800",
+                "values": [2100, 800, "Gbb"]
+            },
+            "patch": [
+                {
+                    "op": "add",
+                    "path": "/foo/0/bar",
+                    "value": {
+                        "foo": [1.0]
+                    }
+                }
+            ]
+        }
+    ],
+    "version": "1.0.0"
+}


### PR DESCRIPTION
# Pull Request Description

This loosens the PatchSet schema to allow for value types in the "values" of a patch to accept strings (in addition to numbers). Therefore one could do patch tuples of `(decay, m1, m2) = ("Gtt", 1000, 800)` for example.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Allow string types for patch values in patchsets
   - Example: "values": [2100, 800, "Gtt"]
   - Extends schemas/1.0.0/defs.json   
* Add tests for string types
```
