### PR TITLE
docs: Add use citation from ATLAS UEH displaced jets CalRatio paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,5 +1,5 @@
 % 2022-03-02
-@article{ATLAS:2022zhj,
+@article{EXOT-2019-23,
     author        = "{ATLAS Collaboration}",
     title         = "{Search for neutral long-lived particles in $pp$ collisions at $\sqrt{s}=13$ TeV that decay into displaced hadronic jets in the ATLAS calorimeter}",
     eprint        = "2203.01009",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,16 @@
+% 2022-03-02
+@article{ATLAS:2022zhj,
+    author        = "{ATLAS Collaboration}",
+    title         = "{Search for neutral long-lived particles in $pp$ collisions at $\sqrt{s}=13$ TeV that decay into displaced hadronic jets in the ATLAS calorimeter}",
+    eprint        = "2203.01009",
+    archivePrefix = "arXiv",
+    primaryClass  = "hep-ex",
+    reportNumber  = "CERN-EP-2022-002",
+    month         = "3",
+    year          = "2022",
+    journal       = ""
+}
+
 % 2022-03-01
 @article{EXOT-2019-24,
     author        = "{ATLAS Collaboration}",


### PR DESCRIPTION
# Description

Add use citation from ATLAS paper [Search for neutral long-lived particles in pp collisions at \sqrt{s}=13 TeV that decay into displaced hadronic jets in the ATLAS calorimeter](https://inspirehep.net/literature/2043503) ([ANA-EXOT-2019-23](https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PAPERS/EXOT-2019-23/)).

Congratulations on the nice publication to @masonproffitt and @gordonwatts who were on the analysis team! :rocket:

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Search for neutral long-lived particles in pp collisions
at \sqrt{s}=13 TeV that decay into displaced hadronic jets in the ATLAS calorimeter'.
   - ATLAS paper: ANA-EXOT-2019-23
   - c.f. https://inspirehep.net/literature/2043503
```