### PR TITLE
docs: Add `uproot4` writing speedup to v0.6.3 release notes

### DIFF
--- a/docs/release-notes/v0.6.3.rst
+++ b/docs/release-notes/v0.6.3.rst
@@ -10,6 +10,7 @@ Important Notes
   ``xmlio`` extra no longer requires ``uproot3`` and all dependencies on
   ``uproot3`` and ``uproot3-methods`` have been dropped.
   (PR :pr:`1567`)
+  uproot4 additionally brings large speedups to writing, that results in an order of magnitude faster conversion times for most workspace conversions from JSON back to XML + ROOT with pyhf json2xml.
 * All backends are now fully compatible and tested with
   `Python 3.9 <https://www.python.org/dev/peps/pep-0596/>`_.
   (PR :pr:`1574`)

--- a/docs/release-notes/v0.6.3.rst
+++ b/docs/release-notes/v0.6.3.rst
@@ -10,8 +10,8 @@ Important Notes
   ``xmlio`` extra no longer requires ``uproot3`` and all dependencies on
   ``uproot3`` and ``uproot3-methods`` have been dropped.
   (PR :pr:`1567`)
-  ``uproot4`` additionally brings large speedups to writing, that results in an
-  order of magnitude faster conversion times for most workspace conversions from
+  ``uproot4`` additionally brings large speedups to writing, which results in an
+  order of magnitude faster conversion time for most workspace conversions from
   JSON back to XML + ROOT with ``pyhf json2xml``.
 * All backends are now fully compatible and tested with
   `Python 3.9 <https://www.python.org/dev/peps/pep-0596/>`_.

--- a/docs/release-notes/v0.6.3.rst
+++ b/docs/release-notes/v0.6.3.rst
@@ -10,7 +10,9 @@ Important Notes
   ``xmlio`` extra no longer requires ``uproot3`` and all dependencies on
   ``uproot3`` and ``uproot3-methods`` have been dropped.
   (PR :pr:`1567`)
-  uproot4 additionally brings large speedups to writing, that results in an order of magnitude faster conversion times for most workspace conversions from JSON back to XML + ROOT with pyhf json2xml.
+  ``uproot4`` additionally brings large speedups to writing, that results in an
+  order of magnitude faster conversion times for most workspace conversions from
+  JSON back to XML + ROOT with ``pyhf json2xml``.
 * All backends are now fully compatible and tested with
   `Python 3.9 <https://www.python.org/dev/peps/pep-0596/>`_.
   (PR :pr:`1574`)


### PR DESCRIPTION
# Description

Retroactively make mention of the speedup in workspace conversion from JSON to XML + ROOT with the improvements in `uproot` `v4.1.1`. This was noticed by @alexander-held and is thanks to @jpivarski fixing a bug in https://github.com/scikit-hep/uproot4/pull/426.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add large speedup of workspace conversion from JSON to XML + ROOT with uproot v4.1.1 to pyhf v0.6.3 release notes
   - c.f. https://github.com/scikit-hep/uproot4/pull/426
```
