### PR TITLE
feat: Drop uproot3 for uproot4 for writing ROOT files

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -63,31 +63,6 @@ jobs:
       run: |
         python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
 
-  uproot3:
-
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade --editable .[test]
-        python -m pip uninstall --yes uproot3
-        python -m pip install --upgrade git+git://github.com/scikit-hep/uproot3.git
-        python -m pip list
-    - name: Test with pytest
-      run: |
-        python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
-
   uproot4:
 
     runs-on: ${{ matrix.os }}

--- a/lower-bound-requirements.txt
+++ b/lower-bound-requirements.txt
@@ -6,8 +6,7 @@ jsonschema==3.0.0
 jsonpatch==1.15
 pyyaml==5.1
 # xmlio
-uproot3==3.14.1
-uproot==4.0.0
+uproot==4.1.0
 # minuit
 iminuit==2.4.0
 # tensorflow

--- a/lower-bound-requirements.txt
+++ b/lower-bound-requirements.txt
@@ -6,7 +6,7 @@ jsonschema==3.0.0
 jsonpatch==1.15
 pyyaml==5.1
 # xmlio
-uproot==4.1.0
+uproot==4.1.1
 # minuit
 iminuit==2.4.0
 # tensorflow

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,7 @@ extras_require = {
     ],
     'torch': ['torch~=1.8'],
     'jax': ['jax~=0.2.8', 'jaxlib~=0.1.58,!=0.1.68'],  # c.f. Issue 1501
-    'xmlio': [
-        'uproot3>=3.14.1',
-        'uproot~=4.0',
-    ],  # uproot3 required until writing to ROOT supported in uproot4
+    'xmlio': ['uproot>=4.1.0'],
     'minuit': ['iminuit>=2.4'],
 }
 extras_require['backends'] = sorted(

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ extras_require = {
     ],
     'torch': ['torch~=1.8'],
     'jax': ['jax~=0.2.8', 'jaxlib~=0.1.58,!=0.1.68'],  # c.f. Issue 1501
-    'xmlio': ['uproot>=4.1.0'],
+    'xmlio': ['uproot>=4.1.1'],
     'minuit': ['iminuit>=2.4'],
 }
 extras_require['backends'] = sorted(

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -45,11 +45,12 @@ def _make_hist_name(channel, sample, modifier='', prefix='hist', suffix=''):
     return f"{prefix}{middle}{suffix}"
 
 
-def _export_root_histogram(histname, data):
-    if histname in _ROOT_DATA_FILE:
-        raise KeyError(f"Duplicate key {histname} being written.")
-    hist_uproot_model = uproot.to_writable((np.asarray(data), np.arange(len(data) + 1)))
-    _ROOT_DATA_FILE[histname] = hist_uproot_model
+def _export_root_histogram(hist_name, data):
+    if hist_name in _ROOT_DATA_FILE:
+        raise KeyError(f"Duplicate key {hist_name} being written.")
+    _ROOT_DATA_FILE[hist_name] = uproot.to_writable(
+        (np.asarray(data), np.arange(len(data) + 1))
+    )
 
 
 # https://stackoverflow.com/a/4590052

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -234,7 +234,7 @@ def build_sample(spec, samplespec, channelname):
     attrs = {
         'Name': samplespec['name'],
         'HistoName': histname,
-        'InputFile': _ROOT_DATA_FILE._path,
+        'InputFile': _ROOT_DATA_FILE.file_path,
         'NormalizeByTheory': 'False',
     }
     sample = ET.Element('Sample', **attrs)
@@ -253,7 +253,7 @@ def build_sample(spec, samplespec, channelname):
 
 def build_data(obsspec, channelname):
     histname = _make_hist_name(channelname, 'data')
-    data = ET.Element('Data', HistoName=histname, InputFile=_ROOT_DATA_FILE._path)
+    data = ET.Element('Data', HistoName=histname, InputFile=_ROOT_DATA_FILE.file_path)
 
     observation = next((obs for obs in obsspec if obs['name'] == channelname), None)
     _export_root_histogram(histname, observation['data'])
@@ -262,7 +262,7 @@ def build_data(obsspec, channelname):
 
 def build_channel(spec, channelspec, obsspec):
     channel = ET.Element(
-        'Channel', Name=channelspec['name'], InputFile=_ROOT_DATA_FILE._path
+        'Channel', Name=channelspec['name'], InputFile=_ROOT_DATA_FILE.file_path
     )
     if obsspec:
         data = build_data(obsspec, channelspec['name'])

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -49,7 +49,6 @@ def _export_root_histogram(histname, data):
     if histname in _ROOT_DATA_FILE:
         raise KeyError(f"Duplicate key {histname} being written.")
     hist_uproot_model = uproot.to_writable((np.asarray(data), np.arange(len(data) + 1)))
-    hist_uproot_model._members["fName"] = histname
     _ROOT_DATA_FILE[histname] = hist_uproot_model
 
 

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -6,9 +6,7 @@ import pkg_resources
 import xml.etree.ElementTree as ET
 import numpy as np
 
-# TODO: Move to uproot4 when ROOT file writing is supported
-import uproot3 as uproot
-from uproot3_methods.classes import TH1
+import uproot
 
 from pyhf.mixins import _ChannelSummaryMixin
 
@@ -48,11 +46,11 @@ def _make_hist_name(channel, sample, modifier='', prefix='hist', suffix=''):
 
 
 def _export_root_histogram(histname, data):
-    hist = TH1.from_numpy((np.asarray(data), np.arange(len(data) + 1)))
-    hist._fName = histname
     if histname in _ROOT_DATA_FILE:
         raise KeyError(f"Duplicate key {histname} being written.")
-    _ROOT_DATA_FILE[histname] = hist
+    _ROOT_DATA_FILE[histname] = np.histogram(
+        np.asarray(data), bins=np.arange(len(data) + 1)
+    )
 
 
 # https://stackoverflow.com/a/4590052

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -48,9 +48,7 @@ def _make_hist_name(channel, sample, modifier='', prefix='hist', suffix=''):
 def _export_root_histogram(histname, data):
     if histname in _ROOT_DATA_FILE:
         raise KeyError(f"Duplicate key {histname} being written.")
-    _ROOT_DATA_FILE[histname] = np.histogram(
-        np.asarray(data), bins=np.arange(len(data) + 1)
-    )
+    _ROOT_DATA_FILE[histname] = (np.asarray(data), np.arange(len(data) + 1))
 
 
 # https://stackoverflow.com/a/4590052

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -48,7 +48,9 @@ def _make_hist_name(channel, sample, modifier='', prefix='hist', suffix=''):
 def _export_root_histogram(histname, data):
     if histname in _ROOT_DATA_FILE:
         raise KeyError(f"Duplicate key {histname} being written.")
-    _ROOT_DATA_FILE[histname] = (np.asarray(data), np.arange(len(data) + 1))
+    hist_uproot_model = uproot.to_writable((np.asarray(data), np.arange(len(data) + 1)))
+    hist_uproot_model._members["fName"] = histname
+    _ROOT_DATA_FILE[histname] = hist_uproot_model
 
 
 # https://stackoverflow.com/a/4590052

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -394,7 +394,6 @@ def test_export_data(mocker):
 
 def test_export_duplicate_hist_name(mocker):
     mocker.patch('pyhf.writexml._ROOT_DATA_FILE', new={'duplicate_name': True})
-    mocker.patch.object(pyhf.writexml, 'TH1')
 
     with pytest.raises(KeyError):
         pyhf.writexml._export_root_histogram('duplicate_name', [0, 1, 2])

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -398,7 +398,8 @@ def test_export_data(mocker):
 def test_export_root_histogram(mocker, tmp_path):
     """
     Test that pyhf.writexml._export_root_histogram writes out a histogram
-    in the manner that uproot is expecting
+    in the manner that uproot is expecting and verifies this by reading
+    the serialized file
     """
     mocker.patch("pyhf.writexml._ROOT_DATA_FILE", {})
     pyhf.writexml._export_root_histogram("hist", [0, 1, 2, 3, 4, 5, 6, 7, 8])
@@ -406,6 +407,7 @@ def test_export_root_histogram(mocker, tmp_path):
     with uproot.recreate(tmp_path.joinpath("test_export_root_histogram.root")) as file:
         file["hist"] = pyhf.writexml._ROOT_DATA_FILE["hist"]
 
+    with uproot.open(tmp_path.joinpath("test_export_root_histogram.root")) as file:
         assert file["hist"].values().tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8]
         assert file["hist"].axis().edges().tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         assert file["hist"].name == "hist"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -395,7 +395,7 @@ def test_export_data(mocker):
     assert pyhf.writexml._ROOT_DATA_FILE.__setitem__.called
 
 
-def test_export_root_histogram(mocker, tmpdir):
+def test_export_root_histogram(mocker, tmp_path):
     """
     Test that pyhf.writexml._export_root_histogram writes out a histogram
     in the manner that uproot is expecting
@@ -403,7 +403,7 @@ def test_export_root_histogram(mocker, tmpdir):
     mocker.patch("pyhf.writexml._ROOT_DATA_FILE", {})
     pyhf.writexml._export_root_histogram("example", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
-    with uproot.recreate(tmpdir.join("test_export_root_histogram.root")) as file:
+    with uproot.recreate(tmp_path.joinpath("test_export_root_histogram.root")) as file:
         file["hist"] = pyhf.writexml._ROOT_DATA_FILE["example"]
         counts, edges = file["hist"].to_numpy()
         values = counts * edges[:-1]

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -405,13 +405,11 @@ def test_export_root_histogram(mocker, tmp_path):
 
     with uproot.recreate(tmp_path.joinpath("test_export_root_histogram.root")) as file:
         file["hist"] = pyhf.writexml._ROOT_DATA_FILE["example"]
-        counts, edges = file["hist"].to_numpy()
-        values = counts * edges[:-1]
+        values, edges = file["hist"].to_numpy()
 
-        assert file["hist"].values().tolist() == [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-        assert counts.tolist() == [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-        assert edges.tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        assert file["hist"].values().tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         assert values.tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        assert edges.tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
 
 def test_export_duplicate_hist_name(mocker):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -405,12 +405,22 @@ def test_export_root_histogram(mocker, tmp_path):
 
     with uproot.recreate(tmp_path.joinpath("test_export_root_histogram.root")) as file:
         file["hist"] = pyhf.writexml._ROOT_DATA_FILE["hist"]
-        values, edges = file["hist"].to_numpy()
 
         assert file["hist"].values().tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        assert file["hist"].axis().edges().tolist() == [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+        ]
         assert file["hist"].name == "hist"
-        assert values.tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-        assert edges.tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
 
 def test_export_duplicate_hist_name(mocker):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -401,13 +401,14 @@ def test_export_root_histogram(mocker, tmp_path):
     in the manner that uproot is expecting
     """
     mocker.patch("pyhf.writexml._ROOT_DATA_FILE", {})
-    pyhf.writexml._export_root_histogram("example", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    pyhf.writexml._export_root_histogram("hist", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
     with uproot.recreate(tmp_path.joinpath("test_export_root_histogram.root")) as file:
-        file["hist"] = pyhf.writexml._ROOT_DATA_FILE["example"]
+        file["hist"] = pyhf.writexml._ROOT_DATA_FILE["hist"]
         values, edges = file["hist"].to_numpy()
 
         assert file["hist"].values().tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        assert file["hist"].name == "hist"
         assert values.tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         assert edges.tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -401,25 +401,13 @@ def test_export_root_histogram(mocker, tmp_path):
     in the manner that uproot is expecting
     """
     mocker.patch("pyhf.writexml._ROOT_DATA_FILE", {})
-    pyhf.writexml._export_root_histogram("hist", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    pyhf.writexml._export_root_histogram("hist", [0, 1, 2, 3, 4, 5, 6, 7, 8])
 
     with uproot.recreate(tmp_path.joinpath("test_export_root_histogram.root")) as file:
         file["hist"] = pyhf.writexml._ROOT_DATA_FILE["hist"]
 
-        assert file["hist"].values().tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-        assert file["hist"].axis().edges().tolist() == [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-        ]
+        assert file["hist"].values().tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8]
+        assert file["hist"].axis().edges().tolist() == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         assert file["hist"].name == "hist"
 
 


### PR DESCRIPTION
# Description

Resolves #1566

Drop all usages of `uproot3` and only use `uproot` `v4.1.1+` for all reading and writing of ROOT files.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove all uproot3 dependency and use uproot4 for all reading and writing of ROOT files
* Require uproot>=4.1.1 in 'xmlio' extra
* Require uproot==4.1.1 in lower-bound-requirements.txt
* Remove uproot3 HEAD of dependencies testing workflow
* Add test to ensure pyhf.writexml writes histograms to ROOT files as expected
```
