### PR TITLE
docs: Add citation from heavy neutral leptons neutrino oscillation model paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -117,15 +117,18 @@
 }
 
 % 2020-12-16
-@inproceedings{Amoroso:2020zrz,
+@article{Amoroso:2020zrz,
     author = "Amoroso, Simone and Kar, Deepak and Schott, Matthias",
     title = "{How to discover QCD Instantons at the LHC}",
-    booktitle = "{Topological Effects in the Standard Model: Instantons, Sphalerons and Beyond at LHC}",
     eprint = "2012.09120",
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
-    month = "12",
-    year = "2020"
+    doi = "10.1140/epjc/s10052-021-09412-1",
+    journal = "Eur. Phys. J. C",
+    volume = "81",
+    number = "7",
+    pages = "624",
+    year = "2021"
 }
 
 % 2020-12-15

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,15 @@
+% 2021-07-27
+@article{Tastet:2021vwp,
+    author = "Tastet, Jean-Loup and Ruchayskiy, Oleg and Timiryasov, Inar",
+    title = "{Reinterpreting the ATLAS bounds on heavy neutral leptons in a realistic neutrino oscillation model}",
+    eprint = "2107.12980",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    month = "7",
+    year = "2021",
+    journal = ""
+}
+
 % 2021-06-03
 @article{ATLAS:SUSY-3L-compressed-combination,
     author = "ATLAS Collaboration",


### PR DESCRIPTION
# Description

Resolves #1534

Add citation from [Reinterpreting the ATLAS bounds on heavy neutral leptons in a realistic neutrino oscillation model](https://inspirehep.net/literature/1893584) by @JLTastet, Oleg Ruchayskiy, Inar Timiryasov.

Also update BibTeX for "How to discover QCD Instantons at the LHC" now that the [paper has been published in European Physical Journal C](https://doi.org/10.1140/epjc/s10052-021-09412-1).

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add citation from 'Reinterpreting the ATLAS bounds on heavy neutral leptons in a realistic neutrino oscillation model'
   - c.f. https://inspirehep.net/literature/1893584
* Update BibTeX record for 'How to discover QCD Instantons at the LHC' to reference EPJC paper
   - c.f. https://doi.org/10.1140/epjc/s10052-021-09412-1
```