### PR TITLE
docs: Add section for tutorial and docs to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -269,6 +269,14 @@ To uninstall run
 
    python -m pip uninstall pyhf
 
+Documentation
+-------------
+
+For model scpecification, API reference, examples, and answers to FAQs visit the |pyhf documentation|_.
+
+.. |pyhf documentation| replace:: ``pyhf`` documentation
+.. _pyhf documentation: https://pyhf.readthedocs.io/
+
 Questions
 ---------
 

--- a/README.rst
+++ b/README.rst
@@ -272,7 +272,7 @@ To uninstall run
 Documentation
 -------------
 
-For model scpecification, API reference, examples, and answers to FAQs visit the |pyhf documentation|_.
+For model specification, API reference, examples, and answers to FAQs visit the |pyhf documentation|_.
 
 .. |pyhf documentation| replace:: ``pyhf`` documentation
 .. _pyhf documentation: https://pyhf.readthedocs.io/

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ pure-python fitting/limit-setting/interval estimation HistFactory-style
 
 |GitHub Project| |DOI| |JOSS DOI| |Scikit-HEP| |NSF Award Number|
 
-|Docs from latest| |Docs from master| |Binder|
+|Docs from latest| |Docs from master| |Jupyter Book tutorial| |Binder|
 
 |PyPI version| |Conda-forge version| |Supported Python versions| |Docker Hub pyhf| |Docker Hub pyhf CUDA|
 
@@ -344,6 +344,8 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
    :target: https://pyhf.readthedocs.io/
 .. |Docs from master| image:: https://img.shields.io/badge/docs-master-blue.svg
    :target: https://scikit-hep.github.io/pyhf
+.. |Jupyter Book tutorial| image:: https://jupyterbook.org/_images/badge.svg
+   :target: https://pyhf.github.io/pyhf-tutorial/
 .. |Binder| image:: https://mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/master?filepath=docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
 

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ and GPU acceleration.
 User Guide
 ----------
 
-For a guided tour of usage of the latest release of ``pyhf`` visit the |pyhf tutorial|_.
+For an in depth walkthrough of usage of the latest release of ``pyhf`` visit the |pyhf tutorial|_.
 
 .. |pyhf tutorial| replace:: ``pyhf`` tutorial
 .. _pyhf tutorial: https://pyhf.github.io/pyhf-tutorial/

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,14 @@ to support modern computational graph libraries such as PyTorch and
 TensorFlow in order to make use of features such as autodifferentiation
 and GPU acceleration.
 
+User Guide
+----------
+
+For a guided tour of usage of the latest release of ``pyhf`` visit the |pyhf tutorial|_.
+
+.. |pyhf tutorial| replace:: ``pyhf`` tutorial
+.. _pyhf tutorial: https://pyhf.github.io/pyhf-tutorial/
+
 Hello World
 -----------
 


### PR DESCRIPTION
# Description

Resolves #1782

Add a "User Guide" section as the very first section in the README that link to the [`pyhf` tutorial](https://pyhf.github.io/pyhf-tutorial/). Also add badge to the Jupyter Book tutorial to the top of the README. [![Jupyter Book Badge](https://jupyterbook.org/_images/badge.svg)](https://pyhf.github.io/pyhf-tutorial/)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add section to README that links to the pyhf tutorial.
   - c.f. https://pyhf.github.io/pyhf-tutorial/
* Add badge to the Jupyter Book tutorial to the top of the README.
* Add section to README that explicitly links to the documentation.
   - c.f. https://pyhf.readthedocs.io/
```