### PR TITLE
docs: Fix download method of probability models archive in pull plot notebook

### DIFF
--- a/docs/examples/notebooks/pullplot.ipynb
+++ b/docs/examples/notebooks/pullplot.ipynb
@@ -8,11 +8,24 @@
    "source": [
     "import pyhf\n",
     "import json\n",
-    "import copy\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download the Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this example we'll download the archive of probability models for the ATLAS analysis [JHEP 12 (2019) 060, 2019](https://inspirehep.net/literature/1748602) from its [HEPData page](https://www.hepdata.net/record/ins1748602) using its [specific DOI](https://www.hepdata.net/record/resource/1935437?landing_page=true). You can download this multiple ways, but for simplicity we'll download it using the `pyhf contrib download` command"
    ]
   },
   {
@@ -24,19 +37,32 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RegionA/BkgOnly.json\n"
+      "\u001b[01;34m1Lbb-probability-models\u001b[00m\n",
+      "├── README.md\n",
+      "├── \u001b[01;34mRegionA\u001b[00m\n",
+      "│   ├── BkgOnly.json\n",
+      "│   └── patchset.json\n",
+      "├── \u001b[01;34mRegionB\u001b[00m\n",
+      "│   ├── BkgOnly.json\n",
+      "│   └── patchset.json\n",
+      "└── \u001b[01;34mRegionC\u001b[00m\n",
+      "    ├── BkgOnly.json\n",
+      "    └── patchset.json\n",
+      "\n",
+      "3 directories, 7 files\n"
      ]
     }
    ],
    "source": [
-    "!curl -sL https://doi.org/10.17182/hepdata.89408.v1/r2  | tar -O -xzv RegionA/BkgOnly.json > lhood.json"
+    "! pyhf contrib download https://doi.org/10.17182/hepdata.89408.v3/r2 1Lbb-probability-models\n",
+    "! tree 1Lbb-probability-models"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Create the Model and Fit it\n"
+    "## Create the Model and Fit it\n"
    ]
   },
   {
@@ -46,8 +72,7 @@
    "outputs": [],
    "source": [
     "def make_model(channel_list):\n",
-    "    spec = json.load(open(\"lhood.json\"))\n",
-    "    spec = copy.copy(spec)\n",
+    "    spec = json.load(open(\"1Lbb-probability-models/RegionA/BkgOnly.json\"))\n",
     "    spec[\"channels\"] = [c for c in spec[\"channels\"] if c[\"name\"] in channel_list]\n",
     "    spec[\"measurements\"][0][\"config\"][\"poi\"] = \"lumi\"\n",
     "\n",
@@ -186,7 +211,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -200,7 +225,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -55,7 +55,11 @@ def test_multibinpois(common_kwargs):
 
 
 def test_pullplot(common_kwargs):
-    pm.execute_notebook('docs/examples/notebooks/pullplot.ipynb', **common_kwargs)
+    # Change directories to make users not have to worry about paths to follow example
+    cwd = os.getcwd()
+    os.chdir(os.path.join(cwd, "docs/examples/notebooks"))
+    pm.execute_notebook("pullplot.ipynb", **common_kwargs)
+    os.chdir(cwd)
 
 
 def test_impactplot(common_kwargs):


### PR DESCRIPTION
# Description

The nightly notebook tests are failing due to the `pullplot`  notebook because of changes in HEPData. Adopting the new DOIs for the probability models and using `pyhf contrib download` to properly deal with HEPData headers fixes this.

This is a similar PR to PR #1721.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use stable DOI https://doi.org/10.17182/hepdata.89408.v3/r2 to download
probability models archive from HEPData.
* Use `pyhf contrib download` as it can properly accept HEPData headers.
* Change directories for the impact plot notebook test so that the paths used
in the notebook do not have to be changed to accommodate testing paths.
* This PR is complimentary to PR #1721
```