### PR TITLE
ci: Launch tmate session if pytest fails on workflow dispatch run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
       run: |
         pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
 
+    - name: Launch a tmate session if tests fail
+      if: failure() && github.event_name == 'workflow_dispatch'
+      uses: mxschmitt/action-tmate@v3
+
     - name: Report core project coverage with Codecov
       if: github.event_name != 'schedule' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2


### PR DESCRIPTION
# Description

If the pytest jobs fail and the ci workflow was triggered as the result of a workflow dispatch, launch a [tmate session](https://github.com/mxschmitt/action-tmate) which allows for sshing into the runner with the environment from the failed job.

This idea comes from Simon Willison's (@simonw) blog post (in his TIL series): [Open a debugging shell in GitHub Actions with tmate](https://til.simonwillison.net/github-actions/debug-tmate). Thanks Simon!

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* If the pytest jobs fail and the ci workflow was triggered as the result of
a workflow dispatch, launch a tmate session which allows for sshing into the
runner with the environment from the failed job.
   - c.f. https://github.com/mxschmitt/action-tmate

This idea comes from Simon Willison's (@simonw) blog post:
https://til.simonwillison.net/github-actions/debug-tmate
```
