### PR TITLE
docs: Update citation for 'Charged Lepton Flavor Violation at the EIC' paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -70,9 +70,11 @@
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
     reportNumber = "LA-UR-21-20531",
-    month = "2",
-    year = "2021",
-    journal = ""
+    doi = "10.1007/JHEP03(2021)256",
+    journal = "JHEP",
+    volume = "03",
+    pages = "256",
+    year = "2021"
 }
 
 % 2021-01-06

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -22,3 +22,4 @@ Contributors include:
 - Pradyumna Rahul K
 - Eric Schanet
 - Henry Schreiner
+- Saransh Chopra


### PR DESCRIPTION
# Description

Resolves #1401

As summarised in the issue, the citation for the paper has been updated with the [new INSPIRE reference](https://inspirehep.net/literature/1846026).

# Checklist Before Requesting Reviewer

- [X] Tests are passing
- [X] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary
(I'm not able to select an assignee for the PR)

# Before Merging

For the PR Assignees:

- [X] Summarize commit messages into a comprehensive review of the PR

```
* Update citation for  'Charged Lepton Flavor Violation at the EIC' paper for publication in JHEP
   - c.f. https://doi.org/10.1007/JHEP03(2021)256
```
