### PR TITLE
docs: Add use citation from simplified likelihoods ATLAS PUB note

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -9,9 +9,7 @@
       month         = "Sep",
       year          = "2021",
       reportNumber  = "ATL-PHYS-PUB-2021-038",
-      url           = "https://cds.cern.ch/record/2782654",
-      note          = "All figures including auxiliary figures are available at
-                       https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PUBNOTES/ATL-PHYS-PUB-2021-038",
+      url           = "https://cds.cern.ch/record/2782654"
 }
 
 % 2021-09-17

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,19 @@
+%2021-09-30
+@booklet{ATL-PHYS-PUB-2021-038,
+      author        = "{ATLAS Collaboration}",
+      title         = "{Implementation of simplified likelihoods in HistFactory
+                       for searches for supersymmetry}",
+      institution   = "CERN",
+      address       = "Geneva",
+      number        = "ATL-PHYS-PUB-2021-038",
+      month         = "Sep",
+      year          = "2021",
+      reportNumber  = "ATL-PHYS-PUB-2021-038",
+      url           = "https://cds.cern.ch/record/2782654",
+      note          = "All figures including auxiliary figures are available at
+                       https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PUBNOTES/ATL-PHYS-PUB-2021-038",
+}
+
 % 2021-09-17
 @article{Baker:2021llj,
     author = "Baker, Michael J. and Faroughy, Darius A. and Trifinopoulos, Sokratis",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,4 +1,4 @@
-%2021-09-30
+% 2021-09-30
 @booklet{ATL-PHYS-PUB-2021-038,
       author        = "{ATLAS Collaboration}",
       title         = "{Implementation of simplified likelihoods in HistFactory


### PR DESCRIPTION
# Description

Add use citation from ATLAS PUB note [Implementation of simplified likelihoods in HistFactory for searches for supersymmetry](https://cdsweb.cern.ch/record/2782654) (ATL-PHYS-PUB-2021-038).

(Full disclosure, Giordon and Lukas were on the analysis team.)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Implementation of simplified likelihoods in HistFactory for searches for supersymmetry'
   - ATLAS PUB note: ATL-PHYS-PUB-2021-038
   - c.f. https://cdsweb.cern.ch/record/2782654
```