### PR TITLE
docs: Add use citation from neos paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,12 +1,13 @@
 % 2022-03-10
-@inproceedings{Simpson:2022suz,
+@article{Simpson:2022suz,
     author = "Simpson, Nathan and Heinrich, Lukas",
     title = "{neos: End-to-End-Optimised Summary Statistics for High Energy Physics}",
     eprint = "2203.05570",
     archivePrefix = "arXiv",
     primaryClass = "physics.data-an",
     month = "3",
-    year = "2022"
+    year = "2022",
+    journal = ""
 }
 
 % 2022-03-02

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,14 @@
+% 2022-03-10
+@inproceedings{Simpson:2022suz,
+    author = "Simpson, Nathan and Heinrich, Lukas",
+    title = "{neos: End-to-End-Optimised Summary Statistics for High Energy Physics}",
+    eprint = "2203.05570",
+    archivePrefix = "arXiv",
+    primaryClass = "physics.data-an",
+    month = "3",
+    year = "2022"
+}
+
 % 2022-03-02
 @article{EXOT-2019-23,
     author        = "{ATLAS Collaboration}",


### PR DESCRIPTION
# Description

Add use citation from [neos: End-to-End-Optimised Summary Statistics for High Energy Physics](https://inspirehep.net/literature/2050088) by @phinate and @lukasheinrich. :rocket: 

Congrats to them both! :)

[![neos_shot](https://user-images.githubusercontent.com/5142394/158256265-45dc95a2-c15c-4ee5-8d66-7c1885137208.png)](https://arxiv.org/abs/2203.05570)

The paper was also submitted to the Proceedings of the 20th International Workshop on Advanced Computing and Analysis Techniques in Physics Research (ACAT 2021), but as that doesn't seem to be published yet we'll just treat it as a standalone paper for now.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'neos: End-to-End-Optimised Summary Statistics for High
Energy Physics'.
   - c.f. https://inspirehep.net/literature/2050088
```
