### PR TITLE
fix: Accept tar and zip headers in contrib.utils.download requests

### DIFF
--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -66,8 +66,6 @@ try:
         # The HEPData landing page for the resource file can check if the Accept
         # request HTTP header matches the content type of the resource file and
         # return the content directly if so.
-        # TODO: Figure out how to accept headers of both application/x-tar and
-        # application/zip.
         with requests.get(
             archive_url, headers={"Accept": "application/x-tar, application/zip"}
         ) as response:

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -69,7 +69,7 @@ try:
         # TODO: Figure out how to accept headers of both application/x-tar and
         # application/zip.
         with requests.get(
-            archive_url, headers={"Accept": "application/x-tar"}
+            archive_url, headers={"Accept": "application/x-tar, application/zip"}
         ) as response:
             if response.status_code != 200:
                 raise exceptions.InvalidArchive(


### PR DESCRIPTION
# Description

From https://github.com/scikit-hep/pyhf/pull/1697#discussion_r751385432 @GraemeWatt notes:

> The `Accept` headers will be ignored if `archive_url` is a HEPData URL (ending in `?view=true`) that returns the content directly.  The `Accept` headers will only become relevant when `archive_url` is a HEPData DOI for a resource file after we redirect to a landing page.  We're still working on the relevant PR (HEPData/hepdata#412) after it expanded in scope.  The default `Accept` header is `*/*` for Python `requests` (and `curl`), different from the [default `Accept` values of most web browsers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values) where `*/*` has a lower weighting ([quality value](https://developer.mozilla.org/en-US/docs/Glossary/Quality_values)) than `text/html`.  With our current implementation, if `*/*` has weight 1 in a request to the landing page, the content will be returned directly instead of the HTML landing page.  This means you don't strictly need to specify the `Accept` header with Python `requests`.  But I'd recommend you keep the `Accept` header to avoid accepting content types that your download code can't process.  To accept both tar and zip files, you just need to use `headers={"Accept": "application/x-tar, application/zip"}`.  We will return a [406 Not Acceptable](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406) status code if a request is made to the landing page where the `Accept` header does not match the media type of the content.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR


```
* Add zip headers to the accepted content headers for contrib.utils.download
* Amends PR #1697

Co-authored-by: Graeme Watt <Graeme.Watt@durham.ac.uk>
```