### PR TITLE
docs: Add use citations from vCHEP 2021

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,14 @@
+% 2021-08-23
+@article{Cranmer:2021oxr,
+    author = "Cranmer, Kyle and Held, Alexander",
+    title = "{Building and steering binned template fits with cabinetry}",
+    doi = "10.1051/epjconf/202125103067",
+    journal = "EPJ Web Conf.",
+    volume = "251",
+    pages = "03067",
+    year = "2021"
+}
+
 % 2021-06-03
 @article{ATLAS:SUSY-3L-compressed-combination,
     author = "ATLAS Collaboration",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -49,6 +49,20 @@
     journal = ""
 }
 
+% 2021-03-03
+@article{Feickert:2021sua,
+    author = "Feickert, Matthew and Heinrich, Lukas and Stark, Giordon and Galewsky, Ben",
+    title = "{Distributed statistical inference with pyhf enabled through funcX}",
+    eprint = "2103.02182",
+    archivePrefix = "arXiv",
+    primaryClass = "cs.DC",
+    doi = "10.1051/epjconf/202125102070",
+    journal = "EPJ Web Conf.",
+    volume = "251",
+    pages = "02070",
+    year = "2021"
+}
+
 % 2021-02-22
 @article{Capdevilla:2021fmj,
     author = "Capdevilla, Rodolfo and Meloni, Federico and Simoniello, Rosa and Zurita, Jose",

--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -17,7 +17,9 @@ archive and the `JOSS <https://joss.theoj.org/>`__ paper:
 Use in Publications
 -------------------
 
-Updating list of citations and use cases of :code:`pyhf`:
+The following is an updating list of citations and use cases of :code:`pyhf`.
+There is an incomplete but automatically updated `list of citations on INSPIRE
+<https://inspirehep.net/literature/1845084>`__ as well.
 
 Use Citations
 ~~~~~~~~~~~~~


### PR DESCRIPTION
# Description

Add citations from vCHEP 2021 papers from [Distributed statistical inference with pyhf enabled through funcX](https://inspirehep.net/literature/1849745) and [Building and steering binned template fits with cabinetry](https://inspirehep.net/literature/1911802). Also note that citations are [automatically updated on INSPIRE](https://inspirehep.net/literature/1845084) but are incomplete.

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Distributed statistical inference with pyhf enabled through funcX'
   - c.f. https://inspirehep.net/literature/1849745
* Add use citation from 'Building and steering binned template fits with cabinetry'
   - c.f. https://inspirehep.net/literature/1911802
* Note that citations are automatically updated on INSPIRE but are incomplete
```
