### PR TITLE
fix: Temporarily restrict jaxlib to below v0.1.68

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ extras_require = {
         'tensorflow-probability~=0.10.1',
     ],
     'torch': ['torch~=1.8'],
-    'jax': ['jax~=0.2.8', 'jaxlib~=0.1.58;'],
+    'jax': ['jax~=0.2.8', 'jaxlib~=0.1.58,<0.1.68'],
     'xmlio': [
         'uproot3>=3.14.1',
         'uproot~=4.0',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ extras_require = {
         'tensorflow-probability~=0.10.1',
     ],
     'torch': ['torch~=1.8'],
-    'jax': ['jax~=0.2.8', 'jaxlib~=0.1.58'],
+    'jax': ['jax~=0.2.8', 'jaxlib~=0.1.58;'],
     'xmlio': [
         'uproot3>=3.14.1',
         'uproot~=4.0',


### PR DESCRIPTION
# Description

Until Issue #1501 can be resolved, restrict `jaxlib` to be below `v0.1.6.8` so that development can continue while the problem is resolved. This PR is similar in outcome to https://github.com/scikit-hep/awkward-1.0/pull/963.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add a _temporary_ upper bound on jaxlib of < 0.1.68 to avoid segfault in CI and allow development to continue while the problem is resolved
   - c.f. Issue #1501
```
