### PR TITLE
docs: Add squarks and gluinos search statistical model record

### DIFF
--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -1,3 +1,12 @@
+@misc{ins1827025,
+    title = "{Search for squarks and gluinos in final states with jets and missing transverse momentum using 139 fb$^{-1}$ of $\sqrt{s}$ =13 TeV $pp$ collision data with the ATLAS detector}",
+    doi = "10.17182/hepdata.95664",
+    url = "https://doi.org/10.17182/hepdata.95664",
+    year = "2021",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
 @misc{ins1831992,
     title = "{Search for trilepton resonances from chargino and neutralino pair production in $\sqrt{s}$ = 13 TeV $pp$ collisions with the ATLAS detector}",
     doi = "10.17182/hepdata.99806",

--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -24,10 +24,10 @@ Updating list of citations and use cases of :code:`pyhf`:
    :all:
    :style: plain
 
-Published Probability Models
+Published Statistical Models
 ----------------------------
 
-Updating list of HEPData entries for publications using ``HistFactory`` JSON probability models:
+Updating list of HEPData entries for publications using ``HistFactory`` JSON statistical models:
 
 .. bibliography:: bib/HEPData_likelihoods.bib
    :list: bullet

--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -24,10 +24,10 @@ Updating list of citations and use cases of :code:`pyhf`:
    :all:
    :style: plain
 
-Published Likelihoods
----------------------
+Published Probability Models
+----------------------------
 
-Updating list of HEPData entries for publications using ``HistFactory`` JSON likelihoods:
+Updating list of HEPData entries for publications using ``HistFactory`` JSON probability models:
 
 .. bibliography:: bib/HEPData_likelihoods.bib
    :list: bullet


### PR DESCRIPTION
# Description

Add HEPData record for published statistical model and observations for [Search for squarks and gluinos in final states with jets and missing transverse momentum using 139 fb−1 of s√ =13 TeV pp collision data with the ATLAS detector](https://www.hepdata.net/record/ins1827025). Revise usages of the term "likelihoods" to more accurate "probability models" in keeping with upcoming white paper on open statistical models and likelihoods.

Needed for https://github.com/scikit-hep/pyhf/issues/1494#issuecomment-865152062

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add ATLAS squarks and gluinos search HEPData record with patchset pallet (stat model and observations)
   - c.f. https://www.hepdata.net/record/ins1827025
* Revise usages of 'likelihoods' to more accurate 'statistical models' in keeping with upcoming white paper on open statistical models and likelihoods
```