### PR TITLE
docs: Add v0.6.2 release notes

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -2,6 +2,7 @@
 Release Notes
 =============
 
+.. include:: release-notes/v0.6.2.rst
 .. include:: release-notes/v0.6.1.rst
 .. include:: release-notes/v0.6.0.rst
 .. include:: release-notes/v0.5.4.rst

--- a/docs/release-notes/v0.6.2.rst
+++ b/docs/release-notes/v0.6.2.rst
@@ -28,6 +28,8 @@ Fixes
   (PR :pr:`1369`)
 * The default precision for all backends is now ``64b``.
   (PR :pr:`1400`)
+* Add check to ensure that POIs are not fixed during a fit.
+  (PR :pr:`1409`)
 
 Features
 --------

--- a/docs/release-notes/v0.6.2.rst
+++ b/docs/release-notes/v0.6.2.rst
@@ -62,6 +62,9 @@ Python API
   :func:`pyhf.contrib.viz.brazil.plot_results` now returns a lists of the artists
   drawn on the axis and moves the ``ax`` arguments to the to the last argument.
   (PR :pr:`1377`)
+* The ``pyhf.compat`` module has been added to aid in translating to and from ROOT
+  names.
+  (PR :pr:`1439`)
 
 CLI API
 ~~~~~~~

--- a/docs/release-notes/v0.6.2.rst
+++ b/docs/release-notes/v0.6.2.rst
@@ -15,9 +15,10 @@ Important Notes
 Fixes
 -----
 
-* In the PyTorch backend the ``validate_args`` kwarg is used with
-  ``torch.distributions`` to ensure a continuous approximation of the Poisson
-  distribution in ``torch`` ``v1.8.0+``.
+* Allow for precision to be properly set for the tensorlib ``ones`` and ``zeros``
+  methods through a ``dtype`` argument.
+  This allows for precision to be properly set through the :func:`pyhf.set_backend`
+  ``precision`` argument.
 
 Features
 --------

--- a/docs/release-notes/v0.6.2.rst
+++ b/docs/release-notes/v0.6.2.rst
@@ -6,7 +6,17 @@ This is a patch release from ``v0.6.1`` → ``v0.6.2``.
 Important Notes
 ---------------
 
-* As a result of changes to the default behavior of ``torch.distributions``
+* Only lower bounds on core dependencies are now set.
+  This allows for greater developer freedom and reduces the risk of breaking
+  user's applications by unnecessarily constraining libraries.
+  This also means that users will be responsible for ensuring that their
+  installed dependencies do not conflict with or break ``pyhf``.
+  c.f. Hynek Schlawack's blog post `Semantic Versioning Will Not Save You
+  <https://hynek.me/articles/semver-will-not-save-you/>`_ for more in coverage
+  on this topic.
+  For most users nothing should change.
+  This mainly affects developers of other libraries in which ``pyhf`` is a dependnecy.
+  (PR :pr:`1382`)
 
 Fixes
 -----

--- a/docs/release-notes/v0.6.2.rst
+++ b/docs/release-notes/v0.6.2.rst
@@ -6,11 +6,7 @@ This is a patch release from ``v0.6.1`` → ``v0.6.2``.
 Important Notes
 ---------------
 
-* As a result of changes to the default behavior of ``torch.distributions`` in
-  PyTorch ``v1.8.0``, accommodating changes have been made in the underlying
-  implementations for :func:`pyhf.tensor.pytorch_backend.pytorch_backend`.
-  These changes require a new lower bound of ``torch`` ``v1.8.0`` for use of the
-  PyTorch backend.
+* As a result of changes to the default behavior of ``torch.distributions``
 
 Fixes
 -----
@@ -19,6 +15,7 @@ Fixes
   methods through a ``dtype`` argument.
   This allows for precision to be properly set through the :func:`pyhf.set_backend`
   ``precision`` argument.
+* The default precision for all backends is now ``64b``.
 
 Features
 --------
@@ -26,13 +23,7 @@ Features
 Python API
 ~~~~~~~~~~
 
-* The ``solver_options`` kwarg can be passed to the
-  :func:`pyhf.optimize.opt_scipy.scipy_optimizer` optimizer for additional
-  configuration of the minimization.
-  See :func:`scipy.optimize.show_options` for additional options of optimization
-  solvers.
-* The ``torch`` API is now used to provide the implementations of the ``ravel``,
-  ``tile``, and ``outer`` tensorlib methods for the PyTorch backend.
+* The ``solver_options`` kwarg can be
 
 Contributors
 ------------

--- a/docs/release-notes/v0.6.2.rst
+++ b/docs/release-notes/v0.6.2.rst
@@ -17,6 +17,8 @@ Important Notes
   For most users nothing should change.
   This mainly affects developers of other libraries in which ``pyhf`` is a dependnecy.
   (PR :pr:`1382`)
+* There is a small breaking API change for :func:`pyhf.contrib.viz.brazil.plot_results`.
+  See the Pyhton API changes section for more information.
 
 Fixes
 -----
@@ -33,6 +35,16 @@ Fixes
 
 Features
 --------
+
+Python API
+~~~~~~~~~~
+
+* Add CLs component plotting kwargs to :func:`pyhf.contrib.viz.brazil.plot_results`.
+  This allows CLs+b and CLb components of the CLs ratio to be polotted as well.
+  To be more consistent with the ``matplotlib`` API,
+  :func:`pyhf.contrib.viz.brazil.plot_results` now returns a lists of the artists
+  drawn on the axis and moves the ``ax`` arguments to the to the last argument.
+  (PR :pr:`1377`)
 
 CLI API
 ~~~~~~~

--- a/docs/release-notes/v0.6.2.rst
+++ b/docs/release-notes/v0.6.2.rst
@@ -12,6 +12,8 @@ Important Notes
   (PR :pr:`1438`)
 * There is a small breaking API change for :func:`pyhf.contrib.viz.brazil.plot_results`.
   See the Pyhton API changes section for more information.
+* The :class:`pyhf.patchset.PatchSet` schema now allows string types for patch values in patchsets.
+  (PR :pr:`1488`)
 * Only lower bounds on core dependencies are now set.
   This allows for greater developer freedom and reduces the risk of breaking
   user's applications by unnecessarily constraining libraries.
@@ -51,6 +53,8 @@ Fixes
   (PR :pr:`1409`)
 * Parameter name strings are now normalized to remove trailing spaces.
   (PR :pr:`1436`)
+* The logging level is now not automatically set in :class:`pyhf.contrib.utils`.
+  (PR :pr:`1460`)
 
 Features
 --------

--- a/docs/release-notes/v0.6.2.rst
+++ b/docs/release-notes/v0.6.2.rst
@@ -34,5 +34,12 @@ Python API
 * The ``torch`` API is now used to provide the implementations of the ``ravel``,
   ``tile``, and ``outer`` tensorlib methods for the PyTorch backend.
 
+Contributors
+------------
+
+``v0.6.2`` benefited from contributions from:
+
+* Alexander Held
+
 .. |release v0.6.2| replace:: ``v0.6.2``
 .. _`release v0.6.2`: https://github.com/scikit-hep/pyhf/releases/tag/v0.6.2

--- a/docs/release-notes/v0.6.2.rst
+++ b/docs/release-notes/v0.6.2.rst
@@ -6,6 +6,12 @@ This is a patch release from ``v0.6.1`` → ``v0.6.2``.
 Important Notes
 ---------------
 
+* The :func:`pyhf.simplemodels.hepdata_like` API has been deprecated in favor of
+  :func:`pyhf.simplemodels.uncorrelated_background`.
+  The :func:`pyhf.simplemodels.hepdata_like` API will be removed in ``pyhf`` ``v0.7.0``.
+  (PR :pr:`1438`)
+* There is a small breaking API change for :func:`pyhf.contrib.viz.brazil.plot_results`.
+  See the Pyhton API changes section for more information.
 * Only lower bounds on core dependencies are now set.
   This allows for greater developer freedom and reduces the risk of breaking
   user's applications by unnecessarily constraining libraries.
@@ -17,8 +23,6 @@ Important Notes
   For most users nothing should change.
   This mainly affects developers of other libraries in which ``pyhf`` is a dependnecy.
   (PR :pr:`1382`)
-* There is a small breaking API change for :func:`pyhf.contrib.viz.brazil.plot_results`.
-  See the Pyhton API changes section for more information.
 * Calling ``dir()`` on any ``pyhf`` module or trying to tab complete an API will
   now provide a more helpfully restricted view of the available APIs.
   This should help provide better exploration of the ``pyhf`` API.
@@ -43,6 +47,13 @@ Features
 Python API
 ~~~~~~~~~~
 
+* The :func:`pyhf.simplemodels.hepdata_like` API has been deprecated in favor of
+  :func:`pyhf.simplemodels.uncorrelated_background`.
+  The :func:`pyhf.simplemodels.hepdata_like` API will be removed in ``pyhf`` ``v0.7.0``.
+  (PR :pr:`1438`)
+* The :func:`pyhf.simplemodels.correlated_background` API has been added to provide a
+  example model with a single channel with a correlated background uncertainty.
+  (PR :pr:`1435`)
 * Add CLs component plotting kwargs to :func:`pyhf.contrib.viz.brazil.plot_results`.
   This allows CLs+b and CLb components of the CLs ratio to be polotted as well.
   To be more consistent with the ``matplotlib`` API,

--- a/docs/release-notes/v0.6.2.rst
+++ b/docs/release-notes/v0.6.2.rst
@@ -27,6 +27,15 @@ Important Notes
   now provide a more helpfully restricted view of the available APIs.
   This should help provide better exploration of the ``pyhf`` API.
   (PR :pr:`1403`)
+* Docker images of releases are now published to both `Docker Hub
+  <https://hub.docker.com/r/pyhf/pyhf/tags>`_ and to the `GitHub Container
+  Registry <https://github.com/scikit-hep/pyhf/pkgs/container/pyhf>`_.
+  (PR :pr:`1444`)
+* CUDA enabled Docker images are now available for release ``v0.6.1`` and later
+  on `Docker Hub <https://hub.docker.com/r/pyhf/cuda>`_ and the `GitHub
+  Container Registry <https://github.com/pyhf/cuda-images/pkgs/container/cuda-images>`_.
+  Visit `github.com/pyhf/cuda-images <https://github.com/pyhf/cuda-images>`_ for more
+  information.
 
 Fixes
 -----

--- a/docs/release-notes/v0.6.2.rst
+++ b/docs/release-notes/v0.6.2.rst
@@ -15,7 +15,9 @@ Fixes
   methods through a ``dtype`` argument.
   This allows for precision to be properly set through the :func:`pyhf.set_backend`
   ``precision`` argument.
+  (PR :pr:`1369`)
 * The default precision for all backends is now ``64b``.
+  (PR :pr:`1400`)
 
 Features
 --------

--- a/docs/release-notes/v0.6.2.rst
+++ b/docs/release-notes/v0.6.2.rst
@@ -11,7 +11,7 @@ Important Notes
   The :func:`pyhf.simplemodels.hepdata_like` API will be removed in ``pyhf`` ``v0.7.0``.
   (PR :pr:`1438`)
 * There is a small breaking API change for :func:`pyhf.contrib.viz.brazil.plot_results`.
-  See the Pyhton API changes section for more information.
+  See the Python API changes section for more information.
 * The :class:`pyhf.patchset.PatchSet` schema now allows string types for patch values in patchsets.
   (PR :pr:`1488`)
 * Only lower bounds on core dependencies are now set.
@@ -20,10 +20,10 @@ Important Notes
   This also means that users will be responsible for ensuring that their
   installed dependencies do not conflict with or break ``pyhf``.
   c.f. Hynek Schlawack's blog post `Semantic Versioning Will Not Save You
-  <https://hynek.me/articles/semver-will-not-save-you/>`_ for more in coverage
+  <https://hynek.me/articles/semver-will-not-save-you/>`_ for more in-depth coverage
   on this topic.
   For most users nothing should change.
-  This mainly affects developers of other libraries in which ``pyhf`` is a dependnecy.
+  This mainly affects developers of other libraries in which ``pyhf`` is a dependency.
   (PR :pr:`1382`)
 * Calling ``dir()`` on any ``pyhf`` module or trying to tab complete an API will
   now provide a more helpfully restricted view of the available APIs.
@@ -66,11 +66,12 @@ Python API
   :func:`pyhf.simplemodels.uncorrelated_background`.
   The :func:`pyhf.simplemodels.hepdata_like` API will be removed in ``pyhf`` ``v0.7.0``.
   (PR :pr:`1438`)
-* The :func:`pyhf.simplemodels.correlated_background` API has been added to provide a
-  example model with a single channel with a correlated background uncertainty.
+* The :func:`pyhf.simplemodels.correlated_background` API has been added to
+  provide an example model with a single channel with a correlated background
+  uncertainty.
   (PR :pr:`1435`)
 * Add CLs component plotting kwargs to :func:`pyhf.contrib.viz.brazil.plot_results`.
-  This allows CLs+b and CLb components of the CLs ratio to be polotted as well.
+  This allows CLs+b and CLb components of the CLs ratio to be plotted as well.
   To be more consistent with the ``matplotlib`` API,
   :func:`pyhf.contrib.viz.brazil.plot_results` now returns a lists of the artists
   drawn on the axis and moves the ``ax`` arguments to the to the last argument.
@@ -83,7 +84,7 @@ CLI API
 ~~~~~~~
 
 * The CLI API now supports a ``patchset inspect`` API to list the individual
-  pathces in a ``PatchSet``.
+  patches in a ``PatchSet``.
   (PR :pr:`1412`)
 
 .. code-block:: shell

--- a/docs/release-notes/v0.6.2.rst
+++ b/docs/release-notes/v0.6.2.rst
@@ -19,6 +19,10 @@ Important Notes
   (PR :pr:`1382`)
 * There is a small breaking API change for :func:`pyhf.contrib.viz.brazil.plot_results`.
   See the Pyhton API changes section for more information.
+* Calling ``dir()`` on any ``pyhf`` module will now provide a more helpfully restricted
+  view.
+  This should help provide better exploration of the ``pyhf`` API.
+  (PR :pr:`1403`)
 
 Fixes
 -----

--- a/docs/release-notes/v0.6.2.rst
+++ b/docs/release-notes/v0.6.2.rst
@@ -40,6 +40,8 @@ Fixes
   (PR :pr:`1400`)
 * Add check to ensure that POIs are not fixed during a fit.
   (PR :pr:`1409`)
+* Parameter name strings are now normalized to remove trailing spaces.
+  (PR :pr:`1436`)
 
 Features
 --------

--- a/docs/release-notes/v0.6.2.rst
+++ b/docs/release-notes/v0.6.2.rst
@@ -34,8 +34,8 @@ Important Notes
   Registry <https://github.com/scikit-hep/pyhf/pkgs/container/pyhf>`_.
   (PR :pr:`1444`)
 * CUDA enabled Docker images are now available for release ``v0.6.1`` and later
-  on `Docker Hub <https://hub.docker.com/r/pyhf/cuda>`_ and the `GitHub
-  Container Registry <https://github.com/pyhf/cuda-images/pkgs/container/cuda-images>`_.
+  on `Docker Hub <https://hub.docker.com/r/pyhf/cuda>`__ and the `GitHub
+  Container Registry <https://github.com/pyhf/cuda-images/pkgs/container/cuda-images>`__.
   Visit `github.com/pyhf/cuda-images <https://github.com/pyhf/cuda-images>`_ for more
   information.
 

--- a/docs/release-notes/v0.6.2.rst
+++ b/docs/release-notes/v0.6.2.rst
@@ -34,10 +34,16 @@ Fixes
 Features
 --------
 
-Python API
-~~~~~~~~~~
+CLI API
+~~~~~~~
 
-* The ``solver_options`` kwarg can be
+* The CLI API now supports a ``patchset inspect`` API to list the individual
+  pathces in a ``PatchSet``.
+  (PR :pr:`1412`)
+
+.. code-block:: shell
+
+  pyhf patchset inspect [OPTIONS] [PATCHSET]
 
 Contributors
 ------------

--- a/docs/release-notes/v0.6.2.rst
+++ b/docs/release-notes/v0.6.2.rst
@@ -19,8 +19,8 @@ Important Notes
   (PR :pr:`1382`)
 * There is a small breaking API change for :func:`pyhf.contrib.viz.brazil.plot_results`.
   See the Pyhton API changes section for more information.
-* Calling ``dir()`` on any ``pyhf`` module will now provide a more helpfully restricted
-  view.
+* Calling ``dir()`` on any ``pyhf`` module or trying to tab complete an API will
+  now provide a more helpfully restricted view of the available APIs.
   This should help provide better exploration of the ``pyhf`` API.
   (PR :pr:`1403`)
 

--- a/docs/release-notes/v0.6.2.rst
+++ b/docs/release-notes/v0.6.2.rst
@@ -1,0 +1,37 @@
+|release v0.6.2|_
+=================
+
+This is a patch release from ``v0.6.1`` → ``v0.6.2``.
+
+Important Notes
+---------------
+
+* As a result of changes to the default behavior of ``torch.distributions`` in
+  PyTorch ``v1.8.0``, accommodating changes have been made in the underlying
+  implementations for :func:`pyhf.tensor.pytorch_backend.pytorch_backend`.
+  These changes require a new lower bound of ``torch`` ``v1.8.0`` for use of the
+  PyTorch backend.
+
+Fixes
+-----
+
+* In the PyTorch backend the ``validate_args`` kwarg is used with
+  ``torch.distributions`` to ensure a continuous approximation of the Poisson
+  distribution in ``torch`` ``v1.8.0+``.
+
+Features
+--------
+
+Python API
+~~~~~~~~~~
+
+* The ``solver_options`` kwarg can be passed to the
+  :func:`pyhf.optimize.opt_scipy.scipy_optimizer` optimizer for additional
+  configuration of the minimization.
+  See :func:`scipy.optimize.show_options` for additional options of optimization
+  solvers.
+* The ``torch`` API is now used to provide the implementations of the ``ravel``,
+  ``tile``, and ``outer`` tensorlib methods for the PyTorch backend.
+
+.. |release v0.6.2| replace:: ``v0.6.2``
+.. _`release v0.6.2`: https://github.com/scikit-hep/pyhf/releases/tag/v0.6.2


### PR DESCRIPTION
# Description

Add `v0.6.2` release notes as part of completing Issue #1494.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add release notes for pyhf v0.6.2
   - c.f. https://github.com/scikit-hep/pyhf/releases/tag/v0.6.2
```