### PR TITLE
ci: Quote GitHub Action python-version number as YAML strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,11 @@ jobs:
       || (github.event_name == 'push' && github.ref != 'refs/heads/master' && contains(github.event.head_commit.message, '[ci all]'))
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: ['3.7', '3.8', '3.9']
-        exclude:
+        include:
           - os: macos-latest
-            python-version: '3.7'
-          - os: macos-latest
-            python-version: '3.8'
+            python-version: '3.9'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9']
         exclude:
           - os: macos-latest
-            python-version: 3.7
+            python-version: '3.7'
           - os: macos-latest
-            python-version: 3.8
+            python-version: '3.8'
 
     steps:
     - uses: actions/checkout@v2
@@ -50,7 +50,7 @@ jobs:
         pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
 
     - name: Report core project coverage with Codecov
-      if: github.event_name != 'schedule' && matrix.python-version == 3.9 && matrix.os == 'ubuntu-latest'
+      if: github.event_name != 'schedule' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2
       with:
         files: ./coverage.xml
@@ -61,24 +61,24 @@ jobs:
         pytest -r sx tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
 
     - name: Report contrib coverage with Codecov
-      if: github.event_name != 'schedule' && matrix.python-version == 3.9 && matrix.os == 'ubuntu-latest'
+      if: github.event_name != 'schedule' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2
       with:
         files: ./coverage.xml
         flags: contrib
 
     - name: Test docstring examples with doctest
-      if: matrix.python-version == 3.9
+      if: matrix.python-version == '3.9'
       run: pytest -r sx src/ README.rst
 
     - name: Report doctest coverage with Codecov
-      if: github.event_name != 'schedule' && matrix.python-version == 3.9 && matrix.os == 'ubuntu-latest'
+      if: github.event_name != 'schedule' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2
       with:
         files: ./coverage.xml
         flags: doctest
 
     - name: Run benchmarks
-      if: github.event_name == 'schedule' && matrix.python-version == 3.9
+      if: github.event_name == 'schedule' && matrix.python-version == '3.9'
       run: |
         pytest -r sx --benchmark-sort=mean tests/benchmarks/test_benchmark.py

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ['3.9']
 
     steps:
     - uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ['3.9']
 
     steps:
     - uses: actions/checkout@v2
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ['3.9']
 
     steps:
     - uses: actions/checkout@v2
@@ -95,7 +95,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ['3.9']
 
     steps:
     - uses: actions/checkout@v2
@@ -120,7 +120,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ['3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ['3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.9'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # minimum supported Python
-        python-version: [3.7]
+        python-version: ['3.7']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ['3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.9'
 
     - name: Install python-build, check-manifest, and twine
       run: |

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9']
         include:
           - os: macos-latest
-            python-version: 3.9
+            python-version: '3.9'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.9'
     - name: Install bump2version
       run: |
         python -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
# Description

As preventative actions, quote the `python-version` numbers in CI as without quotes [YAML will treat `3.10` as a float and interpret it as `3.1`](https://twitter.com/HEPfeickert/status/1445860336565948416) which is certainly not desired. :) This won't affect us until all backends are on Python 3.10, but it will keep us from having the CI fail weirdly in the future.

Also simplify the macos-latest inclusion with `include` keyword.

Please describe the purpose of this pull request in some detail. Reference and link to any relevant issues or pull requests.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Quote all python-version numbers in CI. This is done as a preventive
action to set a YAML string precedence for when Python 3.10 is added
to testing, as without quotes YAML will treat `3.10` as a float and 
interpret it as `3.1`.
* Simplify the inclusion of the latest Python version on macos-latest
by using the `include` keyword in the CI strategy matrix to add it
instead of excluding all Python versions to not test.
```
