### PR TITLE
ci: Add Python 3.9 to 'Current Release' workflow tests

### DIFF
--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         exclude:
           - os: macos-latest
             python-version: 3.7

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -24,19 +24,23 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install from PyPI
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pyhf[backends,xmlio]
         python -m pip install 'pytest~=6.0' pytest-cov
         python -m pip list
+
     - name: Canary test public API
       run: |
         python -m pytest -r sx tests/test_public_api.py
+
     - name: Verify requirements in codemeta.json
       run: |
         python -m pip install jq "codemetapy>=0.3.4"

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -19,6 +19,8 @@ jobs:
         exclude:
           - os: macos-latest
             python-version: 3.7
+          - os: macos-latest
+            python-version: 3.8
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
# Description

Resolves #1581

Now that `pyhf` `v0.6.3` is out and supports Python 3.9 across all backends (TensorFlow was the missing one, all others have been supported for some time) there is a release on PyPI to test against Python 3.9

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add Python 3.9 to public API tests for the 'Current Release' workflow
   - Required a release to be on PyPI that supported _all_ backends on Python 3.9. With pyhf v0.6.3 out this is now possible.
```