### PR TITLE
refactor: Make contrib.utils.download robust to archive file types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ extras_require['test'] = sorted(
             'pytest~=6.0',
             'pytest-cov>=2.5.1',
             'pytest-mock',
+            'requests-mock>=1.9.0',
             'pytest-benchmark[histogram]',
             'pytest-console-scripts',
             'pytest-mpl',

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -66,10 +66,8 @@ try:
         # The HEPData landing page for the resource file can check if the Accept
         # request HTTP header matches the content type of the resource file and
         # return the content directly if so.
-        # TODO: Figure out how to accept both x-tar and zip headers. :?
-        # with requests.get(
-        #     archive_url, headers={"Accept": "application/zip"}
-        # ) as response:
+        # TODO: Figure out how to accept headers of both application/x-tar and
+        # application/zip.
         with requests.get(
             archive_url, headers={"Accept": "application/x-tar"}
         ) as response:

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -5,6 +5,7 @@ import tarfile
 import zipfile
 from io import BytesIO
 from pathlib import Path
+from shutil import rmtree
 from urllib.parse import urlparse
 
 from pyhf import exceptions
@@ -100,6 +101,8 @@ try:
                         archive.extractall(output_directory)
                 else:
                     output_directory = Path(output_directory)
+                    if output_directory.exists():
+                        rmtree(output_directory)
                     with zipfile.ZipFile(BytesIO(response.content)) as archive:
                         archive.extractall(output_directory)
 
@@ -109,7 +112,9 @@ try:
                     # temporary path and then replace the output directory target with
                     # the contents at the temporary path.
                     child_path = [child for child in output_directory.iterdir()][0]
-                    _tmp_path = Path(output_directory.name + "_tmp_")
+                    _tmp_path = output_directory.parent.joinpath(
+                        Path(output_directory.name + "_tmp_")
+                    )
                     child_path.replace(_tmp_path).replace(output_directory)
 
 

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -71,6 +71,11 @@ try:
                     + "There is either something temporarily wrong with the archive host"
                     + f" or {archive_url} is an invalid URL."
                 )
+            if not tarfile.is_tarfile(BytesIO(response.content)):
+                raise exceptions.InvalidArchive(
+                    f"The archive downloaded from {archive_url} is not a tarfile"
+                    + " and so can not be opened as one."
+                )
             if compress:
                 with open(output_directory, "wb") as archive:
                     archive.write(response.content)

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -122,7 +122,8 @@ try:
                             Path(output_directory.name + "__tmp__")
                         )
                         child_path.replace(_tmp_path)
-                        # the zipfile could contain remnant __MACOSX directories from creation time
+                        # the zipfile could contain remnant __MACOSX directories
+                        # from creation time
                         rmtree(output_directory)
                         _tmp_path.replace(output_directory)
 

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -81,7 +81,7 @@ try:
                     archive.write(response.content)
             else:
                 with tarfile.open(
-                    mode="r|gz", fileobj=BytesIO(response.content)
+                    mode="r:*", fileobj=BytesIO(response.content)
                 ) as archive:
                     archive.extractall(output_directory)
 

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -90,6 +90,7 @@ try:
                     archive.write(response.content)
             else:
                 if _format == "tar":
+                    # Use transparent compression to allow for .tar or .tar.gz
                     with tarfile.open(
                         mode="r:*", fileobj=BytesIO(response.content)
                     ) as archive:

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -121,11 +121,9 @@ try:
                         _tmp_path = output_directory.parent.joinpath(
                             Path(output_directory.name + "__tmp__")
                         )
-                        # TODO: Once Python 3.7 support is dropped these two lines can be
-                        # combined by chaining the replace calls. This won't work in
-                        # Python 3.7 as pathlib.Path.replace was:
-                        # > Changed in version 3.8: Added return value, return the new Path instance.
                         child_path.replace(_tmp_path)
+                        # the zipfile could contain remnant __MACOSX directories from creation time
+                        rmtree(output_directory)
                         _tmp_path.replace(output_directory)
 
 

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -85,9 +85,10 @@ try:
                     archive.write(response.content)
             else:
                 # Support for file-like objects for tarfile.is_tarfile was added
-                # in Python 3.9, so as can't do tarfile.is_tarfile(BytesIO(response.content))
-                # just use a 'try except' block to determine if archive is a
-                # valid tarfile.
+                # in Python 3.9, so as pyhf is currently Python 3.7+ then can't
+                # do tarfile.is_tarfile(BytesIO(response.content)).
+                # Instead, just use a 'try except' block to determine if the
+                # archive is a valid tarfile.
                 # TODO: Simplify after pyhf is Python 3.9+ only
                 try:
                     # Use transparent compression to allow for .tar or .tar.gz

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -65,6 +65,12 @@ try:
         with requests.get(
             archive_url, headers={"Accept": "application/x-tar"}
         ) as response:
+            if response.status_code != 200:
+                raise exceptions.InvalidArchive(
+                    f"{archive_url} gives a response code of {response.status_code}.\n"
+                    + "There is either something temporarily wrong with the archive host"
+                    + f" or {archive_url} is an invalid URL."
+                )
             if compress:
                 with open(output_directory, "wb") as archive:
                     archive.write(response.content)

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -111,6 +111,9 @@ try:
                     # tarfile.TarFile.extractall move the extracted directory to a
                     # temporary path and then replace the output directory target with
                     # the contents at the temporary path.
+                    # The directory is moved instead of being extracted one directory
+                    # up and then renamed as the name of the zipfile directory is set
+                    # at zipfile creation time and isn't knowable in advance.
                     child_path = [child for child in output_directory.iterdir()][0]
                     _tmp_path = output_directory.parent.joinpath(
                         Path(output_directory.name + "_tmp_")

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -107,7 +107,7 @@ try:
                     # target directory, so to match the extraction path of
                     # tarfile.TarFile.extractall move the extracted directory to a
                     # temporary path and then replace the output directory target with
-                    # the temporary path.
+                    # the contents at the temporary path.
                     child_path = [child for child in output_directory.iterdir()][0]
                     _tmp_path = Path(output_directory.name + "_tmp_")
                     child_path.replace(_tmp_path).replace(output_directory)

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -123,7 +123,12 @@ try:
                         _tmp_path = output_directory.parent.joinpath(
                             Path(output_directory.name + "__tmp__")
                         )
-                        child_path.replace(_tmp_path).replace(output_directory)
+                        # TODO: Once Python 3.7 support is dropped these two lines can be
+                        # combined by chaining the replace calls. This won't work in
+                        # Python 3.7 as pathlib.Path.replace was:
+                        # > Changed in version 3.8: Added return value, return the new Path instance.
+                        child_path.replace(_tmp_path)
+                        _tmp_path.replace(output_directory)
 
 
 except ModuleNotFoundError:

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -65,6 +65,10 @@ try:
         # The HEPData landing page for the resource file can check if the Accept
         # request HTTP header matches the content type of the resource file and
         # return the content directly if so.
+        # TODO: Figure out how to accept both x-tar and zip headers. :?
+        # with requests.get(
+        #     archive_url, headers={"Accept": "application/zip"}
+        # ) as response:
         with requests.get(
             archive_url, headers={"Accept": "application/x-tar"}
         ) as response:

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -87,7 +87,6 @@ try:
                         + " or a zipfile and so can not be opened as one."
                     )
                 _format = "zip"
-            print(_format)
 
             if compress:
                 with open(output_directory, "wb") as archive:

--- a/src/pyhf/exceptions/__init__.py
+++ b/src/pyhf/exceptions/__init__.py
@@ -70,6 +70,10 @@ class InvalidArchiveHost(Exception):
     """InvalidArchiveHost is raised when a given patchset archive url is not an approved host."""
 
 
+class InvalidArchive(Exception):
+    """InvalidArchive is raised when a given patchset archive url does not return a valid response."""
+
+
 class InvalidPatchSet(Exception):
     """InvalidPatchSet is raised when a given patchset object does not have the right configuration, even though it validates correctly against the schema."""
 

--- a/tests/contrib/test_utils.py
+++ b/tests/contrib/test_utils.py
@@ -28,9 +28,13 @@ def test_download_invalid_archive(tmpdir, requests_mock, archive_url):
         download(archive_url, tmpdir.join("likelihoods").strpath)
 
 
-# @pytest.mark.parametrize(
-#     'compress', [True, False]
-# )
+def test_download_compress(tmpdir, requests_mock):
+    archive_url = "https://www.hepdata.net/record/resource/1408476?view=true"
+    requests_mock.get(archive_url)
+
+    download(archive_url, tmpdir.join("likelihoods").strpath, compress=True)
+
+
 @pytest.mark.parametrize(
     "archive_url",
     [

--- a/tests/contrib/test_utils.py
+++ b/tests/contrib/test_utils.py
@@ -1,3 +1,6 @@
+import tarfile
+import zipfile
+
 import pytest
 
 from pyhf.contrib.utils import download
@@ -21,5 +24,49 @@ def test_download_untrusted_archive_host(tmpdir, requests_mock):
 def test_download_invalid_archive(tmpdir, requests_mock, archive_url):
     requests_mock.get(archive_url, status_code=404)
 
+    with pytest.raises(InvalidArchive):
+        download(archive_url, tmpdir.join("likelihoods").strpath)
+
+
+# @pytest.mark.parametrize(
+#     'compress', [True, False]
+# )
+@pytest.mark.parametrize(
+    "archive_url",
+    [
+        "https://www.hepdata.net/record/resource/1408476?view=true",
+    ],
+)
+def test_download_archive_type(tmpdir, mocker, requests_mock, archive_url):
+    # Give BytesIO a tarfile
+    with tarfile.open(tmpdir.join("test_tar.tar.gz").strpath, mode="w:gz") as archive:
+        with open(tmpdir.join("test_tar_file.txt").strpath, "wb") as write_file:
+            write_file.write(b"tarfile test")
+        archive.add(tmpdir.join("test_tar_file.txt").strpath)
+
+    requests_mock.get(
+        archive_url,
+        content=open(tmpdir.join("test_tar.tar.gz").strpath, "rb").read(),
+    )
+    download(archive_url, tmpdir.join("likelihoods").strpath)
+
+    # Give BytesIO a zipfile
+    with zipfile.ZipFile(tmpdir.join("test_zip.zip").strpath, "w") as archive:
+        with open(tmpdir.join("test_zip_file.txt").strpath, "w") as write_file:
+            write_file.write("zipfile test")
+        archive.write(tmpdir.join("test_zip_file.txt").strpath)
+
+    requests_mock.get(
+        archive_url,
+        content=open(tmpdir.join("test_zip.zip").strpath, "rb").read(),
+    )
+    download(archive_url, tmpdir.join("likelihoods").strpath)
+
+    # TODO: This is hacky and ugly. Try to clean up with something else
+    requests_mock.get(archive_url)
+    mocker.patch(
+        "io.BytesIO",
+        return_value=open(tmpdir.join("test_tar.tar.gz").strpath, "rb"),
+    )
     with pytest.raises(InvalidArchive):
         download(archive_url, tmpdir.join("likelihoods").strpath)

--- a/tests/contrib/test_utils.py
+++ b/tests/contrib/test_utils.py
@@ -62,11 +62,8 @@ def test_download_archive_type(tmpdir, mocker, requests_mock, archive_url):
     )
     download(archive_url, tmpdir.join("likelihoods").strpath)
 
-    # TODO: This is hacky and ugly. Try to clean up with something else
-    requests_mock.get(archive_url)
-    mocker.patch(
-        "io.BytesIO",
-        return_value=open(tmpdir.join("test_tar.tar.gz").strpath, "rb"),
-    )
+    # Give BytesIO a zipfile (using same requests_mock as previous) but have
+    # zipfile.is_zipfile reject it
+    mocker.patch("zipfile.is_zipfile", return_value=False)
     with pytest.raises(InvalidArchive):
         download(archive_url, tmpdir.join("likelihoods").strpath)

--- a/tests/contrib/test_utils.py
+++ b/tests/contrib/test_utils.py
@@ -1,0 +1,25 @@
+import pytest
+
+from pyhf.contrib.utils import download
+from pyhf.exceptions import InvalidArchive, InvalidArchiveHost
+
+
+def test_download_untrusted_archive_host(tmpdir, requests_mock):
+    archive_url = "https://www.pyhfthisdoesnotexist.org"
+    requests_mock.get(archive_url)
+
+    with pytest.raises(InvalidArchiveHost):
+        download(archive_url, tmpdir.join("likelihoods").strpath)
+
+
+@pytest.mark.parametrize(
+    "archive_url",
+    [
+        "https://www.hepdata.net/record/resource/1408476?view=true",
+    ],
+)
+def test_download_invalid_archive(tmpdir, requests_mock, archive_url):
+    requests_mock.get(archive_url, status_code=404)
+
+    with pytest.raises(InvalidArchive):
+        download(archive_url, tmpdir.join("likelihoods").strpath)

--- a/tests/contrib/test_utils.py
+++ b/tests/contrib/test_utils.py
@@ -65,6 +65,8 @@ def test_download_archive_type(tmpdir, mocker, requests_mock, archive_url):
         content=open(tmpdir.join("test_zip.zip").strpath, "rb").read(),
     )
     download(archive_url, tmpdir.join("likelihoods").strpath)
+    # Run a second time to trigger shutil.rmtree of directory
+    download(archive_url, tmpdir.join("likelihoods").strpath)
 
     # Give BytesIO a zipfile (using same requests_mock as previous) but have
     # zipfile.is_zipfile reject it

--- a/tests/contrib/test_utils.py
+++ b/tests/contrib/test_utils.py
@@ -1,5 +1,7 @@
 import tarfile
 import zipfile
+from pathlib import Path
+from shutil import rmtree
 
 import pytest
 
@@ -64,9 +66,11 @@ def test_download_archive_type(tmpdir, mocker, requests_mock, archive_url):
         archive_url,
         content=open(tmpdir.join("test_zip.zip").strpath, "rb").read(),
     )
-    download(archive_url, tmpdir.join("likelihoods").strpath)
-    # Run a second time to trigger shutil.rmtree of directory
-    download(archive_url, tmpdir.join("likelihoods").strpath)
+    # Run without and with existing output_directory to cover both
+    # cases of the shutil.rmtree logic
+    rmtree(Path(tmpdir.join("likelihoods").strpath))
+    download(archive_url, tmpdir.join("likelihoods").strpath)  # without
+    download(archive_url, tmpdir.join("likelihoods").strpath)  # with
 
     # Give BytesIO a zipfile (using same requests_mock as previous) but have
     # zipfile.is_zipfile reject it

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -564,7 +564,7 @@ def test_patchset_download(tmpdir, script_runner, archive):
     command = f'pyhf contrib download --verbose --force https://httpstat.us/404/record/resource/1234567 {tmpdir.join("likelihoods").strpath}'
     ret = script_runner.run(*shlex.split(command))
     assert not ret.success
-    assert "tarfile.ReadError: not a gzip file" in ret.stderr
+    assert "gives a response code of 404" in ret.stderr
 
 
 def test_missing_contrib_extra(caplog):


### PR DESCRIPTION
# Description

* Resolves #1672
* Resolves #1111
* Resolves #1519
* Resolves #1486

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Refactor the internals of contrib.utils.download to be more robust and
handle uncompressed tarfile targets as well as zipfile targets.
* Mock HEPData responses to avoid load on HEPData API and avoid testing
problems due to HEPData outages. This generally makes the test suite more
robust.
* Add requests-mock as a dependency to the 'test' extra. requests-mock makes
mocking requests calls easy and allows for a pytest fixture.
* Add tests for contrib.utils.download Python API to test outside of script runner
```