### PR TITLE
docs: Add GitHub Release Radar check to release checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/~release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/~release-checklist.md
@@ -12,10 +12,13 @@ about: Checklist for core developers to complete as part of making a release
 * [ ] Verify that the release notes files correctly summarize all development changes since the last release.
 * [ ] Draft email to [``pyhf-announcements`` mailing list](https://groups.google.com/group/pyhf-announcements/subscribe) that summarizes the main points of the release notes and circulate it for development team approval.
 * [ ] Update the checklist Issue template in the [``.github/ISSUE_TEMPLATE``](https://github.com/scikit-hep/pyhf/tree/master/.github/ISSUE_TEMPLATE) directory if there are revisions.
-* [ ] Verify that the project README is displaying correctly on [TestPyPI](https://test.pypi.org/project/pyhf/).
+* [ ] Make a release to [TestPyPI][TestPyPI_pyhf] using the [workflow dispatch event trigger](https://github.com/scikit-hep/pyhf/actions/workflows/publish-package.yml).
+* [ ] Verify that the project README is displaying correctly on [TestPyPI][TestPyPI_pyhf].
 * [ ] Add any new use citations or published statistical models to the [Use and Citations page](https://scikit-hep.org/pyhf/citations.html).
 * [ ] Update the [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish) GitHub Action used for deployment to TestPyPI and PyPI to the latest stable release.
 * [ ] Update the ``codemeta.json`` file in the release PR if its requirements have updated.
+
+[TestPyPI_pyhf]: https://test.pypi.org/project/pyhf/
 
 ## Once Release PR is Merged
 

--- a/.github/ISSUE_TEMPLATE/~release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/~release-checklist.md
@@ -38,4 +38,5 @@ about: Checklist for core developers to complete as part of making a release
 * [ ] Make a release for the [`pyhf` tutorial](https://github.com/pyhf/pyhf-tutorial/releases) corresponding to the **previous release** number. This release represents the last version of the tutorial that is guaranteed to work with previous release API.
 * [ ] Update the [tutorial](https://github.com/pyhf/pyhf-tutorial) to use the new release number and API.
 * [ ] Make a PR to use the new release in the [CUDA enabled Docker images](https://github.com/pyhf/cuda-images).
+* [ ] Open a [GitHub Release Radar](https://github.com/github/release-radar) Issue
 * [ ] Close the [release GitHub Project board](https://github.com/scikit-hep/pyhf/projects/).

--- a/.github/ISSUE_TEMPLATE/~release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/~release-checklist.md
@@ -38,5 +38,5 @@ about: Checklist for core developers to complete as part of making a release
 * [ ] Make a release for the [`pyhf` tutorial](https://github.com/pyhf/pyhf-tutorial/releases) corresponding to the **previous release** number. This release represents the last version of the tutorial that is guaranteed to work with previous release API.
 * [ ] Update the [tutorial](https://github.com/pyhf/pyhf-tutorial) to use the new release number and API.
 * [ ] Make a PR to use the new release in the [CUDA enabled Docker images](https://github.com/pyhf/cuda-images).
-* [ ] If the release is a major or minor release, open a [GitHub Release Radar](https://github.com/github/release-radar) Issue for the release to potentially get featured on.
+* [ ] If the release is a **major** or **minor** release, open a [GitHub Release Radar](https://github.com/github/release-radar) Issue for the release to potentially get featured on GitHub's [Release Radar blog](https://github.blog/?s=release+radar).
 * [ ] Close the [release GitHub Project board](https://github.com/scikit-hep/pyhf/projects/).

--- a/.github/ISSUE_TEMPLATE/~release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/~release-checklist.md
@@ -14,11 +14,13 @@ about: Checklist for core developers to complete as part of making a release
 * [ ] Update the checklist Issue template in the [``.github/ISSUE_TEMPLATE``](https://github.com/scikit-hep/pyhf/tree/master/.github/ISSUE_TEMPLATE) directory if there are revisions.
 * [ ] Make a release to [TestPyPI][TestPyPI_pyhf] using the [workflow dispatch event trigger](https://github.com/scikit-hep/pyhf/actions/workflows/publish-package.yml).
 * [ ] Verify that the project README is displaying correctly on [TestPyPI][TestPyPI_pyhf].
-* [ ] Add any new use citations or published statistical models to the [Use and Citations page](https://scikit-hep.org/pyhf/citations.html).
+* [ ] Add any new use citations or published statistical models to the [Use and Citations page][citations_page].
+* [ ] Verify that the citations on the [Use and Citations page][citations_page] are up to date with their current [INSPIRE](https://inspirehep.net/) record.
 * [ ] Update the [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish) GitHub Action used for deployment to TestPyPI and PyPI to the latest stable release.
 * [ ] Update the ``codemeta.json`` file in the release PR if its requirements have updated.
 
 [TestPyPI_pyhf]: https://test.pypi.org/project/pyhf/
+[citations_page]: https://scikit-hep.org/pyhf/citations.html
 
 ## Once Release PR is Merged
 

--- a/.github/ISSUE_TEMPLATE/~release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/~release-checklist.md
@@ -38,5 +38,5 @@ about: Checklist for core developers to complete as part of making a release
 * [ ] Make a release for the [`pyhf` tutorial](https://github.com/pyhf/pyhf-tutorial/releases) corresponding to the **previous release** number. This release represents the last version of the tutorial that is guaranteed to work with previous release API.
 * [ ] Update the [tutorial](https://github.com/pyhf/pyhf-tutorial) to use the new release number and API.
 * [ ] Make a PR to use the new release in the [CUDA enabled Docker images](https://github.com/pyhf/cuda-images).
-* [ ] Open a [GitHub Release Radar](https://github.com/github/release-radar) Issue
+* [ ] If the release is a major or minor release, open a [GitHub Release Radar](https://github.com/github/release-radar) Issue for the release to potentially get featured on.
 * [ ] Close the [release GitHub Project board](https://github.com/scikit-hep/pyhf/projects/).


### PR DESCRIPTION
# Description

Add step of reporting release to [GitHub Release Radar](https://github.com/github/release-radar) and add making release to TestPyPI following PR #1727.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add step of manually releasing to TestPyPI in advance of release
   - Amends PR #1727
* Add step to verify citations are up to date
* Add step of opening GitHub Release Radar issue
   - c.f. https://github.com/github/release-radar
```