### PR TITLE
test: Use xfail for tests that fail for upstream problems

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ ignore = [
     'AUTHORS',
 ]
 
+[tool.pytest]
+xfail_strict = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -390,9 +390,9 @@ def test_percentile(backend):
 # FIXME: PyTorch doesn't yet support interpolation schemes other than "linear"
 # c.f. https://github.com/pytorch/pytorch/pull/59397
 # c.f. https://github.com/scikit-hep/pyhf/issues/1693
-@pytest.mark.skip_pytorch
-@pytest.mark.skip_pytorch64
-@pytest.mark.skip_jax
+@pytest.mark.fail_pytorch
+@pytest.mark.fail_pytorch64
+@pytest.mark.fail_jax
 def test_percentile_interpolation(backend):
     tb = pyhf.tensorlib
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -376,7 +376,7 @@ def test_boolean_mask(backend):
     )
 
 
-@pytest.mark.skip_jax
+@pytest.mark.fail_jax
 def test_percentile(backend):
     tb = pyhf.tensorlib
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -267,8 +267,8 @@ def test_shape(backend):
         )
 
 
-@pytest.mark.skip_pytorch
-@pytest.mark.skip_pytorch64
+@pytest.mark.fail_pytorch
+@pytest.mark.fail_pytorch64
 def test_pdf_calculations(backend):
     tb = pyhf.tensorlib
     assert tb.tolist(tb.normal_cdf(tb.astensor([0.8]))) == pytest.approx(


### PR DESCRIPTION
# Description

As covered in Paul Ganssle's blog post [How and why I use pytest's xfail](https://blog.ganssle.io/articles/2021/11/pytest-xfail.html) for tests that could start passing due upstream fixes in the backends it is perferable to catch this through a failing xfail test and start using these fixes then to skip the tests and have to manually track things.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Mark tests that fail for backends due to upstream problems with the
respective @pytest.mark.fail_<backend> decorator. These tests could
start passing due upstream fixes in the backends and it is perferable
to catch this through a failing xfail test and start using these fixes
then to skip the tests and have to manually track things.
   - Motivation for this change came from Paul Ganssle's blog post
     "How and why I use pytest's xfail"
     c.f. https://blog.ganssle.io/articles/2021/11/pytest-xfail.html
* Set `xfail_strict = true` in pytest config
```
