### PR TITLE
docs: Add v0.6.3 release notes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ Implemented variations:
   - ☑ ShapeSys
   - ☑ NormFactor
   - ☑ Multiple Channels
-  - ☑ Import from XML + ROOT via `uproot <https://github.com/scikit-hep/uproot>`__
+  - ☑ Import from XML + ROOT via `uproot <https://github.com/scikit-hep/uproot4>`__
   - ☑ ShapeFactor
   - ☑ StatError
   - ☑ Lumi Uncertainty

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -23,3 +23,4 @@ Contributors include:
 - Eric Schanet
 - Henry Schreiner
 - Saransh Chopra
+- Sviatoslav Sydorenko

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -3,6 +3,7 @@ Release Notes
 =============
 
 .. include:: release-notes/v0.6.2.rst
+.. include:: release-notes/v0.6.3.rst
 .. include:: release-notes/v0.6.1.rst
 .. include:: release-notes/v0.6.0.rst
 .. include:: release-notes/v0.5.4.rst

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -2,8 +2,8 @@
 Release Notes
 =============
 
-.. include:: release-notes/v0.6.2.rst
 .. include:: release-notes/v0.6.3.rst
+.. include:: release-notes/v0.6.2.rst
 .. include:: release-notes/v0.6.1.rst
 .. include:: release-notes/v0.6.0.rst
 .. include:: release-notes/v0.5.4.rst

--- a/docs/release-notes/v0.6.3.rst
+++ b/docs/release-notes/v0.6.3.rst
@@ -15,12 +15,9 @@ Important Notes
 Fixes
 -----
 
-* XXX Allow for precision to be properly set for the tensorlib ``ones`` and ``zeros``
-  methods through a ``dtype`` argument.
-  This allows for precision to be properly set through the :func:`pyhf.set_backend`
-  ``precision`` argument.
-  (PR :pr:`1369`)
-* X
+* The weakref bug with Click ``v8.0+`` was resolved.
+  ``pyhf`` is now fully compatible with Click ``v7`` and ``v8`` releases.
+  (PR :pr:`1530`)
 
 Features
 --------
@@ -28,22 +25,13 @@ Features
 Python API
 ~~~~~~~~~~
 
-* XXX The :func:`pyhf.simplemodels.hepdata_like` API has been deprecated in favor of
-  :func:`pyhf.simplemodels.uncorrelated_background`.
-  The :func:`pyhf.simplemodels.hepdata_like` API will be removed in ``pyhf`` ``v0.7.0``.
-  (PR :pr:`1438`)
-* X
+* Model parameter names are now propagated to optimizers through additon of the
+  :func:`pyhf.pdf._ModelConfig.par_names` API.
+  (PR :pr:`1536`)
+* The :class:`pyhf.pdf._ModelConfig` ``channel_nbins`` dict is now sorted by
+  keys to match the order of the ``channels`` dict.
+  (PR :pr:`1546`)
 
-CLI API
-~~~~~~~
-
-* XXX The CLI API now supports a ``patchset inspect`` API to list the individual
-  patches in a ``PatchSet``.
-  (PR :pr:`1412`)
-
-.. code-block:: shell
-
-  pyhf patchset inspect [OPTIONS] [PATCHSET]
 
 Contributors
 ------------

--- a/docs/release-notes/v0.6.3.rst
+++ b/docs/release-notes/v0.6.3.rst
@@ -48,13 +48,5 @@ Python API
   renamed to ``include_auxdata`` to improve API consistency.
   (PR :pr:`1562`)
 
-
-Contributors
-------------
-
-``v0.6.3`` benefited from contributions from:
-
-* Alexander Held
-
 .. |release v0.6.3| replace:: ``v0.6.3``
 .. _`release v0.6.3`: https://github.com/scikit-hep/pyhf/releases/tag/v0.6.3

--- a/docs/release-notes/v0.6.3.rst
+++ b/docs/release-notes/v0.6.3.rst
@@ -10,6 +10,12 @@ Important Notes
   ``xmlio`` extra no longer requires ``uproot3`` and all dependncies on
   ``uproot3`` and ``uproot3-methods`` have been dropped.
   (PR :pr:`1567`)
+* All backends are now fully compatible and tested with
+  `Python 3.9 <https://www.python.org/dev/peps/pep-0596/>`_.
+  (PR :pr:`1574`)
+* The TensorFlow backend now supports compatability with TensorFlow ``v2.2.1``
+  and later and TensorFlow Probability ``v0.10.1`` and later.
+  (PR :pr:`1001`)
 * :func:`pyhf.workspace.Workspace.data` ``with_aux`` keyword arg has been
   renamed to ``include_auxdata`` to improve API consistency.
 

--- a/docs/release-notes/v0.6.3.rst
+++ b/docs/release-notes/v0.6.3.rst
@@ -7,13 +7,13 @@ Important Notes
 ---------------
 
 * With the addition of writing ROOT files in |uproot v4.1.0 release|_ the
-  ``xmlio`` extra no longer requires ``uproot3`` and all dependncies on
+  ``xmlio`` extra no longer requires ``uproot3`` and all dependencies on
   ``uproot3`` and ``uproot3-methods`` have been dropped.
   (PR :pr:`1567`)
 * All backends are now fully compatible and tested with
   `Python 3.9 <https://www.python.org/dev/peps/pep-0596/>`_.
   (PR :pr:`1574`)
-* The TensorFlow backend now supports compatability with TensorFlow ``v2.2.1``
+* The TensorFlow backend now supports compatibility with TensorFlow ``v2.2.1``
   and later and TensorFlow Probability ``v0.10.1`` and later.
   (PR :pr:`1001`)
 * The :func:`pyhf.workspace.Workspace.data` ``with_aux`` keyword arg has been
@@ -36,7 +36,7 @@ Features
 Python API
 ~~~~~~~~~~
 
-* Model parameter names are now propagated to optimizers through additon of the
+* Model parameter names are now propagated to optimizers through addition of the
   :func:`pyhf.pdf._ModelConfig.par_names` API.
   :func:`pyhf.pdf._ModelConfig.par_names` also handles non-scalar modifiers with
   1 parameter.

--- a/docs/release-notes/v0.6.3.rst
+++ b/docs/release-notes/v0.6.3.rst
@@ -16,8 +16,9 @@ Important Notes
 * The TensorFlow backend now supports compatability with TensorFlow ``v2.2.1``
   and later and TensorFlow Probability ``v0.10.1`` and later.
   (PR :pr:`1001`)
-* :func:`pyhf.workspace.Workspace.data` ``with_aux`` keyword arg has been
+* The :func:`pyhf.workspace.Workspace.data` ``with_aux`` keyword arg has been
   renamed to ``include_auxdata`` to improve API consistency.
+  (PR :pr:`1562`)
 
 .. |uproot v4.1.0 release| replace:: ``uproot`` ``v4.1.0``
 .. _`uproot v4.1.0 release`: https://github.com/scikit-hep/uproot4/releases/tag/4.1.0
@@ -37,14 +38,28 @@ Python API
 
 * Model parameter names are now propagated to optimizers through additon of the
   :func:`pyhf.pdf._ModelConfig.par_names` API.
-  (PR :pr:`1536`)
+  :func:`pyhf.pdf._ModelConfig.par_names` also handles non-scalar modifiers with
+  1 parameter.
+  (PRs :pr:`1536`, :pr:`1560`)
+
+  .. code:: pycon
+
+      >>> import pyhf
+      >>> model = pyhf.simplemodels.uncorrelated_background(
+      ...     signal=[12.0, 11.0], bkg=[50.0, 52.0], bkg_uncertainty=[3.0, 7.0]
+      ... )
+      >>> model.config.parameters
+      ['mu', 'uncorr_bkguncrt']
+      >>> model.config.npars
+      3
+      >>> model.config.par_names()
+      ['mu', 'uncorr_bkguncrt[0]', 'uncorr_bkguncrt[1]']
+
 * The :class:`pyhf.pdf._ModelConfig` ``channel_nbins`` dict is now sorted by
   keys to match the order of the ``channels`` dict.
   (PR :pr:`1546`)
-* :func:`pyhf.pdf._ModelConfig.par_names` can now handle non-scalar modifiers
-  with 1 parameter.
-  (PR :pr:`1560`)
-* :func:`pyhf.workspace.Workspace.data` ``with_aux`` keyword arg has been
+
+* The :func:`pyhf.workspace.Workspace.data` ``with_aux`` keyword arg has been
   renamed to ``include_auxdata`` to improve API consistency.
   (PR :pr:`1562`)
 

--- a/docs/release-notes/v0.6.3.rst
+++ b/docs/release-notes/v0.6.3.rst
@@ -1,0 +1,56 @@
+|release v0.6.3|_
+=================
+
+This is a patch release from ``v0.6.2`` → ``v0.6.3``.
+
+Important Notes
+---------------
+
+* XXX The :func:`pyhf.simplemodels.hepdata_like` API has been deprecated in favor of
+  :func:`pyhf.simplemodels.uncorrelated_background`.
+  The :func:`pyhf.simplemodels.hepdata_like` API will be removed in ``pyhf`` ``v0.7.0``.
+  (PR :pr:`1438`)
+* XXX
+
+Fixes
+-----
+
+* XXX Allow for precision to be properly set for the tensorlib ``ones`` and ``zeros``
+  methods through a ``dtype`` argument.
+  This allows for precision to be properly set through the :func:`pyhf.set_backend`
+  ``precision`` argument.
+  (PR :pr:`1369`)
+* X
+
+Features
+--------
+
+Python API
+~~~~~~~~~~
+
+* XXX The :func:`pyhf.simplemodels.hepdata_like` API has been deprecated in favor of
+  :func:`pyhf.simplemodels.uncorrelated_background`.
+  The :func:`pyhf.simplemodels.hepdata_like` API will be removed in ``pyhf`` ``v0.7.0``.
+  (PR :pr:`1438`)
+* X
+
+CLI API
+~~~~~~~
+
+* XXX The CLI API now supports a ``patchset inspect`` API to list the individual
+  patches in a ``PatchSet``.
+  (PR :pr:`1412`)
+
+.. code-block:: shell
+
+  pyhf patchset inspect [OPTIONS] [PATCHSET]
+
+Contributors
+------------
+
+``v0.6.3`` benefited from contributions from:
+
+* Alexander Held
+
+.. |release v0.6.3| replace:: ``v0.6.3``
+.. _`release v0.6.3`: https://github.com/scikit-hep/pyhf/releases/tag/v0.6.3

--- a/docs/release-notes/v0.6.3.rst
+++ b/docs/release-notes/v0.6.3.rst
@@ -6,11 +6,15 @@ This is a patch release from ``v0.6.2`` → ``v0.6.3``.
 Important Notes
 ---------------
 
-* XXX The :func:`pyhf.simplemodels.hepdata_like` API has been deprecated in favor of
-  :func:`pyhf.simplemodels.uncorrelated_background`.
-  The :func:`pyhf.simplemodels.hepdata_like` API will be removed in ``pyhf`` ``v0.7.0``.
-  (PR :pr:`1438`)
-* XXX
+* With the addition of writing ROOT files in |uproot v4.1.0 release|_ the
+  ``xmlio`` extra no longer requires ``uproot3`` and all dependncies on
+  ``uproot3`` and ``uproot3-methods`` have been dropped.
+  (PR :pr:`1567`)
+* :func:`pyhf.workspace.Workspace.data` ``with_aux`` keyword arg has been
+  renamed to ``include_auxdata`` to improve API consistency.
+
+.. |uproot v4.1.0 release| replace:: ``uproot`` ``v4.1.0``
+.. _`uproot v4.1.0 release`: https://github.com/scikit-hep/uproot4/releases/tag/4.1.0
 
 Fixes
 -----
@@ -31,6 +35,12 @@ Python API
 * The :class:`pyhf.pdf._ModelConfig` ``channel_nbins`` dict is now sorted by
   keys to match the order of the ``channels`` dict.
   (PR :pr:`1546`)
+* :func:`pyhf.pdf._ModelConfig.par_names` can now handle non-scalar modifiers
+  with 1 parameter.
+  (PR :pr:`1560`)
+* :func:`pyhf.workspace.Workspace.data` ``with_aux`` keyword arg has been
+  renamed to ``include_auxdata`` to improve API consistency.
+  (PR :pr:`1562`)
 
 
 Contributors


### PR DESCRIPTION
# Description

Add `v0.6.3` release notes as part of completing Issue #1578 .

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add release notes for pyhf v0.6.3
   - c.f. https://github.com/scikit-hep/pyhf/releases/tag/v0.6.3
* Update link to uproot in README to point to uproot4 GitHub repo
* Add Sviatoslav Sydorenko as a contributor
```
