### PR TITLE
test: Assert exported StatError has no name attribute

### DIFF
--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -188,6 +188,7 @@ def build_modifier(spec, modifierspec, channelname, samplename, sampledata):
         attrs['HistoName'] = _make_hist_name(
             channelname, samplename, modifierspec['name']
         )
+        # must be deleted, HiFa XML specification does not support 'Name'
         del attrs['Name']
         # need to make this a relative uncertainty stored in ROOT file
         _export_root_histogram(


### PR DESCRIPTION
# Pull Request Description

Resolves #1770.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add comment to writexml.py to clarify the role of staterror's name when
exporting to HistFactory XML.
* Add modifier type to test_export_modifier and assert that the modifier for
StatError has no name attribute.
```
