### PR TITLE
ci: Turn off PyPI release tests on pull requests

### DIFF
--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -13,13 +13,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: [3.7, 3.8, 3.9]
-        exclude:
+        include:
           - os: macos-latest
-            python-version: 3.7
-          - os: macos-latest
-            python-version: 3.8
+            python-version: 3.9
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
# Description

At the moment, the PyPI release tests run on pull requests

https://github.com/scikit-hep/pyhf/blob/9fbbbf9740175fcdfe73fedc4351953be18d2664/.github/workflows/release_tests.yml#L1-L4

but this doesn't add much value and once we know that we've broken the public API there isn't much benefit in being reminded of this every PR. This PR just lets them continue to run nightly and on demand.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Turn off running PyPI release tests on pull requests given limited value add
* Use 'include' keyword over 'exclude' to reduce test matrix maintenance
```