### PR TITLE
docs: Deprecate use of git.io URL shortener

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,8 @@ Alternatively the statistical model and observational data can be read from its 
    >>> import pyhf
    >>> import requests
    >>> pyhf.set_backend("numpy")
-   >>> wspace = pyhf.Workspace(requests.get("https://git.io/JJYDE").json())
+   >>> url = "https://raw.githubusercontent.com/scikit-hep/pyhf/HEAD/docs/examples/json/2-bin_1-channel.json"
+   >>> wspace = pyhf.Workspace(requests.get(url).json())
    >>> model = wspace.model()
    >>> data = wspace.data(model)
    >>> test_mu = 1.0

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ Alternatively the statistical model and observational data can be read from its 
    >>> import pyhf
    >>> import requests
    >>> pyhf.set_backend("numpy")
-   >>> url = "https://raw.githubusercontent.com/scikit-hep/pyhf/HEAD/docs/examples/json/2-bin_1-channel.json"
+   >>> url = "https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/examples/json/2-bin_1-channel.json"
    >>> wspace = pyhf.Workspace(requests.get(url).json())
    >>> model = wspace.model()
    >>> data = wspace.data(model)

--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -63,7 +63,7 @@ def fit(
 
     .. code-block:: shell
 
-        $ curl -sL https://git.io/JJYDE | pyhf fit --value
+        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/HEAD/docs/examples/json/2-bin_1-channel.json | pyhf fit --value
 
         \b
         {
@@ -176,7 +176,7 @@ def cls(
 
     .. code-block:: shell
 
-        $ curl -sL https://git.io/JJYDE | pyhf cls
+        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/HEAD/docs/examples/json/2-bin_1-channel.json | pyhf cls
 
         \b
         {

--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -63,7 +63,7 @@ def fit(
 
     .. code-block:: shell
 
-        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/HEAD/docs/examples/json/2-bin_1-channel.json | pyhf fit --value
+        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/examples/json/2-bin_1-channel.json | pyhf fit --value
 
         \b
         {
@@ -176,7 +176,7 @@ def cls(
 
     .. code-block:: shell
 
-        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/HEAD/docs/examples/json/2-bin_1-channel.json | pyhf cls
+        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/examples/json/2-bin_1-channel.json | pyhf cls
 
         \b
         {


### PR DESCRIPTION
# Description

[GitHub is killing off the `git.io` URL shortening service this Friday (2022-04-29)](https://github.blog/changelog/2022-04-25-git-io-deprecation/) so all URLs in the docs that use it need to be updated.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Replace all instances of git.io shortened URLs with full URLs as git.io is
being killed off by GitHub on 2022-04-29.
   - c.f. https://github.blog/changelog/2022-04-25-git-io-deprecation/
```