### PR TITLE
docs: fix link to TRExFitter documentation

### DIFF
--- a/docs/babel.rst
+++ b/docs/babel.rst
@@ -73,7 +73,7 @@ TRExFitter
 
 .. note::
 
-    For more details on this section, please refer to the ATLAS-internal `TRExFitter documentation <https://trexfitter-docs.web.cern.ch/trexfitter-docs/advanced_topics/pyhf/>`_.
+    For more details on this section, please refer to the ATLAS-internal `TRExFitter documentation <https://trexfitter-docs.web.cern.ch/trexfitter-docs/interfacing_tools/pyhf/>`_.
 
 In order to go from ``TRExFitter`` to ``pyhf``, the good news is that the ``RooWorkspace`` files (``XML`` and ``ROOT``) are already made for you. For a given configuration which looks like
 


### PR DESCRIPTION
# Description

The [`TRExFitter` part of the translation section in the documentation](https://pyhf.readthedocs.io/en/v0.6.3/babel.html#trexfitter) contains a link to ATLAS-internal documentation. Following a restructuring of that internal documentation, the link used on the `pyhf` website is no longer correct. This fixes the link.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
- [ ] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR
