### PR TITLE
chore: Define OS in base image tag of Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=python:3.8-slim
+ARG BASE_IMAGE=python:3.8-slim-bullseye
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE} as base
 


### PR DESCRIPTION
# Description

Update the base image of the Dockerfile from `python:3.8-slim` to `python:3.8-slim-bullseye` to ensure that the OS is set and can only be updated through a manual update process. This provides greater package stability.

c.f. https://gitlab.cern.ch/atlas-amglab/atlstats/-/merge_requests/47

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use python:3.8-slim-bullseye as the base image for the Dockerfile to ensure package stability
   - Packages on distributions of OSes are not all released at the same time and updating OS versions without necessary packages being available can break Docker builds
   - c.f. https://gitlab.cern.ch/atlas-amglab/atlstats/-/merge_requests/47
```