### PR TITLE
ci: Skip doctest for 'Minimum supported dependencies' workflow

### DIFF
--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -18,10 +18,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies and force lowest bound
       run: |
         python -m pip install --upgrade pip setuptools wheel
@@ -29,6 +31,8 @@ jobs:
         python -m pip --no-cache-dir --quiet install --editable .[test]
         python -m pip install --requirement lower-bound-requirements.txt
         python -m pip list
+
     - name: Test with pytest
       run: |
-        python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py --ignore src
+        # Ignore src/ to skip doctests and just tests API in tests/
+        python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py --ignore src/

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -34,5 +34,5 @@ jobs:
 
     - name: Test with pytest
       run: |
-        # Ignore src/ to skip doctests and just tests API in tests/
-        python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py --ignore src/
+        # Run on tests/ to skip doctests of src given examples are for latest APIs
+        python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py tests/

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -31,4 +31,4 @@ jobs:
         python -m pip list
     - name: Test with pytest
       run: |
-        python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+        python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py --ignore src


### PR DESCRIPTION
# Description

Run pytest explicitly over the tests/ directory only to avoid in the 'Minimum supported dependencies' workflow to avoid running doctest on the docstring examples. The latest version of the JAX docsting examples have some print failures that are incompatible with the older versions of JAX, even thought the API tests pass.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Run pytest explicitly over the tests/ directory only to avoid in the 'Minimum supported dependencies' workflow to avoid running doctest on the docstring examples
   - The docstring examples use the latest dependencies which might have different text output than older releases. So focus only on the API tests
```
