### PR TITLE
test: Add html coverage reports from pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       if: github.event_name != 'schedule' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2
       with:
+        files: ./coverage.xml
         flags: unittests
 
     - name: Test Contrib module with pytest
@@ -69,6 +70,7 @@ jobs:
       if: github.event_name != 'schedule' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2
       with:
+        files: ./coverage.xml
         flags: contrib
 
     - name: Test docstring examples with doctest
@@ -79,6 +81,7 @@ jobs:
       if: github.event_name != 'schedule' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2
       with:
+        files: ./coverage.xml
         flags: doctest
 
     - name: Run benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
       if: github.event_name != 'schedule' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2
       with:
-        files: ./coverage.xml
         flags: unittests
 
     - name: Test Contrib module with pytest
@@ -70,7 +69,6 @@ jobs:
       if: github.event_name != 'schedule' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2
       with:
-        files: ./coverage.xml
         flags: contrib
 
     - name: Test docstring examples with doctest
@@ -81,7 +79,6 @@ jobs:
       if: github.event_name != 'schedule' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2
       with:
-        files: ./coverage.xml
         flags: doctest
 
     - name: Run benchmarks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ addopts = [
     "--cov-report=term-missing",
     "--cov-report=xml",
     "--cov-report=html",
+    "--cov-report=annotate:coverage_annotate",
     "--doctest-modules",
     "--doctest-glob='*.rst'"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ addopts = [
     "--cov=pyhf",
     "--cov-report=term-missing",
     "--cov-config=.coveragerc",
-    "--cov-report=xml",
     "--doctest-modules",
     "--doctest-glob='*.rst'"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,10 @@ addopts = [
     "--ignore=binder/",
     "--ignore=docs/",
     "--cov=pyhf",
-    "--cov-report=term-missing",
     "--cov-config=.coveragerc",
+    "--cov-report=term-missing",
+    "--cov-report=xml",
+    "--cov-report=html",
     "--doctest-modules",
     "--doctest-glob='*.rst'"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ addopts = [
     "--cov-report=term-missing",
     "--cov-report=xml",
     "--cov-report=html",
-    "--cov-report=annotate:coverage_annotate",
     "--doctest-modules",
     "--doctest-glob='*.rst'"
 ]


### PR DESCRIPTION
# Description

Add html ~~and annotated source code~~ coverage report option~~s~~ to `pyproject.toml` to get more reports for local testing.

The `html` version is quite nice as you can simply open up the `htmlcov/index.html` file in your browser and scroll through the same report that you'd see on Codecov. :+1: 

Examples:

![overfiew](https://user-images.githubusercontent.com/5142394/153101151-f0669473-3b8b-432d-b18f-9d285cf7be74.png)
![paramset](https://user-images.githubusercontent.com/5142394/153101161-a31e73e4-2f68-445a-a9d7-8223f58b76d9.png)


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add pytest tool options for html coverage reports
```