### PR TITLE
fix: Use https protocol as unauthenticated git protocol is no longer supported

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -108,7 +108,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade .[test]
         python -m pip uninstall --yes uproot
-        python -m pip install --upgrade git+git://github.com/scikit-hep/uproot4.git
+        python -m pip install --upgrade git+https://github.com/scikit-hep/uproot4.git
         python -m pip list
     - name: Test with pytest
       run: |
@@ -133,7 +133,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade .[test]
         python -m pip uninstall --yes pytest
-        python -m pip install --upgrade git+git://github.com/pytest-dev/pytest.git
+        python -m pip install --upgrade git+https://github.com/pytest-dev/pytest.git
         python -m pip list
     - name: Test with pytest
       run: |

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -83,7 +83,7 @@ jobs:
         python -m pip --no-cache-dir --quiet install --upgrade .[test]
         python -m pip uninstall --yes iminuit
         python -m pip install --upgrade cython
-        python -m pip install --upgrade git+git://github.com/scikit-hep/iminuit.git
+        python -m pip install --upgrade git+https://github.com/scikit-hep/iminuit.git
         python -m pip list
     - name: Test with pytest
       run: |


### PR DESCRIPTION
# Description

Use of the unauthenticated git protocol (`git://`) is no longer supported on GitHub (c.f. the 2021-09-01 GitHub Security blog [Improving Git protocol security on GitHub](https://github.blog/2021-09-01-improving-git-protocol-security-github/)). As a result, the [current HEAD of dependencies workflow](https://github.com/scikit-hep/pyhf/blob/377b85de8c5440c8e09bf2945778a4e0dfc65cca/.github/workflows/dependencies-head.yml) fails with the following error.

```
Collecting git+git://github.com/scikit-hep/uproot4.git
  Cloning git://github.com/scikit-hep/uproot4.git to /tmp/pip-req-build-faju_mnt
  Running command git clone --filter=blob:none -q git://github.com/scikit-hep/uproot4.git /tmp/pip-req-build-faju_mnt
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
WARNING: Discarding git+git://github.com/scikit-hep/uproot4.git. Command errored out with exit status 128: git clone --filter=blob:none -q git://github.com/scikit-hep/uproot4.git /tmp/pip-req-build-faju_mnt Check the logs for full command output.
ERROR: Command errored out with exit status 128: git clone --filter=blob:none -q git://github.com/scikit-hep/uproot4.git /tmp/pip-req-build-faju_mnt Check the logs for full command output.
```

To avoid this, use the `https://` for cloning a Git repo.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use the https protocol to clone Git repositories over the
unauthenticated git protocol (git://) as it is no longer
supported on GitHub as of 2021-11-02.
   - c.f. https://github.blog/2021-09-01-improving-git-protocol-security-github/
```