### PR TITLE
test: Remove tests of deprecated simplemodels.hepdata_like API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -17,8 +17,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -45,8 +43,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -73,8 +69,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -100,8 +94,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -127,8 +119,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -18,8 +18,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -209,11 +209,6 @@ def test_pdf_batched_deprecated_api(backend):
     model.expected_data(pars)
 
 
-# TODO: Remove skipif after pyhf v0.6.2 released
-@pytest.mark.skipif(
-    tuple(int(part) for part in pyhf.__version__.split(".")[:3]) < (0, 6, 2),
-    reason="requires pyhf v0.6.2+",
-)
 def test_pdf_batched(backend):
     tb, _ = backend
     source = {

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -7,15 +7,9 @@ import numpy as np
 def model_setup(backend):
     np.random.seed(0)
     n_bins = 100
-    # TODO: Simplify after pyhf v0.6.2 released
-    if tuple(int(part) for part in pyhf.__version__.split(".")[:3]) < (0, 6, 2):
-        model = pyhf.simplemodels.hepdata_like(
-            [10] * n_bins, [50] * n_bins, [1] * n_bins
-        )
-    else:
-        model = pyhf.simplemodels.uncorrelated_background(
-            [10] * n_bins, [50] * n_bins, [1] * n_bins
-        )
+    model = pyhf.simplemodels.uncorrelated_background(
+        [10] * n_bins, [50] * n_bins, [1] * n_bins
+    )
     init_pars = model.config.suggested_init()
     observations = np.random.randint(50, 60, size=n_bins).tolist()
     data = observations + model.config.auxdata
@@ -186,27 +180,6 @@ def test_prob_models(backend):
     pyhf.probability.Normal(tb.astensor([10.0]), tb.astensor([1])).log_prob(
         tb.astensor(2.0)
     )
-
-
-# TODO: Remove after pyhf v0.6.2 released
-def test_pdf_batched_deprecated_api(backend):
-    tb, _ = backend
-    source = {
-        "binning": [2, -0.5, 1.5],
-        "bindata": {"data": [55.0], "bkg": [50.0], "bkgerr": [7.0], "sig": [10.0]},
-    }
-    model = pyhf.simplemodels.hepdata_like(
-        source['bindata']['sig'],
-        source['bindata']['bkg'],
-        source['bindata']['bkgerr'],
-        batch_size=2,
-    )
-
-    pars = [model.config.suggested_init()] * 2
-    data = source['bindata']['data'] + model.config.auxdata
-
-    model.pdf(pars, data)
-    model.expected_data(pars)
 
 
 def test_pdf_batched(backend):

--- a/tests/test_simplemodels.py
+++ b/tests/test_simplemodels.py
@@ -26,7 +26,7 @@ def test_uncorrelated_background():
     assert model.config.suggested_init() == [1.0, 1.0, 1.0]
 
 
-# TODO: Remove after pyhf v0.6.2 is released
+# TODO: Remove when pyhf.simplemodels.hepdata_like is removed in pyhf v0.7.0
 def test_deprecated_apis():
     with warnings.catch_warnings(record=True) as _warning:
         # Cause all warnings to always be triggered


### PR DESCRIPTION
# Description

Resolves #1465

* Removes testing of deprecated `pyhf.simplemodels.hepdata_like` as it was deprecated in `v0.6.2` with the exception of testing that using it properly raises a warning
https://github.com/scikit-hep/pyhf/blob/18a7a08a38676a44048e9a2b88958723e357feee/tests/test_simplemodels.py#L30-L40
* Remove the required full checkouts of the repository history added in PR #1450

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove pyhf version checks
   - Were used only to guard against pyhf.simplemodels.uncorrelated_background not being in the public API until the release of v0.6.2
* Remove full fetch depths in CI where it is not explicitly needed for version information
   - Partially reverts PR #1450
```
