### PR TITLE
build: Add support for Python 3.10 across all backends

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -129,5 +129,5 @@
     "keywords": "physics fitting numpy scipy tensorflow pytorch jax",
     "developmentStatus": "4 - Beta",
     "applicationCategory": "Scientific/Engineering, Scientific/Engineering :: Physics",
-    "programmingLanguage": "Python 3, Python 3.7, Python 3.8, Python 3.9, Python Implementation CPython"
+    "programmingLanguage": "Python 3, Python 3.7, Python 3.8, Python 3.9, Python 3.10, Python Implementation CPython"
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=python:3.9-slim-bullseye
+ARG BASE_IMAGE=python:3.10-slim-bullseye
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE} as base
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
 
 [options]


### PR DESCRIPTION
# Description

Follow up PR to PR #1808 

* Add support for Python 3.10 to the PyPI metadata and codemeta.json.
* Update Dockerfile base image to `python:3.10-slim-bullseye`.


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add support for Python 3.10 to the PyPI metadata and codemeta.json.
* Update Dockerfile base image to python:3.10-slim-bullseye.
```