### PR TITLE
chore: Update pre-commit hooks versions and run order

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
   autoupdate_commit_msg: "chore: [pre-commit.ci] pre-commit autoupdate"
-  autoupdate_schedule: "monthly"
+  autoupdate_schedule: monthly
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,12 @@ repos:
       # exclude generated files
       exclude: ^validation/|\.dtd$|\.xml$
 
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.19.4
+    hooks:
+    - id: pyupgrade
+      args: ["--py37-plus"]
+
 -   repo: https://github.com/psf/black
     rev: 21.6b0
     hooks:
@@ -40,12 +46,6 @@ repos:
     rev: 3.9.2
     hooks:
     - id: flake8
-
--   repo: https://github.com/asottile/pyupgrade
-    rev: v2.19.4
-    hooks:
-    - id: pyupgrade
-      args: ["--py37-plus"]
 
 -   repo: https://github.com/nbQA-dev/nbQA
     rev: 0.12.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
     - id: check-added-large-files
     - id: check-case-conflict
@@ -26,7 +26,7 @@ repos:
       exclude: ^validation/|\.dtd$|\.xml$
 
 -   repo: https://github.com/psf/black
-    rev: 21.5b1
+    rev: 21.6b0
     hooks:
     - id: black
 
@@ -42,13 +42,13 @@ repos:
     - id: flake8
 
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.15.0
+    rev: v2.19.4
     hooks:
     - id: pyupgrade
       args: ["--py37-plus"]
 
 -   repo: https://github.com/nbQA-dev/nbQA
-    rev: 0.8.0
+    rev: 0.12.0
     hooks:
     - id: nbqa-black
       additional_dependencies: [black==21.5b1]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     rev: v1.10.0
     hooks:
     - id: blacken-docs
-      additional_dependencies: [black==21.5b1]
+      additional_dependencies: [black==21.6b0]
 
 -   repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
@@ -51,6 +51,6 @@ repos:
     rev: 0.12.0
     hooks:
     - id: nbqa-black
-      additional_dependencies: [black==21.5b1]
+      additional_dependencies: [black==21.6b0]
     - id: nbqa-pyupgrade
-      additional_dependencies: [pyupgrade==2.15.0]
+      additional_dependencies: [pyupgrade==2.19.4]

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -460,7 +460,7 @@ class AsymptoticCalculator:
             map(
                 list,
                 zip(
-                    *[
+                    *(
                         self.pvalues(
                             test_stat, sig_plus_bkg_distribution, bkg_only_distribution
                         )
@@ -468,7 +468,7 @@ class AsymptoticCalculator:
                             bkg_only_distribution.expected_value(n_sigma)
                             for n_sigma in [2, 1, 0, -1, -2]
                         ]
-                    ]
+                    )
                 ),
             )
         )

--- a/src/pyhf/interpolators/code4.py
+++ b/src/pyhf/interpolators/code4.py
@@ -343,7 +343,7 @@ class _slow_code4:
             ]
 
             coefficients = [
-                sum([A_i * b_j for A_i, b_j in zip(A_row, b)]) for A_row in A_inverse
+                sum(A_i * b_j for A_i, b_j in zip(A_row, b)) for A_row in A_inverse
             ]
             delta = 1
             for i in range(1, 7):

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -15,7 +15,7 @@ def _tensorviewer_from_parmap(par_map, batch_size):
     names, slices, _ = list(
         zip(
             *sorted(
-                [(k, v['slice'], v['slice'].start) for k, v in par_map.items()],
+                ((k, v['slice'], v['slice'].start) for k, v in par_map.items()),
                 key=lambda x: x[2],
             )
         )

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -266,10 +266,10 @@ def _join_measurements(join, left_measurements, right_measurements):
                         'poi': measurements[0]['config']['poi'],
                         'parameters': _join_parameter_configs(
                             measurement_name,
-                            *[
+                            *(
                                 measurement['config']['parameters']
                                 for measurement in measurements
-                            ],
+                            ),
                         ),
                     },
                 }

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -201,10 +201,8 @@ def test_batched_constraints(backend):
     assert np.isclose(
         result,
         sum(
-            [
-                default_backend.poisson_logpdf(data, rate)
-                for data, rate in zip([12, 13, 14], [12, 13, 14])
-            ]
+            default_backend.poisson_logpdf(data, rate)
+            for data, rate in zip([12, 13, 14], [12, 13, 14])
         ),
     )
     assert result.shape == ()
@@ -222,10 +220,8 @@ def test_batched_constraints(backend):
     assert np.isclose(
         result,
         sum(
-            [
-                default_backend.poisson_logpdf(data, rate)
-                for data, rate in zip([12, 13, 14], [12 * 1.1, 13 * 1.1, 14 * 1.1])
-            ]
+            default_backend.poisson_logpdf(data, rate)
+            for data, rate in zip([12, 13, 14], [12 * 1.1, 13 * 1.1, 14 * 1.1])
         ),
     )
     assert result.shape == ()
@@ -294,12 +290,10 @@ def test_batched_constraints(backend):
     assert np.isclose(
         result[0],
         sum(
-            [
-                default_backend.normal_logpdf(data, mu, sigma)
-                for data, mu, sigma in zip(
-                    [0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [1.5, 2.0, 1.0, 1.0, 1.0]
-                )
-            ]
+            default_backend.normal_logpdf(data, mu, sigma)
+            for data, mu, sigma in zip(
+                [0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [1.5, 2.0, 1.0, 1.0, 1.0]
+            )
         ),
     )
     assert result.shape == (1,)
@@ -317,12 +311,10 @@ def test_batched_constraints(backend):
     assert np.isclose(
         result[0],
         sum(
-            [
-                default_backend.normal_logpdf(data, mu, sigma)
-                for data, mu, sigma in zip(
-                    [0, 0, 0, 0, 0], [1, 2, 3, 4, 5], [1.5, 2.0, 1.0, 1.0, 1.0]
-                )
-            ]
+            default_backend.normal_logpdf(data, mu, sigma)
+            for data, mu, sigma in zip(
+                [0, 0, 0, 0, 0], [1, 2, 3, 4, 5], [1.5, 2.0, 1.0, 1.0, 1.0]
+            )
         ),
     )
     assert result.shape == (1,)


### PR DESCRIPTION
# Description

Update pre-commit hooks and bump pyupgrade in the pre-commit hooks run order. As pre-commit hooks execute sequentially as defined in `.pre-commit-config.yaml`, those that can edit the code base like `pyupgade` should run before others like `black` that will apply formatting.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update and apply pre-commit hooks:
   - github.com/pre-commit/pre-commit-hooks: v3.4.0 → v4.0.1
   - github.com/asottile/pyupgrade: v2.15.0 → v2.19.4
   - github.com/psf/black: v21.5b1 → v21.6b0
   - github.com/nbQA-dev/nbQA: v0.8.0 → v0.12.0
* Move pyupgrade so that it runs sooner
   - pre-commit hooks execute in order of definition in .pre-commit-config.yaml, so hooks that can change the codebase should execute before linter hooks
* Remove quotes from time interval on pre-commit.ci autoupdate_schedule
```
