### PR TITLE
docs: Add general citation from MadJAX paper

### DIFF
--- a/docs/bib/general_citations.bib
+++ b/docs/bib/general_citations.bib
@@ -1,12 +1,13 @@
 % 2022-02-28
-@inproceedings{Heinrich:2022xfa,
+@article{Heinrich:2022xfa,
     author = "Heinrich, Lukas and Kagan, Michael",
     title = "{Differentiable Matrix Elements with MadJax}",
     eprint = "2203.00057",
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
     month = "2",
-    year = "2022"
+    year = "2022",
+    journal = ""
 }
 
 % 2022-02-04

--- a/docs/bib/general_citations.bib
+++ b/docs/bib/general_citations.bib
@@ -1,3 +1,14 @@
+% 2022-02-28
+@inproceedings{Heinrich:2022xfa,
+    author = "Heinrich, Lukas and Kagan, Michael",
+    title = "{Differentiable Matrix Elements with MadJax}",
+    eprint = "2203.00057",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    month = "2",
+    year = "2022"
+}
+
 % 2022-02-04
 @article{Pivarski:2022ycs,
     author = "Pivarski, Jim and Rodrigues, Eduardo and Pedro, Kevin and Shadura, Oksana and Krikler, Benjamin and Stewart, Graeme A.",


### PR DESCRIPTION
# Description

Add general citation from [Differentiable Matrix Elements with MadJax](https://inspirehep.net/literature/2040678) by @lukasheinrich and @makagan. :rocket: 

The paper was also submitted to the Proceedings of the 20th International Workshop on Advanced Computing and Analysis Techniques in Physics Research (ACAT 2021), but as that doesn't seem to be published yet we'll just treat it as a standalone paper for now.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add general citation from 'Differentiable Matrix Elements with MadJax'.
   - c.f. https://inspirehep.net/literature/2040678
```