### PR TITLE
fix: Unrestrict jaxlib upper bound and exclude jaxlib v0.1.68

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ extras_require = {
         'tensorflow-probability~=0.10.1',
     ],
     'torch': ['torch~=1.8'],
-    'jax': ['jax~=0.2.8', 'jaxlib~=0.1.58,!=0.1.68'],
+    'jax': ['jax~=0.2.8', 'jaxlib~=0.1.58,!=0.1.68'],  # c.f. Issue 1501
     'xmlio': [
         'uproot3>=3.14.1',
         'uproot~=4.0',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ extras_require = {
         'tensorflow-probability~=0.10.1',
     ],
     'torch': ['torch~=1.8'],
-    'jax': ['jax~=0.2.8', 'jaxlib~=0.1.58,<0.1.68'],
+    'jax': ['jax~=0.2.8', 'jaxlib~=0.1.58,!=0.1.68'],
     'xmlio': [
         'uproot3>=3.14.1',
         'uproot~=4.0',


### PR DESCRIPTION
# Description

* Resolves #1501
* Resolves https://github.com/google/jax/issues/7128
* Resolves https://github.com/actions/virtual-environments/issues/3679

Following the resolution of https://github.com/google/jax/issues/7128, unrestrict `jaxlib`'s upper bound, reverting PR #1502, and exclude `jaxlib` `v0.1.68`.


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Unrestrict the upper bound on jaxlib in 'jax' extra
   - Reverts PR #1502
* Exclude jaxlib v0.1.68 from being installed as part of 'jax' extra
   - c.f. https://github.com/google/jax/issues/7128
```