### PR TITLE
docs: Fix tiny typo in MC Stat Error documentation

### DIFF
--- a/docs/likelihood.rst
+++ b/docs/likelihood.rst
@@ -198,7 +198,7 @@ As explained in detail in :cite:`likelihood-Cranmer:1456844`, adding uncertaint
 each sample would yield a very large number of nuisance parameters with limited
 utility. Therefore a set of bin-wise scale factors :math:`\gamma_b` is
 introduced to model the overall uncertainty in the bin due to MC statistics.
-The constrained term is constructed as a set of Gaussian constraints with a
+The constraint term is constructed as a set of Gaussian constraints with a
 central value equal to unity for each bin in the channel. The scales
 :math:`\sigma_b` of the constraint are computed from the individual
 uncertainties of samples defined within the channel relative to the total event


### PR DESCRIPTION
# Pull Request Description

No issue related. Change minor typo in docs.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Change phrasing in MC Stat Error docs from "constrained term" to "constraint term"
```
