### PR TITLE
ci: Use `jupyter-black` pre-commit hook over `nbqa-black`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,6 @@ repos:
 -   repo: https://github.com/psf/black
     rev: 21.8b0
     hooks:
-    - id: black
     - id: black-jupyter
 
 -   repo: https://github.com/asottile/blacken-docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,5 +52,3 @@ repos:
     hooks:
     - id: nbqa-pyupgrade
       additional_dependencies: [pyupgrade==2.25.0]
-    - id: nbqa-black
-      additional_dependencies: [black==21.8b0]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
     rev: 21.8b0
     hooks:
     - id: black
+    - id: black-jupyter
 
 -   repo: https://github.com/asottile/blacken-docs
     rev: v1.11.0


### PR DESCRIPTION
# Description

Resolves #1594

Wit the addition of the `jupyter-black` hook by @MarcoGorelli (c.f. https://github.com/psf/black/pull/2357) in `black` `v21.8b0` the `nbqa-black` hook has essentially been contributed to Black and now `nbqa-black` is no longer needed. This has the additional advantage of being tied to the Black version directly and doesn't require updating the Black version as an `additional_dependencies` of `nbqa-black` and also that the `black` hook id is now also contained in `black-jupyter`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use jupyter-black pre-commit hook id from Black
   - black-jupyter will run on Python and pyi files, so it replaces the black hook id as well
* Remove nbqa-black pre-commit hook from nbQA
   - Marco Gorelli essentially contributed nbqa-black to Black in the form of jupyter-black
```