### PR TITLE
test: Make fail_backend markers add pytest.mark.xfail and remove fail_jax marker on percentile tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,11 +38,9 @@ ignore = [
     'AUTHORS',
 ]
 
-[tool.pytest]
-xfail_strict = true
-
 [tool.pytest.ini_options]
 minversion = "6.0"
+xfail_strict = true
 addopts = [
     "--ignore=setup.py",
     "--ignore=validation/",

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -287,7 +287,7 @@ class jax_backend:
             >>> import jax.numpy as jnp
             >>> pyhf.set_backend("jax")
             >>> a = pyhf.tensorlib.astensor([[10, 7, 4], [3, 2, 1]])
-            >>> pyhf.tensorlib.percentile(a, jnp.float64(50))
+            >>> pyhf.tensorlib.percentile(a, 50)
             DeviceArray(3.5, dtype=float64)
             >>> pyhf.tensorlib.percentile(a, 50, axis=1)
             DeviceArray([7., 2.], dtype=float64)
@@ -314,8 +314,6 @@ class jax_backend:
             JAX ndarray: The value of the :math:`q`-th percentile of the tensor along the specified axis.
 
         """
-        # TODO: Monitor future JAX releases for changes to percentile dtype promotion
-        # c.f. https://github.com/google/jax/issues/8513
         return jnp.percentile(tensor_in, q, axis=axis, interpolation=interpolation)
 
     def stack(self, sequence, axis=0):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,7 +99,13 @@ def backend(request):
         )
 
     if fail_backend:
-        pytest.xfail(f"expect {func_name} to fail as specified")
+        # Mark the test as xfail to actually run it and ensure that it does
+        # fail. pytest.mark.xfail checks for failure, while pytest.xfail
+        # assumes failure and skips running the test.
+        # c.f. https://docs.pytest.org/en/6.2.x/skipping.html#xfail
+        request.node.add_marker(
+            pytest.mark.xfail(reason=f"expect {func_name} to fail as specified")
+        )
 
     # actual execution here, after all checks is done
     pyhf.set_backend(*request.param)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -376,7 +376,6 @@ def test_boolean_mask(backend):
     )
 
 
-@pytest.mark.fail_jax
 def test_percentile(backend):
     tb = pyhf.tensorlib
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])
@@ -392,39 +391,11 @@ def test_percentile(backend):
 # c.f. https://github.com/scikit-hep/pyhf/issues/1693
 @pytest.mark.fail_pytorch
 @pytest.mark.fail_pytorch64
-@pytest.mark.fail_jax
 def test_percentile_interpolation(backend):
     tb = pyhf.tensorlib
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])
 
     assert tb.tolist(tb.percentile(a, 50, interpolation="linear")) == 3.5
-    assert tb.tolist(tb.percentile(a, 50, interpolation="nearest")) == 3.0
-    assert tb.tolist(tb.percentile(a, 50, interpolation="lower")) == 3.0
-    assert tb.tolist(tb.percentile(a, 50, interpolation="midpoint")) == 3.5
-    assert tb.tolist(tb.percentile(a, 50, interpolation="higher")) == 4.0
-
-
-@pytest.mark.only_jax
-def test_percentile_jax(backend):
-    tb = pyhf.tensorlib
-    a = tb.astensor([[10, 7, 4], [3, 2, 1]])
-    assert tb.tolist(tb.percentile(a, 0)) == 1
-
-    # TODO: Monitor future JAX releases for changes to percentile dtype promotion
-    # c.f. https://github.com/scikit-hep/pyhf/issues/1693
-    assert tb.tolist(tb.percentile(a, np.float64(50))) == 3.5
-    assert tb.tolist(tb.percentile(a, np.float64(100))) == 10
-    assert tb.tolist(tb.percentile(a, 50, axis=1)) == [7.0, 2.0]
-
-
-@pytest.mark.only_jax
-def test_percentile_interpolation_jax(backend):
-    tb = pyhf.tensorlib
-    a = tb.astensor([[10, 7, 4], [3, 2, 1]])
-
-    # TODO: Monitor future JAX releases for changes to percentile dtype promotion
-    # c.f. https://github.com/scikit-hep/pyhf/issues/1693
-    assert tb.tolist(tb.percentile(a, np.float64(50), interpolation="linear")) == 3.5
     assert tb.tolist(tb.percentile(a, 50, interpolation="nearest")) == 3.0
     assert tb.tolist(tb.percentile(a, 50, interpolation="lower")) == 3.0
     assert tb.tolist(tb.percentile(a, 50, interpolation="midpoint")) == 3.5

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -465,7 +465,6 @@ def test_1D_gather(backend):
     ) == [[5, 1], [4, 3]]
 
 
-@pytest.mark.fail_pytorch
 def test_ND_gather(backend):
     tb = pyhf.tensorlib
     assert tb.tolist(


### PR DESCRIPTION
# Description

Resolves #1729

To get `xfail_strict = true` to work properly in `pyproject.toml` it needs to be located under `[tool.pytest.ini_options]` as is [noted in the `pytest` docs](https://docs.pytest.org/en/6.2.x/customize.html#pyproject-toml):

> One might wonder why `[tool.pytest.ini_options]` instead of `[tool.pytest]` as is the case with other tools.
> 
> The reason is that the pytest team intends to fully utilize the rich TOML data format for configuration in the future, reserving the `[tool.pytest]` table for that. The `ini_options` table is being used, for now, as a bridge between the existing `.ini` configuration system and the future configuration format.

Once that has been moved then to deal with the issue of `pytest.xfail` skipping tests instead of running them and checking results like `pytest.mark.xfail` (c.f. Issue #1729 for discussion on this), add `pytest.mark.xfail` to the request node for the `backend` extra that has the `fail_{backend}` marker already placed on it. This marker placing ensures that placing a `fail_backend` marker on a test will fail the test if that backend does NOT fail &mdash; which was the point of PR #1702.

With that working, the `fail_jax` markers can be removed from the `percentile` tests in `test_tensor.py` and remove the `only_jax` tests added for them now that `jax` `v0.2.26` is out and brings with it a fix for https://github.com/google/jax/issues/8513. Also, remove the `fail_pytorch` marker for `test_ND_gather` (thanks to it being found by the now working `xfail` strict).

An update to the lower bounds for the `jax` extra in `setup.py`

https://github.com/scikit-hep/pyhf/blob/43c156702fd2a0392114c5b2468f0128ed16ea72/setup.py#L10

and the lower bound constraints in 

https://github.com/scikit-hep/pyhf/blob/43c156702fd2a0392114c5b2468f0128ed16ea72/tests/constraints.txt#L17-L22

is not needed as (interestingly) these lower bounds are old enough to have the desired behavior that the lastest versions have (again), and so can be left unchanged. So for the time being the `scipy` lower bound increase that is currently in `jax` won't pose an issue for the `constraints.txt` file installs for a while (c.f. https://github.com/google/jax/discussions/8871).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Move `xfail_strict = true` into [tool.pytest.ini_options] to have it
be picked up by pytest properly.
   - c.f. https://docs.pytest.org/en/6.2.x/customize.html#pyproject-toml
   - Amends PR #1702
* Edit the conftest.py `backend` fixture to mark test nodes that have
`@pytest.mark.fail_{backend}` markers (e.g. fail_jax) with
pytest.mark.xfail to ensure that the test are actually run and checked
to make sure that they don't pass when when they are expected to fail.
This is necessary as using pytest.xfail actually skips the test as it
is assumed that the test is known to fail for reasonable reasons, and
pytest.mark.xfail is intended to be the way to check fail status.
c.f.:
   - https://docs.pytest.org/en/6.2.x/skipping.html#xfail
   - https://docs.pytest.org/en/6.2.x/reference.html#pytest-xfail
   - https://docs.pytest.org/en/6.2.x/reference.html#pytest-mark-xfail-ref
* Remove fail_jax marker from percentile tests and remove only_jax
tests as no longer needed given jax v0.2.26 addresses the problems
they were added to work around.
* Remove fail_pytorch marker from test_ND_gather as the test is now
passing, causing an error given xfail_strict.
```