### PR TITLE
ci: Add absolufy-imports pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
 -   repo: https://github.com/MarcoGorelli/absolufy-imports
     rev: v0.3.0
     hooks:
-    -   id: absolufy-imports
+    - id: absolufy-imports
 
 -   repo: https://github.com/psf/black
     rev: 21.9b0


### PR DESCRIPTION
# Description

As PR #1539 switched over to absolute imports, we should codify this by checking for it in `pre-commit`. @MarcoGorelli made a pre-commit hook that does this for us (:tada:): [`absolufy-imports`](https://github.com/MarcoGorelli/absolufy-imports).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add absolufy-imports pre-commit hook to ensure that absolute imports are used
   - Motivation comes from switching over to absolute imports in PR #1539
   - c.f. https://github.com/MarcoGorelli/absolufy-imports
```
