### PR TITLE
ci: Allow reporting of coverage on PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   test:
 
     runs-on: ${{ matrix.os }}
-    # On push events run the CI only on master by default, but run on any branch if the commit message contains 'ci all'
+    # On push events run the CI only on master by default, but run on any branch if the commit message contains '[ci all]'
     if: >-
       github.event_name != 'push'
       || (github.event_name == 'push' && github.ref == 'refs/heads/master')


### PR DESCRIPTION
# Description

Resolves #1559 

On all events (with the exception on `schedule` events) triggered by maintainers on the main project upload coverage to Codecov using the `secrets.CODECOV_TOKEN` (which seems to be faster?). If the event comes from a fork, then rely on the fact that the token isn't required, and upload the Coverage results on `pull_request` events.


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Run CI on push events to master by default, but on any branch on a push event if the commit message contains '[ci all]'
   - Results in a skip of push event tests on PRs by default
* Run CI on pull_request events to master
* Allow reporting of test coverage to Codecov on pull_request events from forks
   - Use fact that secrets.CODECOV_TOKEN is not required for public repos
   - c.f. https://github.com/codecov/codecov-action/blob/260aa3b4b2f265b8578bc0e721e33ebf8ff53313/README.md
   - On all events, except schedule, from maintainers, upload coverage to codecov.io faster using the CODECOV_TOKEN secret
   - On pull_request events from contributor forks, upload coverage to codecov.io without using CODECOV_TOKEN secret
```
