### PR TITLE
revert: Remove Jinja2 restrictions given nbconvert v6.4.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ extras_require['docs'] = sorted(
             'sphinx-click',
             'sphinx_rtd_theme',
             'nbsphinx!=0.8.8',  # c.f. https://github.com/spatialaudio/nbsphinx/issues/620
-            'Jinja2!=3.1.0',  # c.f. https://github.com/spatialaudio/nbsphinx/issues/641
             'ipywidgets',
             'sphinx-issues',
             'sphinx-copybutton>=0.3.2',


### PR DESCRIPTION
# Description

Revert PR #1824 given updates in `nbconvert` `v6.4.5` (c.f. https://github.com/spatialaudio/nbsphinx/issues/641#issuecomment-1086944106). The issues described there were resolved upstream of `nbsphinx` in https://github.com/jupyter/nbconvert/pull/1737.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Revert PR #1824 to remove restrictions place on Jinja2 given
https://github.com/spatialaudio/nbsphinx/issues/641. The issues
described there were resolved upstream of nbsphinx in
https://github.com/jupyter/nbconvert/pull/1737.
   - Lower bounds of 'nbconvert>=6.4.5' are not added as lower
     bound restrictions should be applied upstream of pyhf in
     nbsphinx. PR #1824 was applied only because it was
     necessary.
```