### PR TITLE
refactor: Pass `Accept` header to requests in `contrib.utils.download`

### DIFF
--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -53,6 +53,12 @@ try:
                     + "To download an archive from this host use the --force option."
                 )
 
+        # c.f. https://github.com/scikit-hep/pyhf/issues/1491
+        # > Use content negotiation at the landing page for the resource that
+        # > the DOI resolves to. DataCite content negotiation is forwarding all
+        # > requests with unknown content types to the URL registered in the
+        # > handle system.
+        # c.f. https://blog.datacite.org/changes-to-doi-content-negotiation/
         with requests.get(
             archive_url, headers={"Accept": "application/x-tar"}
         ) as response:

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -53,7 +53,10 @@ try:
                     + "To download an archive from this host use the --force option."
                 )
 
-        with requests.get(archive_url) as response:
+        # _headers={"Accept": "application/x-tar"}
+        with requests.get(
+            archive_url, headers={"Accept": "application/x-tar"}
+        ) as response:
             if compress:
                 with open(output_directory, "wb") as archive:
                     archive.write(response.content)

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -53,7 +53,6 @@ try:
                     + "To download an archive from this host use the --force option."
                 )
 
-        # _headers={"Accept": "application/x-tar"}
         with requests.get(
             archive_url, headers={"Accept": "application/x-tar"}
         ) as response:

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -59,6 +59,9 @@ try:
         # > requests with unknown content types to the URL registered in the
         # > handle system.
         # c.f. https://blog.datacite.org/changes-to-doi-content-negotiation/
+        # The HEPData landing page for the resource file can check if the Accept
+        # request HTTP header matches the content type of the resource file and
+        # return the content directly if so.
         with requests.get(
             archive_url, headers={"Accept": "application/x-tar"}
         ) as response:


### PR DESCRIPTION
# Description

* Resolves #1491
* First step in addressing Issue #1672 

> The HEPData landing page for the resource file can check if the [`Accept`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept) request HTTP header matches the content type of the resource file and return the content directly if so, for example, `curl -LH "Accept: application/x-tar" https://doi.org/10.17182/hepdata.89408.v1/r2`.


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Pass requests the `Accept` HTTP header that matches the content type
of the resource file. The HEPData landing page for the resource
requested can check if the header matches and then return the content
directly.
   - c.f. https://blog.datacite.org/changes-to-doi-content-negotiation/

Co-authored-by: Graeme Watt <Graeme.Watt@durham.ac.uk>
```