### PR TITLE
docs: Update scipy intersphinx url to drop 'reference'

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ xref_links = {"arXiv:1007.1727": ("[1007.1727]", "https://arxiv.org/abs/1007.172
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/html-scipyorg/', None),
     'matplotlib': ('https://matplotlib.org/stable/', None),
     'iminuit': ('https://iminuit.readthedocs.io/en/stable/', None),
     'uproot': ('https://uproot.readthedocs.io/en/latest/', None),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ xref_links = {"arXiv:1007.1727": ("[1007.1727]", "https://arxiv.org/abs/1007.172
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/html-scipyorg/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'matplotlib': ('https://matplotlib.org/stable/', None),
     'iminuit': ('https://iminuit.readthedocs.io/en/stable/', None),
     'uproot': ('https://uproot.readthedocs.io/en/latest/', None),

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -9,7 +9,7 @@ import itertools
 import numpy as np
 
 
-# from https://docs.scipy.org/doc/scipy/reference/tutorial/optimize.html#nelder-mead-simplex-algorithm-method-nelder-mead
+# from https://docs.scipy.org/doc/scipy/html-scipyorg/tutorial/optimize.html#nelder-mead-simplex-algorithm-method-nelder-mead
 @pytest.mark.skip_pytorch
 @pytest.mark.skip_pytorch64
 @pytest.mark.skip_tensorflow

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -9,7 +9,7 @@ import itertools
 import numpy as np
 
 
-# from https://docs.scipy.org/doc/scipy/html-scipyorg/tutorial/optimize.html#nelder-mead-simplex-algorithm-method-nelder-mead
+# from https://docs.scipy.org/doc/scipy/tutorial/optimize.html#nelder-mead-simplex-algorithm-method-nelder-mead
 @pytest.mark.skip_pytorch
 @pytest.mark.skip_pytorch64
 @pytest.mark.skip_tensorflow


### PR DESCRIPTION
# Description

Resolves #1766 

At the time of opening this PR there are still problems (c.f. https://github.com/scipy/scipy/issues/15545#issuecomment-1031909411), however those should be resolved in time. This PR tries to avoid some problems in the future by updating the `scipy` intersphinx url to use `https://docs.scipy.org/doc/scipy/objects.inv` (new as of `scipy` `v1.8.0`) to avoid getting redirected there from `https://docs.scipy.org/doc/scipy/reference/objects.inv`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update scipy scipy intersphinx url to target 'https://docs.scipy.org/doc/scipy/objects.inv'
to avoid redirect from 'https://docs.scipy.org/doc/scipy/reference/'.
   - This is the result of SciPy changing the location in scipy v1.8.0.
```