### PR TITLE
docs: Update JAX backend normal docstring to jax v0.3.2 returns

### DIFF
--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -477,7 +477,7 @@ class jax_backend:
             >>> import pyhf
             >>> pyhf.set_backend("jax")
             >>> pyhf.tensorlib.normal(0.5, 0., 1.)
-            DeviceArray(0.35206533, dtype=float64)
+            DeviceArray(0.35206533, dtype=float64, weak_type=True)
             >>> values = pyhf.tensorlib.astensor([0.5, 2.0])
             >>> means = pyhf.tensorlib.astensor([0., 2.3])
             >>> sigmas = pyhf.tensorlib.astensor([1., 0.8])


### PR DESCRIPTION
# Description

Update `jax` backend `normal` docstring examples to `jax` `v0.3.2+` `DeviceArray` return of showing `weak_type=True`. This is the same sort of thing that was required for PR #1584.

So now after the update

```console
$ python -m pip list | grep jax
jax                               0.3.2
jaxlib                            0.3.2
jupyter-server-mathjax            0.2.3
$ pytest src/pyhf/tensor/jax_backend.py
```

passes the doctest. :+1: 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update jax backend normal docstring examples to jax v0.3.2+
DeviceArray return of showing `weak_type=True`.
```