### PR TITLE
fix: Ensure `_ModelConfig.suggested_fixed` list contains only booleans for all modifiers

### DIFF
--- a/src/pyhf/modifiers/staterror.py
+++ b/src/pyhf/modifiers/staterror.py
@@ -106,7 +106,7 @@ class staterror_builder:
                 modifier_data['data']['mask'] = masks[modname]
             sigmas = relerrs[masks[modname]]
             # list of bools, consistent with other modifiers (no numpy.bool_)
-            fixed = (sigmas == 0).tolist()
+            fixed = default_backend.tolist(sigmas == 0)
             # ensures non-Nan constraint term, but in a future PR we need to remove constraints for these
             sigmas[fixed] = 1.0
             self.required_parsets.setdefault(parname, [required_parset(sigmas, fixed)])

--- a/src/pyhf/modifiers/staterror.py
+++ b/src/pyhf/modifiers/staterror.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 
 import pyhf
 from pyhf import events
@@ -8,7 +9,7 @@ from pyhf.parameters import ParamViewer
 log = logging.getLogger(__name__)
 
 
-def required_parset(sigmas, fixed):
+def required_parset(sigmas, fixed: List[bool]):
     n_parameters = len(sigmas)
     return {
         'paramset_type': 'constrained_by_normal',

--- a/src/pyhf/modifiers/staterror.py
+++ b/src/pyhf/modifiers/staterror.py
@@ -104,7 +104,8 @@ class staterror_builder:
             for modifier_data in self.builder_data[modname].values():
                 modifier_data['data']['mask'] = masks[modname]
             sigmas = relerrs[masks[modname]]
-            fixed = [s == 0 for s in sigmas]
+            # list of bools, consistent with other modifiers (no numpy.bool_)
+            fixed = (sigmas == 0).tolist()
             # ensures non-Nan constraint term, but in a future PR we need to remove constraints for these
             sigmas[fixed] = 1.0
             self.required_parsets.setdefault(parname, [required_parset(sigmas, fixed)])

--- a/src/pyhf/parameters/paramsets.py
+++ b/src/pyhf/parameters/paramsets.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import pyhf
 
 __all__ = [
@@ -27,13 +29,13 @@ class paramset:
             )
 
     @property
-    def suggested_fixed(self):
+    def suggested_fixed(self) -> List[bool]:
         if type(self._suggested_fixed) == bool:
             return [self._suggested_fixed] * self.n_parameters
         return self._suggested_fixed
 
     @property
-    def suggested_fixed_as_bool(self):
+    def suggested_fixed_as_bool(self) -> bool:
         '''compresses list of same-value bools into single bool'''
         suggested_fixed = self.suggested_fixed
         first = suggested_fixed[0]

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -2,6 +2,7 @@
 
 import copy
 import logging
+from typing import List
 
 import pyhf.parameters
 import pyhf
@@ -346,7 +347,7 @@ class _ModelConfig(_ChannelSummaryMixin):
         """
         return self.par_map[name]['paramset']
 
-    def suggested_fixed(self):
+    def suggested_fixed(self) -> List[bool]:
         """
         Identify the fixed parameters in the model.
 

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -91,12 +91,24 @@ def test_staterror_holes():
         True,
         False,
     ]
+    assert all(
+        [
+            isinstance(fixed, bool)
+            for fixed in model.config.param_set("staterror_1").suggested_fixed
+        ]
+    )
     assert model.config.param_set("staterror_2").suggested_fixed == [
         False,
         True,
         False,
         False,
     ]
+    assert all(
+        [
+            isinstance(fixed, bool)
+            for fixed in model.config.param_set("staterror_2").suggested_fixed
+        ]
+    )
     assert (factors[1][0, 0, 0, :] == [2.0, 1.0, 1.0, 3.0, 1.0, 1.0, 1.0, 1.0]).all()
     assert (factors[1][1, 0, 0, :] == [1.0, 1.0, 1.0, 1.0, 4.0, 1.0, 5.0, 6.0]).all()
 


### PR DESCRIPTION
# Description

The `staterror` refactoring in #1639 caused `model.config.suggested_fixed()` to return `numpy.bool_` elements for `staterror` modifiers. Those behave differently from `bool` objects, and for consistency I believe it is useful to have a consistent return type, in line with the documented return type of `List[bool]`:

https://github.com/scikit-hep/pyhf/blob/f25b8ddc6ab34d089954eb4898d54220f7f2defa/src/pyhf/pdf.py#L349-L355

#1701 includes an example to showcase the current status.

There are many places at which a change could be introduced to restore the old behavior. The current implementation applies the change at the first possible point, where the list is initially created. Alternatively, a conversion could probably happen in `paramset` or at the last point in `_ModelConfig.suggested_fixed`. Please let me know if you would prefer another implementation. I picked this approach for consistency with other modifiers, such that `required_parset()["fixed"]` consistently returns `bool` / `List[bool]`.

This also adds tests for the return type behavior for `staterror` modifiers, I'm happy to remove them or add more for other modifiers if desired.

Since this is about types, I thought about adding type hints for the affected code and am happy to do so if you'd like.

resolves #1701 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Have the fixed parameters selection in staterror_builder be a list
of Bools over numpy.bool_
* Add type hints for the relevant sections
* Add test to test_modifiers.py to require the fixed parameters
selection list to be Bool
```