### PR TITLE
test: Avoid tensorflow macOS floating point deviation with pytest.approx

### DIFF
--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1,3 +1,4 @@
+from sys import platform
 import pytest
 import logging
 import numpy as np
@@ -87,6 +88,17 @@ def test_simple_tensor_ops(backend):
         [2.0, 5.0],
         [3.0, 6.0],
     ]
+
+
+@pytest.mark.xfail(platform == "darwin", reason="c.f. Issue #1759")
+@pytest.mark.only_tensorflow
+def test_simple_tensor_ops_floating_point(backend):
+    """
+    xfail test to know if test_simple_tensor_ops stops failing for tensorflow
+    on macos
+    """
+    tb = pyhf.tensorlib
+    assert tb.tolist(tb.log(tb.exp(tb.astensor([2, 3, 4])))) == [2, 3, 4]
 
 
 def test_tensor_where_scalar(backend):

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -51,7 +51,10 @@ def test_simple_tensor_ops(backend):
         4,
     ]
     assert tb.tolist(tb.sqrt(tb.astensor([4, 9, 16]))) == [2, 3, 4]
-    assert tb.tolist(tb.log(tb.exp(tb.astensor([2, 3, 4])))) == [2, 3, 4]
+    # c.f. Issue #1759
+    assert tb.tolist(tb.log(tb.exp(tb.astensor([2, 3, 4])))) == pytest.approx(
+        [2, 3, 4], 1e-9
+    )
     assert tb.tolist(tb.abs(tb.astensor([-1, -2]))) == [1, 2]
     assert tb.tolist(tb.erf(tb.astensor([-2.0, -1.0, 0.0, 1.0, 2.0]))) == pytest.approx(
         [


### PR DESCRIPTION
# Description

Resolves #1759

To avoid the floating point deviations that are seen only on macOS runners with TensorFlow `v1.8.0` use `pytest.approx` for the failing test. Add the corresponding `xfail` test to know if this ever stops being needed.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use pytest.approx in test_simple_tensor_ops to avoid floating point
difference with tensorflow on macOS (compared to Linux).
* Add a pytest.mark.xfail test for the failing operation to know if future
tensorflow releases cause this to floating point difference to stop happening.
```