### PR TITLE
ci: Publish to TestPyPI on tag or by workflow dispatch trigger

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -83,8 +83,9 @@ jobs:
       run: python -m zipfile --list dist/pyhf-*.whl
 
     - name: Publish distribution 📦 to Test PyPI
-      # every PR will trigger a push event on master, so check the push event is actually coming from master
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pyhf'
+      if: >-
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == 'scikit-hep/pyhf')
+        || (github.event_name == 'workflow_dispatch' && ${{ github.event.inputs.part }} == 'testpypi' && github.repository == 'scikit-hep/pyhf')
       uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         password: ${{ secrets.test_pypi_password }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -10,9 +10,12 @@ on:
     - master
   workflow_dispatch:
     inputs:
-      index:
-        description: 'Index type (testpypi | skip)'
-        required: true
+      publish:
+        type: choice
+        description: 'Publish to TestPyPI?'
+        options:
+        - false
+        - true
 
 jobs:
   build-and-publish:
@@ -82,10 +85,12 @@ jobs:
     - name: List contents of wheel
       run: python -m zipfile --list dist/pyhf-*.whl
 
+    # Compare to 'true' string as booleans get turned into strings in the console
     - name: Publish distribution 📦 to Test PyPI
+      # publish to TestPyPI on tag events of if manually triggered
       if: >-
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == 'scikit-hep/pyhf')
-        || (github.event_name == 'workflow_dispatch' && ${{ github.event.inputs.part }} == 'testpypi' && github.repository == 'scikit-hep/pyhf')
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
+        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
       uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         password: ${{ secrets.test_pypi_password }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -85,9 +85,9 @@ jobs:
     - name: List contents of wheel
       run: python -m zipfile --list dist/pyhf-*.whl
 
-    # Compare to 'true' string as booleans get turned into strings in the console
     - name: Publish distribution 📦 to Test PyPI
-      # publish to TestPyPI on tag events of if manually triggered
+      # Publish to TestPyPI on tag events of if manually triggered
+      # Compare to 'true' string as booleans get turned into strings in the console
       if: >-
         (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
         || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -9,6 +9,10 @@ on:
     branches:
     - master
   workflow_dispatch:
+    inputs:
+      index:
+        description: 'Index type (testpypi | skip)'
+        required: true
 
 jobs:
   build-and-publish:

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -58,11 +58,11 @@ modifications made.
 TestPyPI
 ~~~~~~~~
 
-``pyhf`` tests packaging and distributing by publishing each commit to
-``master`` to `TestPyPI <https://test.pypi.org/project/pyhf/>`__.
-In addition, installation of the latest test release from TestPyPI can be tested
+``pyhf`` tests packaging and distributing by publishing in advance of releases
+to `TestPyPI <https://test.pypi.org/project/pyhf/>`__.
+Installation of the latest test release from TestPyPI can be tested
 by first installing ``pyhf`` normally, to ensure all dependencies are installed
-from PyPI, and then upgrading ``pyhf`` to a dev release from TestPyPI
+from PyPI, and then upgrading ``pyhf`` to a test release from TestPyPI
 
 .. code-block:: bash
 


### PR DESCRIPTION
# Description

There is a build up of releases on TestPyPI that will eventually need to get deleted into the future. This is a manual process (which will be done by me) and is very slow. To avoid this, only publish to TestPyPI on tags (that start with `v`) or if a workflow dispatch event is run with the user selecting the `true` option from the drop down menu in response to the question 'Publish to TestPyPI?'

![dispatch_option](https://user-images.githubusercontent.com/5142394/145182513-62d024dd-51c8-4d71-a006-3908e1e264de.png)

Using workflow dispatch will still allow for using TestPyPI to check images before release.

https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows/

I've tested this setup of the CI config on my fork.


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Publish to TestPyPI on push events where a tag is pushed that starts with
a 'v' (release tags of form vX.Y.Z) or on workflow dispatch events where the
maintainer running the workflow has selected the 'true' option from the
drop-down menu for whether to publish.
   - The workflow dispatch option defaults to 'false' to avoid accidental
     publishing.
* Update development docs to reflect that not every commit is published to
TestPyPI
```