### PR TITLE
fix: Disallow nbsphinx v0.8.8 to avoid empty "raw" directive bug

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,13 +31,6 @@ jobs:
         python -m pip list
         sudo apt-get update
         sudo apt-get -qq install pandoc
-
-    - name: Patch dependencies
-      run: |
-        python -m pip uninstall -y nbsphinx
-        python -m pip install --upgrade "git+https://github.com/mgeier/nbsphinx.git@protect-from-empty-text#egg=nbsphinx"
-        python -m pip list
-
     - name: Check docstrings
       run: |
         # Group 1 is related to docstrings

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,13 @@ jobs:
         python -m pip list
         sudo apt-get update
         sudo apt-get -qq install pandoc
+
+    - name: Patch dependencies
+      run: |
+        python -m pip uninstall -y nbsphinx
+        python -m pip install --upgrade "git+https://github.com/mgeier/nbsphinx.git@protect-from-empty-text#egg=nbsphinx"
+        python -m pip list
+
     - name: Check docstrings
       run: |
         # Group 1 is related to docstrings

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ extras_require['docs'] = sorted(
             'sphinxcontrib-bibtex~=2.1',
             'sphinx-click',
             'sphinx_rtd_theme',
-            'nbsphinx',
+            'nbsphinx!=0.8.8',
             'ipywidgets',
             'sphinx-issues',
             'sphinx-copybutton>=0.3.2',

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ extras_require['docs'] = sorted(
             'sphinxcontrib-bibtex~=2.1',
             'sphinx-click',
             'sphinx_rtd_theme',
-            'nbsphinx!=0.8.8',
+            'nbsphinx!=0.8.8',  # c.f. https://github.com/spatialaudio/nbsphinx/issues/620
             'ipywidgets',
             'sphinx-issues',
             'sphinx-copybutton>=0.3.2',


### PR DESCRIPTION
# Description

Disallow [`nbsphinx` `v0.8.8`](https://pypi.org/project/nbsphinx/0.8.8/) as it introduces a bug for empty 'raw' directives (c.f. https://github.com/spatialaudio/nbsphinx/issues/620). This is fixed in https://github.com/spatialaudio/nbsphinx/pull/621 and so should work its way into the next `nbsphinx` release. :+1: 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Disallow nbsphinx v0.8.8 as it introduces a bug for empty 'raw' directives.
   - c.f. https://github.com/spatialaudio/nbsphinx/issues/620
```