### PR TITLE
feat: par_names handles non-scalar modifiers with 1 parameter

### DIFF
--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -319,12 +319,9 @@ class _ModelConfig(_ChannelSummaryMixin):
         """
         return self.par_map[name]['slice']
 
-    def par_names(self, fstring='{name}[{index}]'):
+    def par_names(self):
         """
         The names of the parameters in the model including binned-parameter indexing.
-
-        Args:
-            fstring (:obj:`str`): Format string for the parameter names using ``name`` and ``index`` variables. Default: ``'{name}[{index}]'``.
 
         Returns:
             :obj:`list`: Names of the model parameters.
@@ -336,18 +333,16 @@ class _ModelConfig(_ChannelSummaryMixin):
             ... )
             >>> model.config.par_names()
             ['mu', 'uncorr_bkguncrt[0]', 'uncorr_bkguncrt[1]']
-            >>> model.config.par_names(fstring='{name}_{index}')
-            ['mu', 'uncorr_bkguncrt_0', 'uncorr_bkguncrt_1']
         """
         _names = []
         for name in self.par_order:
-            _npars = self.param_set(name).n_parameters
-            if _npars == 1:
+            param_set = self.param_set(name)
+            if param_set.is_scalar:
                 _names.append(name)
                 continue
 
             _names.extend(
-                [fstring.format(name=name, index=idx) for idx in range(_npars)]
+                [f'{name}[{index}]' for index in range(param_set.n_parameters)]
             )
         return _names
 

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -581,7 +581,7 @@ def test_minuit_param_names(mocker):
     data = [10] + pdf.config.auxdata
     _, result = pyhf.infer.mle.fit(data, pdf, return_result_obj=True)
     assert 'minuit' in result
-    assert result.minuit.parameters == ('mu', 'uncorr_bkguncrt')
+    assert result.minuit.parameters == ('mu', 'uncorr_bkguncrt[0]')
 
     pdf.config.par_names = mocker.Mock(return_value=None)
     _, result = pyhf.infer.mle.fit(data, pdf, return_result_obj=True)

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -890,3 +890,34 @@ def test_reproducible_model_spec():
         {'bounds': [[0, 5]], 'inits': [1], 'name': 'mu'}
     ]
     assert pyhf.Model(model_from_ws.spec)
+
+
+def test_par_names_scalar_nonscalar():
+    """
+    Testing to ensure that nonscalar parameters are still indexed, even if
+    n_parameters==1.
+    """
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {
+                        'name': 'goodsample',
+                        'data': [1.0],
+                        'modifiers': [
+                            {'type': 'normfactor', 'name': 'scalar', 'data': None},
+                            {'type': 'shapesys', 'name': 'nonscalar', 'data': [1.0]},
+                        ],
+                    },
+                ],
+            }
+        ]
+    }
+
+    model = pyhf.Model(spec, poi_name="scalar")
+    assert model.config.par_order == ["scalar", "nonscalar"]
+    assert model.config.par_names() == [
+        'scalar',
+        'nonscalar[0]',
+    ]


### PR DESCRIPTION
# Pull Request Description

Should fully resolve the last remaining parts of #867. There are two issues handled:

- `par_names` did allow for customizable fstring, but this would never get passed through to the underlying optimizers that use it, so it's being dropped as the benefit of configurability is outweighed by the extra work on the user to maintain and bookkeep
- `par_names` now correctly uses the fact that parameter sets which are non-scalar but only have one parameter (e.g. channel of 1 bin) will still be named with the index `{parameter}[0]` rather than just `{parameter}` to clarify that it's a non-scalar parameter explicitly (but also somewhat implicitly).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* change par_names API to drop fstring configurability
* modify par_names to handle non-scalar parameters in 1-bin channels
```
