### PR TITLE
fix: writexml handles missing parameter configs for normfactor

### DIFF
--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -178,7 +178,7 @@ def build_modifier(spec, modifierspec, channelname, samplename, sampledata):
         high = 10
         for p in spec['measurements'][0]['config']['parameters']:
             if p['name'] == modifierspec['name']:
-                val = p.get('inits', val)
+                val = p.get('inits', [val])[0]
                 low, high = p.get('bounds', [[low, high]])[0]
         attrs['Val'] = str(val)
         attrs['Low'] = str(low)

--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -178,8 +178,8 @@ def build_modifier(spec, modifierspec, channelname, samplename, sampledata):
         high = 10
         for p in spec['measurements'][0]['config']['parameters']:
             if p['name'] == modifierspec['name']:
-                val = p['inits'][0]
-                low, high = p['bounds'][0]
+                val = p.get('inits', val)
+                low, high = p.get('bounds', [[low, high]])[0]
         attrs['Val'] = str(val)
         attrs['Low'] = str(low)
         attrs['High'] = str(high)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -428,3 +428,30 @@ def test_integer_data(datadir, mocker):
 
     channel = pyhf.writexml.build_channel(spec, channel_spec, {})
     assert channel
+
+
+@pytest.mark.parametrize(
+    "fname,val,low,high",
+    [
+        ('workspace_no_parameter_inits.json', '1', '-5', '5'),
+        ('workspace_no_parameter_bounds.json', '5', '0', '10'),
+    ],
+    ids=['no_inits', 'no_bounds'],
+)
+def test_issue1814(datadir, mocker, fname, val, low, high):
+    with open(datadir / fname) as spec_file:
+        spec = json.load(spec_file)
+
+    modifierspec = {'data': None, 'name': 'mu_sig', 'type': 'normfactor'}
+    channelname = None
+    samplename = None
+    sampledata = None
+
+    modifier = pyhf.writexml.build_modifier(
+        spec, modifierspec, channelname, samplename, sampledata
+    )
+    assert modifier is not None
+    assert sorted(modifier.keys()) == ['High', 'Low', 'Name', 'Val']
+    modifier.get('Val') == val
+    modifier.get('Low') == low
+    modifier.get('High') == high

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -452,6 +452,6 @@ def test_issue1814(datadir, mocker, fname, val, low, high):
     )
     assert modifier is not None
     assert sorted(modifier.keys()) == ['High', 'Low', 'Name', 'Val']
-    modifier.get('Val') == val
-    modifier.get('Low') == low
-    modifier.get('High') == high
+    assert modifier.get('Val') == val
+    assert modifier.get('Low') == low
+    assert modifier.get('High') == high

--- a/tests/test_export/workspace_no_parameter_bounds.json
+++ b/tests/test_export/workspace_no_parameter_bounds.json
@@ -1,0 +1,37 @@
+{
+    "channels": [
+        {
+            "name": "ch",
+            "samples": [
+                {
+                    "data": [1000.0],
+                    "modifiers": [
+                        {"data": null, "name": "mu_sig", "type": "normfactor"},
+                        {
+                            "data": {"hi": 1.5, "lo": 0.5},
+                            "name": "unc",
+                            "type": "normsys"
+                        }
+                    ],
+                    "name": "signal"
+                }
+            ]
+        }
+    ],
+    "measurements": [
+        {
+            "config": {
+                "parameters": [
+                    {
+                        "name": "mu_sig",
+                        "inits": [5]
+                    }
+                ],
+                "poi": "mu_sig"
+            },
+            "name": "meas"
+        }
+    ],
+    "observations": [{"data": [1000], "name": "ch"}],
+    "version": "1.0.0"
+}

--- a/tests/test_export/workspace_no_parameter_inits.json
+++ b/tests/test_export/workspace_no_parameter_inits.json
@@ -1,0 +1,37 @@
+{
+    "channels": [
+        {
+            "name": "ch",
+            "samples": [
+                {
+                    "data": [1000.0],
+                    "modifiers": [
+                        {"data": null, "name": "mu_sig", "type": "normfactor"},
+                        {
+                            "data": {"hi": 1.5, "lo": 0.5},
+                            "name": "unc",
+                            "type": "normsys"
+                        }
+                    ],
+                    "name": "signal"
+                }
+            ]
+        }
+    ],
+    "measurements": [
+        {
+            "config": {
+                "parameters": [
+                    {
+                        "name": "mu_sig",
+                        "bounds": [[-5, 5]]
+                    }
+                ],
+                "poi": "mu_sig"
+            },
+            "name": "meas"
+        }
+    ],
+    "observations": [{"data": [1000], "name": "ch"}],
+    "version": "1.0.0"
+}


### PR DESCRIPTION
# Pull Request Description

Fixes #1814.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* In situations in writexml where the normfactor parameter config is missing
inits or bounds, fall back to using default values instead.
* Add tests that use workspaces with no parameter inits and no parameter bounds
to cover this behavior.
```
