### PR TITLE
docs: Use sphinx-copybutton prompt regex to fully capture examples

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -325,7 +325,8 @@ html_extra_path = ['_extras']
 htmlhelp_basename = 'pyhfdoc'
 
 # sphinx-copybutton configuration
-copybutton_prompt_text = ">>> "
+copybutton_prompt_text = ">>> |\\\\$ |\\[\\d*\\]: |\\.\\.\\.: |\\.\\.\\. "
+copybutton_prompt_is_regexp = True
 
 # -- Options for LaTeX output ---------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -325,7 +325,7 @@ html_extra_path = ['_extras']
 htmlhelp_basename = 'pyhfdoc'
 
 # sphinx-copybutton configuration
-copybutton_prompt_text = ">>> |\\\\$ |\\[\\d*\\]: |\\.\\.\\.: |\\.\\.\\. "
+copybutton_prompt_text = ">>> |\\\\$ |\\.\\.\\. "
 copybutton_prompt_is_regexp = True
 
 # -- Options for LaTeX output ---------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -325,8 +325,9 @@ html_extra_path = ['_extras']
 htmlhelp_basename = 'pyhfdoc'
 
 # sphinx-copybutton configuration
-copybutton_prompt_text = ">>> |\\\\$ |\\.\\.\\. "
+copybutton_prompt_text = r">>> |\.\.\. |\$ "
 copybutton_prompt_is_regexp = True
+copybutton_here_doc_delimiter = "EOF"
 
 # -- Options for LaTeX output ---------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ extras_require['docs'] = sorted(
             'nbsphinx',
             'ipywidgets',
             'sphinx-issues',
-            'sphinx-copybutton>0.2.9',
+            'sphinx-copybutton>0.3.0',
         ]
     )
 )

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ extras_require['docs'] = sorted(
             'nbsphinx',
             'ipywidgets',
             'sphinx-issues',
-            'sphinx-copybutton>0.3.0',
+            'sphinx-copybutton>=0.3.2',
         ]
     )
 )


### PR DESCRIPTION
# Description

Apply results of https://github.com/executablebooks/sphinx-copybutton/pull/82 (released in [`sphinx-copybutton` `v0.3.0`](https://pypi.org/project/sphinx-copybutton/0.3.0/)) to use the `copybutton_prompt_text` regex support to accept both `>>>` and `...` as valid prompt text (along with the others shown in https://github.com/executablebooks/sphinx-copybutton/pull/82 to safeguard against future prompts) to allow for the "hello world" example from the README

https://github.com/scikit-hep/pyhf/blob/6db5223278bb3b54cb803c41d90e3972870ad1eb/README.rst#L42-L52

to be copied correctly.

This is covered in more depth in the sphinx-copybutton docs on how to [Strip and configure input prompts for code cells](https://sphinx-copybutton.readthedocs.io/en/latest/#strip-and-configure-input-prompts-for-code-cells).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add copybutton_prompt_text regex support to allow for the prompt character to be `>>>`, `$`, or `...` to handle newlines
   - c.f. https://sphinx-copybutton.readthedocs.io/en/latest/#strip-and-configure-input-prompts-for-code-cells
* Add support for HERE-document syntax with $ prompt
* Update minimum required version of sphinx-copybutton to v0.3.2 to ensure HERE-document support
```
