### PR TITLE
chore: Update codemeta softwareRequirements to match setup.cfg

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -129,5 +129,5 @@
     "keywords": "physics fitting numpy scipy tensorflow pytorch jax",
     "developmentStatus": "4 - Beta",
     "applicationCategory": "Scientific/Engineering, Scientific/Engineering :: Physics",
-    "programmingLanguage": "Python 3, Python 3.7, Python 3.8"
+    "programmingLanguage": "Python 3, Python 3.7, Python 3.8, Python Implementation CPython"
 }

--- a/codemeta.json
+++ b/codemeta.json
@@ -44,7 +44,7 @@
                 "url": "https://pypi.org"
             },
             "runtimePlatform": "Python 3",
-            "version": "~=1.4"
+            "version": ">=1.4.1"
         },
         {
             "@type": "SoftwareApplication",
@@ -57,7 +57,7 @@
                 "url": "https://pypi.org"
             },
             "runtimePlatform": "Python 3",
-            "version": "~=7.0"
+            "version": ">=7.0"
         },
         {
             "@type": "SoftwareApplication",
@@ -70,7 +70,7 @@
                 "url": "https://pypi.org"
             },
             "runtimePlatform": "Python 3",
-            "version": "~=4.56"
+            "version": ">=4.56.0"
         },
         {
             "@type": "SoftwareApplication",
@@ -83,7 +83,7 @@
                 "url": "https://pypi.org"
             },
             "runtimePlatform": "Python 3",
-            "version": "~=3.2"
+            "version": ">=3.0.0"
         },
         {
             "@type": "SoftwareApplication",
@@ -96,7 +96,7 @@
                 "url": "https://pypi.org"
             },
             "runtimePlatform": "Python 3",
-            "version": "~=1.23"
+            "version": ">=1.15"
         },
         {
             "@type": "SoftwareApplication",
@@ -109,7 +109,7 @@
                 "url": "https://pypi.org"
             },
             "runtimePlatform": "Python 3",
-            "version": "~=5.1"
+            "version": ">=5.1"
         }
     ],
     "audience": [


### PR DESCRIPTION
# Description

Needed for part of Issue #1494

Applies the changes from PR #1382 to `codemeta.json` for them to match in `v0.6.2`.

This PR will fail the following test

https://github.com/scikit-hep/pyhf/blob/a244d65f395da74877670cac37317926509c579e/.github/workflows/release_tests.yml#L38-L42

but it will pass in the next release.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update softwareRequirements in codemeta.json to use required lower bounds on all core dependencies
   - Applies lower bounds from PR #1382
* Add CPython implimentation to programmingLanguage codemeta.json metadata
```
