### PR TITLE
feat: Catch unexpected keyword arguments in workspace construction

### DIFF
--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -305,6 +305,11 @@ class Workspace(_ChannelSummaryMixin, dict):
         for obs in self['observations']:
             self.observations[obs['name']] = obs['data']
 
+        if config_kwargs:
+            raise exceptions.Unsupported(
+                f"Unsupported options were passed in: {list(config_kwargs.keys())}."
+            )
+
     def __eq__(self, other):
         """Equality is defined as equal dict representations."""
         if not isinstance(other, Workspace):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -866,8 +866,7 @@ def test_closure_over_workspace_build(simplemodels_model_data):
 def test_wspace_immutable(simplemodels_model_data):
     model, data = simplemodels_model_data
     workspace = pyhf.Workspace.build(model, data)
-
-    spec = json.loads(json.dumps(workspace))
+    spec = dict(workspace)
 
     ws = pyhf.Workspace(spec)
     model = ws.model()
@@ -895,8 +894,7 @@ def test_workspace_poiless(datadir):
 def test_wspace_unexpected_keyword_argument(simplemodels_model_data):
     model, data = simplemodels_model_data
     workspace = pyhf.Workspace.build(model, data)
-
-    spec = json.loads(json.dumps(workspace))
+    spec = dict(workspace)
 
     with pytest.raises(pyhf.exceptions.Unsupported):
         pyhf.Workspace(spec, abc=True)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -36,7 +36,7 @@ def workspace_factory(workspace_xml):
     return lambda: pyhf.Workspace(workspace_xml)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def simplemodels_model_data():
     model = pyhf.simplemodels.uncorrelated_background(
         signal=[12.0, 11.0], bkg=[50.0, 52.0], bkg_uncertainty=[3.0, 7.0]


### PR DESCRIPTION
# Description

When building a model, unexpected kwargs are caught in `_ModelConfig` and an error is raised:
https://github.com/scikit-hep/pyhf/blob/34dd45c84426c5e14a280b7da8742d0d4fd7c83d/src/pyhf/pdf.py#L218-L221

This PR ports the same behavior over to `Workspace` construction as well. I believe this is useful to catch typos. Slightly related to #1699, where I came across this originally.

A test has been added for the new behavior. Since the workspace tests used the same `simplemodels` setup a few times for different purposes, I factored that out into a fixture. Happy to implement any other solution you may prefer for this instead.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [X] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Raise an Unsupported exception if unexpected kwargs are passed during
pyhf.Workspace creation.
* Add test for this behavior.
* Refactor workspace test model and data into a pytest fixture.
```