### PR TITLE
fix: Override error on filterwarnings to pass notebook tests

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -39,6 +39,4 @@ jobs:
         # Override the ini option for filterwarnings with an empty list to disable error
         # on filterwarnings as testing for notebooks to run with the latest API, not if
         # Jupyter infrastructure is warning free.
-        # Though still show warnings by setting warning control to 'default'.
-        # export PYTHONWARNINGS='default'
         pytest --override-ini filterwarnings= tests/test_notebooks.py

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -37,11 +37,13 @@ jobs:
       run: python -m pip list
 
     - name: REMOVE test a failing test by self
+      shell: bash
       run: |
         export PYTHONWARNINGS='default'
         pytest --override-ini filterwarnings= tests/test_notebooks.py -k test_xml_importexport
 
     - name: Test example notebooks
+      shell: bash
       run: |
         # Override the ini option for filterwarnings with an empty list to disable error
         # on filterwarnings as testing for notebooks to run with the latest API, not if

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install --upgrade .[test]
+        python -m pip install --upgrade .[test]
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -1,6 +1,8 @@
 name: Notebooks
 
 on:
+  # REMOVE
+  push:
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -32,4 +32,9 @@ jobs:
 
     - name: Test example notebooks
       run: |
-        pytest tests/test_notebooks.py
+        # Override the ini option for filterwarnings with an empty list to disable error
+        # on filterwarnings as testing for notebooks to run with the latest API, not if
+        # Jupyter infrastructure is warning free. Though still show warnings by setting
+        # warning control to 'default'.
+        export PYTHONWARNINGS='default'
+        pytest --override-ini filterwarnings= tests/test_notebooks.py

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -36,6 +36,11 @@ jobs:
     - name: List installed Python packages
       run: python -m pip list
 
+    - name: REMOVE test a failing test by self
+      run: |
+        export PYTHONWARNINGS='default'
+        pytest --override-ini filterwarnings= tests/test_notebooks.py -k test_xml_importexport
+
     - name: Test example notebooks
       run: |
         # Override the ini option for filterwarnings with an empty list to disable error

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -8,6 +8,10 @@ on:
   - cron:  '1 0 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: notebooks-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
 

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -16,15 +16,20 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install --upgrade .[complete]
-        python -m pip list
+        python -m pip --quiet install --upgrade .[test]
+
+    - name: List installed Python packages
+      run: python -m pip list
+
     - name: Test example notebooks
       run: |
         pytest tests/test_notebooks.py

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -34,10 +34,6 @@ jobs:
     - name: List installed Python packages
       run: python -m pip list
 
-    - name: REMOVE test a failing test by self
-      run: |
-        pytest --override-ini filterwarnings= tests/test_notebooks.py -k test_xml_importexport
-
     - name: Test example notebooks
       run: |
         # Override the ini option for filterwarnings with an empty list to disable error

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -1,8 +1,6 @@
 name: Notebooks
 
 on:
-  # REMOVE
-  push:
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'
@@ -37,17 +35,14 @@ jobs:
       run: python -m pip list
 
     - name: REMOVE test a failing test by self
-      shell: bash
       run: |
-        export PYTHONWARNINGS='default'
         pytest --override-ini filterwarnings= tests/test_notebooks.py -k test_xml_importexport
 
     - name: Test example notebooks
-      shell: bash
       run: |
         # Override the ini option for filterwarnings with an empty list to disable error
         # on filterwarnings as testing for notebooks to run with the latest API, not if
         # Jupyter infrastructure is warning free.
         # Though still show warnings by setting warning control to 'default'.
-        export PYTHONWARNINGS='default'
+        # export PYTHONWARNINGS='default'
         pytest --override-ini filterwarnings= tests/test_notebooks.py

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
@@ -36,7 +36,7 @@ jobs:
       run: |
         # Override the ini option for filterwarnings with an empty list to disable error
         # on filterwarnings as testing for notebooks to run with the latest API, not if
-        # Jupyter infrastructure is warning free. Though still show warnings by setting
-        # warning control to 'default'.
+        # Jupyter infrastructure is warning free.
+        # Though still show warnings by setting warning control to 'default'.
         export PYTHONWARNINGS='default'
         pytest --override-ini filterwarnings= tests/test_notebooks.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ filterwarnings = [
     'ignore:divide by zero encountered in true_divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]
     'ignore:[A-Z]+ is deprecated and will be removed in Pillow 10:DeprecationWarning',  # keras
     'ignore:Passing unrecognized arguments to super:DeprecationWarning',  # traitlets in notebook tests
+    "ignore:coroutine 'NotebookClient.async_start_new_kernel' was never awaited:RuntimeWarning"  # notebook tests
 ]
 
 [tool.nbqa.mutate]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ filterwarnings = [
     'ignore:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with:UserWarning',  #FIXME: tests/test_optim.py::test_minimize[no_grad-scipy-pytorch-no_stitch]
     'ignore:divide by zero encountered in true_divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]
     'ignore:[A-Z]+ is deprecated and will be removed in Pillow 10:DeprecationWarning',  # keras
+    'ignore:Passing unrecognized arguments to super:DeprecationWarning',  # traitlets in notebook tests
 ]
 
 [tool.nbqa.mutate]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ filterwarnings = [
     'ignore:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with:UserWarning',  #FIXME: tests/test_optim.py::test_minimize[no_grad-scipy-pytorch-no_stitch]
     'ignore:divide by zero encountered in true_divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]
     'ignore:[A-Z]+ is deprecated and will be removed in Pillow 10:DeprecationWarning',  # keras
-    'ignore:Passing unrecognized arguments to super:DeprecationWarning',  # traitlets in notebook tests
 ]
 
 [tool.nbqa.mutate]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,6 @@ filterwarnings = [
     'ignore:divide by zero encountered in true_divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]
     'ignore:[A-Z]+ is deprecated and will be removed in Pillow 10:DeprecationWarning',  # keras
     'ignore:Passing unrecognized arguments to super:DeprecationWarning',  # traitlets in notebook tests
-    "ignore:coroutine 'NotebookClient.async_start_new_kernel' was never awaited:RuntimeWarning"  # notebook tests
 ]
 
 [tool.nbqa.mutate]

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ extras_require['test'] = sorted(
             'pytest-console-scripts',
             'pytest-mpl',
             'pydocstyle',
-            'papermill~=2.0',
+            'papermill~=2.3.4',
             'scrapbook~=0.5.0',
             'jupyter',
             'graphviz',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ extras_require['test'] = sorted(
             'pytest-mpl',
             'pydocstyle',
             'papermill~=2.0',
-            'scrapbook~=0.2',
+            'scrapbook~=0.5.0',
             'jupyter',
             'graphviz',
         ]

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ extras_require['test'] = sorted(
             'pytest-mpl',
             'pydocstyle',
             'papermill~=2.0',
-            'nteract-scrapbook~=0.2',
+            'scrapbook~=0.2',
             'jupyter',
             'graphviz',
         ]

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -10,7 +10,7 @@ import scrapbook as sb
 def common_kwargs(tmpdir):
     outputnb = tmpdir.join('output.ipynb')
     return {
-        'output_path': str(outputnb),
+        'output_path': Path(outputnb),
         'kernel_name': f'python{sys.version_info.major}',
         'progress_bar': False,
     }

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -13,6 +13,7 @@ def common_kwargs(tmpdir):
         'output_path': Path(outputnb),
         'kernel_name': f'python{sys.version_info.major}',
         'progress_bar': False,
+        'start_timeout': 120,
     }
 
 

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -23,7 +23,9 @@ def test_hello_world(common_kwargs):
 
 def test_xml_importexport(common_kwargs):
     pm.execute_notebook(
-        'docs/examples/notebooks/XML_ImportExport.ipynb', **common_kwargs
+        'docs/examples/notebooks/XML_ImportExport.ipynb',
+        cwd=Path.cwd(),
+        **common_kwargs,
     )
 
 

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,5 +1,5 @@
-import os
 import sys
+from pathlib import Path
 
 import papermill as pm
 import pytest
@@ -28,10 +28,10 @@ def test_xml_importexport(common_kwargs):
 
 def test_statisticalanalysis(common_kwargs):
     # The Binder example uses specific relative paths
-    cwd = os.getcwd()
-    os.chdir(os.path.join(cwd, 'docs/examples/notebooks/binderexample'))
-    pm.execute_notebook('StatisticalAnalysis.ipynb', **common_kwargs)
-    os.chdir(cwd)
+    execution_dir = Path.cwd() / "docs" / "examples" / "notebooks" / "binderexample"
+    pm.execute_notebook(
+        execution_dir / "StatisticalAnalysis.ipynb", cwd=execution_dir, **common_kwargs
+    )
 
 
 def test_shapefactor(common_kwargs):
@@ -58,18 +58,18 @@ def test_multibinpois(common_kwargs):
 
 def test_pullplot(common_kwargs):
     # Change directories to make users not have to worry about paths to follow example
-    cwd = os.getcwd()
-    os.chdir(os.path.join(cwd, "docs/examples/notebooks"))
-    pm.execute_notebook("pullplot.ipynb", **common_kwargs)
-    os.chdir(cwd)
+    execution_dir = Path.cwd() / "docs" / "examples" / "notebooks"
+    pm.execute_notebook(
+        execution_dir / "pullplot.ipynb", cwd=execution_dir, **common_kwargs
+    )
 
 
 def test_impactplot(common_kwargs):
     # Change directories to make users not have to worry about paths to follow example
-    cwd = os.getcwd()
-    os.chdir(os.path.join(cwd, "docs/examples/notebooks"))
-    pm.execute_notebook("ImpactPlot.ipynb", **common_kwargs)
-    os.chdir(cwd)
+    execution_dir = Path.cwd() / "docs" / "examples" / "notebooks"
+    pm.execute_notebook(
+        execution_dir / "ImpactPlot.ipynb", cwd=execution_dir, **common_kwargs
+    )
 
 
 def test_toys(common_kwargs):

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -12,6 +12,7 @@ def common_kwargs(tmpdir):
     return {
         'output_path': str(outputnb),
         'kernel_name': f'python{sys.version_info.major}',
+        'progress_bar': False,
     }
 
 

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -22,10 +22,10 @@ def test_hello_world(common_kwargs):
 
 
 def test_xml_importexport(common_kwargs):
+    # Change directories to make users not have to worry about paths to follow example
+    execution_dir = Path.cwd() / "docs" / "examples" / "notebooks"
     pm.execute_notebook(
-        'docs/examples/notebooks/XML_ImportExport.ipynb',
-        cwd=Path.cwd(),
-        **common_kwargs,
+        execution_dir / "XML_ImportExport.ipynb", cwd=execution_dir, **common_kwargs
     )
 
 

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,8 +1,9 @@
-# import sys
 import os
+import sys
+
 import papermill as pm
-import scrapbook as sb
 import pytest
+import scrapbook as sb
 
 
 @pytest.fixture()
@@ -10,7 +11,7 @@ def common_kwargs(tmpdir):
     outputnb = tmpdir.join('output.ipynb')
     return {
         'output_path': str(outputnb),
-        # 'kernel_name': f'python{sys.version_info.major}',
+        'kernel_name': f'python{sys.version_info.major}',
     }
 
 

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -50,9 +50,11 @@ def test_multichannel_coupled_histos(common_kwargs):
 
 
 def test_multibinpois(common_kwargs):
+    execution_dir = Path.cwd() / "docs" / "examples"
     pm.execute_notebook(
-        'docs/examples/notebooks/multiBinPois.ipynb',
+        execution_dir / "notebooks" / "multiBinPois.ipynb",
         parameters={'validation_datadir': 'validation/data'},
+        cwd=execution_dir,
         **common_kwargs,
     )
     nb = sb.read_notebook(common_kwargs['output_path'])
@@ -60,7 +62,6 @@ def test_multibinpois(common_kwargs):
 
 
 def test_pullplot(common_kwargs):
-    # Change directories to make users not have to worry about paths to follow example
     execution_dir = Path.cwd() / "docs" / "examples" / "notebooks"
     pm.execute_notebook(
         execution_dir / "pullplot.ipynb", cwd=execution_dir, **common_kwargs
@@ -68,7 +69,6 @@ def test_pullplot(common_kwargs):
 
 
 def test_impactplot(common_kwargs):
-    # Change directories to make users not have to worry about paths to follow example
     execution_dir = Path.cwd() / "docs" / "examples" / "notebooks"
     pm.execute_notebook(
         execution_dir / "ImpactPlot.ipynb", cwd=execution_dir, **common_kwargs

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -10,10 +10,9 @@ import scrapbook as sb
 def common_kwargs(tmpdir):
     outputnb = tmpdir.join('output.ipynb')
     return {
-        'output_path': Path(outputnb),
+        'output_path': str(outputnb),
         'kernel_name': f'python{sys.version_info.major}',
         'progress_bar': False,
-        'start_timeout': 120,
     }
 
 
@@ -44,17 +43,15 @@ def test_shapefactor(common_kwargs):
 def test_multichannel_coupled_histos(common_kwargs):
     pm.execute_notebook(
         'docs/examples/notebooks/multichannel-coupled-histo.ipynb',
-        parameters={'validation_datadir': 'validation/data'},
+        parameters={"validation_datadir": str(Path.cwd() / "validation" / "data")},
         **common_kwargs,
     )
 
 
 def test_multibinpois(common_kwargs):
-    execution_dir = Path.cwd() / "docs" / "examples"
     pm.execute_notebook(
-        execution_dir / "notebooks" / "multiBinPois.ipynb",
-        parameters={'validation_datadir': 'validation/data'},
-        cwd=execution_dir,
+        'docs/examples/notebooks/multiBinPois.ipynb',
+        parameters={"validation_datadir": str(Path.cwd() / "validation" / "data")},
         **common_kwargs,
     )
     nb = sb.read_notebook(common_kwargs['output_path'])

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,4 +1,4 @@
-import sys
+# import sys
 import os
 import papermill as pm
 import scrapbook as sb
@@ -10,7 +10,7 @@ def common_kwargs(tmpdir):
     outputnb = tmpdir.join('output.ipynb')
     return {
         'output_path': str(outputnb),
-        'kernel_name': f'python{sys.version_info.major}',
+        # 'kernel_name': f'python{sys.version_info.major}',
     }
 
 


### PR DESCRIPTION
# Description

To get the notebook tests to pass given the many warnings that pop up from the Jupyter infrastructure and `papermill`, override the ini option for `filterwarnings` (added in PR #1773) with an empty list to disable error on filterwarnings as the notebook tests are testing for notebooks to run with the latest API, not if Jupyter infrastructure is warning free.

The use of `PYTHONWARNINGS='default'` should be possible, but is causing errors and is now Issue #1840.

Use `scrapbook` as it is the new name of `nteract-scrapbook` and `nteract-scrapbook` is no longer maintained or developed.
Restrict `papermill` and `scrapbook` to compatible releases at the patch level for API stability.

Use the `papermill.execute_notebook` `cwd` optional argument to change the execution directory safely to avoid having the state of operations change in the test.

Add concurrency group to avoid wasting run time.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use 'scrapbook' as it is the new name of 'nteract-scrapbook', which is no longer
maintained or developed.
* Restrict 'papermill' and 'scrapbook' to compatible releases at the patch level
for API stability.
* Override error on filterwarnings for the 'notebooks' GHA workflow as it is testing
for the notebooks to run with the latest pyhf API, not if the Jupyter infrastructure
is warning free.
* Use the papermill.execute_notebook 'cwd' optional argument to change the execution
directory safely.
* Use a concurrency group to limit the notebook testing workflow to only one run
at a time.
   - c.f. https://docs.github.com/en/actions/using-jobs/using-concurrency
```