### PR TITLE
ci: Add matplotlib nightly wheels to HEAD of dependencies testing

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -146,11 +146,7 @@ jobs:
     - name: List installed Python packages
       run: python -m pip list
 
-    - name: Test with pytest
-      run: |
-        pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
-
-    - name: Test Contrib module API with pytest
+    - name: Test contrib module API with pytest
       run: |
         pytest tests/contrib
 

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -136,7 +136,9 @@ jobs:
         python -m pip --no-cache-dir --quiet install --upgrade .[test]
         python -m pip uninstall --yes matplotlib
         python -m pip install --upgrade --index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple matplotlib
-        python -m pip list
+
+    - name: List installed Python packages
+      run: python -m pip list
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -135,7 +135,11 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade .[test]
         python -m pip uninstall --yes matplotlib
-        python -m pip install --upgrade --index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple matplotlib
+        python -m pip install \
+          --upgrade \
+          --pre \
+          --extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple \
+          matplotlib
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -148,7 +148,11 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
+        pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+
+    - name: Test Contrib module with pytest
+      run: |
+        pytest tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
 
   pytest:
 

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -114,6 +114,34 @@ jobs:
       run: |
         pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
 
+  matplotlib:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.10']
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip --no-cache-dir --quiet install --upgrade .[test]
+        python -m pip uninstall --yes scipy
+        python -m pip install --upgrade --index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
+        python -m pip list
+
+    - name: Test with pytest
+      run: |
+        pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+
   pytest:
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -134,13 +134,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade .[test]
-        python -m pip uninstall --yes scipy
-        python -m pip install --upgrade --index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
+        python -m pip uninstall --yes matplotlib
+        python -m pip install --upgrade --index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple matplotlib
         python -m pip list
 
     - name: Test with pytest
       run: |
-        pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+        pytest --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
 
   pytest:
 

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -150,9 +150,9 @@ jobs:
       run: |
         pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
 
-    - name: Test Contrib module with pytest
+    - name: Test Contrib module API with pytest
       run: |
-        pytest tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
+        pytest tests/contrib
 
   pytest:
 

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -135,6 +135,8 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade .[test]
         python -m pip uninstall --yes matplotlib
+        # Need to use --extra-index-url as dependencies aren't on scipy-wheels-nightly package index.
+        # Need to use --pre as dev releases will need priority over stable releases.
         python -m pip install \
           --upgrade \
           --pre \


### PR DESCRIPTION
# Description

With the addition of `matplotlib` nightly wheels on the [`scipy-wheels-nightly` Anaconda Cloud organization](https://anaconda.org/scipy-wheels-nightly) package index (c.f. https://github.com/matplotlib/matplotlib/pull/22733), wheels that are either at, or very close to, matplotlib's HEAD on GitHub can now be tested.

As the only place that `matplotlib` is used in `pyhf` is in `pyhf.contrib`, only test the `contrib` module instead of all of `pyhf`.

Note for devs: 
* Need to use `--extra-index-url` as dependencies aren't on scipy-wheels-nightly package index.
* Need to use `--pre` as dev releases will need priority over stable releases.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* With the addition of matplotlib nightly wheels on the
scipy-wheels-nightly Anaconda Cloud organization package index,
wheels that are either at, or very close to, matplotlib's HEAD
on GitHub can now be tested. As the only place that matplotlib
is used in pyhf is in pyhf.contrib, only test the contrib module
instead of all of pyhf.
   - c.f. https://anaconda.org/scipy-wheels-nightly
```