### PR TITLE
ci: Report coverage to Codecov without token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
       if: github.event_name != 'schedule' && matrix.python-version == 3.9 && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml
         flags: unittests
 
@@ -65,7 +64,6 @@ jobs:
       if: github.event_name != 'schedule' && matrix.python-version == 3.9 && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml
         flags: contrib
 


### PR DESCRIPTION
# Description

Resolves #1559

This should _actually_ resolve Issue #1559 by using the tokenless infrastructure that Codecov now supports (c.f. https://github.com/codecov/codecov-action/issues/29#issuecomment-595288709).

This infrastructure has already existed, but in newer versions of the GitHub Action it is supposed to work better, so we'll see how quickly the coverage report comes in.

(cc @alexander-held as this has been an Issue for `cabinetry` in the past I think).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Report coverage to Codecov without using a secret Codecov token
   - c.f. https://github.com/codecov/codecov-action/issues/29#issuecomment-595288709
   - Effectively reverts Codecov logic part of PR #1622
* Ensure codecov/codecov-action v2 used
   - Amends PR #1623
```