### PR TITLE
docs: Update maintainer release checklist with v0.6.3 notes

### DIFF
--- a/.github/ISSUE_TEMPLATE/~release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/~release-checklist.md
@@ -25,6 +25,7 @@ about: Checklist for core developers to complete as part of making a release
 * [ ] Verify that a Binder has properly built for the new release.
 * [ ] Watch for a GitHub notification that there is an automatic PR to the
   [Conda-forge feedstock](https://github.com/conda-forge/pyhf-feedstock). This may take multiple hours to happen. If there are any changes needed to the Conda-forge release make them **from a personal account** and not from an organization account to have workflows properly trigger.
+   - [ ] Verify the requirements in the [Conda-forge feedstock](https://github.com/conda-forge/pyhf-feedstock) recipe `meta.yaml` match those in `setup.cfg` and `pyproject.toml`.
 
 ## After Release
 

--- a/.github/ISSUE_TEMPLATE/~release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/~release-checklist.md
@@ -23,7 +23,7 @@ about: Checklist for core developers to complete as part of making a release
 * [ ] Create a [GitHub release](https://github.com/scikit-hep/pyhf/releases) from the generated PR tag and copy the release notes published to the GitHub release page. The creation of the GitHub release triggers all other release related activities.
    - [ ] Before pasting in the release notes copy the changes that the GitHub bot has already queued up and pasted into the tag and place them in the "Changes" section of the release notes. If the release notes are published before these are copied then they will be overwritten and you'll have to add them back in by hand.
 * [ ] Verify there is a new [Zenodo DOI](https://doi.org/10.5281/zenodo.1169739) minted for the release.
-   - [ ] Verify that the new release archive metadata on Zenodo matches is being picked up correctly from `CITATION.cff`.
+   - [ ] Verify that the new release archive metadata on Zenodo matches is being picked up as expected from [`CITATION.cff`](https://github.com/scikit-hep/pyhf/blob/master/CITATION.cff).
 * [ ] Verify that a Binder has properly built for the new release.
 * [ ] Watch for a GitHub notification that there is an automatic PR to the
   [Conda-forge feedstock](https://github.com/conda-forge/pyhf-feedstock). This may take multiple hours to happen. If there are any changes needed to the Conda-forge release make them **from a personal account** and not from an organization account to have workflows properly trigger.

--- a/.github/ISSUE_TEMPLATE/~release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/~release-checklist.md
@@ -23,6 +23,7 @@ about: Checklist for core developers to complete as part of making a release
 * [ ] Create a [GitHub release](https://github.com/scikit-hep/pyhf/releases) from the generated PR tag and copy the release notes published to the GitHub release page. The creation of the GitHub release triggers all other release related activities.
    - [ ] Before pasting in the release notes copy the changes that the GitHub bot has already queued up and pasted into the tag and place them in the "Changes" section of the release notes. If the release notes are published before these are copied then they will be overwritten and you'll have to add them back in by hand.
 * [ ] Verify there is a new [Zenodo DOI](https://doi.org/10.5281/zenodo.1169739) minted for the release.
+   - [ ] Verify that the new release archive metadata on Zenodo matches is being picked up correctly from `CITATION.cff`.
 * [ ] Verify that a Binder has properly built for the new release.
 * [ ] Watch for a GitHub notification that there is an automatic PR to the
   [Conda-forge feedstock](https://github.com/conda-forge/pyhf-feedstock). This may take multiple hours to happen. If there are any changes needed to the Conda-forge release make them **from a personal account** and not from an organization account to have workflows properly trigger.

--- a/.github/ISSUE_TEMPLATE/~release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/~release-checklist.md
@@ -21,6 +21,7 @@ about: Checklist for core developers to complete as part of making a release
 
 * [ ] Watch the CI to ensure that the deployment to [PyPI](https://pypi.org/project/pyhf/) is successful.
 * [ ] Create a [GitHub release](https://github.com/scikit-hep/pyhf/releases) from the generated PR tag and copy the release notes published to the GitHub release page. The creation of the GitHub release triggers all other release related activities.
+   - [ ] Before pasting in the release notes copy the changes that the GitHub bot has already queued up and pasted into the tag and place them in the "Changes" section of the release notes. If the release notes are published before these are copied then they will be overwritten and you'll have to add them back in by hand.
 * [ ] Verify there is a new [Zenodo DOI](https://doi.org/10.5281/zenodo.1169739) minted for the release.
 * [ ] Verify that a Binder has properly built for the new release.
 * [ ] Watch for a GitHub notification that there is an automatic PR to the


### PR DESCRIPTION
# Description

Resolves #1578

Update the release checklist for project maintainers with notes taken during the pyhf v0.6.3 release process

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update the release checklist for project maintainers with notes taken during the pyhf v0.6.3 release process
   - Add check for copying release notes into GitHub release
   - Add check for Zenodo metadata consistency
   - Add check for Conda-forge feedstock requirements matching those of the GitHub project
```