### PR TITLE
ci: Limit concurrent workflow jobs to one per workflow per branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.head_ref }}
+  group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
   - cron:  '1 0 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: codeql-${{ github.head_ref }}
+  group: codeql-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,10 @@ on:
     - cron: '1 0 * * 0'
   workflow_dispatch:
 
+concurrency:
+  group: codeql-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,10 @@ on:
     types: [published]
   workflow_dispatch:
 
+concurrency:
+  group: docker-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   docker:
     name: Build, test, and publish Docker images to Docker Hub

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: docker-${{ github.head_ref }}
+  group: docker-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: docs-${{ github.head_ref }}
+  group: docs-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: docs-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   docs:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: lint-${{ github.head_ref }}
+  group: lint-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: lint-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
 

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -18,7 +18,7 @@ on:
         - true
 
 concurrency:
-  group: package-${{ github.head_ref }}
+  group: package-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -17,6 +17,10 @@ on:
         - false
         - true
 
+concurrency:
+  group: package-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-publish:
     name: Build and publish Python distro to (Test)PyPI

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -6,6 +6,10 @@ on:
   - cron:  '1 0 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: release-tests-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
 
   pypi_release:

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: release-tests-${{ github.head_ref }}
+  group: release-tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
# Description

Resolves #1631 

Use GitHub Actions `concurrency` key with `cancel-in-progress` option to limit the number of concurrent workflow jobs to one per workflow per ~~`github.head_ref`~~ `github.ref` (so per branch which results in per PR). This should speed up CI by keeping the queue clear by canceling CI jobs when another commit has been pushed that would kick off the same workflow.

Example:
* On a PR a commit is pushed that doesn't pass the `pre-commit` checks.
* `pre-commit.ci` pushes back the changes that allows for `pre-commit` to pass.
* There would now be two jobs running for all the GHA workflows that run per PR, which is wasteful and slows things down.
* With 

```yaml
concurrency:
  group: some-identifying-string-${{ github.ref }}
  cancel-in-progress: true
```

the offending first workflow job is canceled and the second workflow job from `pre-commit.ci`'s push can start.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add concurrency groups to all workflows that run on PRs
   - Use 'cancel-in-progress' option to cancel already running workflow jobs
   - This should speed up CI by keeping the queue clear by canceling CI jobs
      when another commit has been pushed that would kick off the same
      workflow
   - https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency
```