### PR TITLE
docs: Correct Giordon's affiliation to SCIPP in CITATON.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -54,7 +54,7 @@ references:
     - family-names: "Stark"
       given-names: "Giordon"
       orcid: "https://orcid.org/0000-0001-6616-3433"
-      affiliation: "University of Illinois at Urbana-Champaign"
+      affiliation: "SCIPP, University of California, Santa Cruz"
     - family-names: "Cranmer"
       given-names: "Kyle"
       orcid: "https://orcid.org/0000-0002-5769-7094"


### PR DESCRIPTION
# Description

In PR #1551 we accidentally had @kratsg listed as being at Illinois in the `CITATON.cff` file. whoops.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Fix typo that had Illinois twice instead of SCIPP
   - Amend PR #1551
```