### PR TITLE
docs: Promote comments to docstring examples for pyhf.event

### DIFF
--- a/src/pyhf/events.py
+++ b/src/pyhf/events.py
@@ -89,7 +89,9 @@ def subscribe(event):
     """
     Subscribe a function or object method as a callback to an event.
 
-    Note: this is meant to be used as a decorator.
+    .. note::
+
+     This is meant to be used as a decorator.
 
     Args:
         event (:obj:`str`): The name of the event to subscribe to.
@@ -122,7 +124,9 @@ def register(event):
     Register a function or object method to trigger an event.  This creates two
     events: ``{event_name}::before`` and ``{event_name}::after``.
 
-    Note: this is meant to be used as a decorator.
+    .. note::
+
+     This is meant to be used as a decorator.
 
     Args:
         event (:obj:`str`): The name of the event to subscribe to.

--- a/src/pyhf/events.py
+++ b/src/pyhf/events.py
@@ -47,9 +47,9 @@ def subscribe(event):
     #
     # >>> @pyhf.events.subscribe('myevent')
     # ... def test(a,b):
-    # ...   print a+b
+    # ...   print(a+b)
     # ...
-    # >>> pyhf.events.trigger_myevent(1,2)
+    # >>> pyhf.events.trigger.("myevent")(1,2)
     # 3
     global __events
 
@@ -70,15 +70,15 @@ def register(event):
     #
     # >>> @pyhf.events.register('test_func')
     # ... def test(a,b):
-    # ...   print a+b
+    # ...   print(a+b)
     # ...
     # >>> @pyhf.events.subscribe('test_func::before')
     # ... def precall():
-    # ...   print 'before call'
+    # ...   print('before call')
     # ...
     # >>> @pyhf.events.subscribe('test_func::after')
     # ... def postcall():
-    # ...   print 'after call'
+    # ...   print('after call')
     # ...
     # >>> test(1,2)
     # "before call"

--- a/src/pyhf/events.py
+++ b/src/pyhf/events.py
@@ -42,15 +42,18 @@ class Callables(WeakList):
 def subscribe(event):
     """
     This is meant to be used as a decorator.
+
+    Example:
+        >>> import pyhf
+        >>> @pyhf.events.subscribe("myevent")
+        ... def test(a, b):
+        ...     print(a + b)
+        ...
+        >>> pyhf.events.trigger("myevent")(1, 2)
+        3
+
     """
-    # Example:
-    #
-    # >>> @pyhf.events.subscribe('myevent')
-    # ... def test(a,b):
-    # ...   print(a+b)
-    # ...
-    # >>> pyhf.events.trigger.("myevent")(1,2)
-    # 3
+
     global __events
 
     def __decorator(func):
@@ -64,27 +67,28 @@ def register(event):
     """
     This is meant to be used as a decorator to register a function for triggering events.
 
-    This creates two events: "<event_name>::before" and "<event_name>::after"
+    This creates two events: ``<event_name>::before`` and ``<event_name>::after``
+
+    Example:
+        >>> import pyhf
+        >>> @pyhf.events.register("test_func")
+        ... def test(a, b):
+        ...     print(a + b)
+        ...
+        >>> @pyhf.events.subscribe("test_func::before")
+        ... def precall():
+        ...     print("before call")
+        ...
+        >>> @pyhf.events.subscribe("test_func::after")
+        ... def postcall():
+        ...     print("after call")
+        ...
+        >>> test(1, 2)
+        before call
+        3
+        after call
+
     """
-    # Examples:
-    #
-    # >>> @pyhf.events.register('test_func')
-    # ... def test(a,b):
-    # ...   print(a+b)
-    # ...
-    # >>> @pyhf.events.subscribe('test_func::before')
-    # ... def precall():
-    # ...   print('before call')
-    # ...
-    # >>> @pyhf.events.subscribe('test_func::after')
-    # ... def postcall():
-    # ...   print('after call')
-    # ...
-    # >>> test(1,2)
-    # "before call"
-    # 3
-    # "after call"
-    # >>>
 
     def _register(func):
         @wraps(func)


### PR DESCRIPTION
# Description

Fixes #1555 

Promote event examples to docstrings and use Python 3 syntax.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Promote pyhf.event.subscribe and pyhf.event.register examples to docstring examples
* Use Python 3 syntax in examples
```