### PR TITLE
docs: Add ATLAS top group probability model records through June 2021

### DIFF
--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -61,6 +61,15 @@
     collaboration = "ATLAS",
 }
 
+@misc{1802524,
+    title = "{Measurement of the $t\bar{t}$ production cross-section in the lepton+jets channel at $\sqrt{s}=13$ TeV with the ATLAS experiment}",
+    doi = "10.17182/hepdata.95748",
+    url = "https://doi.org/10.17182/hepdata.95748",
+    year = "2020",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
 @misc{ins1788448,
     title = "{Search for long-lived, massive particles in events with a displaced vertex and a muon with large impact parameter in $pp$ collisions at $\sqrt{s} = 13$ TeV with the ATLAS detector}",
     doi = "10.17182/hepdata.91760",

--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -7,6 +7,15 @@
     collaboration = "ATLAS",
 }
 
+@misc{ins1869695,
+    title = "{Measurement of the $t\bar{t}t\bar{t}$ production cross section in $pp$ collisions at $\sqrt{s}$=13 TeV with the ATLAS detector}",
+    doi = "10.17182/hepdata.105039",
+    url = "https://doi.org/10.17182/hepdata.105039",
+    year = "2021",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
 @misc{ins1869040,
     title = "{Search for R-parity violating supersymmetry in a final state containing leptons and many jets with the ATLAS experiment using $\sqrt{s} = 13$ TeV proton-proton collision data}",
     doi = "10.17182/hepdata.104860",
@@ -20,6 +29,15 @@
     title = "{Search for chargino--neutralino pair production in final states with three leptons and missing transverse momentum in $\sqrt{s} = 13$ TeV $pp$ collisions with the ATLAS detector}",
     doi = "10.17182/hepdata.95751",
     url = "https://doi.org/10.17182/hepdata.95751",
+    year = "2021",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
+@misc{ins1853014,
+    title = "{Measurements of the inclusive and differential production cross sections of a top-quark-antiquark pair in association with a $Z$ boson at $\sqrt{s} = 13$ TeV with the ATLAS detector}",
+    doi = "10.17182/hepdata.100351",
+    url = "https://doi.org/10.17182/hepdata.100351",
     year = "2021",
     type = "Data Collection",
     collaboration = "ATLAS",

--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -61,7 +61,7 @@
     collaboration = "ATLAS",
 }
 
-@misc{1802524,
+@misc{ins1802524,
     title = "{Measurement of the $t\bar{t}$ production cross-section in the lepton+jets channel at $\sqrt{s}=13$ TeV with the ATLAS experiment}",
     doi = "10.17182/hepdata.95748",
     url = "https://doi.org/10.17182/hepdata.95748",

--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -50,4 +50,6 @@ Updating list of HEPData entries for publications using ``HistFactory`` JSON sta
 .. note::
 
    ATLAS maintains a public list of `all published statistical models for supersymmetry
-   searches <https://twiki.cern.ch/twiki/bin/view/AtlasPublic/SupersymmetryPublicResults>`__.
+   searches <https://twiki.cern.ch/twiki/bin/view/AtlasPublic/SupersymmetryPublicResults>`__
+   and for `top physics results
+   <https://twiki.cern.ch/twiki/bin/view/AtlasPublic/TopPublicResults>`__.


### PR DESCRIPTION
# Description

Add HEPData record for published statistical model and observations for the following ATLAS top physics results:

* [Measurement of the tt̅ production cross-section in the lepton+jets channel at s√ =13 TeV with the ATLAS experiment](https://www.hepdata.net/record/ins1802524)
* [Measurements of the inclusive and differential production cross sections of a top-quark-antiquark pair in association with a Z boson at s√ =13 TeV with the ATLAS detector](https://www.hepdata.net/record/ins1853014)
* [Measurement of the tt̅tt̅ production cross section in pp collisions at s√ =13 TeV with the ATLAS detector](https://www.hepdata.net/record/ins1869695)

These models started to be published [in Summer 2020 along with Phys. Lett. B 810 (2020) 135797](https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PAPERS/TOPQ-2020-02/), but were somehow missed by the `pyhf` team until [very recently](https://twitter.com/kratsg/status/1454134846654062598).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add HEPData records for published statistical models for ATLAS:
   - Measurement of the ttbar production cross-section in the lepton+jets channel at 13 TeV
      + c.f. https://www.hepdata.net/record/ins1802524
   - Measurement of ttZ cross sections in Run 2
      + c.f. https://www.hepdata.net/record/ins1853014
   - 4-top cross-section measurement
      + c.f. https://www.hepdata.net/record/ins1869695
* Add link ATLAS top physics public results page
```
