### PR TITLE
docs: Update URL to 'TRExFitter to pyhf' translation docs

### DIFF
--- a/docs/babel.rst
+++ b/docs/babel.rst
@@ -73,7 +73,7 @@ TRExFitter
 
 .. note::
 
-    For more details on this section, please refer to the ATLAS-internal `TRExFitter documentation <https://trexfitter-docs.web.cern.ch/trexfitter-docs/advanced_topics/pyhf/>`_.
+    For more details on this section, please refer to the ATLAS-internal `TRExFitter documentation <https://trexfitter-docs.web.cern.ch/trexfitter-docs/interfacing_tools/pyhf/>`_.
 
 In order to go from ``TRExFitter`` to ``pyhf``, the good news is that the ``RooWorkspace`` files (``XML`` and ``ROOT``) are already made for you. For a given configuration which looks like
 


### PR DESCRIPTION
# Description

Update link on https://pyhf.readthedocs.io/en/v0.6.3/babel.html#trexfitter to the new docs URL: https://trexfitter-docs.web.cern.ch/trexfitter-docs/interfacing_tools/pyhf/ (thanks to @alexander-held for the heads up on this!).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* c.f. https://trexfitter-docs.web.cern.ch/trexfitter-docs/interfacing_tools/pyhf/
```
