### PR TITLE
ci: Add concurrency group to HEAD of dependencies workflow

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -6,6 +6,10 @@ on:
   - cron:  '1 0 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: dependencies-head-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release-candidates:
 


### PR DESCRIPTION
# Description

Use a [GitHub Actions concurrency group](https://docs.github.com/en/actions/using-jobs/using-concurrency) to limit the HEAD of dependencies workflow to only one run at a time.

Normally this will never get used, but if someone is trying to test something on a dev branch then this will be helpful to avoid wasting a lot of cycles.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use a concurrency group to limit the HEAD of dependencies workflow
to only one run at a time.
   - c.f. https://docs.github.com/en/actions/using-jobs/using-concurrency
```