### PR TITLE
test: Use scikit-hep-testdata to provide probability models for regression tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ extras_require['test'] = sorted(
         + extras_require['contrib']
         + extras_require['shellcomplete']
         + [
+            'scikit-hep-testdata>=0.4.10',
             'pytest>=6.0',
             'pytest-cov>=2.5.1',
             'pytest-mock',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ extras_require['test'] = sorted(
         + extras_require['contrib']
         + extras_require['shellcomplete']
         + [
-            'scikit-hep-testdata>=0.4.10',
+            'scikit-hep-testdata>=0.4.11',
             'pytest>=6.0',
             'pytest-cov>=2.5.1',
             'pytest-mock',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,6 +130,7 @@ def datadir(tmpdir, request):
     if test_dir.is_dir():
         distutils.dir_util.copy_tree(test_dir, tmpdir.strpath)
         # shutil is nicer, but doesn't work: https://bugs.python.org/issue20849
+        # Once pyhf is Python 3.8+ only then the below can be used.
         # shutil.copytree(test_dir, tmpdir)
 
     return tmpdir

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,31 +1,10 @@
 import pytest
 import pyhf
 import sys
-import requests
-import hashlib
 import tarfile
 import json
-import os
 import pathlib
 import distutils.dir_util
-
-
-@pytest.fixture(scope='module')
-def sbottom_likelihoods_download():
-    """Download the sbottom likelihoods tarball from HEPData"""
-    sbottom_HEPData_URL = "https://doi.org/10.17182/hepdata.89408.v1/r2"
-    targz_filename = "sbottom_workspaces.tar.gz"
-    response = requests.get(sbottom_HEPData_URL, stream=True)
-    assert response.status_code == 200
-    with open(targz_filename, "wb") as file:
-        file.write(response.content)
-    assert (
-        hashlib.sha256(open(targz_filename, "rb").read()).hexdigest()
-        == "9089b0e5fabba335bea4c94545ccca8ddd21289feeab2f85e5bcc8bada37be70"
-    )
-    # Open as a tarfile
-    yield tarfile.open(targz_filename, "r:gz")
-    os.remove(targz_filename)
 
 
 # Factory as fixture pattern

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,10 +31,11 @@ def sbottom_likelihoods_download():
 # Factory as fixture pattern
 @pytest.fixture
 def get_json_from_tarfile():
-    def _get_json_from_tarfile(tarfile, json_name):
-        json_file = (
-            tarfile.extractfile(tarfile.getmember(json_name)).read().decode("utf8")
-        )
+    def _get_json_from_tarfile(archive_data_path, json_name):
+        with tarfile.open(archive_data_path, "r:gz") as archive:
+            json_file = (
+                archive.extractfile(archive.getmember(json_name)).read().decode("utf8")
+            )
         return json.loads(json_file)
 
     return _get_json_from_tarfile

--- a/tests/test_paramviewer.py
+++ b/tests/test_paramviewer.py
@@ -1,3 +1,5 @@
+from skhep_testdata import data_path
+
 import pyhf
 from pyhf.parameters import ParamViewer
 
@@ -20,10 +22,11 @@ def test_paramviewer_simple_nonbatched(backend):
     assert pyhf.tensorlib.tolist(par_slice) == [6, 7, 1, 2]
 
 
-def test_paramviewer_order(sbottom_likelihoods_download, get_json_from_tarfile):
-    lhood = get_json_from_tarfile(sbottom_likelihoods_download, "RegionA/BkgOnly.json")
+def test_paramviewer_order(get_json_from_tarfile):
+    sbottom_archive = data_path("pyhf-ins1748602-probability-models.tar.gz")
+    lhood = get_json_from_tarfile(sbottom_archive, "RegionA/BkgOnly.json")
     patch = get_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionA/patch.sbottom_1300_205_60.json"
+        sbottom_archive, "RegionA/patch.sbottom_1300_205_60.json"
     )
     workspace = pyhf.workspace.Workspace(lhood)
     model = workspace.model(patches=[patch])

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,6 +1,8 @@
-import pytest
-import pyhf
 import numpy as np
+import pytest
+from skhep_testdata import data_path
+
+import pyhf
 
 
 def calculate_CLs(bkgonly_json, signal_patch_json):
@@ -31,14 +33,13 @@ def calculate_CLs(bkgonly_json, signal_patch_json):
     return result[0].tolist(), result[-1]
 
 
-def test_sbottom_regionA_1300_205_60(
-    sbottom_likelihoods_download, get_json_from_tarfile
-):
+def test_sbottom_regionA_1300_205_60(get_json_from_tarfile):
+    sbottom_archive = data_path("pyhf-ins1748602-probability-models.tar.gz")
     sbottom_regionA_bkgonly_json = get_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionA/BkgOnly.json"
+        sbottom_archive, "RegionA/BkgOnly.json"
     )
     sbottom_regionA_1300_205_60_patch_json = get_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionA/patch.sbottom_1300_205_60.json"
+        sbottom_archive, "RegionA/patch.sbottom_1300_205_60.json"
     )
     CLs_obs, CLs_exp = calculate_CLs(
         sbottom_regionA_bkgonly_json, sbottom_regionA_1300_205_60_patch_json
@@ -61,14 +62,13 @@ def test_sbottom_regionA_1300_205_60(
     )
 
 
-def test_sbottom_regionA_1400_950_60(
-    sbottom_likelihoods_download, get_json_from_tarfile
-):
+def test_sbottom_regionA_1400_950_60(get_json_from_tarfile):
+    sbottom_archive = data_path("pyhf-ins1748602-probability-models.tar.gz")
     sbottom_regionA_bkgonly_json = get_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionA/BkgOnly.json"
+        sbottom_archive, "RegionA/BkgOnly.json"
     )
     sbottom_regionA_1400_950_60_patch_json = get_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionA/patch.sbottom_1400_950_60.json"
+        sbottom_archive, "RegionA/patch.sbottom_1400_950_60.json"
     )
     CLs_obs, CLs_exp = calculate_CLs(
         sbottom_regionA_bkgonly_json, sbottom_regionA_1400_950_60_patch_json
@@ -91,14 +91,13 @@ def test_sbottom_regionA_1400_950_60(
     )
 
 
-def test_sbottom_regionA_1500_850_60(
-    sbottom_likelihoods_download, get_json_from_tarfile
-):
+def test_sbottom_regionA_1500_850_60(get_json_from_tarfile):
+    sbottom_archive = data_path("pyhf-ins1748602-probability-models.tar.gz")
     sbottom_regionA_bkgonly_json = get_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionA/BkgOnly.json"
+        sbottom_archive, "RegionA/BkgOnly.json"
     )
     sbottom_regionA_1500_850_60_patch_json = get_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionA/patch.sbottom_1500_850_60.json"
+        sbottom_archive, "RegionA/patch.sbottom_1500_850_60.json"
     )
     CLs_obs, CLs_exp = calculate_CLs(
         sbottom_regionA_bkgonly_json, sbottom_regionA_1500_850_60_patch_json
@@ -121,14 +120,13 @@ def test_sbottom_regionA_1500_850_60(
     )
 
 
-def test_sbottom_regionB_1400_550_60(
-    sbottom_likelihoods_download, get_json_from_tarfile
-):
+def test_sbottom_regionB_1400_550_60(get_json_from_tarfile):
+    sbottom_archive = data_path("pyhf-ins1748602-probability-models.tar.gz")
     sbottom_regionB_bkgonly_json = get_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionB/BkgOnly.json"
+        sbottom_archive, "RegionB/BkgOnly.json"
     )
     sbottom_regionB_1400_550_60_patch_json = get_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionB/patch.sbottom_1400_550_60.json"
+        sbottom_archive, "RegionB/patch.sbottom_1400_550_60.json"
     )
     CLs_obs, CLs_exp = calculate_CLs(
         sbottom_regionB_bkgonly_json, sbottom_regionB_1400_550_60_patch_json
@@ -151,14 +149,13 @@ def test_sbottom_regionB_1400_550_60(
     )
 
 
-def test_sbottom_regionC_1600_850_60(
-    sbottom_likelihoods_download, get_json_from_tarfile
-):
+def test_sbottom_regionC_1600_850_60(get_json_from_tarfile):
+    sbottom_archive = data_path("pyhf-ins1748602-probability-models.tar.gz")
     sbottom_regionC_bkgonly_json = get_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionC/BkgOnly.json"
+        sbottom_archive, "RegionC/BkgOnly.json"
     )
     sbottom_regionC_1600_850_60_patch_json = get_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionC/patch.sbottom_1600_850_60.json"
+        sbottom_archive, "RegionC/patch.sbottom_1600_850_60.json"
     )
     CLs_obs, CLs_exp = calculate_CLs(
         sbottom_regionC_bkgonly_json, sbottom_regionC_1600_850_60_patch_json


### PR DESCRIPTION
# Description

With https://github.com/scikit-hep/scikit-hep-testdata/pull/67, the sbottom probability models that are used for regression tests are added to `scikit-hep-testdata`. This provides stability in testing that is independent of HEPData's availability and doesn't abuse HEPData either as we currently ping them _a lot_ with our test suite.

This also simplifies the tests a bit by removing the need for a fixture to provide the tarfile archive.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add scikit-hep-testdata to the 'test' extra
* Use scikit-hep-testdata to provide the file path to the tar.gz that
contains the sbottom probability models used for regression tests
(pyhf-ins1748602-probability-models.tar.gz)
   - File added in release scikit-hep-testdata v0.4.11
* Refactor get_json_from_tarfile pytest fixture to open the tarfile archive
* Remove sbottom_likelihoods_download pytest fixture as no longer needed
```
