### PR TITLE
docs: Add release notes URL to PyPI project urls metadata

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,8 +3,6 @@ current_version = 0.6.2
 commit = True
 tag = True
 
-[bumpversion:file:setup.cfg]
-
 [bumpversion:file:src/pyhf/utils.py]
 
 [bumpversion:file:README.rst]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,6 +3,8 @@ current_version = 0.6.2
 commit = True
 tag = True
 
+[bumpversion:file:setup.cfg]
+
 [bumpversion:file:src/pyhf/utils.py]
 
 [bumpversion:file:README.rst]

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ project_urls =
     Documentation = https://pyhf.readthedocs.io/
     Source Code = https://github.com/scikit-hep/pyhf
     Issue Tracker = https://github.com/scikit-hep/pyhf/issues
+    Release Notes = https://pyhf.readthedocs.io/en/v0.6.2/release-notes.html
 classifiers =
     Development Status :: 4 - Beta
     License :: OSI Approved :: Apache Software License

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,8 +11,8 @@ license_file = LICENSE
 keywords = physics fitting numpy scipy tensorflow pytorch jax
 project_urls =
     Documentation = https://pyhf.readthedocs.io/
-    Source = https://github.com/scikit-hep/pyhf
-    Tracker = https://github.com/scikit-hep/pyhf/issues
+    Source Code = https://github.com/scikit-hep/pyhf
+    Issue Tracker = https://github.com/scikit-hep/pyhf/issues
 classifiers =
     Development Status :: 4 - Beta
     License :: OSI Approved :: Apache Software License

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ project_urls =
     Documentation = https://pyhf.readthedocs.io/
     Source Code = https://github.com/scikit-hep/pyhf
     Issue Tracker = https://github.com/scikit-hep/pyhf/issues
-    Release Notes = https://pyhf.readthedocs.io/en/v0.6.2/release-notes.html
+    Release Notes = https://pyhf.readthedocs.io/en/stable/release-notes.html
 classifiers =
     Development Status :: 4 - Beta
     License :: OSI Approved :: Apache Software License


### PR DESCRIPTION
# Description

This PR adds the release notes webpage to the PyPI project URL metadata in `setup.cfg` so that it shows up on PyPI in a similar fashion to how [`click`'s page](https://pypi.org/project/click/) has it.

The name of the `project_urls` keys is based off what [`click` has in their `setup.cfg`](https://github.com/pallets/click/blob/70358c57b20454c262bceaa901ab273b2487d7f3/setup.cfg#L5-L12) and the [template rules for the PyPA warehouse](https://github.com/pypa/warehouse/blob/3a93612489a47e37c68419821061a530064677ed/warehouse/templates/packaging/detail.html#L20-L58) that @duetosymmetry [found](https://twitter.com/duetosymmetry/status/1410687033237028876) (thanks Leo!).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add release notes webpage to PyPI project metadata
   - Follows PyPA warehouse template rules: https://github.com/pypa/warehouse/blob/3a93612489a47e37c68419821061a530064677ed/warehouse/templates/packaging/detail.html#L20-L58
* Expand the names of the project url keys to make them more clear and explicit on the PyPI webpage
```