### PR TITLE
fix: Add filterwarnings ignore for Pillow DeprecationWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ filterwarnings = [
     "ignore:In future, it will be an error for 'np.bool_' scalars to be interpreted as an index:DeprecationWarning",  #FIXME: tests/test_tensor.py::test_pdf_eval[pytorch]
     'ignore:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with:UserWarning',  #FIXME: tests/test_optim.py::test_minimize[no_grad-scipy-pytorch-no_stitch]
     'ignore:divide by zero encountered in true_divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]
-    'ignore:NEAREST is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
+    'ignore:is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
 ]
 
 [tool.nbqa.mutate]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,12 +88,7 @@ filterwarnings = [
     "ignore:In future, it will be an error for 'np.bool_' scalars to be interpreted as an index:DeprecationWarning",  #FIXME: tests/test_tensor.py::test_pdf_eval[pytorch]
     'ignore:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with:UserWarning',  #FIXME: tests/test_optim.py::test_minimize[no_grad-scipy-pytorch-no_stitch]
     'ignore:divide by zero encountered in true_divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]
-    'ignore:NEAREST is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
-    'ignore:BILINEAR is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
-    'ignore:BICUBIC is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
-    'ignore:HAMMING is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
-    'ignore:BOX is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
-    'ignore:LANCZOS is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
+    'ignore:[A-Z]+ is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
 ]
 
 [tool.nbqa.mutate]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,9 @@ filterwarnings = [
     'ignore:NEAREST is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
     'ignore:BILINEAR is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
     'ignore:BICUBIC is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
+    'ignore:HAMMING is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
+    'ignore:BOX is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
+    'ignore:LANCZOS is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
 ]
 
 [tool.nbqa.mutate]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ filterwarnings = [
     "ignore:In future, it will be an error for 'np.bool_' scalars to be interpreted as an index:DeprecationWarning",  #FIXME: tests/test_tensor.py::test_pdf_eval[pytorch]
     'ignore:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with:UserWarning',  #FIXME: tests/test_optim.py::test_minimize[no_grad-scipy-pytorch-no_stitch]
     'ignore:divide by zero encountered in true_divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]
+    'ignore:NEAREST is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
 ]
 
 [tool.nbqa.mutate]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ filterwarnings = [
     'ignore:divide by zero encountered in true_divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]
     'ignore:NEAREST is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
     'ignore:BILINEAR is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
+    'ignore:BICUBIC is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
 ]
 
 [tool.nbqa.mutate]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,8 @@ filterwarnings = [
     "ignore:In future, it will be an error for 'np.bool_' scalars to be interpreted as an index:DeprecationWarning",  #FIXME: tests/test_tensor.py::test_pdf_eval[pytorch]
     'ignore:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with:UserWarning',  #FIXME: tests/test_optim.py::test_minimize[no_grad-scipy-pytorch-no_stitch]
     'ignore:divide by zero encountered in true_divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]
-    'ignore:is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
+    'ignore:NEAREST is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
+    'ignore:BILINEAR is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
 ]
 
 [tool.nbqa.mutate]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ filterwarnings = [
     "ignore:In future, it will be an error for 'np.bool_' scalars to be interpreted as an index:DeprecationWarning",  #FIXME: tests/test_tensor.py::test_pdf_eval[pytorch]
     'ignore:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with:UserWarning',  #FIXME: tests/test_optim.py::test_minimize[no_grad-scipy-pytorch-no_stitch]
     'ignore:divide by zero encountered in true_divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]
-    'ignore:[A-Z]+ is deprecated and will be removed in Pillow 10:DeprecationWarning',  # matplotlib
+    'ignore:[A-Z]+ is deprecated and will be removed in Pillow 10:DeprecationWarning',  # keras
 ]
 
 [tool.nbqa.mutate]


### PR DESCRIPTION
# Description

Add a ignore to pytest `filterwarnings` to avoid `Pillow` `DeprecationWarning`

> DeprecationWarning: NEAREST is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.NEAREST or Dither.NONE instead.
> DeprecationWarning: BILINEAR is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BILINEAR instead.
> DeprecationWarning: BICUBIC is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BICUBIC instead.
> DeprecationWarning: HAMMING is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.HAMMING instead.
> DeprecationWarning: BOX is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BOX instead.
> DeprecationWarning: LANCZOS is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.LANCZOS instead.

from `Keras`'s use of `Pillow`.

This is showing up now and not in PR #1773 as [`Pillow` `v9.1.0`](https://pypi.org/project/Pillow/9.1.0/#history) was released today (2022-04-01).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add a ignore to filterwarnings to avoid Pillow DeprecationWarnings

> DeprecationWarning: NEAREST is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.NEAREST or Dither.NONE instead.
> DeprecationWarning: BILINEAR is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BILINEAR instead.
> DeprecationWarning: BICUBIC is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BICUBIC instead.
> DeprecationWarning: HAMMING is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.HAMMING instead.
> DeprecationWarning: BOX is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.BOX instead.
> DeprecationWarning: LANCZOS is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.LANCZOS instead.

from Keras's use of Pillow.

Co-authored-by: Henry Schreiner <henry.fredrick.schreiner@cern.ch>
```