### PR TITLE
refactor: Deprecate distutils in favor of setuptools._distutils

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
-import pytest
-import pyhf
-import sys
-import tarfile
 import json
 import pathlib
+import sys
+import tarfile
+
+import pytest
 from setuptools._distutils import dir_util
+
+import pyhf
 
 
 # Factory as fixture pattern

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import sys
 import tarfile
 import json
 import pathlib
-import distutils.dir_util
+from setuptools._distutils import dir_util
 
 
 # Factory as fixture pattern
@@ -134,7 +134,7 @@ def datadir(tmp_path, request):
     test_dir = pathlib.Path(request.module.__file__).with_suffix('')
 
     if test_dir.is_dir():
-        distutils.dir_util.copy_tree(test_dir, str(tmp_path))
+        dir_util.copy_tree(test_dir, str(tmp_path))
         # shutil is nicer, but doesn't work: https://bugs.python.org/issue20849
         # Once pyhf is Python 3.8+ only then the below can be used.
         # shutil.copytree(test_dir, tmpdir)


### PR DESCRIPTION
# Description

Resolves #1728

Use `setuptools._distutils` over `distutils` as `distutils` is deprecated in Python 3.10 and scheduled for removal in Python 3.12 as noted in the [`pip` `v21.3` release notes](https://pip.pypa.io/en/stable/news/#v21-3).

Also apply `isort` to `tests/conftest.py` as a small change like this seemed like a good time to sneak it in.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use setuptools._distutils over distutils as distutils is deprecated in
Python 3.10 and scheduled for removal in Python 3.12 as noted in the pip v21.3
release notes.
   - c.f. https://pip.pypa.io/en/stable/news/#v21-3
```