### PR TITLE
fix: Accept ValueError for JAX backend `tolist` fallback

### DIFF
--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -180,7 +180,7 @@ class jax_backend:
     def tolist(self, tensor_in):
         try:
             return jnp.asarray(tensor_in).tolist()
-        except TypeError:
+        except (TypeError, ValueError):
             if isinstance(tensor_in, list):
                 return tensor_in
             raise


### PR DESCRIPTION
# Description

In [JAX `v0.2.27`](https://github.com/google/jax/releases/tag/jax-v0.2.27) the error raised for trying to pass a sequence as a list includes a `ValueError`

```python
>>> import jax
>>> import jax.numpy as jnp
>>> jax.__version__
'0.2.27'
>>> jnp.asarray([[1, 2], 3, [4]])
TypeError: int() argument must be a string, a bytes-like object or a number, not 'list'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../site-packages/jax/_src/numpy/lax_numpy.py", line 3648, in asarray
    return array(a, dtype=dtype, copy=False, order=order)
  File "/.../site-packages/jax/_src/numpy/lax_numpy.py", line 3606, in array
    out = np.array(object, dtype=dtype, ndmin=ndmin, copy=False)
ValueError: setting an array element with a sequence.
```

To handle this, also accept `ValueError` as a valid exception when falling back to list.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
In JAX v0.2.27 the error raised for trying to pass a sequence as a list
includes a ValueError

>>> import jax
>>> import jax.numpy as jnp
>>> jax.__version__
'0.2.27'
>>> jnp.asarray([[1, 2], 3, [4]])
TypeError: int() argument must be a string, a bytes-like object or a number, not 'list'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../site-packages/jax/_src/numpy/lax_numpy.py", line 3648, in asarray
    return array(a, dtype=dtype, copy=False, order=order)
  File "/.../site-packages/jax/_src/numpy/lax_numpy.py", line 3606, in array
    out = np.array(object, dtype=dtype, ndmin=ndmin, copy=False)
ValueError: setting an array element with a sequence.

To handle this, also accept ValueError as a valid exception when falling back
to list.
```
