### PR TITLE
fix: Skip doctest of `pyhf.contrib.utils.download`

### DIFF
--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -30,7 +30,7 @@ try:
         Example:
 
             >>> from pyhf.contrib.utils import download
-            >>> download("https://doi.org/10.17182/hepdata.90607.v3/r3", "1Lbb-likelihoods")
+            >>> download("https://doi.org/10.17182/hepdata.90607.v3/r3", "1Lbb-likelihoods")  # doctest: +SKIP
             >>> import os
             >>> sorted(os.listdir("1Lbb-likelihoods"))
             ['BkgOnly.json', 'README.md', 'patchset.json']

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -32,11 +32,11 @@ try:
             >>> from pyhf.contrib.utils import download
             >>> download("https://doi.org/10.17182/hepdata.90607.v3/r3", "1Lbb-likelihoods")  # doctest: +SKIP
             >>> import os
-            >>> sorted(os.listdir("1Lbb-likelihoods"))
+            >>> sorted(os.listdir("1Lbb-likelihoods"))  # doctest: +SKIP
             ['BkgOnly.json', 'README.md', 'patchset.json']
-            >>> download("https://doi.org/10.17182/hepdata.90607.v3/r3", "1Lbb-likelihoods.tar.gz", compress=True)
+            >>> download("https://doi.org/10.17182/hepdata.90607.v3/r3", "1Lbb-likelihoods.tar.gz", compress=True)  # doctest: +SKIP
             >>> import glob
-            >>> glob.glob("1Lbb-likelihoods.tar.gz")
+            >>> glob.glob("1Lbb-likelihoods.tar.gz")  # doctest: +SKIP
             ['1Lbb-likelihoods.tar.gz']
 
         Args:


### PR DESCRIPTION
# Description

Resolves #1714

Use the [`doctest` SKIP directive](https://docs.python.org/3/library/doctest.html#doctest.SKIP) to skip evaluation of all `pyhf.contrib.utils.download` related commands in the docstring example to avoid reliance on HEPData for testing. Along with PRs #1697, #1704, and #1711, this should remove all direct usage of HEPData infrastructure for testing.


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use the doctest SKIP directive to skip commands related to
pyhf.contrib.utils.download in its docstring example to remove
reliance on HEPData infrastructure for testing.
   - c.f. https://docs.python.org/3/library/doctest.html#doctest.SKIP
```