### PR TITLE
refactor: Use absolute imports over explicit relative imports

### DIFF
--- a/src/pyhf/__init__.py
+++ b/src/pyhf/__init__.py
@@ -1,8 +1,8 @@
-from .tensor import BackendRetriever as tensor
-from .optimize import OptimizerRetriever as optimize
-from ._version import version as __version__
-from .exceptions import InvalidBackend, InvalidOptimizer, Unsupported
-from . import events
+from pyhf.tensor import BackendRetriever as tensor
+from pyhf.optimize import OptimizerRetriever as optimize
+from pyhf._version import version as __version__
+from pyhf.exceptions import InvalidBackend, InvalidOptimizer, Unsupported
+from pyhf import events
 
 tensorlib = None
 optimizer = None
@@ -151,12 +151,12 @@ def set_backend(backend, custom_optimizer=None, precision=None):
     tensorlib._setup()
 
 
-from .pdf import Model
-from .workspace import Workspace
-from . import simplemodels
-from . import infer
-from . import compat
-from .patchset import PatchSet
+from pyhf.pdf import Model
+from pyhf.workspace import Workspace
+from pyhf import simplemodels
+from pyhf import infer
+from pyhf import compat
+from pyhf.patchset import PatchSet
 
 __all__ = [
     "Model",

--- a/src/pyhf/cli/__init__.py
+++ b/src/pyhf/cli/__init__.py
@@ -1,10 +1,10 @@
 """The pyhf command line interface."""
-from .cli import pyhf as cli
-from .rootio import cli as rootio
-from .spec import cli as spec
-from .infer import cli as infer
-from .complete import cli as complete
-from ..contrib import cli as contrib
+from pyhf.cli.cli import pyhf as cli
+from pyhf.cli.rootio import cli as rootio
+from pyhf.cli.spec import cli as spec
+from pyhf.cli.infer import cli as infer
+from pyhf.cli.complete import cli as complete
+from pyhf.contrib import cli as contrib
 
 __all__ = ['cli', 'rootio', 'spec', 'infer', 'complete', 'contrib']
 

--- a/src/pyhf/cli/cli.py
+++ b/src/pyhf/cli/cli.py
@@ -3,10 +3,10 @@ import logging
 
 import click
 
-from .. import __version__
-from . import rootio, spec, infer, patchset, complete
-from ..contrib import cli as contrib
-from .. import utils
+from pyhf import __version__
+from pyhf.cli import rootio, spec, infer, patchset, complete
+from pyhf.contrib import cli as contrib
+from pyhf import utils
 
 logging.basicConfig()
 log = logging.getLogger(__name__)

--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -4,11 +4,11 @@ import logging
 import click
 import json
 
-from ..utils import EqDelimStringParamType
-from ..infer import hypotest
-from ..infer import mle
-from ..workspace import Workspace
-from .. import get_backend, set_backend, optimize
+from pyhf.utils import EqDelimStringParamType
+from pyhf.infer import hypotest
+from pyhf.infer import mle
+from pyhf.workspace import Workspace
+from pyhf import get_backend, set_backend, optimize
 
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/cli/patchset.py
+++ b/src/pyhf/cli/patchset.py
@@ -4,8 +4,8 @@ import logging
 import click
 import json
 
-from ..patchset import PatchSet
-from ..workspace import Workspace
+from pyhf.patchset import PatchSet
+from pyhf.workspace import Workspace
 
 logging.basicConfig()
 log = logging.getLogger(__name__)

--- a/src/pyhf/cli/rootio.py
+++ b/src/pyhf/cli/rootio.py
@@ -41,7 +41,7 @@ def xml2json(entrypoint_xml, basedir, output_file, track_progress):
             "xmlio extra: python -m pip install pyhf[xmlio]",
             exc_info=True,
         )
-    from .. import readxml
+    from pyhf import readxml
 
     spec = readxml.parse(entrypoint_xml, basedir, track_progress=track_progress)
     if output_file is None:
@@ -71,7 +71,7 @@ def json2xml(workspace, output_dir, specroot, dataroot, resultprefix, patch):
             "xmlio extra: python -m pip install pyhf[xmlio]",
             exc_info=True,
         )
-    from .. import writexml
+    from pyhf import writexml
 
     os.makedirs(output_dir, exist_ok=True)
     with click.open_file(workspace, 'r') as specstream:

--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -4,9 +4,9 @@ import logging
 import click
 import json
 
-from ..workspace import Workspace
-from .. import modifiers
-from .. import utils
+from pyhf.workspace import Workspace
+from pyhf import modifiers
+from pyhf import utils
 
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/constraints.py
+++ b/src/pyhf/constraints.py
@@ -1,7 +1,7 @@
-from . import get_backend, default_backend
-from . import events
-from . import probability as prob
-from .parameters import ParamViewer
+from pyhf import get_backend, default_backend
+from pyhf import events
+from pyhf import probability as prob
+from pyhf.parameters import ParamViewer
 
 __all__ = ["gaussian_constraint_combined", "poisson_constraint_combined"]
 

--- a/src/pyhf/contrib/cli.py
+++ b/src/pyhf/contrib/cli.py
@@ -26,7 +26,7 @@ def cli():
 
             $ python -m pip install pyhf[contrib]
     """
-    from . import utils  # Guard CLI from missing extra # noqa: F401
+    from pyhf.contrib import utils  # Guard CLI from missing extra # noqa: F401
 
 
 @cli.command()
@@ -62,7 +62,7 @@ def download(archive_url, output_directory, verbose, force, compress):
         :class:`~pyhf.exceptions.InvalidArchiveHost`: if the provided archive host name is not known to be valid
     """
     try:
-        from . import utils
+        from pyhf.contrib import utils
 
         utils.download(archive_url, output_directory, force, compress)
 

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 import tarfile
 from io import BytesIO
 import logging
-from .. import exceptions
+from pyhf import exceptions
 
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -1,8 +1,8 @@
 """Inference for Statistical Models."""
 
-from . import utils
-from .. import get_backend
-from .. import exceptions
+from pyhf.infer import utils
+from pyhf import get_backend
+from pyhf import exceptions
 
 
 def _check_hypotest_prerequisites(pdf, data, init_pars, par_bounds, fixed_params):
@@ -192,7 +192,7 @@ def hypotest(
     return tuple(_returns) if len(_returns) > 1 else _returns[0]
 
 
-from . import intervals  # noqa: F401
+from pyhf.infer import intervals  # noqa: F401
 
 __all__ = ["hypotest", "calculators", "intervals", "mle", "test_statistics", "utils"]
 

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -7,9 +7,9 @@ hypotheses.
 
 Using the calculators hypothesis tests can then be performed.
 """
-from .mle import fixed_poi_fit
-from .. import get_backend
-from . import utils
+from pyhf.infer.mle import fixed_poi_fit
+from pyhf import get_backend
+from pyhf.infer import utils
 import tqdm
 
 import logging

--- a/src/pyhf/infer/intervals.py
+++ b/src/pyhf/infer/intervals.py
@@ -1,6 +1,6 @@
 """Interval estimation"""
-from . import hypotest
-from .. import get_backend
+from pyhf.infer import hypotest
+from pyhf import get_backend
 import numpy as np
 
 __all__ = ["upperlimit"]

--- a/src/pyhf/infer/mle.py
+++ b/src/pyhf/infer/mle.py
@@ -1,6 +1,6 @@
 """Module for Maximum Likelihood Estimation."""
-from .. import get_backend
-from ..exceptions import UnspecifiedPOI
+from pyhf import get_backend
+from pyhf.exceptions import UnspecifiedPOI
 
 __all__ = ["fit", "fixed_poi_fit", "twice_nll"]
 

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -1,6 +1,6 @@
-from .. import get_backend
-from .mle import fixed_poi_fit, fit
-from ..exceptions import UnspecifiedPOI
+from pyhf import get_backend
+from pyhf.infer.mle import fixed_poi_fit, fit
+from pyhf.exceptions import UnspecifiedPOI
 
 import logging
 

--- a/src/pyhf/infer/utils.py
+++ b/src/pyhf/infer/utils.py
@@ -1,8 +1,8 @@
 """Inference for Statistical Models."""
 
-from .calculators import AsymptoticCalculator, ToyCalculator
-from ..exceptions import InvalidTestStatistic
-from .test_statistics import q0, qmu, qmu_tilde
+from pyhf.infer.calculators import AsymptoticCalculator, ToyCalculator
+from pyhf.exceptions import InvalidTestStatistic
+from pyhf.infer.test_statistics import q0, qmu, qmu_tilde
 
 import logging
 

--- a/src/pyhf/interpolators/__init__.py
+++ b/src/pyhf/interpolators/__init__.py
@@ -19,12 +19,12 @@ def _slow_interpolator_looper(histogramssets, alphasets, func):
 
 
 # interpolation codes come from https://cds.cern.ch/record/1456844/files/CERN-OPEN-2012-016.pdf
-from .code0 import code0, _slow_code0
-from .code1 import code1, _slow_code1
-from .code2 import code2, _slow_code2
-from .code4 import code4, _slow_code4
-from .code4p import code4p, _slow_code4p
-from .. import exceptions
+from pyhf.interpolators.code0 import code0, _slow_code0
+from pyhf.interpolators.code1 import code1, _slow_code1
+from pyhf.interpolators.code2 import code2, _slow_code2
+from pyhf.interpolators.code4 import code4, _slow_code4
+from pyhf.interpolators.code4p import code4p, _slow_code4p
+from pyhf import exceptions
 
 
 def get(interpcode, do_tensorized_calc=True):

--- a/src/pyhf/interpolators/code0.py
+++ b/src/pyhf/interpolators/code0.py
@@ -1,8 +1,8 @@
 """Piecewise-linear Interpolation. (Code 0)."""
 import logging
-from .. import get_backend, default_backend
-from .. import events
-from . import _slow_interpolator_looper
+from pyhf import get_backend, default_backend
+from pyhf import events
+from pyhf.interpolators import _slow_interpolator_looper
 
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/interpolators/code1.py
+++ b/src/pyhf/interpolators/code1.py
@@ -1,9 +1,9 @@
 """Piecewise-Exponential Interpolation (Code 1)."""
 import logging
 import math
-from .. import get_backend, default_backend
-from .. import events
-from . import _slow_interpolator_looper
+from pyhf import get_backend, default_backend
+from pyhf import events
+from pyhf.interpolators import _slow_interpolator_looper
 
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/interpolators/code2.py
+++ b/src/pyhf/interpolators/code2.py
@@ -1,8 +1,8 @@
 """Quadratic Interpolation (Code 2)."""
 import logging
-from .. import get_backend, default_backend
-from .. import events
-from . import _slow_interpolator_looper
+from pyhf import get_backend, default_backend
+from pyhf import events
+from pyhf.interpolators import _slow_interpolator_looper
 
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/interpolators/code4.py
+++ b/src/pyhf/interpolators/code4.py
@@ -1,9 +1,9 @@
 """Polynomial Interpolation (Code 4)."""
 import logging
 import math
-from .. import get_backend, default_backend
-from .. import events
-from . import _slow_interpolator_looper
+from pyhf import get_backend, default_backend
+from pyhf import events
+from pyhf.interpolators import _slow_interpolator_looper
 
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/interpolators/code4p.py
+++ b/src/pyhf/interpolators/code4p.py
@@ -1,8 +1,8 @@
 """Piecewise-Linear + Polynomial Interpolation (Code 4p)."""
 import logging
-from .. import get_backend, default_backend
-from .. import events
-from . import _slow_interpolator_looper
+from pyhf import get_backend, default_backend
+from pyhf import events
+from pyhf.interpolators import _slow_interpolator_looper
 
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/modifiers/__init__.py
+++ b/src/pyhf/modifiers/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
-from .. import exceptions
-from .. import get_backend
+from pyhf import exceptions
+from pyhf import get_backend
 
 log = logging.getLogger(__name__)
 
@@ -163,13 +163,13 @@ def modifier(*args, **kwargs):
     )
 
 
-from .histosys import histosys, histosys_combined
-from .lumi import lumi, lumi_combined
-from .normfactor import normfactor, normfactor_combined
-from .normsys import normsys, normsys_combined
-from .shapefactor import shapefactor, shapefactor_combined
-from .shapesys import shapesys, shapesys_combined
-from .staterror import staterror, staterror_combined
+from pyhf.modifiers.histosys import histosys, histosys_combined
+from pyhf.modifiers.lumi import lumi, lumi_combined
+from pyhf.modifiers.normfactor import normfactor, normfactor_combined
+from pyhf.modifiers.normsys import normsys, normsys_combined
+from pyhf.modifiers.shapefactor import shapefactor, shapefactor_combined
+from pyhf.modifiers.shapesys import shapesys, shapesys_combined
+from pyhf.modifiers.staterror import staterror, staterror_combined
 
 uncombined = {
     'histosys': histosys,

--- a/src/pyhf/modifiers/histosys.py
+++ b/src/pyhf/modifiers/histosys.py
@@ -1,9 +1,9 @@
 import logging
 
-from . import modifier
-from .. import get_backend, events
-from .. import interpolators
-from ..parameters import constrained_by_normal, ParamViewer
+from pyhf.modifiers import modifier
+from pyhf import get_backend, events
+from pyhf import interpolators
+from pyhf.parameters import constrained_by_normal, ParamViewer
 
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/modifiers/lumi.py
+++ b/src/pyhf/modifiers/lumi.py
@@ -1,8 +1,8 @@
 import logging
 
-from . import modifier
-from .. import get_backend, events
-from ..parameters import constrained_by_normal, ParamViewer
+from pyhf.modifiers import modifier
+from pyhf import get_backend, events
+from pyhf.parameters import constrained_by_normal, ParamViewer
 
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/modifiers/normfactor.py
+++ b/src/pyhf/modifiers/normfactor.py
@@ -1,8 +1,8 @@
 import logging
 
-from . import modifier
-from .. import get_backend, events
-from ..parameters import unconstrained, ParamViewer
+from pyhf.modifiers import modifier
+from pyhf import get_backend, events
+from pyhf.parameters import unconstrained, ParamViewer
 
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/modifiers/normsys.py
+++ b/src/pyhf/modifiers/normsys.py
@@ -1,9 +1,9 @@
 import logging
 
-from . import modifier
-from .. import get_backend, events
-from .. import interpolators
-from ..parameters import constrained_by_normal, ParamViewer
+from pyhf.modifiers import modifier
+from pyhf import get_backend, events
+from pyhf import interpolators
+from pyhf.parameters import constrained_by_normal, ParamViewer
 
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/modifiers/shapefactor.py
+++ b/src/pyhf/modifiers/shapefactor.py
@@ -1,8 +1,8 @@
 import logging
 
-from . import modifier
-from .. import get_backend, default_backend, events
-from ..parameters import unconstrained, ParamViewer
+from pyhf.modifiers import modifier
+from pyhf import get_backend, default_backend, events
+from pyhf.parameters import unconstrained, ParamViewer
 
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -1,8 +1,8 @@
 import logging
 
-from . import modifier
-from .. import get_backend, default_backend, events
-from ..parameters import constrained_by_poisson, ParamViewer
+from pyhf.modifiers import modifier
+from pyhf import get_backend, default_backend, events
+from pyhf.parameters import constrained_by_poisson, ParamViewer
 
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/modifiers/staterror.py
+++ b/src/pyhf/modifiers/staterror.py
@@ -1,8 +1,8 @@
 import logging
 
-from . import modifier
-from .. import get_backend, default_backend, events
-from ..parameters import constrained_by_normal, ParamViewer
+from pyhf.modifiers import modifier
+from pyhf import get_backend, default_backend, events
+from pyhf.parameters import constrained_by_normal, ParamViewer
 
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/optimize/__init__.py
+++ b/src/pyhf/optimize/__init__.py
@@ -1,12 +1,12 @@
 """Optimizers for Tensor Functions."""
 
-from .. import exceptions
+from pyhf import exceptions
 
 
 class _OptimizerRetriever:
     def __getattr__(self, name):
         if name == 'scipy_optimizer':
-            from .opt_scipy import scipy_optimizer
+            from pyhf.optimize.opt_scipy import scipy_optimizer
 
             assert scipy_optimizer
             # hide away one level of the module name
@@ -17,7 +17,7 @@ class _OptimizerRetriever:
             return scipy_optimizer
         elif name == 'minuit_optimizer':
             try:
-                from .opt_minuit import minuit_optimizer
+                from pyhf.optimize.opt_minuit import minuit_optimizer
 
                 assert minuit_optimizer
                 # hide away one level of the module name

--- a/src/pyhf/optimize/common.py
+++ b/src/pyhf/optimize/common.py
@@ -1,11 +1,11 @@
 """Common Backend Shim to prepare minimization for optimizer."""
-from .. import get_backend
-from ..tensor.common import _TensorViewer
+from pyhf import get_backend
+from pyhf.tensor.common import _TensorViewer
 
 
 def _make_stitch_pars(tv=None, fixed_values=None):
     """
-    Construct a callable to stitch fixed paramter values into the unfixed parameters. See :func:`shim`.
+    Construct a callable to stitch fixed parameter values into the unfixed parameters. See :func:`shim`.
 
     This is extracted out to be unit-tested for proper behavior.
 
@@ -37,22 +37,22 @@ def _get_tensor_shim():
     """
     tensorlib, _ = get_backend()
     if tensorlib.name == 'numpy':
-        from .opt_numpy import wrap_objective as numpy_shim
+        from pyhf.optimize.opt_numpy import wrap_objective as numpy_shim
 
         return numpy_shim
 
     if tensorlib.name == 'tensorflow':
-        from .opt_tflow import wrap_objective as tflow_shim
+        from pyhf.optimize.opt_tflow import wrap_objective as tflow_shim
 
         return tflow_shim
 
     if tensorlib.name == 'pytorch':
-        from .opt_pytorch import wrap_objective as pytorch_shim
+        from pyhf.optimize.opt_pytorch import wrap_objective as pytorch_shim
 
         return pytorch_shim
 
     if tensorlib.name == 'jax':
-        from .opt_jax import wrap_objective as jax_shim
+        from pyhf.optimize.opt_jax import wrap_objective as jax_shim
 
         return jax_shim
     raise ValueError(f'No optimizer shim for {tensorlib.name}.')

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -1,6 +1,6 @@
 """Helper Classes for use of automatic differentiation."""
-from .. import get_backend, exceptions
-from .common import shim
+from pyhf import get_backend, exceptions
+from pyhf.optimize.common import shim
 
 import logging
 

--- a/src/pyhf/optimize/opt_jax.py
+++ b/src/pyhf/optimize/opt_jax.py
@@ -1,7 +1,7 @@
 """JAX Backend Function Shim."""
 
-from .. import get_backend
-from ..tensor.common import _TensorViewer
+from pyhf import get_backend
+from pyhf.tensor.common import _TensorViewer
 import jax
 import logging
 

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -1,6 +1,6 @@
 """Minuit Optimizer Class."""
-from .. import exceptions
-from .mixins import OptimizerMixin
+from pyhf import exceptions
+from pyhf.optimize.mixins import OptimizerMixin
 import scipy
 import iminuit
 

--- a/src/pyhf/optimize/opt_numpy.py
+++ b/src/pyhf/optimize/opt_numpy.py
@@ -1,7 +1,7 @@
 """Numpy Backend Function Shim."""
 
-from .. import get_backend
-from .. import exceptions
+from pyhf import get_backend
+from pyhf import exceptions
 
 
 def wrap_objective(objective, data, pdf, stitch_pars, do_grad=False, jit_pieces=None):

--- a/src/pyhf/optimize/opt_pytorch.py
+++ b/src/pyhf/optimize/opt_pytorch.py
@@ -1,6 +1,6 @@
 """PyTorch Backend Function Shim."""
 
-from .. import get_backend
+from pyhf import get_backend
 import torch
 
 

--- a/src/pyhf/optimize/opt_scipy.py
+++ b/src/pyhf/optimize/opt_scipy.py
@@ -1,6 +1,6 @@
 """SciPy Optimizer Class."""
-from .. import exceptions
-from .mixins import OptimizerMixin
+from pyhf import exceptions
+from pyhf.optimize.mixins import OptimizerMixin
 import scipy
 
 

--- a/src/pyhf/optimize/opt_tflow.py
+++ b/src/pyhf/optimize/opt_tflow.py
@@ -1,5 +1,5 @@
 """Tensorflow Backend Function Shim."""
-from .. import get_backend
+from pyhf import get_backend
 import tensorflow as tf
 
 

--- a/src/pyhf/parameters/__init__.py
+++ b/src/pyhf/parameters/__init__.py
@@ -1,11 +1,11 @@
-from .paramsets import (
+from pyhf.parameters.paramsets import (
     paramset,
     unconstrained,
     constrained_by_normal,
     constrained_by_poisson,
 )
-from .utils import reduce_paramsets_requirements
-from .paramview import ParamViewer
+from pyhf.parameters.utils import reduce_paramsets_requirements
+from pyhf.parameters.paramview import ParamViewer
 
 __all__ = [
     'paramset',

--- a/src/pyhf/parameters/paramsets.py
+++ b/src/pyhf/parameters/paramsets.py
@@ -1,4 +1,4 @@
-from .. import default_backend
+from pyhf import default_backend
 
 __all__ = [
     "constrained_by_normal",

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -1,5 +1,5 @@
-from .. import get_backend, default_backend, events
-from ..tensor.common import (
+from pyhf import get_backend, default_backend, events
+from pyhf.tensor.common import (
     _tensorviewer_from_slices,
     _tensorviewer_from_sizes,
 )

--- a/src/pyhf/parameters/utils.py
+++ b/src/pyhf/parameters/utils.py
@@ -1,4 +1,4 @@
-from .. import exceptions
+from pyhf import exceptions
 
 __all__ = ["reduce_paramsets_requirements"]
 

--- a/src/pyhf/patchset.py
+++ b/src/pyhf/patchset.py
@@ -3,9 +3,9 @@ pyhf patchset provides a user-friendly interface for interacting with patchsets.
 """
 import logging
 import jsonpatch
-from . import exceptions
-from . import utils
-from .workspace import Workspace
+from pyhf import exceptions
+from pyhf import utils
+from pyhf.workspace import Workspace
 
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -3,16 +3,16 @@
 import copy
 import logging
 
-from . import get_backend, default_backend
-from . import exceptions
-from . import modifiers
-from . import utils
-from . import events
-from . import probability as prob
-from .constraints import gaussian_constraint_combined, poisson_constraint_combined
-from .parameters import reduce_paramsets_requirements, ParamViewer
-from .tensor.common import _TensorViewer, _tensorviewer_from_sizes
-from .mixins import _ChannelSummaryMixin
+from pyhf import get_backend, default_backend
+from pyhf import exceptions
+from pyhf import modifiers
+from pyhf import utils
+from pyhf import events
+from pyhf import probability as prob
+from pyhf.constraints import gaussian_constraint_combined, poisson_constraint_combined
+from pyhf.parameters import reduce_paramsets_requirements, ParamViewer
+from pyhf.tensor.common import _TensorViewer, _tensorviewer_from_sizes
+from pyhf.mixins import _ChannelSummaryMixin
 
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/probability.py
+++ b/src/pyhf/probability.py
@@ -1,5 +1,5 @@
 """The probability density function module."""
-from . import get_backend
+from pyhf import get_backend
 
 __all__ = ["Independent", "Normal", "Poisson", "Simultaneous"]
 

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -1,5 +1,5 @@
-from . import utils
-from . import compat
+from pyhf import utils
+from pyhf import compat
 
 import logging
 

--- a/src/pyhf/simplemodels.py
+++ b/src/pyhf/simplemodels.py
@@ -1,6 +1,6 @@
 from warnings import warn
 
-from . import Model
+from pyhf import Model
 
 __all__ = ["correlated_background", "uncorrelated_background"]
 

--- a/src/pyhf/tensor/__init__.py
+++ b/src/pyhf/tensor/__init__.py
@@ -1,10 +1,10 @@
-from .. import exceptions
+from pyhf import exceptions
 
 
 class _BackendRetriever:
     def __getattr__(self, name):
         if name == 'numpy_backend':
-            from .numpy_backend import numpy_backend
+            from pyhf.tensor.numpy_backend import numpy_backend
 
             assert numpy_backend
             # for autocomplete and dir() calls
@@ -12,7 +12,7 @@ class _BackendRetriever:
             return numpy_backend
         elif name == 'jax_backend':
             try:
-                from .jax_backend import jax_backend
+                from pyhf.tensor.jax_backend import jax_backend
 
                 assert jax_backend
                 # for autocomplete and dir() calls
@@ -25,7 +25,7 @@ class _BackendRetriever:
                 )
         elif name == 'pytorch_backend':
             try:
-                from .pytorch_backend import pytorch_backend
+                from pyhf.tensor.pytorch_backend import pytorch_backend
 
                 assert pytorch_backend
                 # for autocomplete and dir() calls
@@ -38,7 +38,7 @@ class _BackendRetriever:
                 )
         elif name == 'tensorflow_backend':
             try:
-                from .tensorflow_backend import tensorflow_backend
+                from pyhf.tensor.tensorflow_backend import tensorflow_backend
 
                 assert tensorflow_backend
                 # for autocomplete and dir() calls

--- a/src/pyhf/tensor/common.py
+++ b/src/pyhf/tensor/common.py
@@ -1,5 +1,5 @@
-from .. import default_backend, get_backend
-from .. import events
+from pyhf import default_backend, get_backend
+from pyhf import events
 
 
 class _TensorViewer:

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -6,7 +6,7 @@ import yaml
 import click
 import hashlib
 
-from .exceptions import InvalidSpecification
+from pyhf.exceptions import InvalidSpecification
 
 SCHEMA_CACHE = {}
 SCHEMA_BASE = "https://scikit-hep.org/pyhf/schemas/"

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -9,10 +9,10 @@ import logging
 import jsonpatch
 import copy
 import collections
-from . import exceptions
-from . import utils
-from .pdf import Model
-from .mixins import _ChannelSummaryMixin
+from pyhf import exceptions
+from pyhf import utils
+from pyhf.pdf import Model
+from pyhf.mixins import _ChannelSummaryMixin
 
 log = logging.getLogger(__name__)
 

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -10,7 +10,7 @@ import numpy as np
 import uproot3 as uproot
 from uproot3_methods.classes import TH1
 
-from .mixins import _ChannelSummaryMixin
+from pyhf.mixins import _ChannelSummaryMixin
 
 _ROOT_DATA_FILE = None
 


### PR DESCRIPTION
# Description

`pyhf` has used explicit relative imports for all of the development. Now that the module structure is more established, this PR changes them all to absolute imports. Use of absolute imports is easier for probably everyone to read (and probably easier for any new developer to learn the module structure).

The fact that 

```console
$ git grep "from \."
```

returns nothing now and that the CI is passing means that this all worked as expected, so this should be hopefully easy to review, unless there are concerns on this change from a developer perspective. :+1: 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Change all explicit relative imports to absolute imports
   - Provides clearer more explicit imports for new developers
```