### PR TITLE
Removed hepdata-like with the test

### DIFF
--- a/src/pyhf/simplemodels.py
+++ b/src/pyhf/simplemodels.py
@@ -151,20 +151,3 @@ def _deprecated_api_warning(
         DeprecationWarning,
         stacklevel=3,  # Raise to user level
     )
-
-
-def hepdata_like(signal_data, bkg_data, bkg_uncerts, batch_size=None):
-    """
-    .. note:: Deprecated API: Use :func:`~pyhf.simplemodels.uncorrelated_background`
-     instead.
-
-    .. warning:: :func:`~pyhf.simplemodels.hepdata_like` will be removed in
-     ``pyhf`` ``v0.7.0``.
-    """
-    _deprecated_api_warning(
-        "pyhf.simplemodels.hepdata_like",
-        "pyhf.simplemodels.uncorrelated_background",
-        "0.6.2",
-        "0.7.0",
-    )
-    return uncorrelated_background(signal_data, bkg_data, bkg_uncerts, batch_size)

--- a/tests/test_simplemodels.py
+++ b/tests/test_simplemodels.py
@@ -1,5 +1,3 @@
-import warnings
-
 import pytest
 import pyhf
 
@@ -76,17 +74,3 @@ def test_uncorrelated_background_default_backend(default_backend):
         'uncorr_bkguncrt[1]',
     ]
     assert model.config.suggested_init() == [1.0, 1.0, 1.0]
-
-
-# TODO: Remove when pyhf.simplemodels.hepdata_like is removed in pyhf v0.7.0
-def test_deprecated_apis():
-    with warnings.catch_warnings(record=True) as _warning:
-        # Cause all warnings to always be triggered
-        warnings.simplefilter("always")
-        pyhf.simplemodels.hepdata_like([12.0, 11.0], [50.0, 52.0], [3.0, 7.0])
-        assert len(_warning) == 1
-        assert issubclass(_warning[-1].category, DeprecationWarning)
-        assert (
-            "pyhf.simplemodels.hepdata_like is deprecated in favor of pyhf.simplemodels.uncorrelated_background"
-            in str(_warning[-1].message)
-        )


### PR DESCRIPTION
# Description
Resolves #1658.
This PR removes ```pyhf.simplemodels.hepdata_like``` in src/simplemodels along with the test in tests/test_simplemodels for ```v0.7.0```. It has been deprecated since ```v0.6.2```.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
- [ ] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR
