### PR TITLE
build: Set only lower bounds on backend dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,12 @@ extras_require = {
     'shellcomplete': ['click_completion'],
     'tensorflow': [
         'tensorflow>=2.3.1',  # c.f. https://github.com/tensorflow/tensorflow/pull/40789
-        'tensorflow-probability>=0.11.0',
+        'tensorflow-probability>=0.11.0',  # c.f. PR #1657
     ],
-    'torch': ['torch>=1.10.0'],
+    'torch': ['torch>=1.10.0'],  # c.f. PR #1657
     'jax': ['jax>=0.2.10', 'jaxlib>=0.1.60,!=0.1.68'],  # c.f. Issue 1501
-    'xmlio': ['uproot>=4.1.1'],
-    'minuit': ['iminuit>=2.4'],
+    'xmlio': ['uproot>=4.1.1'],  # c.f. PR #1567
+    'minuit': ['iminuit>=2.4.0'],  # c.f. PR #1306
 }
 extras_require['backends'] = sorted(
     set(

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ extras_require['test'] = sorted(
         + extras_require['contrib']
         + extras_require['shellcomplete']
         + [
-            'pytest~=6.0',
+            'pytest>=6.0',
             'pytest-cov>=2.5.1',
             'pytest-mock',
             'pytest-benchmark[histogram]',

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup
 extras_require = {
     'shellcomplete': ['click_completion'],
     'tensorflow': [
-        'tensorflow~=2.3,!=2.3.0',  # c.f. https://github.com/tensorflow/tensorflow/pull/40789
-        'tensorflow-probability~=0.11',
+        'tensorflow>=2.3.1',  # c.f. https://github.com/tensorflow/tensorflow/pull/40789
+        'tensorflow-probability>=0.11.0',
     ],
     'torch': ['torch~=1.10'],
     'jax': ['jax>=0.2.10', 'jaxlib>=0.1.60,!=0.1.68'],  # c.f. Issue 1501

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ extras_require = {
         'tensorflow>=2.3.1',  # c.f. https://github.com/tensorflow/tensorflow/pull/40789
         'tensorflow-probability>=0.11.0',
     ],
-    'torch': ['torch~=1.10'],
+    'torch': ['torch>=1.10.0'],
     'jax': ['jax>=0.2.10', 'jaxlib>=0.1.60,!=0.1.68'],  # c.f. Issue 1501
     'xmlio': ['uproot>=4.1.1'],
     'minuit': ['iminuit>=2.4'],


### PR DESCRIPTION
# Description

Set only lower bounds for all the `pyhf` backend extras. `pyhf` is testing daily the lower bounds, latest releases, and pre-releases, so these are empirically arrived at and tested. Note this is simply just enforcing the lower bounds already tested

```console
$ grep 'tensor\|torch' lower-bound-requirements.txt 
# tensorflow
tensorflow==2.3.1  # tensorflow-probability v0.11.0 requires tensorflow>=2.3
tensorflow-probability==0.11.0  # c.f. PR #1657
# torch
torch==1.10.0
```

c.f. Henry's upcoming blog post for the deep dive on why this is optimal for libraries

Also add a note for the PR that caused these lower bounds to exist for easy reference for the core devs or the curious contributor.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Set only lower bounds on the requirements for all backend extras.
   - This is done to avoid creating installation blocking scenarios
     and in situations where users find that the latest release of
     a dependency breaks pyhf code the user can be recommended to
     install the version of that dependency that was available when
     their version of pyhf was released.
* Add notes in setup.py pointing to the PR that caused the lower bound
to be needed for easy future reference
```
