### PR TITLE
docs: Correct v0.6.3 release notes to note `pyhf.pdf._ModelConfig.channels` is a list

### DIFF
--- a/docs/release-notes/v0.6.3.rst
+++ b/docs/release-notes/v0.6.3.rst
@@ -56,7 +56,7 @@ Python API
       ['mu', 'uncorr_bkguncrt[0]', 'uncorr_bkguncrt[1]']
 
 * The :class:`pyhf.pdf._ModelConfig` ``channel_nbins`` dict is now sorted by
-  keys to match the order of the ``channels`` dict.
+  keys to match the order of the ``channels`` list.
   (PR :pr:`1546`)
 
 * The :func:`pyhf.workspace.Workspace.data` ``with_aux`` keyword arg has been


### PR DESCRIPTION
# Description

Fixes #1590
Change dict to list for ``channels`` because ``channels`` is a list, not a dict. 

Hi @matthewfeickert, how does this look?
Let me know if this needs any changes.
Thanks 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* In pyhf v0.6.3 pyhf.pdf._ModelConfig.channels is a list, but in the release notes it was incorreclty noted as a dict. Correct this.
   - Amends PR #1583
```