### PR TITLE
docs: Add use citation from ATLAS UEH MS displaced jet paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -7,7 +7,8 @@
     primaryClass  = "hep-ex",
     reportNumber  = "CERN-EP-2021-195",
     month         = "3",
-    year          = "2022"
+    year          = "2022",
+    journal       = ""
 }
 
 % 2021-12-29

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,15 @@
+% 2022-03-01
+@article{EXOT-2019-24,
+    author        = "{ATLAS Collaboration}",
+    title         = "{Search for events with a pair of displaced vertices from long-lived neutral particles decaying into hadronic jets in the ATLAS muon spectrometer in pp collisions at $\sqrt{s}=13$ TeV}",
+    eprint        = "2203.00587",
+    archivePrefix = "arXiv",
+    primaryClass  = "hep-ex",
+    reportNumber  = "CERN-EP-2021-195",
+    month         = "3",
+    year          = "2022"
+}
+
 % 2021-12-29
 @article{Jaffredo:2021ymt,
     author = "Jaffredo, Florentin",


### PR DESCRIPTION
# Description

Add use citation from ATLAS paper [Search for events with a pair of displaced vertices from long-lived neutral particles decaying into hadronic jets in the ATLAS muon spectrometer in pp collisions at \sqrt{s}=13 TeV](https://inspirehep.net/literature/2040545) ([ANA-EXOT-2019-24](https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PAPERS/EXOT-2019-24/)).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Search for events with a pair of displaced vertices
from long-lived neutral particles decaying into hadronic jets in the ATLAS
muon spectrometer in pp collisions at \sqrt{s}=13 TeV'
   - ATLAS paper: ANA-EXOT-2019-24
   - c.f. https://inspirehep.net/literature/2040545
```