### PR TITLE
docs: Fix download method of probability models archive in impact plot notebook

### DIFF
--- a/docs/examples/notebooks/ImpactPlot.ipynb
+++ b/docs/examples/notebooks/ImpactPlot.ipynb
@@ -77,7 +77,9 @@
    "source": [
     "def make_model(channel_list):\n",
     "    spec = json.load(open(\"1Lbb-probability-models/RegionA/BkgOnly.json\"))\n",
-    "    patchset = json.load(open(\"1Lbb-probability-models/RegionA/patchset.json\"))\n",
+    "    patchset = pyhf.PatchSet(\n",
+    "        json.load(open(\"1Lbb-probability-models/RegionA/patchset.json\"))\n",
+    "    )\n",
     "    patch = patchset[\"sbottom_750_745_60\"]\n",
     "    spec = jsonpatch.apply_patch(spec, patch)\n",
     "    spec[\"channels\"] = [c for c in spec[\"channels\"] if c[\"name\"] in channel_list]\n",

--- a/docs/examples/notebooks/ImpactPlot.ipynb
+++ b/docs/examples/notebooks/ImpactPlot.ipynb
@@ -77,9 +77,8 @@
    "source": [
     "def make_model(channel_list):\n",
     "    spec = json.load(open(\"1Lbb-probability-models/RegionA/BkgOnly.json\"))\n",
-    "    patch = json.load(\n",
-    "        open(\"1Lbb-probability-models/RegionA/patch.sbottom_750_745_60.json\")\n",
-    "    )\n",
+    "    patchset = json.load(open(\"1Lbb-probability-models/RegionA/patchset.json\"))\n",
+    "    patch = patchset[\"sbottom_750_745_60\"]\n",
     "    spec = jsonpatch.apply_patch(spec, patch)\n",
     "    spec[\"channels\"] = [c for c in spec[\"channels\"] if c[\"name\"] in channel_list]\n",
     "\n",

--- a/docs/examples/notebooks/ImpactPlot.ipynb
+++ b/docs/examples/notebooks/ImpactPlot.ipynb
@@ -58,8 +58,8 @@
     }
    ],
    "source": [
-    "! pyhf contrib download https://doi.org/10.17182/hepdata.89408.v3/r2 1Lbb-probability-models\n",
-    "! tree 1Lbb-probability-models"
+    "! pyhf contrib download https://doi.org/10.17182/hepdata.89408.v3/r2 /tmp/1Lbb-probability-models\n",
+    "! tree /tmp/1Lbb-probability-models"
    ]
   },
   {
@@ -76,9 +76,9 @@
    "outputs": [],
    "source": [
     "def make_model(channel_list):\n",
-    "    spec = json.load(open(\"1Lbb-probability-models/RegionA/BkgOnly.json\"))\n",
+    "    spec = json.load(open(\"/tmp/1Lbb-probability-models/RegionA/BkgOnly.json\"))\n",
     "    patch = json.load(\n",
-    "        open(\"1Lbb-probability-models/RegionA/patch.sbottom_750_745_60.json\")\n",
+    "        open(\"/tmp/1Lbb-probability-models/RegionA/patch.sbottom_750_745_60.json\")\n",
     "    )\n",
     "    spec = jsonpatch.apply_patch(spec, patch)\n",
     "    spec[\"channels\"] = [c for c in spec[\"channels\"] if c[\"name\"] in channel_list]\n",

--- a/docs/examples/notebooks/ImpactPlot.ipynb
+++ b/docs/examples/notebooks/ImpactPlot.ipynb
@@ -58,8 +58,8 @@
     }
    ],
    "source": [
-    "! pyhf contrib download https://doi.org/10.17182/hepdata.89408.v3/r2 /tmp/1Lbb-probability-models\n",
-    "! tree /tmp/1Lbb-probability-models"
+    "! pyhf contrib download https://doi.org/10.17182/hepdata.89408.v3/r2 1Lbb-probability-models\n",
+    "! tree 1Lbb-probability-models"
    ]
   },
   {
@@ -76,9 +76,9 @@
    "outputs": [],
    "source": [
     "def make_model(channel_list):\n",
-    "    spec = json.load(open(\"/tmp/1Lbb-probability-models/RegionA/BkgOnly.json\"))\n",
+    "    spec = json.load(open(\"1Lbb-probability-models/RegionA/BkgOnly.json\"))\n",
     "    patch = json.load(\n",
-    "        open(\"/tmp/1Lbb-probability-models/RegionA/patch.sbottom_750_745_60.json\")\n",
+    "        open(\"1Lbb-probability-models/RegionA/patch.sbottom_750_745_60.json\")\n",
     "    )\n",
     "    spec = jsonpatch.apply_patch(spec, patch)\n",
     "    spec[\"channels\"] = [c for c in spec[\"channels\"] if c[\"name\"] in channel_list]\n",

--- a/docs/examples/notebooks/ImpactPlot.ipynb
+++ b/docs/examples/notebooks/ImpactPlot.ipynb
@@ -26,6 +26,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this example we'll download the archive of probability models for the ATLAS analysis [JHEP 12 (2019) 060, 2019](https://inspirehep.net/literature/1748602) from its [HEPData page](https://www.hepdata.net/record/ins1748602) using its [specific DOI](https://www.hepdata.net/record/resource/1935437?landing_page=true). You can download this multiple ways, but for simplicity we'll download it using the `pyhf contrib download` command."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},

--- a/docs/examples/notebooks/ImpactPlot.ipynb
+++ b/docs/examples/notebooks/ImpactPlot.ipynb
@@ -41,14 +41,25 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RegionA/BkgOnly.json\n",
-      "RegionA/patch.sbottom_750_745_60.json\n"
+      "\u001b[01;34m1Lbb-probability-models\u001b[00m\n",
+      "├── README.md\n",
+      "├── \u001b[01;34mRegionA\u001b[00m\n",
+      "│   ├── BkgOnly.json\n",
+      "│   └── patchset.json\n",
+      "├── \u001b[01;34mRegionB\u001b[00m\n",
+      "│   ├── BkgOnly.json\n",
+      "│   └── patchset.json\n",
+      "└── \u001b[01;34mRegionC\u001b[00m\n",
+      "    ├── BkgOnly.json\n",
+      "    └── patchset.json\n",
+      "\n",
+      "3 directories, 7 files\n"
      ]
     }
    ],
    "source": [
-    "!curl -sL https://doi.org/10.17182/hepdata.89408.v1/r2  | tar -O -xzv RegionA/BkgOnly.json > lhood.json\n",
-    "!curl -sL https://doi.org/10.17182/hepdata.89408.v1/r2  | tar -O -xzv RegionA/patch.sbottom_750_745_60.json > patch.json"
+    "! pyhf contrib download https://doi.org/10.17182/hepdata.89408.v3/r2 1Lbb-probability-models\n",
+    "! tree 1Lbb-probability-models"
    ]
   },
   {
@@ -65,8 +76,10 @@
    "outputs": [],
    "source": [
     "def make_model(channel_list):\n",
-    "    spec = json.load(open(\"lhood.json\"))\n",
-    "    patch = json.load(open(\"patch.json\"))\n",
+    "    spec = json.load(open(\"1Lbb-probability-models/RegionA/BkgOnly.json\"))\n",
+    "    patch = json.load(\n",
+    "        open(\"1Lbb-probability-models/RegionA/patch.sbottom_750_745_60.json\")\n",
+    "    )\n",
     "    spec = jsonpatch.apply_patch(spec, patch)\n",
     "    spec[\"channels\"] = [c for c in spec[\"channels\"] if c[\"name\"] in channel_list]\n",
     "\n",

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -59,7 +59,11 @@ def test_pullplot(common_kwargs):
 
 
 def test_impactplot(common_kwargs):
-    pm.execute_notebook('docs/examples/notebooks/ImpactPlot.ipynb', **common_kwargs)
+    # Change directories to make users not have to worry about paths to follow example
+    cwd = os.getcwd()
+    os.chdir(os.path.join(cwd, "docs/examples/notebooks"))
+    pm.execute_notebook("ImpactPlot.ipynb", **common_kwargs)
+    os.chdir(cwd)
 
 
 def test_toys(common_kwargs):


### PR DESCRIPTION
# Description

The nightly notebook tests are failing due to the ImpactPlot notebook because of changes in HEPData. Adopting the new DOIs for the probability models and using `pyhf contrib download` to properly deal with HEPData headers fixes this.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use stable DOI https://doi.org/10.17182/hepdata.89408.v3/r2 to download
probability models archive from HEPData.
   - This version of the 1Lbb probability models uses a pyhf PatchSet, so
     update the impact plot notebook accordingly.
* Use `pyhf contrib download` as it can properly accept HEPData headers.
* Change directories for the impact plot notebook test so that the paths used
in the notebook do not have to be changed to accommodate testing paths.
```