### PR TITLE
fix: Disallow Jinja2 v3.1.0 to avoid nbsphinx triggering attribute error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ extras_require['docs'] = sorted(
             'sphinx-click',
             'sphinx_rtd_theme',
             'nbsphinx!=0.8.8',  # c.f. https://github.com/spatialaudio/nbsphinx/issues/620
-            'Jinja2!=3.1.0',
+            'Jinja2!=3.1.0',  # c.f. https://github.com/spatialaudio/nbsphinx/issues/641
             'ipywidgets',
             'sphinx-issues',
             'sphinx-copybutton>=0.3.2',

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ extras_require['docs'] = sorted(
             'sphinx-click',
             'sphinx_rtd_theme',
             'nbsphinx!=0.8.8',  # c.f. https://github.com/spatialaudio/nbsphinx/issues/620
+            'Jinja2!=3.1.0',
             'ipywidgets',
             'sphinx-issues',
             'sphinx-copybutton>=0.3.2',


### PR DESCRIPTION
# Description

Stopgap measure to deal with Issue #1823 for the time being until there is a fix. As `nbsphinx` `v0.8.7` is reliant on `Jinja2` `v3.0.X` APIs and so `Jinja2` `v3.1.0` breaks it.

This is a stopgap measure and this should be removed as soon as there is a resolution and new `nbsphinx` release.

c.f. https://github.com/spatialaudio/nbsphinx/issues/641 for more details.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Disallow Jinja2 v3.1.0 to avoid nbsphinx triggering attribute error:
    
    AttributeError: module 'jinja2.utils' has no attribute 'escape'

This is a stopgap measure and this line should be removed as soon as there
is a resolution and new nbsphinx release.
   - c.f. https://github.com/spatialaudio/nbsphinx/issues/641
```