### PR TITLE
docs: Fix broken links identified by Sphinx linkcheck

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -157,7 +157,7 @@ from PyPI, and then upgrading ``pyhf`` to a test release from TestPyPI
 .. note::
 
   This adds TestPyPI as `an additional package index to search
-  <https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-extra-index-url>`__
+  <https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-extra-index-url>`__
   when installing.
   PyPI will still be the default package index ``pip`` will attempt to install
   from for all dependencies, but if a package has a release on TestPyPI that

--- a/docs/examples/notebooks/binderexample/StatisticalAnalysis.ipynb
+++ b/docs/examples/notebooks/binderexample/StatisticalAnalysis.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "## The Demo\n",
     "\n",
-    "The input data for the statistical analysis was built generated using the containerized workflow engine [yadage](https://github.com/scikit-hep/yadage) (see demo from KubeCon 2018 [[youtube](https://github.com/scikit-hep/yadage)]). Similarly to Binder this utilizes modern container technology for reproducible science. Below you see the execution graph leading up to the model input data at the bottom."
+    "The input data for the statistical analysis was built generated using the containerized workflow engine [yadage](https://github.com/yadage/yadage) (see demo from KubeCon 2018 [[youtube](https://github.com/scikit-hep/yadage)]). Similarly to Binder this utilizes modern container technology for reproducible science. Below you see the execution graph leading up to the model input data at the bottom."
    ]
   },
   {

--- a/docs/examples/notebooks/binderexample/StatisticalAnalysis.ipynb
+++ b/docs/examples/notebooks/binderexample/StatisticalAnalysis.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "## The Demo\n",
     "\n",
-    "The input data for the statistical analysis was built generated using the containerized workflow engine [yadage](https://github.com/yadage/yadage) (see demo from KubeCon 2018 [[youtube](https://github.com/scikit-hep/yadage)]). Similarly to Binder this utilizes modern container technology for reproducible science. Below you see the execution graph leading up to the model input data at the bottom."
+    "The input data for the statistical analysis was built generated using the containerized workflow engine [yadage](https://github.com/yadage/yadage) (see demo from KubeCon 2018 [[youtube](https://youtu.be/2PRGUOxL36M)]). Similarly to Binder this utilizes modern container technology for reproducible science. Below you see the execution graph leading up to the model input data at the bottom."
    ]
   },
   {

--- a/docs/governance/ROADMAP.rst
+++ b/docs/governance/ROADMAP.rst
@@ -70,7 +70,7 @@ Roadmap
       #502) and write submission to
       `pyOpenSci <https://www.pyopensci.org/>`__ [2019-Q4 → 2020-Q2]
    -  |check| Contribute to `IRIS-HEP Analysis Systems
-      Milestones <https://docs.google.com/spreadsheets/d/1VKpHlQWXu_p8AUv5E5H_BzqF_i7hh2Z-Id0XPwNHu8o/edit#gid=1864915304>`__
+      Milestones <https://docs.google.com/spreadsheets/d/1VKpHlQWXu_p8AUv5E5H_BzqF_i7hh2Z-Id0XPwNHu8o/>`__
       "`Initial roadmap for ecosystem
       coherency <https://github.com/iris-hep/project-milestones/issues/8>`__"
       and "`Initial roadmap for high-level cyberinfrastructure
@@ -127,7 +127,7 @@ Roadmap
    -  |uncheck| Attempt to use pyhf as fitting tool for full Analysis Systems
       pipeline test in early 2020 [2019-Q4 → 2020-Q1]
    -  |uncheck| pyhf should satisfy `IRIS-HEP Analysis Systems
-      Milestone <https://docs.google.com/spreadsheets/d/1VKpHlQWXu_p8AUv5E5H_BzqF_i7hh2Z-Id0XPwNHu8o/edit#gid=1864915304>`__
+      Milestone <https://docs.google.com/spreadsheets/d/1VKpHlQWXu_p8AUv5E5H_BzqF_i7hh2Z-Id0XPwNHu8o/>`__
       "`GPU/accelerator-based implementation of statistical and other
       appropriate
       components <https://github.com/iris-hep/project-milestones/issues/15>`__"

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -18,10 +18,11 @@ class minuit_optimizer(OptimizerMixin):
 
         .. note::
 
-            ``errordef`` should be 1.0 for a least-squares cost function and 0.5
-            for negative log-likelihood function. See page 37 of
-            http://hep.fi.infn.it/minuit.pdf. This parameter is sometimes
-            called ``UP`` in the ``MINUIT`` docs.
+            ``errordef`` should be 1.0 for a least-squares cost function and 0.50
+            for negative log-likelihood function --- see `MINUIT: Function Minimization
+            and Error Analysis Reference Manual <https://cdsweb.cern.ch/record/2296388/>`_
+            Section 7.1: Function normalization and ERROR DEF.
+            This parameter is sometimes called ``UP`` in the ``MINUIT`` docs.
 
 
         Args:


### PR DESCRIPTION
# Description

Update all links that `sphinx -b linkcheck` identifies as being broken as part of Issue #1853.

* Use [new URL](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-extra-index-url) for the docs on `pip install --extra-index-url`.
* Fix yadage GitHub organization and also link to @lukasheinrich's [KubeCon 2018 keynote](https://youtu.be/2PRGUOxL36M) instead of yadage on GitHub.
* Remove the 'edit#gid' key from the end of Google Sheets URLs that direct to a specific page on a Google Sheet. While [they are valid links](https://docs.google.com/spreadsheets/d/1VKpHlQWXu_p8AUv5E5H_BzqF_i7hh2Z-Id0XPwNHu8o/edit#gid=1864915304), linkcheck doesn't properly handle them and it is easier to just avoid it.
 * Use the CERN CDS entry for the [MINUIT: Function Minimization and Error Analysis Reference Manual](https://cdsweb.cern.ch/record/2296388/) as it is stable. http://hep.fi.infn.it/minuit.pdf seems to be gone.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update all links that are identified by Sphinx's linkcheck builder as being broken.
   - Use new URL for the docs on `pip install --extra-index-url`.
   - Fix yadage GitHub organization and also link to KubeCon 2018 keynote instead of
   yadage on GitHub.
   - Remove the 'edit#gid' key from the end of Google Sheets URLs that direct to a specific
   page on a Google Sheet. While they are valid links, linkcheck doesn't properly handle
   them and it is easier to just avoid it.
   - Use the CERN CDS entry for the MINUIT: Function Minimization and Error Analysis
     Reference Manual as it is stable.
```