### PR TITLE
docs: Add use citation from collider signatures of coannihilating dark matter paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,14 @@
+% 2021-09-17
+@article{Baker:2021llj,
+    author = "Baker, Michael J. and Faroughy, Darius A. and Trifinopoulos, Sokratis",
+    title = "{Collider Signatures of Coannihilating Dark Matter in Light of the B-Physics Anomalies}",
+    eprint = "2109.08689",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    month = "9",
+    year = "2021"
+}
+
 % 2021-09-10
 @article{Cranmer:2021urp,
     author = "Cranmer, Kyle and others",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -6,7 +6,8 @@
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
     month = "9",
-    year = "2021"
+    year = "2021",
+    journal = ""
 }
 
 % 2021-09-10


### PR DESCRIPTION
# Description

Add use citation from [Collider Signatures of Coannihilating Dark Matter in Light of the B-Physics Anomalies](https://inspirehep.net/literature/1924354) by Michael J. Baker, Darius A. Faroughy, and Sokratis Trifinopoulos

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Collider Signatures of Coannihilating Dark Matter in Light of the B-Physics Anomalies'
   - c.f. https://inspirehep.net/literature/1924354
```
