### PR TITLE
test: Consolidate and update pytest options in pyproject.toml

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 branch = True
-source = src/pyhf
+source = pyhf
 
 [report]
 exclude_lines =

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,11 +1,6 @@
-[run]
-branch = True
-source = pyhf
-
 [report]
 exclude_lines =
     if self.debug:
     pragma: no cover
     raise NotImplementedError
     if __name__ == .__main__.:
-ignore_errors = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -9,8 +9,3 @@ exclude_lines =
     raise NotImplementedError
     if __name__ == .__main__.:
 ignore_errors = True
-omit =
-    binder/*
-    docker/*
-    tests/*
-    validation/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,0 @@
-[report]
-exclude_lines =
-    if self.debug:
-    pragma: no cover
-    raise NotImplementedError
-    if __name__ == .__main__.:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+        pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
 
     - name: Launch a tmate session if tests fail
       if: failure() && github.event_name == 'workflow_dispatch'
@@ -64,7 +64,7 @@ jobs:
 
     - name: Test Contrib module with pytest
       run: |
-        pytest -r sx tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
+        pytest tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
 
     - name: Report contrib coverage with Codecov
       if: github.event_name != 'schedule' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
@@ -75,7 +75,7 @@ jobs:
 
     - name: Test docstring examples with doctest
       if: matrix.python-version == '3.9'
-      run: pytest -r sx src/ README.rst
+      run: pytest src/ README.rst
 
     - name: Report doctest coverage with Codecov
       if: github.event_name != 'schedule' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
@@ -87,4 +87,4 @@ jobs:
     - name: Run benchmarks
       if: github.event_name == 'schedule' && matrix.python-version == '3.9'
       run: |
-        pytest -r sx --benchmark-sort=mean tests/benchmarks/test_benchmark.py
+        pytest --benchmark-sort=mean tests/benchmarks/test_benchmark.py

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+        pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
 
   scipy:
 
@@ -61,7 +61,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+        pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
 
   iminuit:
 
@@ -87,7 +87,7 @@ jobs:
         python -m pip list
     - name: Test with pytest
       run: |
-        pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+        pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
 
   uproot4:
 
@@ -112,7 +112,7 @@ jobs:
         python -m pip list
     - name: Test with pytest
       run: |
-        pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+        pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
 
   pytest:
 
@@ -137,4 +137,4 @@ jobs:
         python -m pip list
     - name: Test with pytest
       run: |
-        pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+        pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -35,4 +35,4 @@ jobs:
     - name: Test with pytest
       run: |
         # Run on tests/ to skip doctests of src given examples are for latest APIs
-        pytest -r sx --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py tests/
+        pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py tests/

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -37,5 +37,7 @@ jobs:
         # Disable error on filterwarnings as testing for oldest releases that work with latest API,
         # not the oldest releases that are warning free
         sed -i '/"error",/d' pyproject.toml
+        # Still show warnings though
+        export PYTHONWARNINGS='default'
         # Run on tests/ to skip doctests of src given examples are for latest APIs
         pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py tests/

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -34,5 +34,8 @@ jobs:
 
     - name: Test with pytest
       run: |
+        # Disable error on filterwarnings as testing for oldest releases that work with latest API,
+        # not the oldest releases that are warning free
+        sed -i '/"error",/d' pyproject.toml
         # Run on tests/ to skip doctests of src given examples are for latest APIs
         pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py tests/

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -34,10 +34,9 @@ jobs:
 
     - name: Test with pytest
       run: |
-        # Disable error on filterwarnings as testing for oldest releases that work with latest API,
-        # not the oldest releases that are warning free
-        sed -i '/"error",/d' pyproject.toml
-        # Still show warnings though
+        # Override the ini option for filterwarnings with an empty list to disable error on filterwarnings
+        # as testing for oldest releases that work with latest API, not the oldest releases that are warning
+        # free. Though still show warnings by setting warning control to 'default'.
         export PYTHONWARNINGS='default'
         # Run on tests/ to skip doctests of src given examples are for latest APIs
-        pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py tests/
+        pytest --override-ini filterwarnings= --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py tests/

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -27,4 +27,4 @@ jobs:
         python -m pip list
     - name: Test example notebooks
       run: |
-        pytest -r sx tests/test_notebooks.py
+        pytest tests/test_notebooks.py

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Canary test public API
       run: |
-        pytest -r sx tests/test_public_api.py
+        pytest tests/test_public_api.py
 
     - name: Verify requirements in codemeta.json
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ addopts = [
     "--ignore=docs/",
     "--cov=pyhf",
     "--cov-config=.coveragerc",
+    "--cov-branch",
     "--cov-report=term-missing",
     "--cov-report=xml",
     "--cov-report=html",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ ignore = [
 minversion = "6.0"
 xfail_strict = true
 addopts = [
+    "-r a",
     "--cov=pyhf",
     "--cov-config=.coveragerc",
     "--cov-branch",
@@ -50,7 +51,6 @@ addopts = [
     "--cov-report=html",
     "--doctest-modules",
     "--doctest-glob='*.rst'",
-    "-ra",
     "--showlocals",
     "--strict-markers",
     "--strict-config"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ filterwarnings = [
     'ignore:distutils Version classes are deprecated:DeprecationWarning',  # tensorflow-probability
     'ignore:the `interpolation=` argument to percentile was renamed to `method=`, which has additional options:DeprecationWarning',  # Issue #1772
     "ignore:The interpolation= argument to 'quantile' is deprecated. Use 'method=' instead:DeprecationWarning",  # Issue #1772
+    'ignore:Please use `OptimizeWarning` from the `scipy.optimize` namespace, the `scipy.optimize.optimize` namespace is deprecated.',  # Issue #1772, scipy v1.8.0+
     "ignore:In future, it will be an error for 'np.bool_' scalars to be interpreted as an index:DeprecationWarning",  #FIXME: tests/test_tensor.py::test_pdf_eval[pytorch]
     'ignore:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with:UserWarning',  #FIXME: tests/test_optim.py::test_minimize[no_grad-scipy-pytorch-no_stitch]
     'ignore:divide by zero encountered in true_divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ minversion = "6.0"
 xfail_strict = true
 addopts = [
     "-ra",
-    "-Wd",
     "--cov=pyhf",
     "--cov-branch",
     "--showlocals",
@@ -54,6 +53,19 @@ addopts = [
     "--cov-report=html",
     "--doctest-modules",
     "--doctest-glob='*.rst'",
+]
+filterwarnings = [
+    "error",
+    'ignore:the imp module is deprecated:DeprecationWarning',  # tensorflow
+    'ignore:distutils Version classes are deprecated:DeprecationWarning',  # tensorflow-probability
+    'ignore:the `interpolation=` argument to percentile was renamed to `method=`, which has additional options:DeprecationWarning',  # Issue #1772
+    "ignore:The interpolation= argument to 'quantile' is deprecated. Use 'method=' instead:DeprecationWarning",  # Issue #1772
+    'ignore:invalid value encountered in true_divide:RuntimeWarning',  #FIXME
+    'ignore:invalid value encountered in add:RuntimeWarning',  #FIXME
+    "ignore:In future, it will be an error for 'np.bool_' scalars to be interpreted as an index:DeprecationWarning",  #FIXME
+    "ignore:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with:UserWarning",  #FIXME
+    'ignore:divide by zero encountered in log:RuntimeWarning',
+    'ignore:divide by zero encountered in true_divide:RuntimeWarning',
 ]
 log_cli_level = "info"
 testpaths = "tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,16 +44,15 @@ xfail_strict = true
 addopts = [
     "-r a",
     "--cov=pyhf",
-    "--cov-config=.coveragerc",
     "--cov-branch",
+    "--showlocals",
+    "--strict-markers",
+    "--strict-config",
     "--cov-report=term-missing",
     "--cov-report=xml",
     "--cov-report=html",
     "--doctest-modules",
     "--doctest-glob='*.rst'",
-    "--showlocals",
-    "--strict-markers",
-    "--strict-config"
 ]
 log_cli_level = "info"
 testpaths = "tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ ignore = [
 minversion = "6.0"
 xfail_strict = true
 addopts = [
-    "-r a",
+    "-ra",
+    "-Wd",
     "--cov=pyhf",
     "--cov-branch",
     "--showlocals",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,13 @@ addopts = [
     "--cov-report=xml",
     "--cov-report=html",
     "--doctest-modules",
-    "--doctest-glob='*.rst'"
+    "--doctest-glob='*.rst'",
+    "-ra",
+    "--showlocals",
+    "--strict-markers",
+    "--strict-config"
 ]
+log_cli_level = "info"
 testpaths = "tests"
 markers = [
     "fail_jax",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,19 +54,6 @@ addopts = [
     "--doctest-modules",
     "--doctest-glob='*.rst'",
 ]
-filterwarnings = [
-    "error",
-    'ignore:the imp module is deprecated:DeprecationWarning',  # tensorflow
-    'ignore:distutils Version classes are deprecated:DeprecationWarning',  # tensorflow-probability
-    'ignore:the `interpolation=` argument to percentile was renamed to `method=`, which has additional options:DeprecationWarning',  # Issue #1772
-    "ignore:The interpolation= argument to 'quantile' is deprecated. Use 'method=' instead:DeprecationWarning",  # Issue #1772
-    'ignore:invalid value encountered in true_divide:RuntimeWarning',  #FIXME
-    'ignore:invalid value encountered in add:RuntimeWarning',  #FIXME
-    "ignore:In future, it will be an error for 'np.bool_' scalars to be interpreted as an index:DeprecationWarning",  #FIXME
-    "ignore:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with:UserWarning",  #FIXME
-    'ignore:divide by zero encountered in log:RuntimeWarning',
-    'ignore:divide by zero encountered in true_divide:RuntimeWarning',
-]
 log_cli_level = "info"
 testpaths = "tests"
 markers = [
@@ -88,6 +75,19 @@ markers = [
     "skip_pytorch",
     "skip_pytorch64",
     "skip_tensorflow",
+]
+filterwarnings = [
+    "error",
+    'ignore:the imp module is deprecated:DeprecationWarning',  # tensorflow
+    'ignore:distutils Version classes are deprecated:DeprecationWarning',  # tensorflow-probability
+    'ignore:the `interpolation=` argument to percentile was renamed to `method=`, which has additional options:DeprecationWarning',  # Issue #1772
+    "ignore:The interpolation= argument to 'quantile' is deprecated. Use 'method=' instead:DeprecationWarning",  # Issue #1772
+    'ignore:invalid value encountered in true_divide:RuntimeWarning',  #FIXME
+    'ignore:invalid value encountered in add:RuntimeWarning',  #FIXME
+    "ignore:In future, it will be an error for 'np.bool_' scalars to be interpreted as an index:DeprecationWarning",  #FIXME
+    "ignore:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with:UserWarning",  #FIXME
+    'ignore:divide by zero encountered in log:RuntimeWarning',
+    'ignore:divide by zero encountered in true_divide:RuntimeWarning',
 ]
 
 [tool.nbqa.mutate]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,11 +78,7 @@ markers = [
     "skip_tensorflow",
 ]
 
-[tool.nbqa.config]
-black = "pyproject.toml"
-
 [tool.nbqa.mutate]
-black = 1
 pyupgrade = 1
 
 [tool.nbqa.addopts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ filterwarnings = [
     'ignore:distutils Version classes are deprecated:DeprecationWarning',  # tensorflow-probability
     'ignore:the `interpolation=` argument to percentile was renamed to `method=`, which has additional options:DeprecationWarning',  # Issue #1772
     "ignore:The interpolation= argument to 'quantile' is deprecated. Use 'method=' instead:DeprecationWarning",  # Issue #1772
+    'ignore: Exception ignored in:pytest.PytestUnraisableExceptionWarning',  #FIXME: Exception ignored in: <_io.FileIO [closed]>
+    'ignore:invalid value encountered in true_divide:RuntimeWarning',  #FIXME
+    'ignore:invalid value encountered in add:RuntimeWarning',  #FIXME
     "ignore:In future, it will be an error for 'np.bool_' scalars to be interpreted as an index:DeprecationWarning",  #FIXME: tests/test_tensor.py::test_pdf_eval[pytorch]
     'ignore:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with:UserWarning',  #FIXME: tests/test_optim.py::test_minimize[no_grad-scipy-pytorch-no_stitch]
     'ignore:divide by zero encountered in true_divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,7 @@ filterwarnings = [
     'ignore:invalid value encountered in add:RuntimeWarning',  #FIXME
     "ignore:In future, it will be an error for 'np.bool_' scalars to be interpreted as an index:DeprecationWarning",  #FIXME
     "ignore:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with:UserWarning",  #FIXME
-    'ignore:divide by zero encountered in log:RuntimeWarning',
-    'ignore:divide by zero encountered in true_divide:RuntimeWarning',
+    'ignore:divide by zero encountered in true_divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py -k test_pdf_calculations[numpy]
 ]
 
 [tool.nbqa.mutate]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,6 @@ ignore = [
 minversion = "6.0"
 xfail_strict = true
 addopts = [
-    "--ignore=setup.py",
-    "--ignore=validation/",
-    "--ignore=binder/",
-    "--ignore=docs/",
     "--cov=pyhf",
     "--cov-config=.coveragerc",
     "--cov-branch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,6 @@ filterwarnings = [
     'ignore:distutils Version classes are deprecated:DeprecationWarning',  # tensorflow-probability
     'ignore:the `interpolation=` argument to percentile was renamed to `method=`, which has additional options:DeprecationWarning',  # Issue #1772
     "ignore:The interpolation= argument to 'quantile' is deprecated. Use 'method=' instead:DeprecationWarning",  # Issue #1772
-    'ignore:Please use `OptimizeWarning` from the `scipy.optimize` namespace, the `scipy.optimize.optimize` namespace is deprecated.',  # Issue #1772, scipy v1.8.0+
     "ignore:In future, it will be an error for 'np.bool_' scalars to be interpreted as an index:DeprecationWarning",  #FIXME: tests/test_tensor.py::test_pdf_eval[pytorch]
     'ignore:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with:UserWarning',  #FIXME: tests/test_optim.py::test_minimize[no_grad-scipy-pytorch-no_stitch]
     'ignore:divide by zero encountered in true_divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,11 +82,9 @@ filterwarnings = [
     'ignore:distutils Version classes are deprecated:DeprecationWarning',  # tensorflow-probability
     'ignore:the `interpolation=` argument to percentile was renamed to `method=`, which has additional options:DeprecationWarning',  # Issue #1772
     "ignore:The interpolation= argument to 'quantile' is deprecated. Use 'method=' instead:DeprecationWarning",  # Issue #1772
-    'ignore:invalid value encountered in true_divide:RuntimeWarning',  #FIXME
-    'ignore:invalid value encountered in add:RuntimeWarning',  #FIXME
-    "ignore:In future, it will be an error for 'np.bool_' scalars to be interpreted as an index:DeprecationWarning",  #FIXME
-    "ignore:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with:UserWarning",  #FIXME
-    'ignore:divide by zero encountered in true_divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py -k test_pdf_calculations[numpy]
+    "ignore:In future, it will be an error for 'np.bool_' scalars to be interpreted as an index:DeprecationWarning",  #FIXME: tests/test_tensor.py::test_pdf_eval[pytorch]
+    'ignore:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with:UserWarning',  #FIXME: tests/test_optim.py::test_minimize[no_grad-scipy-pytorch-no_stitch]
+    'ignore:divide by zero encountered in true_divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]
 ]
 
 [tool.nbqa.mutate]

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -352,17 +352,14 @@ def test_export_sample_zerodata(mocker, spec):
     sampledata = [0.0] * len(samplespec['data'])
 
     mocker.patch('pyhf.writexml._ROOT_DATA_FILE')
-    # make sure no RuntimeWarning, https://stackoverflow.com/a/45671804
-    with pytest.warns(None) as record:
-        for modifierspec in samplespec['modifiers']:
-            pyhf.writexml.build_modifier(
-                {'measurements': [{'config': {'parameters': []}}]},
-                modifierspec,
-                channelname,
-                samplename,
-                sampledata,
-            )
-    assert not record.list
+    for modifierspec in samplespec['modifiers']:
+        pyhf.writexml.build_modifier(
+            {'measurements': [{'config': {'parameters': []}}]},
+            modifierspec,
+            channelname,
+            samplename,
+            sampledata,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -424,7 +424,8 @@ def test_integer_data(datadir, mocker):
     """
     Test that a spec with only integer data will be written correctly
     """
-    spec = json.load(open(datadir.join("workspace_integer_data.json")))
+    with open(datadir.join("workspace_integer_data.json")) as spec_file:
+        spec = json.load(spec_file)
     channel_spec = spec["channels"][0]
     mocker.patch("pyhf.writexml._ROOT_DATA_FILE")
 

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -576,7 +576,9 @@ def test_bad_solver_options_scipy(mocker):
     model = pyhf.simplemodels.uncorrelated_background([50.0], [100.0], [10.0])
     data = pyhf.tensorlib.astensor([125.0] + model.config.auxdata)
 
-    with pytest.warns(OptimizeWarning):
+    with pytest.warns(
+        OptimizeWarning, match="Unknown solver options: arbitrary_option"
+    ):
         assert pyhf.infer.mle.fit(data, model).tolist()
 
 

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -4,6 +4,7 @@ from pyhf.optimize.common import _get_tensor_shim, _make_stitch_pars
 from pyhf.tensor.common import _TensorViewer
 import pytest
 from scipy.optimize import minimize, OptimizeResult
+from scipy.optimize.optimize import OptimizeWarning
 import iminuit
 import itertools
 import numpy as np
@@ -563,7 +564,8 @@ def test_solver_options_scipy(mocker):
 
 
 # Note: in this case, scipy won't usually raise errors for arbitrary options
-# so this test exists as a sanity reminder that scipy is not perfect
+# so this test exists as a sanity reminder that scipy is not perfect.
+# It does raise a scipy.optimize.optimize.OptimizeWarning though.
 def test_bad_solver_options_scipy(mocker):
     optimizer = pyhf.optimize.scipy_optimizer(
         solver_options={'arbitrary_option': 'foobar'}
@@ -573,7 +575,9 @@ def test_bad_solver_options_scipy(mocker):
 
     model = pyhf.simplemodels.uncorrelated_background([50.0], [100.0], [10.0])
     data = pyhf.tensorlib.astensor([125.0] + model.config.auxdata)
-    assert pyhf.infer.mle.fit(data, model).tolist()
+
+    with pytest.warns(OptimizeWarning):
+        assert pyhf.infer.mle.fit(data, model).tolist()
 
 
 def test_minuit_param_names(mocker):

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -4,7 +4,7 @@ from pyhf.optimize.common import _get_tensor_shim, _make_stitch_pars
 from pyhf.tensor.common import _TensorViewer
 import pytest
 from scipy.optimize import minimize, OptimizeResult
-from scipy.optimize.optimize import OptimizeWarning
+from scipy.optimize import OptimizeWarning
 import iminuit
 import itertools
 import numpy as np
@@ -565,7 +565,7 @@ def test_solver_options_scipy(mocker):
 
 # Note: in this case, scipy won't usually raise errors for arbitrary options
 # so this test exists as a sanity reminder that scipy is not perfect.
-# It does raise a scipy.optimize.optimize.OptimizeWarning though.
+# It does raise a scipy.optimize.OptimizeWarning though.
 def test_bad_solver_options_scipy(mocker):
     optimizer = pyhf.optimize.scipy_optimizer(
         solver_options={'arbitrary_option': 'foobar'}

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -274,37 +274,39 @@ def test_shape(backend):
 @pytest.mark.fail_pytorch64
 def test_pdf_calculations(backend):
     tb = pyhf.tensorlib
-    assert tb.tolist(tb.normal_cdf(tb.astensor([0.8]))) == pytest.approx(
-        [0.7881446014166034], 1e-07
-    )
-    assert tb.tolist(
-        tb.normal_logpdf(
-            tb.astensor([0, 0, 1, 1, 0, 0, 1, 1]),
-            tb.astensor([0, 1, 0, 1, 0, 1, 0, 1]),
-            tb.astensor([0, 0, 0, 0, 1, 1, 1, 1]),
+    # FIXME
+    with pytest.warns(RuntimeWarning, match="divide by zero encountered in log"):
+        assert tb.tolist(tb.normal_cdf(tb.astensor([0.8]))) == pytest.approx(
+            [0.7881446014166034], 1e-07
         )
-    ) == pytest.approx(
-        [
-            np.nan,
-            np.nan,
-            np.nan,
-            np.nan,
-            -0.91893853,
-            -1.41893853,
-            -1.41893853,
-            -0.91893853,
-        ],
-        nan_ok=True,
-    )
-    # Allow poisson(lambda=0) under limit Poisson(n = 0 | lambda -> 0) = 1
-    assert tb.tolist(
-        tb.poisson(tb.astensor([0, 0, 1, 1]), tb.astensor([0, 1, 0, 1]))
-    ) == pytest.approx([1.0, 0.3678794503211975, 0.0, 0.3678794503211975])
-    assert tb.tolist(
-        tb.poisson_logpdf(tb.astensor([0, 0, 1, 1]), tb.astensor([0, 1, 0, 1]))
-    ) == pytest.approx(
-        np.log([1.0, 0.3678794503211975, 0.0, 0.3678794503211975]).tolist()
-    )
+        assert tb.tolist(
+            tb.normal_logpdf(
+                tb.astensor([0, 0, 1, 1, 0, 0, 1, 1]),
+                tb.astensor([0, 1, 0, 1, 0, 1, 0, 1]),
+                tb.astensor([0, 0, 0, 0, 1, 1, 1, 1]),
+            )
+        ) == pytest.approx(
+            [
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+                -0.91893853,
+                -1.41893853,
+                -1.41893853,
+                -0.91893853,
+            ],
+            nan_ok=True,
+        )
+        # Allow poisson(lambda=0) under limit Poisson(n = 0 | lambda -> 0) = 1
+        assert tb.tolist(
+            tb.poisson(tb.astensor([0, 0, 1, 1]), tb.astensor([0, 1, 0, 1]))
+        ) == pytest.approx([1.0, 0.3678794503211975, 0.0, 0.3678794503211975])
+        assert tb.tolist(
+            tb.poisson_logpdf(tb.astensor([0, 0, 1, 1]), tb.astensor([0, 1, 0, 1]))
+        ) == pytest.approx(
+            np.log([1.0, 0.3678794503211975, 0.0, 0.3678794503211975]).tolist()
+        )
 
     # Ensure continuous approximation is valid
     assert tb.tolist(
@@ -343,11 +345,12 @@ def test_pdf_calculations_pytorch(backend):
     assert tb.tolist(
         tb.poisson(tb.astensor([0, 0, 1, 1]), tb.astensor([0, 1, 0, 1]))
     ) == pytest.approx([1.0, 0.3678794503211975, 0.0, 0.3678794503211975])
-    assert tb.tolist(
-        tb.poisson_logpdf(tb.astensor([0, 0, 1, 1]), tb.astensor([0, 1, 0, 1]))
-    ) == pytest.approx(
-        np.log([1.0, 0.3678794503211975, 0.0, 0.3678794503211975]).tolist()
-    )
+    with pytest.warns(RuntimeWarning):
+        assert tb.tolist(
+            tb.poisson_logpdf(tb.astensor([0, 0, 1, 1]), tb.astensor([0, 1, 0, 1]))
+        ) == pytest.approx(
+            np.log([1.0, 0.3678794503211975, 0.0, 0.3678794503211975]).tolist()
+        )
 
     # Ensure continuous approximation is valid
     assert tb.tolist(

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -345,7 +345,7 @@ def test_pdf_calculations_pytorch(backend):
     assert tb.tolist(
         tb.poisson(tb.astensor([0, 0, 1, 1]), tb.astensor([0, 1, 0, 1]))
     ) == pytest.approx([1.0, 0.3678794503211975, 0.0, 0.3678794503211975])
-    with pytest.warns(RuntimeWarning):
+    with pytest.warns(RuntimeWarning, match="divide by zero encountered in log"):
         assert tb.tolist(
             tb.poisson_logpdf(tb.astensor([0, 0, 1, 1]), tb.astensor([0, 1, 0, 1]))
         ) == pytest.approx(


### PR DESCRIPTION
# Description

Resolves #1685

Remove `.coveragerc` and consolidate pytest options to `pyproject.toml` (this results in `--cov-branch` getting added.) In doing so, also apply the [Configuring pytest recommendations from Scikit-HEP](https://scikit-hep.org/developer/pytest#configuring-pytest) that Henry wrote.

* `-ra` includes a report after pytest runs with a summary on all tests except those that passed. From `pytest --help`:
   - > -r chars              show extra test summary info as specified by chars: (f)ailed, (E)rror, (s)kipped, (x)failed, (X)passed, (p)assed, (P)assed with output, (a)ll except passed (p/P), or (A)ll. (w)arnings are enabled by default (see --disable-warnings), 'N' can be used to reset the list. (default: 'fE').
   - This allows for removal of `-r sx` in all the CI jobs.
* ~~`-Wd` enables all warnings.~~
   - ~~> [It adds 'd' to sys.warnoptions, which in turn adds a new first entry to _warnings.filters which matches all warnings and enables the "default" behavior, which is to show it once per execution of the Python interpreter.](https://mail.python.org/pipermail/python-dev/2010-April/099116.html)~~
* `--showlocal` prints locals in tracebacks.
* `--strict-markers` will complain if you use an unspecified fixture.
* `--strict-config` will raise an error if there is a mistake in the pytest config.
* `log_cli_level = "info"` reports `INFO` and above log messages on a failure.
* `filterwarnings = ["error"]` sets all warnings to be errors and allows for some warnings to be ignored with [`-W` warn control syntax](https://docs.python.org/dev/using/cmdline.html#cmdoption-W).
* Remove `tests/__init__.py` as "there’s not often a reason to make the test directory importable, and it can confuse package discovery algorithms."

To deal with the fact that the minimum supported dependencies workflow is using intentionally older releases that will have different behaviors and warnings then the rest of the tests, use the `--override-ini` pytest option to override the `filterwarnings` option with an empty list for that workflow

```
pytest --override-ini filterwarnings=
```

though also set warning control to `'default'` to see the warnings.

Also remove the now unused nbQA options for black. (Amends PR #1598)

(Thanks to @alexander-held for reminding me about [branch coverage](https://coverage.readthedocs.io/en/latest/branch.html) in general.)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove .coveragerc and consolidate pytest options to pyproject.toml.
* Apply 'configuring pytest' recommendations for pytest from Scikit-HEP
(c.f. https://scikit-hep.org/developer/pytest#configuring-pytest ).
   - '-ra' includes a report after pytest runs with a summary on all tests
     except those that passed. From 'pytest --help':
     > -r chars: show extra test summary info as specified by chars: (f)ailed,
     > (E)rror, (s)kipped, (x)failed, (X)passed, (p)assed, (P)assed with output,
     > (a)ll except passed (p/P), or (A)ll. (w)arnings are enabled by default
     > (see --disable-warnings), 'N' can be used to reset the list. (default: 'fE').
   - '--showlocal' prints locals in tracebacks.
   - '--strict-markers' will complain if you use an unspecified fixture.
   - '--strict-config' will raise an error if there is a mistake in the pytest config.
   - 'log_cli_level = "info"' reports INFO and above log messages on a failure.
   - 'filterwarnings = ["error"]' sets all warnings to be errors and allows for
     some warnings to be ignored with -W warn control syntax.
     (c.f. https://docs.python.org/dev/using/cmdline.html#cmdoption-W )
* Remove `tests/__init__.py` as no reason to make the tests directory importable.
* Remove '-r sx' from pytest calls in CI jobs as pyproject.toml now applies '-ra'.
* Use 'with pytest.warns' to assert expected warnings in tests.
(c.f. https://docs.pytest.org/en/7.0.x/how-to/capture-warnings.html#warns )
* Override error on filterwarnings for the 'minimum supported dependencies' GHA workflow
as it is testing for the oldest releases that work with the latest API, not the oldest
releases that are warning free.
* Remove unused nbQA options for black from pyproject.toml.
   - Amends PR #1598
```