### PR TITLE
docs: Add general use citation from SimpleAnalysis ATLAS PUB note

### DIFF
--- a/docs/bib/general_citations.bib
+++ b/docs/bib/general_citations.bib
@@ -7,9 +7,7 @@
       reportNumber  = "ATL-PHYS-PUB-2022-017",
       month         = "Apr",
       year          = "2022",
-      url           = "https://cds.cern.ch/record/2805991",
-      note          = "All figures including auxiliary figures are available at
-                       https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PUBNOTES/ATL-PHYS-PUB-2022-017",
+      url           = "https://cds.cern.ch/record/2805991"
 }
 
 % 2022-02-28

--- a/docs/bib/general_citations.bib
+++ b/docs/bib/general_citations.bib
@@ -1,3 +1,17 @@
+% 2022-04-05
+@techreport{ATL-PHYS-PUB-2022-017,
+      title         = "{SimpleAnalysis: Truth-level Analysis Framework}",
+      institution   = "CERN",
+      collaboration = "ATLAS Collaboration",
+      address       = "Geneva",
+      reportNumber  = "ATL-PHYS-PUB-2022-017",
+      month         = "Apr",
+      year          = "2022",
+      url           = "https://cds.cern.ch/record/2805991",
+      note          = "All figures including auxiliary figures are available at
+                       https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PUBNOTES/ATL-PHYS-PUB-2022-017",
+}
+
 % 2022-02-28
 @article{Heinrich:2022xfa,
     author = "Heinrich, Lukas and Kagan, Michael",

--- a/docs/bib/general_citations.bib
+++ b/docs/bib/general_citations.bib
@@ -1,8 +1,8 @@
 % 2022-04-05
-@techreport{ATL-PHYS-PUB-2022-017,
+@booklet{ATL-PHYS-PUB-2022-017,
+      author        = "{ATLAS Collaboration}",
       title         = "{SimpleAnalysis: Truth-level Analysis Framework}",
       institution   = "CERN",
-      collaboration = "ATLAS Collaboration",
       address       = "Geneva",
       reportNumber  = "ATL-PHYS-PUB-2022-017",
       month         = "Apr",


### PR DESCRIPTION
# Description

Add general citation from ATLAS PUB note [SimpleAnalysis: Truth-level Analysis Framework](https://cds.cern.ch/record/2805991/) (ATL-PHYS-PUB-2022-017). @kratsg and @lukasheinrich were on the analysis team for the note.

All figures including auxiliary figures are available at https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PUBNOTES/ATL-PHYS-PUB-2022-017


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add general citation from ATLAS PUB note 'SimpleAnalysis: Truth-level Analysis Framework'.
   - ATL-PHYS-PUB-2022-017
   - c.f. https://cds.cern.ch/record/2805991/
```