### PR TITLE
feat: Propagate model parameter names to optimizers

### DIFF
--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -169,8 +169,14 @@ class OptimizerMixin:
             do_stitch=do_stitch,
         )
 
+        try:
+            par_names = pdf.config.par_names()
+        except AttributeError:
+            # handle non-pyhf ModelConfigs
+            par_names = None
+
         result = self._internal_minimize(
-            **minimizer_kwargs, options=kwargs, par_names=pdf.config.par_names()
+            **minimizer_kwargs, options=kwargs, par_names=par_names
         )
         result = self._internal_postprocess(
             result, stitch_pars, return_uncertainties=return_uncertainties

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -169,11 +169,17 @@ class OptimizerMixin:
             do_stitch=do_stitch,
         )
 
+        # handle non-pyhf ModelConfigs
         try:
             par_names = pdf.config.par_names()
         except AttributeError:
-            # handle non-pyhf ModelConfigs
             par_names = None
+
+        # need to remove parameters that are fixed in the fit
+        if par_names and do_stitch and fixed_vals:
+            for index, _ in fixed_vals:
+                par_names[index] = None
+            par_names = [name for name in par_names if name]
 
         result = self._internal_minimize(
             **minimizer_kwargs, options=kwargs, par_names=par_names

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -29,11 +29,23 @@ class OptimizerMixin:
             )
 
     def _internal_minimize(
-        self, func, x0, do_grad=False, bounds=None, fixed_vals=None, options={}
+        self,
+        func,
+        x0,
+        do_grad=False,
+        bounds=None,
+        fixed_vals=None,
+        options={},
+        par_names=None,
     ):
 
         minimizer = self._get_minimizer(
-            func, x0, bounds, fixed_vals=fixed_vals, do_grad=do_grad
+            func,
+            x0,
+            bounds,
+            fixed_vals=fixed_vals,
+            do_grad=do_grad,
+            par_names=par_names,
         )
         result = self._minimize(
             minimizer,
@@ -157,7 +169,9 @@ class OptimizerMixin:
             do_stitch=do_stitch,
         )
 
-        result = self._internal_minimize(**minimizer_kwargs, options=kwargs)
+        result = self._internal_minimize(
+            **minimizer_kwargs, options=kwargs, par_names=pdf.config.par_names()
+        )
         result = self._internal_postprocess(
             result, stitch_pars, return_uncertainties=return_uncertainties
         )

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -40,7 +40,13 @@ class minuit_optimizer(OptimizerMixin):
         super().__init__(*args, **kwargs)
 
     def _get_minimizer(
-        self, objective_and_grad, init_pars, init_bounds, fixed_vals=None, do_grad=False
+        self,
+        objective_and_grad,
+        init_pars,
+        init_bounds,
+        fixed_vals=None,
+        do_grad=False,
+        par_names=None,
     ):
 
         step_sizes = [(b[1] - b[0]) / float(self.steps) for b in init_bounds]
@@ -60,7 +66,7 @@ class minuit_optimizer(OptimizerMixin):
             wrapped_objective = objective_and_grad
             jac = None
 
-        minuit = iminuit.Minuit(wrapped_objective, init_pars, grad=jac)
+        minuit = iminuit.Minuit(wrapped_objective, init_pars, grad=jac, name=par_names)
         minuit.errors = step_sizes
         minuit.limits = init_bounds
         minuit.fixed = fixed_bools

--- a/src/pyhf/optimize/opt_scipy.py
+++ b/src/pyhf/optimize/opt_scipy.py
@@ -31,7 +31,13 @@ class scipy_optimizer(OptimizerMixin):
         super().__init__(*args, **kwargs)
 
     def _get_minimizer(
-        self, objective_and_grad, init_pars, init_bounds, fixed_vals=None, do_grad=False
+        self,
+        objective_and_grad,
+        init_pars,
+        init_bounds,
+        fixed_vals=None,
+        do_grad=False,
+        par_names=None,
     ):
         return scipy.optimize.minimize
 

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -319,6 +319,31 @@ class _ModelConfig(_ChannelSummaryMixin):
         """
         return self.par_map[name]['slice']
 
+    def par_names(self):
+        """
+        The names of the parameters in the model including binned-parameter indexing.
+
+        Returns:
+            :obj:`list`: Names of the model parameters.
+
+        Example:
+            >>> import pyhf
+            >>> model = pyhf.simplemodels.uncorrelated_background(
+            ...     signal=[12.0, 11.0], bkg=[50.0, 52.0], bkg_uncertainty=[3.0, 7.0]
+            ... )
+            >>> model.config.par_names()
+            ['mu', 'uncorr_bkguncrt[0]', 'uncorr_bkguncrt[1]']
+        """
+        _names = []
+        for name in self.par_order:
+            _npars = self.param_set(name).n_parameters
+            if _npars == 1:
+                _names.append(name)
+                continue
+
+            _names.extend([f'{name}[{i}]' for i in range(_npars)])
+        return _names
+
     def param_set(self, name):
         """
         The :class:`~pyhf.parameters.paramset` for the model parameter ``name``.

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -324,7 +324,7 @@ class _ModelConfig(_ChannelSummaryMixin):
         The names of the parameters in the model including binned-parameter indexing.
 
         Args:
-            fstring (:obj:`str`): Format string for the parameter names using `name` and `index` variables. Default: '{name}[{index}]'.
+            fstring (:obj:`str`): Format string for the parameter names using ``name`` and ``index`` variables. Default: ``'{name}[{index}]'``.
 
         Returns:
             :obj:`list`: Names of the model parameters.
@@ -346,7 +346,9 @@ class _ModelConfig(_ChannelSummaryMixin):
                 _names.append(name)
                 continue
 
-            _names.extend([fstring.format(name=name, index=i) for i in range(_npars)])
+            _names.extend(
+                [fstring.format(name=name, index=idx) for idx in range(_npars)]
+            )
         return _names
 
     def param_set(self, name):

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -319,9 +319,12 @@ class _ModelConfig(_ChannelSummaryMixin):
         """
         return self.par_map[name]['slice']
 
-    def par_names(self):
+    def par_names(self, fstring='{name}[{index}]'):
         """
         The names of the parameters in the model including binned-parameter indexing.
+
+        Args:
+            fstring (:obj:`str`): Format string for the parameter names using `name` and `index` variables. Default: '{name}[{index}]'.
 
         Returns:
             :obj:`list`: Names of the model parameters.
@@ -333,6 +336,8 @@ class _ModelConfig(_ChannelSummaryMixin):
             ... )
             >>> model.config.par_names()
             ['mu', 'uncorr_bkguncrt[0]', 'uncorr_bkguncrt[1]']
+            >>> model.config.par_names(fstring='{name}_{index}')
+            ['mu', 'uncorr_bkguncrt_0', 'uncorr_bkguncrt_1']
         """
         _names = []
         for name in self.par_order:
@@ -341,7 +346,7 @@ class _ModelConfig(_ChannelSummaryMixin):
                 _names.append(name)
                 continue
 
-            _names.extend([f'{name}[{i}]' for i in range(_npars)])
+            _names.extend([fstring.format(name=name, index=i) for i in range(_npars)])
         return _names
 
     def param_set(self, name):

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -573,3 +573,12 @@ def test_bad_solver_options_scipy(mocker):
     model = pyhf.simplemodels.uncorrelated_background([50.0], [100.0], [10.0])
     data = pyhf.tensorlib.astensor([125.0] + model.config.auxdata)
     assert pyhf.infer.mle.fit(data, model).tolist()
+
+
+def test_minuit_param_names():
+    pyhf.set_backend('numpy', 'minuit')
+    pdf = pyhf.simplemodels.uncorrelated_background([5], [10], [3.5])
+    data = [10] + pdf.config.auxdata
+    _, result = pyhf.infer.mle.fit(data, pdf, return_result_obj=True)
+    assert 'minuit' in result
+    assert result.minuit.parameters == ('mu', 'uncorr_bkguncrt')

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -575,10 +575,15 @@ def test_bad_solver_options_scipy(mocker):
     assert pyhf.infer.mle.fit(data, model).tolist()
 
 
-def test_minuit_param_names():
+def test_minuit_param_names(mocker):
     pyhf.set_backend('numpy', 'minuit')
     pdf = pyhf.simplemodels.uncorrelated_background([5], [10], [3.5])
     data = [10] + pdf.config.auxdata
     _, result = pyhf.infer.mle.fit(data, pdf, return_result_obj=True)
     assert 'minuit' in result
     assert result.minuit.parameters == ('mu', 'uncorr_bkguncrt')
+
+    pdf.config.par_names = mocker.Mock(return_value=None)
+    _, result = pyhf.infer.mle.fit(data, pdf, return_result_obj=True)
+    assert 'minuit' in result
+    assert result.minuit.parameters == ('x0', 'x1')

--- a/tests/test_simplemodels.py
+++ b/tests/test_simplemodels.py
@@ -13,6 +13,7 @@ def test_correlated_background():
     assert model.config.channels == ["single_channel"]
     assert model.config.samples == ["background", "signal"]
     assert model.config.par_order == ["mu", "correlated_bkg_uncertainty"]
+    assert model.config.par_names() == ['mu', 'correlated_bkg_uncertainty']
     assert model.config.suggested_init() == [1.0, 0.0]
 
 
@@ -23,6 +24,11 @@ def test_uncorrelated_background():
     assert model.config.channels == ["singlechannel"]
     assert model.config.samples == ["background", "signal"]
     assert model.config.par_order == ["mu", "uncorr_bkguncrt"]
+    assert model.config.par_names() == [
+        'mu',
+        'uncorr_bkguncrt[0]',
+        'uncorr_bkguncrt[1]',
+    ]
     assert model.config.suggested_init() == [1.0, 1.0, 1.0]
 
 


### PR DESCRIPTION
# Pull Request Description

Resolves #1099. This passes through parameter names to the optimizers, both scipy and minuit. This is done by adding `ModelConfig.par_names()` which returns the parameter names in a format that has yet to be agreed upon (for indexing n-binned parameters). This function output is threaded through the optimizer framework via the `Optimizer._get_minimizer()` function call. However, scipy does not make use of this, so not much changes except to support the updated function signature, while Minuit is able to take advantage of this.

A format string is allowed as an optional keyword argument so we're not locked into a specific format.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Propagate model parameter names through to the optimizers (primarily Minuit)
   - Additionally allow a customizable format for the parameter names
* Add par_names method to _ModelConfig
* Add tests for _ModelConfig.par_names
```
