### PR TITLE
feat: Allow for clipping negative yields in the main model

### DIFF
--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -556,7 +556,6 @@ class _MainModel:
         return True
 
     def make_pdf(self, pars):
-        tensorlib, _ = get_backend()
         lambdas_data = self.expected_data(pars)
         return prob.Independent(prob.Poisson(lambdas_data))
 
@@ -820,8 +819,6 @@ class Model:
             pdf: A distribution object implementing the main measurement pdf of HistFactory
 
         """
-        tensorlib, _ = get_backend()
-
         pdfobjs = []
         mainpdf = self.main_model.make_pdf(pars)
         if mainpdf:

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -631,7 +631,7 @@ class _MainModel:
         allfac = tensorlib.concatenate(factors + [nom_plus_delta])
 
         newbysample = tensorlib.product(allfac, axis=0)
-        if self.clip_sample_data:
+        if self.clip_sample_data is not None:
             newbysample = tensorlib.clip(
                 newbysample, self.clip_sample_data, max_value=None
             )
@@ -643,7 +643,7 @@ class _MainModel:
             return batch_first
 
         newresults = tensorlib.sum(newbysample, axis=0)
-        if self.clip_bin_data:
+        if self.clip_bin_data is not None:
             newresults = tensorlib.clip(newresults, self.clip_bin_data, max_value=None)
 
         if self.batch_size is None:

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -526,6 +526,14 @@ class _MainModel:
         self.clip_sample_data = clip_sample_data
         self.clip_bin_data = clip_bin_data
 
+        if self.clip_sample_data is not None:
+            log.warning(
+                f"Clipping expected data per-bin for each sample below {self.clip_sample_data}"
+            )
+
+        if self.clip_bin_data is not None:
+            log.warning(f"Clipping expected data per-bin below {self.clip_bin_data}")
+
         self._nominal_rates = default_backend.tile(
             nominal_rates, (1, 1, self.batch_size or 1, 1)
         )

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -545,7 +545,9 @@ class _MainModel:
         return True
 
     def make_pdf(self, pars):
+        tensorlib, _ = get_backend()
         lambdas_data = self.expected_data(pars)
+        lambdas_data = tensorlib.clip(lambdas_data, 1e-6, max_value=None)
         return prob.Independent(prob.Poisson(lambdas_data))
 
     def logpdf(self, maindata, pars):


### PR DESCRIPTION
# Description

Provides functionality for clipping `expected_data` in the `_MainModel` via `pyhf.Model(clip_sample_data=0.0, clip_bin_data=0.0)` keyword arguments. Added to the docstrings.

Backwards functionality is preserved, which is that clipping is not done. There does not seem to be a performance hit in checking for clipping or not. Clipping can be done at two levels:

- the level at which we have the individual samples (perhaps useful if we need the granularity and a specific sample is providing large negative yields)
- the level at which we have the bin-by-bin data (this is primarily the expected use case that makes the most sense? Maybe...)

Note that it seems ROOT primarily goes for the level of the individual samples, so adding both options and leaving it up to the user to decide if they want to use this. If you have all but one sample which is ok, and one sample providing large negative yields, you can either zero out the sample, or zero out the bin.

See documentation changes here: https://pyhf--1845.org.readthedocs.build/en/1845/_generated/pyhf.pdf.Model.html#pyhf.pdf.Model

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* API change to allow for the _MainModel to clip expected data at the sample-wise
data, or bin-wise data levels.
   - Should help make Minuit a little more robust in particular cases where the
     workspace provided has regions of phase-space where the model is not
     well-behaved (negative yields).
   - Add warning to initialization of _MainModel if clipping is used to ensure that users are
     aware of what they are doing.
* Add tests for clipping by-sample and clipping by-bin.
```