### PR TITLE
test: Use netlocs that are known to not exist or give known return

### DIFF
--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -560,7 +560,7 @@ def test_patchset_download(tmpdir, script_runner, archive):
         "pyhf.exceptions.InvalidArchiveHost: www.pyhfthisdoesnotexist.org is not an approved archive host"
         in ret.stderr
     )
-    # Valid URL but doesn't contain file
+    # Force a download from a real URL, but one that doesn't have an existing file
     command = f'pyhf contrib download --verbose --force https://httpstat.us/404/record/resource/1234567 {tmpdir.join("likelihoods").strpath}'
     ret = script_runner.run(*shlex.split(command))
     assert not ret.success


### PR DESCRIPTION
# Description

* Resolves #1451
* Needed for PR #1647 and others


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use netloc of www.pyhfthisdoesnotexist.org which is known to not exist
to test not an approved archive host
* Use https://httpstat.us/404/ to provide a valid URL that exists but
which does not contain a valid file
   - c.f. https://httpstat.us/
```