### PR TITLE
ci: Update codecov-action to v2 API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+        files: ./coverage.xml
         flags: unittests
 
     - name: Report core project coverage with Codecov (contributors)
@@ -63,7 +63,7 @@ jobs:
       if: github.repository != 'scikit-hep/pyhf' && github.event_name == 'pull_request' && matrix.python-version == 3.9 && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         flags: unittests
 
     - name: Test Contrib module with pytest
@@ -76,7 +76,7 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+        files: ./coverage.xml
         flags: contrib
 
     - name: Report contrib coverage with Codecov (contributors)
@@ -84,7 +84,7 @@ jobs:
       if: github.repository != 'scikit-hep/pyhf' && github.event_name == 'pull_request' && matrix.python-version == 3.9 && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         flags: contrib
 
     - name: Run benchmarks


### PR DESCRIPTION
# Description

Requires PR #1622 to go in first.

Update [codecov/codecov-action](https://github.com/codecov/codecov-action) to `v2` API as [`v1` API is being deprecated in 2022](https://github.com/codecov/codecov-action/blob/260aa3b4b2f265b8578bc0e721e33ebf8ff53313/README.md).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update to codecov/codecov-action v2
   - c.f. https://github.com/codecov/codecov-action
   - Update `file` -> `files`
```
