### PR TITLE
docs: Separate citations into 'use' and 'general'

### DIFF
--- a/docs/bib/general_citations.bib
+++ b/docs/bib/general_citations.bib
@@ -23,6 +23,23 @@
     journal = ""
 }
 
+% 2020-03-17
+@article{LHCReinterpretationForum:2020xtr,
+    author = "Abdallah, Waleed and others",
+    collaboration = "LHC Reinterpretation Forum",
+    title = "{Reinterpretation of LHC Results for New Physics: Status and Recommendations after Run 2}",
+    eprint = "2003.07868",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "CERN-LPCC-2020-001, FERMILAB-FN-1098-CMS-T, Imperial/HEP/2020/RIF/01",
+    doi = "10.21468/SciPostPhys.9.2.022",
+    journal = "SciPost Phys.",
+    volume = "9",
+    number = "2",
+    pages = "022",
+    year = "2020"
+}
+
 % 2019-09-30
 @article{DiMicco:2019ngk,
     author = "Alison, J. and others",

--- a/docs/bib/general_citations.bib
+++ b/docs/bib/general_citations.bib
@@ -1,0 +1,11 @@
+% 2021-07-27
+@article{Tastet:2021vwp,
+    author = "Tastet, Jean-Loup and Ruchayskiy, Oleg and Timiryasov, Inar",
+    title = "{Reinterpreting the ATLAS bounds on heavy neutral leptons in a realistic neutrino oscillation model}",
+    eprint = "2107.12980",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    month = "7",
+    year = "2021",
+    journal = ""
+}

--- a/docs/bib/general_citations.bib
+++ b/docs/bib/general_citations.bib
@@ -9,3 +9,50 @@
     year = "2021",
     journal = ""
 }
+
+% 2020-06-20
+@article{Krupa:2020bwg,
+    author = "Krupa, Jeffrey and others",
+    title = "{GPU coprocessors as a service for deep learning inference in high energy physics}",
+    eprint = "2007.10359",
+    archivePrefix = "arXiv",
+    primaryClass = "physics.comp-ph",
+    reportNumber = "FERMILAB-PUB-20-338-E-SCD",
+    month = "7",
+    year = "2020",
+    journal = ""
+}
+
+% 2019-09-30
+@article{DiMicco:2019ngk,
+    author = "Alison, J. and others",
+    editor = "Di Micco, Biagio and Gouzevitch, Maxime and Mazzitelli, Javier and Vernieri, Caterina",
+    title = "{Higgs boson potential at colliders: Status and perspectives}",
+    eprint = "1910.00012",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "FERMILAB-CONF-19-468-E-T, LHCXSWG-2019-005",
+    doi = "10.1016/j.revip.2020.100045",
+    journal = "Rev. Phys.",
+    volume = "5",
+    pages = "100045",
+    year = "2020"
+}
+
+% 2019-06-24
+@article{Brehmer:2019xox,
+      author         = "Brehmer, Johann and Kling, Felix and Espejo, Irina and
+                        Cranmer, Kyle",
+      title          = "{MadMiner: Machine learning-based inference for particle
+                        physics}",
+      journal        = "Comput. Softw. Big Sci.",
+      volume         = "4",
+      year           = "2020",
+      number         = "1",
+      pages          = "3",
+      doi            = "10.1007/s41781-020-0035-2",
+      eprint         = "1907.10621",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      SLACcitation   = "%%CITATION = ARXIV:1907.10621;%%"
+}

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -168,19 +168,6 @@
     journal = ""
 }
 
-% 2020-06-20
-@article{Krupa:2020bwg,
-    author = "Krupa, Jeffrey and others",
-    title = "{GPU coprocessors as a service for deep learning inference in high energy physics}",
-    eprint = "2007.10359",
-    archivePrefix = "arXiv",
-    primaryClass = "physics.comp-ph",
-    reportNumber = "FERMILAB-PUB-20-338-E-SCD",
-    month = "7",
-    year = "2020",
-    journal = ""
-}
-
 % 2020-05-01
 @article{Khosa:2020zar,
     author = "Khosa, Charanjit K. and Kraml, Sabine and Lessa, Andre and Neuhuber, Philipp and Waltenberger, Wolfgang",
@@ -254,19 +241,6 @@
     year = "2020"
 }
 
-@inproceedings{DiMicco:2019ngk,
-    author = "Alison, J. and others",
-    editor = "Di Micco, B. and Gouzevitch, M. and Mazzitelli, J. and Vernieri, C.",
-    title = "{Higgs Boson Pair Production at Colliders: Status and Perspectives}",
-    booktitle = "{Double Higgs Production at Colliders}",
-    eprint = "1910.00012",
-    archivePrefix = "arXiv",
-    primaryClass = "hep-ph",
-    reportNumber = "FERMILAB-CONF-19-468-E-T, LHCXSWG-2019-005",
-    month = "9",
-    year = "2019"
-}
-
 @booklet{ATL-PHYS-PUB-2019-029,
       author        = "{ATLAS Collaboration}",
       title         = "{Reproducing searches for new physics with the ATLAS
@@ -279,23 +253,6 @@
       year          = "2019",
       reportNumber  = "ATL-PHYS-PUB-2019-029",
       url           = "https://cds.cern.ch/record/2684863",
-}
-
-@article{Brehmer:2019xox,
-      author         = "Brehmer, Johann and Kling, Felix and Espejo, Irina and
-                        Cranmer, Kyle",
-      title          = "{MadMiner: Machine learning-based inference for particle
-                        physics}",
-      journal        = "Comput. Softw. Big Sci.",
-      volume         = "4",
-      year           = "2020",
-      number         = "1",
-      pages          = "3",
-      doi            = "10.1007/s41781-020-0035-2",
-      eprint         = "1907.10621",
-      archivePrefix  = "arXiv",
-      primaryClass   = "hep-ph",
-      SLACcitation   = "%%CITATION = ARXIV:1907.10621;%%"
 }
 
 @article{Heinrich:2018nip,

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,15 +1,3 @@
-% 2021-07-27
-@article{Tastet:2021vwp,
-    author = "Tastet, Jean-Loup and Ruchayskiy, Oleg and Timiryasov, Inar",
-    title = "{Reinterpreting the ATLAS bounds on heavy neutral leptons in a realistic neutrino oscillation model}",
-    eprint = "2107.12980",
-    archivePrefix = "arXiv",
-    primaryClass = "hep-ph",
-    month = "7",
-    year = "2021",
-    journal = ""
-}
-
 % 2021-06-03
 @article{ATLAS:SUSY-3L-compressed-combination,
     author = "ATLAS Collaboration",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -183,21 +183,6 @@
     year = "2020"
 }
 
-@article{Abdallah:2020pec,
-      author         = "Abdallah, Waleed and others",
-      title          = "{Reinterpretation of LHC Results for New Physics: Status
-                        and Recommendations after Run 2}",
-      collaboration  = "LHC Reinterpretation Forum",
-      year           = "2020",
-      eprint         = "2003.07868",
-      archivePrefix  = "arXiv",
-      primaryClass   = "hep-ph",
-      reportNumber   = "CERN-LPCC-2020-001, FERMILAB-FN-1098-CMS-T,
-                        Imperial/HEP/2020/RIF/01",
-      SLACcitation   = "%%CITATION = ARXIV:2003.07868;%%",
-      journal        = ""
-}
-
 @inproceedings{Brooijmans:2020yij,
       author         = "Brooijmans, G. and others",
       title          = "{Les Houches 2019 Physics at TeV Colliders: New Physics

--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -30,7 +30,7 @@ Use Citations
 General Citations
 ~~~~~~~~~~~~~~~~~
 
-.. bibliography:: bib/use_citations.bib
+.. bibliography:: bib/general_citations.bib
    :list: bullet
    :all:
    :style: plain

--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -19,6 +19,17 @@ Use in Publications
 
 Updating list of citations and use cases of :code:`pyhf`:
 
+Use Citations
+~~~~~~~~~~~~~
+
+.. bibliography:: bib/use_citations.bib
+   :list: bullet
+   :all:
+   :style: plain
+
+General Citations
+~~~~~~~~~~~~~~~~~
+
 .. bibliography:: bib/use_citations.bib
    :list: bullet
    :all:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,7 @@ bibtex_bibfiles = [
     "bib/talks.bib",
     "bib/tutorials.bib",
     "bib/use_citations.bib",
+    "bib/general_citations.bib",
 ]
 
 # external links


### PR DESCRIPTION
# Description

Resolves #1538

Separates out "general" citations in which `pyhf` is recommended or described but not actually used from "use" citations in which the software was used for the publication.

Additionally, update the following citations which now have publications in journals:
- Reinterpretation of LHC Results for New Physics: Status and Recommendations after Run 2
- Higgs boson potential at colliders: Status and perspectives

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Separate citation into 'general' and 'use' citations
   - Add docs/bib/use_citations.bib for general citations and add it to known Sphinx BibTeX files
* Update BibTeX record for 'Reinterpretation of LHC Results for New Physics'
   - c.f. https://doi.org/10.21468/SciPostPhys.9.2.022
* Update BibTeX record for 'Higgs boson potential at colliders'
   - c.f. https://doi.org/10.1016/j.revip.2020.100045
```
