### PR TITLE
refactor: Use tensorlib.percentile in calculators

### DIFF
--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -925,11 +925,26 @@ class ToyCalculator:
         normal_percentiles = tb.astensor(
             [2.27501319, 15.86552539, 50.0, 84.13447461, 97.72498681]
         )
+
+        # TODO: Add transpose to tensorlib
+        # pvalues_exp_band = tb.transpose(
+        #     tb.percentile(
+        #         pvalues,
+        #         normal_percentiles,
+        #         axis=0,
+        #     )
+        # )
         pvalues_exp_band = tb.percentile(
             pvalues,
             normal_percentiles,
             axis=0,
-        ).T.tolist()
+        )
+        if tb.name == "tensorflow":
+            import tensorflow as tf
+
+            pvalues_exp_band = tf.transpose(pvalues_exp_band)
+        else:
+            pvalues_exp_band = pvalues_exp_band.T
         return [[tb.astensor(pvalue) for pvalue in band] for band in pvalues_exp_band]
 
     def teststatistic(self, poi_test):

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -926,25 +926,13 @@ class ToyCalculator:
             [2.27501319, 15.86552539, 50.0, 84.13447461, 97.72498681]
         )
 
-        # TODO: Add transpose to tensorlib
-        # pvalues_exp_band = tb.transpose(
-        #     tb.percentile(
-        #         pvalues,
-        #         normal_percentiles,
-        #         axis=0,
-        #     )
-        # )
-        pvalues_exp_band = tb.percentile(
-            pvalues,
-            normal_percentiles,
-            axis=0,
+        pvalues_exp_band = tb.transpose(
+            tb.percentile(
+                pvalues,
+                normal_percentiles,
+                axis=0,
+            )
         )
-        if tb.name == "tensorflow":
-            import tensorflow as tf
-
-            pvalues_exp_band = tf.transpose(pvalues_exp_band)
-        else:
-            pvalues_exp_band = pvalues_exp_band.T
         return [[tb.astensor(pvalue) for pvalue in band] for band in pvalues_exp_band]
 
     def teststatistic(self, poi_test):

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -665,11 +665,11 @@ class EmpiricalDistribution:
             Float: The expected value of the test statistic.
         """
         tensorlib, _ = get_backend()
-        import numpy as np
+        # import numpy as np
 
         # TODO: tensorlib.percentile function
         # c.f. https://github.com/scikit-hep/pyhf/pull/817
-        return np.percentile(
+        return tensorlib.percentile(
             self.samples, tensorlib.normal_cdf(nsigma) * 100, interpolation="linear"
         )
 
@@ -924,11 +924,11 @@ class ToyCalculator:
         ]
         # TODO: Add percentile to tensorlib
         # c.f. Issue #815, PR #817
-        import numpy as np
+        # import numpy as np
 
         # percentiles for -2, -1, 0, 1, 2 standard deviations of the Normal distribution
         normal_percentiles = [2.27501319, 15.86552539, 50.0, 84.13447461, 97.72498681]
-        pvalues_exp_band = np.percentile(
+        pvalues_exp_band = tb.percentile(
             pvalues,
             normal_percentiles,
             axis=0,

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -665,10 +665,6 @@ class EmpiricalDistribution:
             Float: The expected value of the test statistic.
         """
         tensorlib, _ = get_backend()
-        # import numpy as np
-
-        # TODO: tensorlib.percentile function
-        # c.f. https://github.com/scikit-hep/pyhf/pull/817
         return tensorlib.percentile(
             self.samples, tensorlib.normal_cdf(nsigma) * 100, interpolation="linear"
         )
@@ -922,9 +918,6 @@ class ToyCalculator:
             )
             for test_stat in bkg_only_distribution.samples
         ]
-        # TODO: Add percentile to tensorlib
-        # c.f. Issue #815, PR #817
-        # import numpy as np
 
         # percentiles for -2, -1, 0, 1, 2 standard deviations of the Normal distribution
         normal_percentiles = [2.27501319, 15.86552539, 50.0, 84.13447461, 97.72498681]

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -910,17 +910,21 @@ class ToyCalculator:
             :math:`\mathrm{CL}_{b}`, and :math:`\mathrm{CL}_{s}`.
         """
         tb, _ = get_backend()
-        pvalues = [
-            self.pvalues(
-                test_stat,
-                sig_plus_bkg_distribution,
-                bkg_only_distribution,
-            )
-            for test_stat in bkg_only_distribution.samples
-        ]
+        pvalues = tb.astensor(
+            [
+                self.pvalues(
+                    test_stat,
+                    sig_plus_bkg_distribution,
+                    bkg_only_distribution,
+                )
+                for test_stat in bkg_only_distribution.samples
+            ]
+        )
 
         # percentiles for -2, -1, 0, 1, 2 standard deviations of the Normal distribution
-        normal_percentiles = [2.27501319, 15.86552539, 50.0, 84.13447461, 97.72498681]
+        normal_percentiles = tb.astensor(
+            [2.27501319, 15.86552539, 50.0, 84.13447461, 97.72498681]
+        )
         pvalues_exp_band = tb.percentile(
             pvalues,
             normal_percentiles,

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -927,11 +927,7 @@ class ToyCalculator:
         )
 
         pvalues_exp_band = tb.transpose(
-            tb.percentile(
-                pvalues,
-                normal_percentiles,
-                axis=0,
-            )
+            tb.percentile(pvalues, normal_percentiles, axis=0)
         )
         return [[tb.astensor(pvalue) for pvalue in band] for band in pvalues_exp_band]
 

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -913,9 +913,7 @@ class ToyCalculator:
         pvalues = tb.astensor(
             [
                 self.pvalues(
-                    test_stat,
-                    sig_plus_bkg_distribution,
-                    bkg_only_distribution,
+                    test_stat, sig_plus_bkg_distribution, bkg_only_distribution
                 )
                 for test_stat in bkg_only_distribution.samples
             ]


### PR DESCRIPTION
# Description

Now that PR #817 (and PR #1696), use `tensorlib.percentile` for the calculators.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use the tensorlib backends percentile functions when calculating
p-values in the calculators
   - tensorlib.percentile requires all inputs be tensors so ensure
     with tensorlib.astensor
```
