### PR TITLE
ci: Add macos-latest to dependency release candidates testing

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ['3.9']
 
     steps:


### PR DESCRIPTION
# Description

As seen in Issue #1759, testing release candidates of software only on Linux distributions is not enough to catch bugs before they hit in public releases. To guard against this in the future, add `macos-latest` to tests for release candidates on PyPI.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* As seen in Issue #1759, testing pre-releases of software only on Linux
distributions is not enough to catch bugs before they hit in public
releases. To guard against this in the future, add macos-latest to
tests for release candidates on PyPI.
```