### PR TITLE
docs: Add ATLAS third-generation scalar leptoquarks search statistical model record

### DIFF
--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -43,6 +43,15 @@
     collaboration = "ATLAS",
 }
 
+@misc{ins1843001,
+    title = "{Search for pair production of third-generation scalar leptoquarks decaying into a top quark and a $\tau$-lepton in $pp$ collisions at $ \sqrt{s} $ = 13 TeV with the ATLAS detector}",
+    doi = "10.17182/hepdata.100174",
+    url = "https://doi.org/10.17182/hepdata.100174",
+    year = "2021",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
 @misc{ins1839446,
     title = "{Search for squarks and gluinos in final states with one isolated lepton, jets, and missing transverse momentum at $\sqrt{s}=13$  with the ATLAS detector}",
     doi = "10.17182/hepdata.97041",

--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -49,7 +49,6 @@ Updating list of HEPData entries for publications using ``HistFactory`` JSON sta
 
 .. note::
 
-   ATLAS maintains a public list of `all published statistical models for supersymmetry
-   searches <https://twiki.cern.ch/twiki/bin/view/AtlasPublic/SupersymmetryPublicResults>`__
-   and for `top physics results
-   <https://twiki.cern.ch/twiki/bin/view/AtlasPublic/TopPublicResults>`__.
+   ATLAS maintains a public listing of all published statistical models on the `ATLAS public results
+   page <https://twiki.cern.ch/twiki/bin/view/AtlasPublic>`__ which can be found by filtering all
+   public results by the "Likelihood available" analysis characteristics keyword.


### PR DESCRIPTION
# Description

Add HEPData record for published statistical model and observations for ATLAS Exotics search [Search for pair production of third-generation scalar leptoquarks decaying into a top quark and a tau-lepton in pp collisions at √s = 13 TeV with the ATLAS detector](https://www.hepdata.net/record/ins1843001) (c.f. [JHEP 06 (2021) 179](https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PAPERS/EXOT-2019-15/)). Also link to the ATLAS public results page for stats model listing.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add ATLAS third-generation scalar leptoquarks search probability model
HEPDdata record
   - c.f. https://www.hepdata.net/record/ins1843001
* Change ATLAS probability models listing to all ATLAS public results
page with clarification on keyword filters
```
