### PR TITLE
build: Remove wheel and attrs from build-system requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools>=42.0.0", "attrs>=17.1", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=42.0.0", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["wheel", "setuptools>=42.0.0", "attrs>=17.1", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=42.0.0", "attrs>=17.1", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
# Description

Resolves #1787 

As noted by @henryiii in https://github.com/scikit-hep/pylhe/pull/111, neither `wheel` or `attrs` are needed.

* Remove wheel from build-system requires as it is declared by PEP 517's `get_requires_for_build_sdist` and so already covered.
   - c.f. https://www.python.org/dev/peps/pep-0517/
* Remove attrs as not required at build time.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove wheel from build-system requires as it is declared by
PEP 517's get_requires_for_build_sdist and so already covered.
   - c.f. https://www.python.org/dev/peps/pep-0517/
* Remove attrs as not required at build time.
```