### PR TITLE
fix: Use nightly SciPy wheels from Anaconda in HEAD of dependencies testing

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -23,8 +23,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    # For the time being only test SciPy pre-releases
-    # c.f. Issue #1531
+    # Use nightly SciPy wheels from Anaconda's PyPI
+    # c.f. https://twitter.com/ralfgommers/status/1419917265781334025
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -29,7 +29,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade --editable .[test]
-        python -m pip install --upgrade --pre scipy
+        python -m pip uninstall --yes scipy
+        python -m pip install --upgrade --index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
         python -m pip list
 
     - name: Test with pytest


### PR DESCRIPTION
# Description

* Resolves #1531
* Effectively reverts PR #1532

To avoid having to build SciPy from source (slowing things down and [doing redundant work worse](https://twitter.com/ralfgommers/status/1419917265781334025)) take @rgommers advice and install the [nightly SciPy wheels available on Anaconda's PyPI](https://anaconda.org/scipy-wheels-nightly/scipy) with

```console
python -m pip install --upgrade --index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
```

This works great!

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use nightly wheels of SciPy from Anaconda's PyPI to avoid building SciPy from source for 'HEAD of dependencies' workflow
   - Huge thanks to Ralf Gommers (@rgommers) for pointing this out!
   - c.f. https://anaconda.org/scipy-wheels-nightly/scipy
* Effectively reverts PR #1532
```
