### PR TITLE
feat: Rename kwarg with_aux to include_auxdata in pyhf.Workspace.data API

### DIFF
--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -417,7 +417,7 @@ class Workspace(_ChannelSummaryMixin, dict):
 
         return Model(modelspec, poi_name=measurement['config']['poi'], **config_kwargs)
 
-    def data(self, model, with_aux=True):
+    def data(self, model, include_auxdata=True):
         """
         Return the data for the supplied model with or without auxiliary data from the model.
 
@@ -428,7 +428,7 @@ class Workspace(_ChannelSummaryMixin, dict):
 
         Args:
             model (~pyhf.pdf.Model): A model object adhering to the schema model.json
-            with_aux (:obj:`bool`): Whether to include auxiliary data from the model or not
+            include_auxdata (:obj:`bool`): Whether to include auxiliary data from the model or not
 
         Returns:
             :obj:`list`: data
@@ -444,7 +444,7 @@ class Workspace(_ChannelSummaryMixin, dict):
                 exc_info=True,
             )
             raise
-        if with_aux:
+        if include_auxdata:
             observed_data += model.config.auxdata
         return observed_data
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -142,13 +142,13 @@ def test_workspace_observations(workspace_factory):
 
 
 @pytest.mark.parametrize(
-    "with_aux",
+    "include_auxdata",
     [True, False],
 )
-def test_get_workspace_data(workspace_factory, with_aux):
+def test_get_workspace_data(workspace_factory, include_auxdata):
     w = workspace_factory()
     m = w.model()
-    assert w.data(m, with_aux=with_aux)
+    assert w.data(m, include_auxdata=include_auxdata)
 
 
 def test_get_workspace_data_bad_model(workspace_factory, caplog):


### PR DESCRIPTION
# Pull Request Description

Closes #1561. This harmonizes the API a little more by renaming with_aux to include_auxdata in `ws.data()` calls to match `model.expected_data()`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* rename keyword argument in pyhf.Workspace.data with_aux to include_auxdata
  - harmonize the API between workspace and model
```
