### PR TITLE
ci: Add release candidates to HEAD of dependencies workflow

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  releasecandidates:
+  release-candidates:
 
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
# Description

Resolves #1659

Add release-candidates job to HEAD of dependencies workflow that uses pip's `--pre` option to pickup release candidates on PyPI during installation. This should mean that we catch API and behavioral changes from things like TensorFlow and PyTorch a few weeks in advance.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add release-candidates job to HEAD of dependencies workflow that
uses pip's `--pre` option to pickup release candidates on PyPI
during installation.
   - From `pip install --help`:
     --pre Include pre-release and development versions. By default,
     pip only finds stable versions.
   - This should catch upcoming API breaking changes a few weeks in
    advance from the major backends
```