### PR TITLE
docs: Use sphinxcontrib-bibtex style 'unsrt' to sort citations in reverse chronological order

### DIFF
--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -25,17 +25,17 @@ Use Citations
 ~~~~~~~~~~~~~
 
 .. bibliography:: bib/use_citations.bib
-   :list: bullet
+   :list: enumerated
    :all:
-   :style: plain
+   :style: unsrt
 
 General Citations
 ~~~~~~~~~~~~~~~~~
 
 .. bibliography:: bib/general_citations.bib
-   :list: bullet
+   :list: enumerated
    :all:
-   :style: plain
+   :style: unsrt
 
 Published Statistical Models
 ----------------------------
@@ -43,6 +43,6 @@ Published Statistical Models
 Updating list of HEPData entries for publications using ``HistFactory`` JSON statistical models:
 
 .. bibliography:: bib/HEPData_likelihoods.bib
-   :list: bullet
+   :list: enumerated
    :all:
-   :style: plain
+   :style: unsrt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,6 +65,7 @@ bibtex_bibfiles = [
     "bib/use_citations.bib",
     "bib/general_citations.bib",
 ]
+bibtex_default_style = "unsrt"
 
 # external links
 xref_links = {"arXiv:1007.1727": ("[1007.1727]", "https://arxiv.org/abs/1007.1727")}

--- a/docs/outreach.rst
+++ b/docs/outreach.rst
@@ -41,9 +41,9 @@ Presentations
 This list will be updated with talks given on :code:`pyhf`:
 
 .. bibliography:: bib/talks.bib
-   :list: bullet
+   :list: enumerated
    :all:
-   :style: plain
+   :style: unsrt
 
 Tutorials
 ---------
@@ -51,9 +51,9 @@ Tutorials
 This list will be updated with tutorials and schools given on :code:`pyhf`:
 
 .. bibliography:: bib/tutorials.bib
-   :list: bullet
+   :list: enumerated
    :all:
-   :style: plain
+   :style: unsrt
 
 
 Posters
@@ -62,9 +62,9 @@ Posters
 This list will be updated with posters presented on :code:`pyhf`:
 
 .. bibliography:: bib/posters.bib
-   :list: bullet
+   :list: enumerated
    :all:
-   :style: plain
+   :style: unsrt
 
 In the Media
 ------------
@@ -72,6 +72,6 @@ In the Media
 This list will be updated with media publications featuring :code:`pyhf`:
 
 .. bibliography:: bib/media.bib
-   :list: bullet
+   :list: enumerated
    :all:
-   :style: plain
+   :style: unsrt

--- a/docs/outreach.rst
+++ b/docs/outreach.rst
@@ -41,7 +41,7 @@ Presentations
 This list will be updated with talks given on :code:`pyhf`:
 
 .. bibliography:: bib/talks.bib
-   :list: enumerated
+   :list: bullet
    :all:
    :style: unsrt
 
@@ -51,7 +51,7 @@ Tutorials
 This list will be updated with tutorials and schools given on :code:`pyhf`:
 
 .. bibliography:: bib/tutorials.bib
-   :list: enumerated
+   :list: bullet
    :all:
    :style: unsrt
 
@@ -62,7 +62,7 @@ Posters
 This list will be updated with posters presented on :code:`pyhf`:
 
 .. bibliography:: bib/posters.bib
-   :list: enumerated
+   :list: bullet
    :all:
    :style: unsrt
 
@@ -72,6 +72,6 @@ In the Media
 This list will be updated with media publications featuring :code:`pyhf`:
 
 .. bibliography:: bib/media.bib
-   :list: enumerated
+   :list: bullet
    :all:
    :style: unsrt


### PR DESCRIPTION
# Description

Resolves #969

Set the `sphinxcontrib-bibtex` style to 'unsert` so that citations are sorted in reverse chronological order. Also make them enumerated lists (can they be made reverse order enumerated lists?)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use sphinxcontrib-bibtex style 'unsrt' to sort bibtex entries in reverse chronological order
* Set the conf.py bibtex_default_style to 'unsrt'
* Use the enumerated lists option for lists of citations
```