### PR TITLE
docs: Fix links to existing issues for 'docs' and 'feat' labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation-report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-report.yml
@@ -15,7 +15,7 @@ body:
       GitHub][issue search].
 
 
-      [issue search]: https://github.com/scikit-hep/pyhf/issues?q=is%3Aopen+is%3Aissue+label%3Abug
+      [issue search]: https://github.com/scikit-hep/pyhf/issues?q=is%3Aopen+is%3Aissue+label%3Adocs
 
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -17,7 +17,7 @@ body:
       already be implemented in a development release.
 
 
-      [issue search]: https://github.com/scikit-hep/pyhf/issues?q=is%3Aopen+is%3Aissue+label%3Abug
+      [issue search]: https://github.com/scikit-hep/pyhf/issues?q=is%3Aopen+is%3Aissue+label%3Afeat%2Fenhancement
 
 
 - type: textarea


### PR DESCRIPTION
# Description

Fix the links in the Issue forms to point to the same Issue type label as the form. So have the docs Issue templates point to "docs" label, etc. Amends PR #1576 where @matthewfeickert forgot to fix this.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Fix the links in the Issue forms to point to the same Issue type label as the form
* Amends PR #1576
```
