### PR TITLE
test: Temporarily move to testing against SciPy pre-releases

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -17,19 +17,21 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
+    # For the time being only test SciPy pre-releases
+    # c.f. Issue #1531
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade --editable .[test]
         python -m pip install --upgrade --pre scipy
-        python -m pip uninstall --yes scipy
-        python -m pip install --upgrade cython
-        python -m pip install --upgrade git+git://github.com/scipy/scipy.git
         python -m pip list
+
     - name: Test with pytest
       run: |
         python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade --editable .[test]
+        python -m pip install --upgrade --pre scipy
         python -m pip uninstall --yes scipy
         python -m pip install --upgrade cython
         python -m pip install --upgrade git+git://github.com/scipy/scipy.git


### PR DESCRIPTION
# Description

As described in Issue #1531, the nightly tests against the `HEAD` of SciPy's source have been failing for so long that they are no longer useful and are generating too many false positives (test failures) for the `HEAD` of dependencies workflow to be a useful test. Until the build issue can be resolved, replace testing from `HEAD` against testing against releases with release candidates as eligible installs.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Temporarily remove installs of SciPy from the HEAD of source to reduce false failures in 'HEAD of dependencies' workflow
   - c.f. Issue #1531
* Use pip install --pre to test against release candidates of SciPy
```
