### PR TITLE
ci: Add CPython 3.10 to testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
           - os: macos-latest
-            python-version: '3.9'
+            python-version: '3.10'
 
     steps:
     - uses: actions/checkout@v2
@@ -56,7 +56,7 @@ jobs:
       uses: mxschmitt/action-tmate@v3
 
     - name: Report core project coverage with Codecov
-      if: github.event_name != 'schedule' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
+      if: github.event_name != 'schedule' && matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2
       with:
         files: ./coverage.xml
@@ -67,24 +67,24 @@ jobs:
         pytest tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
 
     - name: Report contrib coverage with Codecov
-      if: github.event_name != 'schedule' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
+      if: github.event_name != 'schedule' && matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2
       with:
         files: ./coverage.xml
         flags: contrib
 
     - name: Test docstring examples with doctest
-      if: matrix.python-version == '3.9'
+      if: matrix.python-version == '3.10'
       run: pytest src/ README.rst
 
     - name: Report doctest coverage with Codecov
-      if: github.event_name != 'schedule' && matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'
+      if: github.event_name != 'schedule' && matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v2
       with:
         files: ./coverage.xml
         flags: doctest
 
     - name: Run benchmarks
-      if: github.event_name == 'schedule' && matrix.python-version == '3.9'
+      if: github.event_name == 'schedule' && matrix.python-version == '3.10'
       run: |
         pytest --benchmark-sort=mean tests/benchmarks/test_benchmark.py

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.9']
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9']
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9']
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -95,7 +95,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9']
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -120,7 +120,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9']
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -30,10 +30,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: '3.10'
 
     - name: Install python-build, check-manifest, and twine
       run: |

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pyhf[backends,xmlio]
-        python -m pip install 'pytest~=6.0' pytest-cov
+        python -m pip install 'pytest~=7.0' pytest-cov
         python -m pip list
 
     - name: Canary test public API

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -18,10 +18,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         include:
           - os: macos-latest
-            python-version: '3.9'
+            python-version: '3.10'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -58,10 +58,10 @@ jobs:
       run: |
         git merge --squash "origin/${GITHUB_HEAD_REF}"
         git commit -m "${PR_TITLE} (#${PR_NUMBER})"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Install bump2version
       run: |
         python -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
# Description

Resolves #1758 

Now that PyTorch [`v1.11.0`](https://pypi.org/project/torch/1.11.0/) is out with [Python 3.10 support](https://pypi.org/project/torch/1.11.0/#files), we can add CPython 3.10 to the CI. A follow up PR will add Python 3.10 to the metadata.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add CPython 3.10 to the testing matrix in CI.
* Use CPython 3.10 as the default Python for all CI/CD workflows.
```