### PR TITLE
WIP: expose fitted parameter values of implicit fits in test statistic calls

### DIFF
--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -29,7 +29,9 @@ def __dir__():
     return __all__
 
 
-def generate_asimov_data(asimov_mu, data, pdf, init_pars, par_bounds, fixed_params):
+def generate_asimov_data(
+    asimov_mu, data, pdf, init_pars, par_bounds, fixed_params, return_fitted_pars=False
+):
     """
     Compute Asimov Dataset (expected yields at best-fit values) for a given POI value.
 
@@ -46,6 +48,13 @@ def generate_asimov_data(asimov_mu, data, pdf, init_pars, par_bounds, fixed_para
         >>> pyhf.infer.calculators.generate_asimov_data(mu_test, data, model, None, None, None)
         array([ 60.61229858,  56.52802479, 270.06832542,  48.31545488])
 
+        to also access the Asimov parameters:
+        >>> pyhf.infer.calculators.generate_asimov_data(
+        ...     mu_test, data, model, None, None, None,
+        ...     return_fitted_pars = True
+        ... )
+        (array([ 60.61229858,  56.52802479, 270.06832542,  48.31545488]), array([1.        , 0.97224597, 0.87553894]))
+
     Args:
         asimov_mu (:obj:`float`): The value for the parameter of interest to be used.
         data (:obj:`tensor`): The observed data.
@@ -56,15 +65,20 @@ def generate_asimov_data(asimov_mu, data, pdf, init_pars, par_bounds, fixed_para
             The shape should be ``(n, 2)`` for ``n`` model parameters.
         fixed_params (:obj:`tensor` of :obj:`bool`): The flag to set a parameter constant to its starting
             value during minimization.
+        return_fitted_pars (:obj:`bool`): Return the best-fit parameter values for the given ``asimov_mu``.
+
 
     Returns:
         Tensor: The Asimov dataset.
-
+        Tensor: (If ``return_fitted_pars`` is ``True``) the Asimov parameters.
     """
     bestfit_nuisance_asimov = fixed_poi_fit(
         asimov_mu, data, pdf, init_pars, par_bounds, fixed_params
     )
-    return pdf.expected_data(bestfit_nuisance_asimov)
+    asimov_data = pdf.expected_data(bestfit_nuisance_asimov)
+    if return_fitted_pars:
+        return asimov_data, bestfit_nuisance_asimov
+    return asimov_data
 
 
 class AsymptoticTestStatDistribution:

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -13,7 +13,9 @@ def __dir__():
     return __all__
 
 
-def _qmu_like(mu, data, pdf, init_pars, par_bounds, fixed_params):
+def _qmu_like(
+    mu, data, pdf, init_pars, par_bounds, fixed_params, return_fitted_pars=False
+):
     """
     Clipped version of _tmu_like where the returned test statistic
     is 0 if muhat > 0 else tmu_like_stat.
@@ -22,12 +24,14 @@ def _qmu_like(mu, data, pdf, init_pars, par_bounds, fixed_params):
     qmu_tilde. Otherwise this is qmu (no tilde).
     """
     tensorlib, optimizer = get_backend()
-    tmu_like_stat, (_, muhatbhat) = _tmu_like(
+    tmu_like_stat, (mubhathat, muhatbhat) = _tmu_like(
         mu, data, pdf, init_pars, par_bounds, fixed_params, return_fitted_pars=True
     )
     qmu_like_stat = tensorlib.where(
         muhatbhat[pdf.config.poi_index] > mu, tensorlib.astensor(0.0), tmu_like_stat
     )
+    if return_fitted_pars:
+        return qmu_like_stat, (mubhathat, muhatbhat)
     return qmu_like_stat
 
 
@@ -56,7 +60,7 @@ def _tmu_like(
     return tmu_like_stat
 
 
-def qmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
+def qmu(mu, data, pdf, init_pars, par_bounds, fixed_params, return_fitted_pars=False):
     r"""
     The test statistic, :math:`q_{\mu}`, for establishing an upper
     limit on the strength parameter, :math:`\mu`, as defiend in
@@ -94,6 +98,10 @@ def qmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
         >>> pyhf.infer.test_statistics.qmu(test_mu, data, model, init_pars, par_bounds, fixed_params)
         array(3.9549891)
 
+        or, also return the best-fit parameter arrays:
+        >>> pyhf.infer.test_statistics.qmu(test_mu, data, model, init_pars, par_bounds, fixed_params, return_fitted_pars = True)
+        (array(3.9549891), (array([1.        , 0.97224597, 0.87553894]), array([-0.06679525,  1.00555369,  0.96930896])))
+
     Args:
         mu (Number or Tensor): The signal strength parameter
         data (Tensor): The data to be considered
@@ -104,9 +112,14 @@ def qmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
             The shape should be ``(n, 2)`` for ``n`` model parameters.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
             value during minimization.
+        return_fitted_pars (:obj:`bool`): Return the best-fit parameter tensors
+            the fixed-POI and unconstrained fits have converged on
+            (i.e. :math:`\mu, \hat{\hat{\theta}}` and :math:`\hat{\mu}, \hat{\theta}`)
 
     Returns:
         Float: The calculated test statistic, :math:`q_{\mu}`
+        Tuple of two Tensors: (only if ``return_fitted_pars`` is ``True``) the best-fit parameter tensors,
+             :math:`\mu, \hat{\hat{\theta}}` and :math:`\hat{\mu}, \hat{\theta}`
     """
     if pdf.config.poi_index is None:
         raise UnspecifiedPOI(
@@ -117,10 +130,20 @@ def qmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
             'qmu test statistic used for fit configuration with POI bounded at zero.\n'
             + 'Use the qmu_tilde test statistic (pyhf.infer.test_statistics.qmu_tilde) instead.'
         )
-    return _qmu_like(mu, data, pdf, init_pars, par_bounds, fixed_params)
+    return _qmu_like(
+        mu,
+        data,
+        pdf,
+        init_pars,
+        par_bounds,
+        fixed_params,
+        return_fitted_pars=return_fitted_pars,
+    )
 
 
-def qmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
+def qmu_tilde(
+    mu, data, pdf, init_pars, par_bounds, fixed_params, return_fitted_pars=False
+):
     r"""
     The "alternative" test statistic, :math:`\tilde{q}_{\mu}`, for establishing
     an upper limit on the strength parameter, :math:`\mu`, for models with
@@ -163,6 +186,10 @@ def qmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
         >>> pyhf.infer.test_statistics.qmu_tilde(test_mu, data, model, init_pars, par_bounds, fixed_params)
         array(3.93824492)
 
+        or, also return the best-fit parameter arrays:
+        >>> pyhf.infer.test_statistics.qmu_tilde(test_mu, data, model, init_pars, par_bounds, fixed_params, return_fitted_pars = True)
+        (array(3.93824492), (array([1.        , 0.97224597, 0.87553894]), array([0.        , 1.0030512 , 0.96266961])))
+
     Args:
         mu (Number or Tensor): The signal strength parameter
         data (:obj:`tensor`): The data to be considered
@@ -173,9 +200,14 @@ def qmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
             The shape should be ``(n, 2)`` for ``n`` model parameters.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
             value during minimization.
+        return_fitted_pars (:obj:`bool`): Return the best-fit parameter tensors
+            the fixed-POI and unconstrained fits have converged on
+            (i.e. :math:`\mu, \hat{\hat{\theta}}` and :math:`\hat{\mu}, \hat{\theta}`)
 
     Returns:
         Float: The calculated test statistic, :math:`\tilde{q}_{\mu}`
+        Tuple of two Tensors: (only if ``return_fitted_pars`` is ``True``) the best-fit parameter tensors,
+             :math:`\mu, \hat{\hat{\theta}}` and :math:`\hat{\mu}, \hat{\theta}`
     """
     if pdf.config.poi_index is None:
         raise UnspecifiedPOI(
@@ -186,10 +218,18 @@ def qmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
             'qmu_tilde test statistic used for fit configuration with POI not bounded at zero.\n'
             + 'Use the qmu test statistic (pyhf.infer.test_statistics.qmu) instead.'
         )
-    return _qmu_like(mu, data, pdf, init_pars, par_bounds, fixed_params)
+    return _qmu_like(
+        mu,
+        data,
+        pdf,
+        init_pars,
+        par_bounds,
+        fixed_params,
+        return_fitted_pars=return_fitted_pars,
+    )
 
 
-def tmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
+def tmu(mu, data, pdf, init_pars, par_bounds, fixed_params, return_fitted_pars=False):
     r"""
     The test statistic, :math:`t_{\mu}`, for establishing a two-sided
     interval on the strength parameter, :math:`\mu`, as defiend in Equation (8)
@@ -221,6 +261,10 @@ def tmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
         >>> pyhf.infer.test_statistics.tmu(test_mu, data, model, init_pars, par_bounds, fixed_params)
         array(3.9549891)
 
+        or, also return the best-fit parameter arrays:
+        >>> pyhf.infer.test_statistics.tmu(test_mu, data, model, init_pars, par_bounds, fixed_params, return_fitted_pars = True)
+        (array(3.9549891), (array([1.        , 0.97224597, 0.87553894]), array([-0.06679525,  1.00555369,  0.96930896])))
+
     Args:
         mu (Number or Tensor): The signal strength parameter
         data (Tensor): The data to be considered
@@ -231,9 +275,14 @@ def tmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
             The shape should be ``(n, 2)`` for ``n`` model parameters.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
             value during minimization.
+        return_fitted_pars (:obj:`bool`): Return the best-fit parameter tensors
+            the fixed-POI and unconstrained fits have converged on
+            (i.e. :math:`\mu, \hat{\hat{\theta}}` and :math:`\hat{\mu}, \hat{\theta}`)
 
     Returns:
         Float: The calculated test statistic, :math:`t_{\mu}`
+        Tuple of two Tensors: (only if ``return_fitted_pars`` is ``True``) the best-fit parameter tensors,
+             :math:`\mu, \hat{\hat{\theta}}` and :math:`\hat{\mu}, \hat{\theta}`
     """
     if pdf.config.poi_index is None:
         raise UnspecifiedPOI(
@@ -244,10 +293,20 @@ def tmu(mu, data, pdf, init_pars, par_bounds, fixed_params):
             'tmu test statistic used for fit configuration with POI bounded at zero.\n'
             + 'Use the tmu_tilde test statistic (pyhf.infer.test_statistics.tmu_tilde) instead.'
         )
-    return _tmu_like(mu, data, pdf, init_pars, par_bounds, fixed_params)
+    return _tmu_like(
+        mu,
+        data,
+        pdf,
+        init_pars,
+        par_bounds,
+        fixed_params,
+        return_fitted_pars=return_fitted_pars,
+    )
 
 
-def tmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
+def tmu_tilde(
+    mu, data, pdf, init_pars, par_bounds, fixed_params, return_fitted_pars=False
+):
     r"""
     The test statistic, :math:`\tilde{t}_{\mu}`, for establishing a two-sided
     interval on the strength parameter, :math:`\mu`, for models with
@@ -284,6 +343,10 @@ def tmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
         >>> pyhf.infer.test_statistics.tmu_tilde(test_mu, data, model, init_pars, par_bounds, fixed_params)
         array(3.93824492)
 
+        or, also return the best-fit parameter arrays:
+        >>> pyhf.infer.test_statistics.tmu_tilde(test_mu, data, model, init_pars, par_bounds, fixed_params, return_fitted_pars = True)
+        (array(3.93824492), (array([1.        , 0.97224597, 0.87553894]), array([0.        , 1.0030512 , 0.96266961])))
+
     Args:
         mu (Number or Tensor): The signal strength parameter
         data (:obj:`tensor`): The data to be considered
@@ -294,9 +357,14 @@ def tmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
             The shape should be ``(n, 2)`` for ``n`` model parameters.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
             value during minimization.
+        return_fitted_pars (:obj:`bool`): Return the best-fit parameter tensors
+            the fixed-POI and unconstrained fits have converged on
+            (i.e. :math:`\mu, \hat{\hat{\theta}}` and :math:`\hat{\mu}, \hat{\theta}`)
 
     Returns:
         Float: The calculated test statistic, :math:`\tilde{t}_{\mu}`
+        Tuple of two Tensors: (only if ``return_fitted_pars`` is ``True``) the best-fit parameter tensors,
+             :math:`\mu, \hat{\hat{\theta}}` and :math:`\hat{\mu}, \hat{\theta}`
     """
     if pdf.config.poi_index is None:
         raise UnspecifiedPOI(
@@ -307,10 +375,18 @@ def tmu_tilde(mu, data, pdf, init_pars, par_bounds, fixed_params):
             'tmu_tilde test statistic used for fit configuration with POI not bounded at zero.\n'
             + 'Use the tmu test statistic (pyhf.infer.test_statistics.tmu) instead.'
         )
-    return _tmu_like(mu, data, pdf, init_pars, par_bounds, fixed_params)
+    return _tmu_like(
+        mu,
+        data,
+        pdf,
+        init_pars,
+        par_bounds,
+        fixed_params,
+        return_fitted_pars=return_fitted_pars,
+    )
 
 
-def q0(mu, data, pdf, init_pars, par_bounds, fixed_params):
+def q0(mu, data, pdf, init_pars, par_bounds, fixed_params, return_fitted_pars=False):
     r"""
     The test statistic, :math:`q_{0}`, for discovery of a positive signal
     as defined in Equation (12) in :xref:`arXiv:1007.1727`, for :math:`\mu=0`.
@@ -340,6 +416,10 @@ def q0(mu, data, pdf, init_pars, par_bounds, fixed_params):
         >>> pyhf.infer.test_statistics.q0(test_mu, data, model, init_pars, par_bounds, fixed_params)
         array(2.98339447)
 
+        or, also return the best-fit parameter arrays:
+        >>> pyhf.infer.test_statistics.q0(test_mu, data, model, init_pars, par_bounds, fixed_params, return_fitted_pars = True)
+        (array(2.98339447), (array([0.        , 1.03050845, 1.12128752]), array([0.95260667, 0.99635345, 1.02140172])))
+
     Args:
         mu (Number or Tensor): The signal strength parameter (must be set to zero)
         data (Tensor): The data to be considered
@@ -350,9 +430,14 @@ def q0(mu, data, pdf, init_pars, par_bounds, fixed_params):
             The shape should be ``(n, 2)`` for ``n`` model parameters.
         fixed_params (:obj:`list` of :obj:`bool`): The flag to set a parameter constant to its starting
             value during minimization.
+        return_fitted_pars (:obj:`bool`): Return the best-fit parameter tensors
+            the fixed-POI and unconstrained fits have converged on
+            (i.e. :math:`\mu, \hat{\hat{\theta}}` and :math:`\hat{\mu}, \hat{\theta}`)
 
     Returns:
         Float: The calculated test statistic, :math:`q_{0}`
+        Tuple of two Tensors: (only if ``return_fitted_pars`` is ``True``) the best-fit parameter tensors,
+             :math:`\mu, \hat{\hat{\theta}}` and :math:`\hat{\mu}, \hat{\theta}`
     """
 
     if pdf.config.poi_index is None:
@@ -367,10 +452,12 @@ def q0(mu, data, pdf, init_pars, par_bounds, fixed_params):
 
     tensorlib, optimizer = get_backend()
 
-    tmu_like_stat, (_, muhatbhat) = _tmu_like(
+    tmu_like_stat, (mubhathat, muhatbhat) = _tmu_like(
         mu, data, pdf, init_pars, par_bounds, fixed_params, return_fitted_pars=True
     )
     q0_stat = tensorlib.where(
         muhatbhat[pdf.config.poi_index] < 0, tensorlib.astensor(0.0), tmu_like_stat
     )
+    if return_fitted_pars:
+        return q0_stat, (mubhathat, muhatbhat)
     return q0_stat

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -32,3 +32,67 @@ def test_generate_asimov_can_return_fitted_pars(return_fitted_pars):
         result, asimov_pars = result
         assert pytest.approx([1.0, 1.0, 1.0]) == pyhf.tensorlib.tolist(asimov_pars)
     assert pytest.approx([2.0, 2.0, 1.0, 1.0]) == pyhf.tensorlib.tolist(result)
+
+
+# test different test stats because those affect the control flow
+# in AsymptotiCalculator.teststatistic, where the fit results should be set
+# the other kwargs don't impact the logic of that method,
+# so leave them at the default so as not to put a burden on future changes
+@pytest.mark.parametrize('test_stat', ['qtilde', 'q', 'q0'])
+def test_asymptotic_calculator_has_fitted_pars(test_stat):
+    model = pyhf.simplemodels.uncorrelated_background([1], [1], [1])
+    data = [2, 1]  # [main, aux]
+
+    calc = pyhf.infer.calculators.AsymptoticCalculator(data, model, test_stat=test_stat)
+    calc.teststatistic(0 if test_stat == 'q0' else 1)
+
+    assert hasattr(calc, 'fitted_pars')
+    fitted_pars = calc.fitted_pars
+    assert hasattr(fitted_pars, 'asimov_pars')
+    assert hasattr(fitted_pars, 'fixed_poi_fit_to_data')
+    assert hasattr(fitted_pars, 'fixed_poi_fit_to_asimov')
+    assert hasattr(fitted_pars, 'free_fit_to_data')
+    assert hasattr(fitted_pars, 'free_fit_to_asimov')
+
+    rtol = 1e-5
+    if test_stat == 'q0':
+        assert pytest.approx([1.0, 1.0], rel=rtol) == pyhf.tensorlib.tolist(
+            fitted_pars.asimov_pars
+        )
+        assert pytest.approx([0.0, 1.5], rel=rtol) == pyhf.tensorlib.tolist(
+            fitted_pars.fixed_poi_fit_to_data
+        )
+        assert pytest.approx([0.0, 1.5], rel=rtol) == pyhf.tensorlib.tolist(
+            fitted_pars.fixed_poi_fit_to_asimov
+        )
+        assert pytest.approx([1.0, 1.0], rel=rtol) == pyhf.tensorlib.tolist(
+            fitted_pars.free_fit_to_data
+        )
+        assert pytest.approx([1.0, 1.0], rel=rtol) == pyhf.tensorlib.tolist(
+            fitted_pars.free_fit_to_asimov
+        )
+    else:
+        assert pytest.approx([0.0, 1.5], rel=rtol) == pyhf.tensorlib.tolist(
+            fitted_pars.asimov_pars
+        )
+        assert pytest.approx([1.0, 1.0], rel=rtol) == pyhf.tensorlib.tolist(
+            fitted_pars.fixed_poi_fit_to_data
+        )
+        assert pytest.approx([1.0, 1.1513553], rel=rtol) == pyhf.tensorlib.tolist(
+            fitted_pars.fixed_poi_fit_to_asimov
+        )
+        assert pytest.approx([1.0, 1.0], rel=rtol) == pyhf.tensorlib.tolist(
+            fitted_pars.free_fit_to_data
+        )
+        assert pytest.approx(
+            [7.6470499e-05, 1.4997178], rel=rtol
+        ) == pyhf.tensorlib.tolist(fitted_pars.free_fit_to_asimov)
+
+
+def test_asympotic_calculator_fitted_pars_before_teststatistic_raises():
+    model = pyhf.simplemodels.uncorrelated_background([0], [0], [0])
+    data = [0, 0]  # [main, aux]
+    calc = pyhf.infer.calculators.AsymptoticCalculator(data, model)
+    with pytest.raises(RuntimeError) as exc_info:
+        calc.fitted_pars
+    assert 'teststatistic' in str(exc_info.value)

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -30,10 +30,5 @@ def test_generate_asimov_can_return_fitted_pars(return_fitted_pars):
     if return_fitted_pars:
         assert len(result) == 2
         result, asimov_pars = result
-        # asimov_pars and result could be tensors, so convert to List[float] first
-        assert list(map(float, asimov_pars)) == [
-            1.0,
-            1.0,
-            1.0,
-        ]  # mu, 2x uncorr_bkguncrt
-    assert list(map(float, result)) == [2.0, 2.0, 1.0, 1.0]
+        assert pytest.approx([1.0, 1.0, 1.0]) == pyhf.tensorlib.tolist(asimov_pars)
+    assert pytest.approx([2.0, 2.0, 1.0, 1.0]) == pyhf.tensorlib.tolist(result)

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1,3 +1,5 @@
+import pytest
+
 import pyhf
 import pyhf.infer.calculators
 
@@ -5,3 +7,33 @@ import pyhf.infer.calculators
 def test_calc_dist():
     asymptotic_dist = pyhf.infer.calculators.AsymptoticTestStatDistribution(0.0)
     assert asymptotic_dist.pvalue(-1) == 1 - asymptotic_dist.cdf(-1)
+
+
+@pytest.mark.parametrize("return_fitted_pars", [False, True])
+def test_generate_asimov_can_return_fitted_pars(return_fitted_pars):
+    model = pyhf.simplemodels.uncorrelated_background([1, 1], [1, 1], [1, 1])
+    data = [2, 2, 1, 1]  # [main x 2, aux x 2]
+    init_pars = model.config.suggested_init()
+    par_bounds = model.config.suggested_bounds()
+    fixed_params = model.config.suggested_fixed()
+
+    result = pyhf.infer.calculators.generate_asimov_data(
+        1.0,
+        data,
+        model,
+        init_pars,
+        par_bounds,
+        fixed_params,
+        return_fitted_pars=return_fitted_pars,
+    )
+
+    if return_fitted_pars:
+        assert len(result) == 2
+        result, asimov_pars = result
+        # asimov_pars and result could be tensors, so convert to List[float] first
+        assert list(map(float, asimov_pars)) == [
+            1.0,
+            1.0,
+            1.0,
+        ]  # mu, 2x uncorr_bkguncrt
+    assert list(map(float, result)) == [2.0, 2.0, 1.0, 1.0]

--- a/tests/test_teststats.py
+++ b/tests/test_teststats.py
@@ -172,3 +172,35 @@ def test_get_teststat_by_name(test_stat):
 def test_get_teststat_error():
     with pytest.raises(pyhf.exceptions.InvalidTestStatistic):
         pyhf.infer.utils.get_test_stat("look at me i'm not real")
+
+
+@pytest.mark.parametrize("switch,expected_len", [(False, 1), (True, 2)])
+@pytest.mark.parametrize(
+    "test_stat",
+    [
+        pyhf.infer.test_statistics.q0,
+        pyhf.infer.test_statistics.qmu,
+        pyhf.infer.test_statistics.qmu_tilde,
+        pyhf.infer.test_statistics.tmu,
+        pyhf.infer.test_statistics.tmu_tilde,
+    ],
+)
+def test_return_fitted_pars(test_stat, switch, expected_len):
+    mu = 0.0 if test_stat is pyhf.infer.test_statistics.q0 else 1.0
+    model = pyhf.simplemodels.uncorrelated_background([6], [9], [3])
+    data = [9] + model.config.auxdata
+    init_pars = model.config.suggested_init()
+    par_bounds = model.config.suggested_bounds()
+    fixed_params = model.config.suggested_fixed()
+
+    result = test_stat(
+        mu,
+        data,
+        model,
+        init_pars,
+        par_bounds,
+        fixed_params,
+        return_fitted_pars=switch,
+    )
+
+    assert len(result) == expected_len

--- a/tests/test_teststats.py
+++ b/tests/test_teststats.py
@@ -204,5 +204,8 @@ def test_return_fitted_pars(test_stat, return_fitted_pars):
     )
     if return_fitted_pars:
         assert len(result) == 2
-        assert len(result[1]) == len(init_pars)
+        assert len(result[1]) == 2
+        result, (pars_bestfit, pars_constrained_fit) = result
+        assert len(pars_bestfit) == len(init_pars)
+        assert len(pars_constrained_fit) == len(init_pars)
     assert result > -1e4  # >= 0 but with generous tolerance

--- a/tests/test_teststats.py
+++ b/tests/test_teststats.py
@@ -174,7 +174,7 @@ def test_get_teststat_error():
         pyhf.infer.utils.get_test_stat("look at me i'm not real")
 
 
-@pytest.mark.parametrize("switch,expected_len", [(False, 1), (True, 2)])
+@pytest.mark.parametrize("return_fitted_pars", [False, True])
 @pytest.mark.parametrize(
     "test_stat",
     [
@@ -185,7 +185,7 @@ def test_get_teststat_error():
         pyhf.infer.test_statistics.tmu_tilde,
     ],
 )
-def test_return_fitted_pars(test_stat, switch, expected_len):
+def test_return_fitted_pars(test_stat, return_fitted_pars):
     mu = 0.0 if test_stat is pyhf.infer.test_statistics.q0 else 1.0
     model = pyhf.simplemodels.uncorrelated_background([6], [9], [3])
     data = [9] + model.config.auxdata
@@ -200,7 +200,9 @@ def test_return_fitted_pars(test_stat, switch, expected_len):
         init_pars,
         par_bounds,
         fixed_params,
-        return_fitted_pars=switch,
+        return_fitted_pars=return_fitted_pars,
     )
-
-    assert len(result) == expected_len
+    if return_fitted_pars:
+        assert len(result) == 2
+        assert len(result[1]) == len(init_pars)
+    assert result > -1e4  # >= 0 but with generous tolerance


### PR DESCRIPTION
# Description

Implements issue #1550.

Functions in `pyhf.infer` that call `pyhf.infer.mle.fit` or `pyhf.infer.mle.fixed_poi_fit` (except `pyhf.infer.upperlimit`) return the best-fit parameters if they recieve `return_fitted_pars=True` as a kwarg. The `pyhf.infer.calculators.AymptoticCalculator` has an attribute holding the best-fit parameters of the most recent five fits. 
# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
- [ ] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR
