### PR TITLE
docs: Improve badge layout and fix broken Docker badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ pure-python fitting/limit-setting/interval estimation HistFactory-style
 |Code Coverage| |CodeFactor| |pre-commit.ci Status| |Code style: black|
 
 |GitHub Actions Status: CI| |GitHub Actions Status: Docs| |GitHub Actions Status: Publish|
-|Docker Automated|
+|GitHub Actions Status: Docker|
 
 The HistFactory p.d.f. template
 [`CERN-OPEN-2012-016 <https://cds.cern.ch/record/1456844>`__] is per-se
@@ -371,5 +371,5 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
    :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3ADocs+branch%3Amaster
 .. |GitHub Actions Status: Publish| image:: https://github.com/scikit-hep/pyhf/workflows/publish%20distributions/badge.svg?branch=master
    :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3A%22publish+distributions%22+branch%3Amaster
-.. |Docker Automated| image:: https://img.shields.io/docker/automated/pyhf/pyhf.svg
-   :target: https://hub.docker.com/r/pyhf/pyhf/
+.. |GitHub Actions Status: Docker| image:: https://github.com/scikit-hep/pyhf/actions/workflows/docker.yml/badge.svg?branch=master
+   :target: https://github.com/scikit-hep/pyhf/actions/workflows/docker.yml?query=branch%3Amaster

--- a/README.rst
+++ b/README.rst
@@ -8,13 +8,14 @@ pure-python fitting/limit-setting/interval estimation HistFactory-style
 
 |GitHub Project| |DOI| |JOSS DOI| |Scikit-HEP| |NSF Award Number|
 
-|GitHub Actions Status: CI| |GitHub Actions Status: Docs| |GitHub Actions Status: Publish|
-|Docker Automated| |Code Coverage| |CodeFactor| |pre-commit.ci Status| |Code style: black|
-
 |Docs from latest| |Docs from master| |Binder|
 
-|PyPI version| |Conda-forge version| |Supported Python versions| |Docker Stars| |Docker
-Pulls|
+|PyPI version| |Conda-forge version| |Supported Python versions| |Docker Hub pyhf| |Docker Hub pyhf CUDA|
+
+|Code Coverage| |CodeFactor| |pre-commit.ci Status| |Code style: black|
+
+|GitHub Actions Status: CI| |GitHub Actions Status: Docs| |GitHub Actions Status: Publish|
+|Docker Automated|
 
 The HistFactory p.d.f. template
 [`CERN-OPEN-2012-016 <https://cds.cern.ch/record/1456844>`__] is per-se
@@ -369,3 +370,7 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
    :target: https://hub.docker.com/r/pyhf/pyhf/
 .. |Docker Pulls| image:: https://img.shields.io/docker/pulls/pyhf/pyhf.svg
    :target: https://hub.docker.com/r/pyhf/pyhf/
+.. |Docker Hub pyhf| image:: https://img.shields.io/badge/pyhf-v0.6.1-blue?logo=Docker
+   :target: https://hub.docker.com/r/pyhf/pyhf/tags
+.. |Docker Hub pyhf CUDA| image:: https://img.shields.io/badge/pyhf-CUDA-blue?logo=Docker
+   :target: https://hub.docker.com/r/pyhf/cuda/tags

--- a/README.rst
+++ b/README.rst
@@ -337,14 +337,24 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
    :target: https://scikit-hep.org/
 .. |NSF Award Number| image:: https://img.shields.io/badge/NSF-1836650-blue.svg
    :target: https://nsf.gov/awardsearch/showAward?AWD_ID=1836650
-.. |GitHub Actions Status: CI| image:: https://github.com/scikit-hep/pyhf/workflows/CI/CD/badge.svg?branch=master
-   :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3ACI%2FCD+branch%3Amaster
-.. |GitHub Actions Status: Docs| image:: https://github.com/scikit-hep/pyhf/workflows/Docs/badge.svg?branch=master
-   :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3ADocs+branch%3Amaster
-.. |GitHub Actions Status: Publish| image:: https://github.com/scikit-hep/pyhf/workflows/publish%20distributions/badge.svg?branch=master
-   :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3A%22publish+distributions%22+branch%3Amaster
-.. |Docker Automated| image:: https://img.shields.io/docker/automated/pyhf/pyhf.svg
-   :target: https://hub.docker.com/r/pyhf/pyhf/
+.. |Docs from latest| image:: https://img.shields.io/badge/docs-v0.6.1-blue.svg
+   :target: https://pyhf.readthedocs.io/
+.. |Docs from master| image:: https://img.shields.io/badge/docs-master-blue.svg
+   :target: https://scikit-hep.github.io/pyhf
+.. |Binder| image:: https://mybinder.org/badge_logo.svg
+   :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/master?filepath=docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
+
+.. |PyPI version| image:: https://badge.fury.io/py/pyhf.svg
+   :target: https://badge.fury.io/py/pyhf
+.. |Conda-forge version| image:: https://img.shields.io/conda/vn/conda-forge/pyhf.svg
+   :target: https://github.com/conda-forge/pyhf-feedstock
+.. |Supported Python versions| image:: https://img.shields.io/pypi/pyversions/pyhf.svg
+   :target: https://pypi.org/project/pyhf/
+.. |Docker Hub pyhf| image:: https://img.shields.io/badge/pyhf-v0.6.1-blue?logo=Docker
+   :target: https://hub.docker.com/r/pyhf/pyhf/tags
+.. |Docker Hub pyhf CUDA| image:: https://img.shields.io/badge/pyhf-CUDA-blue?logo=Docker
+   :target: https://hub.docker.com/r/pyhf/cuda/tags
+
 .. |Code Coverage| image:: https://codecov.io/gh/scikit-hep/pyhf/graph/badge.svg?branch=master
    :target: https://codecov.io/gh/scikit-hep/pyhf?branch=master
 .. |CodeFactor| image:: https://www.codefactor.io/repository/github/scikit-hep/pyhf/badge
@@ -354,23 +364,12 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
   :alt: pre-commit.ci status
 .. |Code style: black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :target: https://github.com/psf/black
-.. |Docs from latest| image:: https://img.shields.io/badge/docs-v0.6.1-blue.svg
-   :target: https://pyhf.readthedocs.io/
-.. |Docs from master| image:: https://img.shields.io/badge/docs-master-blue.svg
-   :target: https://scikit-hep.github.io/pyhf
-.. |Binder| image:: https://mybinder.org/badge_logo.svg
-   :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/master?filepath=docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
-.. |PyPI version| image:: https://badge.fury.io/py/pyhf.svg
-   :target: https://badge.fury.io/py/pyhf
-.. |Conda-forge version| image:: https://img.shields.io/conda/vn/conda-forge/pyhf.svg
-   :target: https://github.com/conda-forge/pyhf-feedstock
-.. |Supported Python versions| image:: https://img.shields.io/pypi/pyversions/pyhf.svg
-   :target: https://pypi.org/project/pyhf/
-.. |Docker Stars| image:: https://img.shields.io/docker/stars/pyhf/pyhf.svg
+
+.. |GitHub Actions Status: CI| image:: https://github.com/scikit-hep/pyhf/workflows/CI/CD/badge.svg?branch=master
+   :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3ACI%2FCD+branch%3Amaster
+.. |GitHub Actions Status: Docs| image:: https://github.com/scikit-hep/pyhf/workflows/Docs/badge.svg?branch=master
+   :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3ADocs+branch%3Amaster
+.. |GitHub Actions Status: Publish| image:: https://github.com/scikit-hep/pyhf/workflows/publish%20distributions/badge.svg?branch=master
+   :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3A%22publish+distributions%22+branch%3Amaster
+.. |Docker Automated| image:: https://img.shields.io/docker/automated/pyhf/pyhf.svg
    :target: https://hub.docker.com/r/pyhf/pyhf/
-.. |Docker Pulls| image:: https://img.shields.io/docker/pulls/pyhf/pyhf.svg
-   :target: https://hub.docker.com/r/pyhf/pyhf/
-.. |Docker Hub pyhf| image:: https://img.shields.io/badge/pyhf-v0.6.1-blue?logo=Docker
-   :target: https://hub.docker.com/r/pyhf/pyhf/tags
-.. |Docker Hub pyhf CUDA| image:: https://img.shields.io/badge/pyhf-CUDA-blue?logo=Docker
-   :target: https://hub.docker.com/r/pyhf/cuda/tags


### PR DESCRIPTION
# Description

Resolves #1361 

The old Docker deployment badge is now broken, 

[![badge](https://img.shields.io/docker/automated/pyhf/pyhf.svg)](https://hub.docker.com/r/pyhf/pyhf/)

so fix it by using the GitHub Actions stats badge. Also reorder badges for user convince over developer convenience.

**Current layout**

![current_layout](https://user-images.githubusercontent.com/5142394/122822292-7dfa7400-d2a3-11eb-9d65-218f0900ae8b.png)

**PR layout**

![badge_layout](https://user-images.githubusercontent.com/5142394/122821674-c06f8100-d2a2-11eb-946c-2b59e1fcf61d.png)

@phinate we'll merge this before you can probably look at it, but feedback and future revision suggestions are welcome.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update broken Docker deployment badge with GitHub Actions Docker workflow status badge
* Remove Docker stars and pulls badges
* Add pyhf CUDA enabled Docker images badge
* Revise badge layout to prioritize user needs (docs and distributions) over developer interests (code quality and CI status)
```