### PR TITLE
refactor: Clarify exception message applies only to profile likelihood ratio

### DIFF
--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -13,7 +13,7 @@ def _check_hypotest_prerequisites(pdf, data, init_pars, par_bounds, fixed_params
 
     if not utils.all_pois_floating(pdf, fixed_params):
         raise exceptions.InvalidModel(
-            f'POI at index [{pdf.config.poi_index}] is set as fixed, which makes profile likelihood ratio inference impossible. Please unfix the POI to continue.'
+            f'POI at index [{pdf.config.poi_index}] is set as fixed, which makes profile likelihood ratio based inference impossible. Please unfix the POI to continue.'
         )
 
 

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -13,7 +13,7 @@ def _check_hypotest_prerequisites(pdf, data, init_pars, par_bounds, fixed_params
 
     if not utils.all_pois_floating(pdf, fixed_params):
         raise exceptions.InvalidModel(
-            f'POI at index [{pdf.config.poi_index}] is set as fixed, which makes inference impossible. Please unfix the POI to continue.'
+            f'POI at index [{pdf.config.poi_index}] is set as fixed, which makes profile likelihood ratio inference impossible. Please unfix the POI to continue.'
         )
 
 


### PR DESCRIPTION
# Description

Clarify that the warning RE: 'inference [being] impossible' the user gets if `pyhf.infer.hypotest` is called with fixed POIs is limited to profile likelihood ratio based methods, and not to methods like MLE fits. Thanks to a discussion with @alexander-held for helping me realize this warning wasn't very clear in general.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Clarify that the message RE: 'inference [being] impossible' the user
gets if pyhf.infer.hypotest is called with fixed POIs is limited to
profile likelihood ratio based methods, and not to methods like MLE fits.
```