### PR TITLE
feat: Sort `_ChannelSummaryMixin.channel_nbins` by keys to match `channels` order

### DIFF
--- a/src/pyhf/mixins.py
+++ b/src/pyhf/mixins.py
@@ -43,7 +43,7 @@ class _ChannelSummaryMixin:
         self.parameters = sorted(list(set(self.parameters)))
         self.modifiers = sorted(list(set(self.modifiers)))
         self.channel_nbins = {
-            self.channel_name: self.channel_nbins[channel] for channel in self.channels
+            channel: self.channel_nbins[channel] for channel in self.channels
         }
 
         self.channel_slices = {}

--- a/src/pyhf/mixins.py
+++ b/src/pyhf/mixins.py
@@ -42,6 +42,9 @@ class _ChannelSummaryMixin:
         self.samples = sorted(list(set(self.samples)))
         self.parameters = sorted(list(set(self.parameters)))
         self.modifiers = sorted(list(set(self.modifiers)))
+        self.channel_nbins = {
+            self.channel_name: self.channel_nbins[channel] for channel in self.channels
+        }
 
         self.channel_slices = {}
         begin = 0

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -53,4 +53,4 @@ def test_channel_nbins_sorted_as_channels(spec):
     spec["channels"][-1]["name"] = "a_make_first_in_sort_channel2"
     mixin = pyhf.mixins._ChannelSummaryMixin(channels=spec["channels"])
     assert mixin.channels == ["a_make_first_in_sort_channel2", "channel1"]
-    assert mixin.channel_nbins == {"a_make_first_in_sort_channel2": 2, "channel1": 2}
+    assert list(mixin.channel_nbins.keys()) == mixin.channels

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -45,3 +45,12 @@ def test_channel_summary_mixin_empty():
     assert mixin.modifiers == []
     assert mixin.parameters == []
     assert mixin.samples == []
+
+
+def test_channel_nbins_sorted_as_channels(spec):
+    assert "channels" in spec
+    spec["channels"].append(spec["channels"][0].copy())
+    spec["channels"][-1]["name"] = "a_make_first_in_sort_channel2"
+    mixin = pyhf.mixins._ChannelSummaryMixin(channels=spec["channels"])
+    assert mixin.channels == ["a_make_first_in_sort_channel2", "channel1"]
+    assert mixin.channel_nbins == {"a_make_first_in_sort_channel2": 2, "channel1": 2}


### PR DESCRIPTION
# Description

Resolves #1545 

This PR sorts the `_ChannelSummaryMixin.channel_nbins` `dict` by its keys such that its keys are in the same order as the entries of the `_ChannelSummaryMixin.channels` `list`. This is done for aesthetics mostly and for quick checks, as users should rely on `dict` keys not `dict` ordering. It additionally adds a test.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Sort _ChannelSummaryMixin.channel_nbins dict by keys to match the order of _ChannelSummaryMixin.channels
* Add a test for the order of channel_nbins keys matching the order of channels entries
```