### PR TITLE
docs: Add use citation from publishing statistical models white paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,4 @@
+% 2021-09-10
 @article{Cranmer:2021urp,
     author = "Cranmer, Kyle and others",
     title = "{Publishing statistical models: Getting the most out of particle physics experiments}",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,13 @@
+@article{Cranmer:2021urp,
+    author = "Cranmer, Kyle and others",
+    title = "{Publishing statistical models: Getting the most out of particle physics experiments}",
+    eprint = "2109.04981",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    month = "9",
+    year = "2021"
+}
+
 % 2021-08-23
 @article{Cranmer:2021oxr,
     author = "Cranmer, Kyle and Held, Alexander",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -6,7 +6,8 @@
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
     month = "9",
-    year = "2021"
+    year = "2021",
+    journal = ""
 }
 
 % 2021-08-23


### PR DESCRIPTION
# Description

Add use citation from [Publishing statistical models: Getting the most out of particle physics experiments](https://inspirehep.net/literature/1919763) &mdash; the particle physics broader community white paper. The pyhf dev team were all coauthors on this paper.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Publishing statistical models: Getting the most out of particle physics experiments'
   - c.f. https://inspirehep.net/literature/1919763
```