### PR TITLE
build: Require setuptools v42.0.0+ for stability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["wheel", "setuptools>=30.3.0", "attrs>=17.1", "setuptools_scm[toml]>=3.4"]
+requires = ["wheel", "setuptools>=42.0.0", "attrs>=17.1", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
# Description

Resolves #1774


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* setuptools releases prior to v42.0.0 had stability issues with
pyproject.toml or didn't support PEP 517 and so couldn't support
pyproject.toml.
   - c.f. https://www.python.org/dev/peps/pep-0517/

Co-authored-by: Henry Schreiner <henry.fredrick.schreiner@cern.ch>
```