### PR TITLE
fix: bump black to 22.3.0 due to click 8.1 release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     - id: absolufy-imports
 
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     - id: black-jupyter
 
@@ -44,7 +44,7 @@ repos:
     rev: v1.12.1
     hooks:
     - id: blacken-docs
-      additional_dependencies: [black==22.1.0]
+      additional_dependencies: [black==22.3.0]
 
 -   repo: https://github.com/PyCQA/flake8
     rev: 4.0.1


### PR DESCRIPTION
See https://github.com/psf/black/issues/2964 for details.

Committed via https://github.com/asottile/all-repos

```
* Update black pre-commit hook to avoid incompatibly with click v8.1.0:
   - https://github.com/psf/black: v22.1.0 → v22.3.0
   - c.f. https://github.com/psf/black/issues/2964 for details.
```