### PR TITLE
docs: Add general use citation from End-to-End Optimization paper

### DIFF
--- a/docs/bib/general_citations.bib
+++ b/docs/bib/general_citations.bib
@@ -10,6 +10,17 @@
       url           = "https://cds.cern.ch/record/2805991"
 }
 
+@article{Dorigo:2022gqm,
+    author = "Dorigo, Tommaso and others",
+    title = "{Toward the End-to-End Optimization of Particle Physics Instruments with Differentiable Programming: a White Paper}",
+    eprint = "2203.13818",
+    archivePrefix = "arXiv",
+    primaryClass = "physics.ins-det",
+    month = "3",
+    year = "2022",
+    journal = ""
+}
+
 % 2022-02-28
 @article{Heinrich:2022xfa,
     author = "Heinrich, Lukas and Kagan, Michael",

--- a/docs/bib/general_citations.bib
+++ b/docs/bib/general_citations.bib
@@ -10,6 +10,7 @@
       url           = "https://cds.cern.ch/record/2805991"
 }
 
+% 2022-03-22
 @article{Dorigo:2022gqm,
     author = "Dorigo, Tommaso and others",
     title = "{Toward the End-to-End Optimization of Particle Physics Instruments with Differentiable Programming: a White Paper}",


### PR DESCRIPTION
# Description

Add general citation from [Toward the End-to-End Optimization of Particle Physics Instruments with Differentiable Programming: a White Paper](https://inspirehep.net/literature/2059102). @lukasheinrich is an author on the paper.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add general citation from 'Toward the End-to-End Optimization of Particle
Physics Instruments with Differentiable Programming: a White Paper'.
   - c.f. https://inspirehep.net/literature/2059102
```