### PR TITLE
docs: Clarify staterror modifier specification

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -27,3 +27,4 @@ Contributors include:
 - Mason Proffitt
 - Lars Henkelmann
 - Aryan Roy
+- Jerry Ling

--- a/docs/likelihood.rst
+++ b/docs/likelihood.rst
@@ -199,11 +199,13 @@ each sample would yield a very large number of nuisance parameters with limited
 utility. Therefore a set of bin-wise scale factors :math:`\gamma_b` is
 introduced to model the overall uncertainty in the bin due to MC statistics.
 The constraint term is constructed as a set of Gaussian constraints with a
-central value equal to unity for each bin in the channel. The scales
-:math:`\sigma_b` of the constraint are computed from the individual
+central value equal to unity (one Gaussian for each bin). The scales
+:math:`\sigma_b` of the Gaussian are computed from the individual
 uncertainties of samples defined within the channel relative to the total event
-rate of all samples: :math:`\delta_{csb} = \sigma_{csb}/\sum_s \nu^0_{scb}`. As
-not all samples are within a channel are estimated from MC simulations, only
+rate of all samples: :math:`\sigma_{csb} = \delta_{csb}/\sum_s \nu^0_{scb}`.
+Where :math:`\delta_{csb}` is the absolute yield uncertainty in each bin.
+
+As not all samples are within a channel are estimated from MC simulations, only
 the samples with a declared statistical uncertainty modifier enter the sum.
 An example of a statistical uncertainty modifier for a single bin channel is
 shown below:

--- a/docs/likelihood.rst
+++ b/docs/likelihood.rst
@@ -202,8 +202,8 @@ The constraint term is constructed as a set of constraints with a
 central value equal to unity (e.g. `Gauss(:math:`\mu` = 1, :math:`\sigma_b`)` for each bin). The scales
 :math:`\sigma_b` of the constraints are computed from the individual
 uncertainties of samples defined within the channel relative to the total event
-rate of all samples: :math:`\sigma_{csb} = \delta_{csb}/\sum_s \nu^0_{scb}`.
-Where :math:`\delta_{csb}` is the absolute yield uncertainty in each bin.
+rate of all samples: :math:`\sigma_{b} = \sqrt{\sum_s\delta_{sb}}/\sum_s \nu^0_{sb}`.
+Where :math:`\delta_{sb}` is the absolute yield uncertainty in each bin, each sample.
 
 As not all samples are within a channel are estimated from MC simulations, only
 the samples with a declared statistical uncertainty modifier enter the sum.

--- a/docs/likelihood.rst
+++ b/docs/likelihood.rst
@@ -196,14 +196,15 @@ As the sample counts are often derived from Monte Carlo (MC) datasets, they
 necessarily carry an uncertainty due to the finite sample size of the datasets.
 As explained in detail in :cite:`likelihood-Cranmer:1456844`, adding uncertainties for
 each sample would yield a very large number of nuisance parameters with limited
-utility. Therefore a set of bin-wise scale factors :math:`\gamma_{cb}` is
+utility.
+Therefore a set of bin-wise scale factors :math:`\gamma_{cb}` is
 introduced to model the overall uncertainty in the bin due to MC statistics.
 The constraint term is constructed as a set of constraints with a
 central value equal to unity (e.g. Gauss(:math:`\mu` = 1, :math:`\sigma_{cb}`) for
-each bin in the channel). The scales :math:`\sigma_{cb}` of the
-constraints are computed from the individual uncertainties of samples
-defined within the channel relative to the total event rate of all samples:
-:math:`\sigma_{cb} = \sqrt{\sum_s\delta_{csb}}/\sum_s \nu^0_{csb}`.
+each bin in the channel).
+The scales :math:`\sigma_{cb}` of the constraints are computed from the individual
+uncertainties of samples defined within the channel relative to the total event rate
+of all samples: :math:`\sigma_{cb} = \sqrt{\sum_s\delta_{csb}}/\sum_s \nu^0_{csb}`.
 Where :math:`\delta_{csb}` is the absolute yield uncertainty in each bin.
 
 As not all samples are within a channel are estimated from MC simulations, only

--- a/docs/likelihood.rst
+++ b/docs/likelihood.rst
@@ -200,8 +200,8 @@ utility.
 Therefore a set of bin-wise scale factors :math:`\gamma_{cb}` is
 introduced to model the overall uncertainty in the bin due to MC statistics.
 The constraint term is constructed as a set of constraints with a
-central value equal to unity (e.g. :math:`\mathrm{Gauss} (\mu = 1, \sigma_{cb}`) for
-each bin in the channel).
+central value equal to unity, e.g. :math:`\mathrm{Gauss} (\mu = 1, \sigma_{cb})`, for
+each bin in the channel.
 The scales :math:`\sigma_{cb}` of the constraints are computed from the individual
 uncertainties of samples defined within the channel relative to the total event rate
 of all samples: :math:`\sigma_{cb} = \sqrt{\sum_s\delta_{csb}}/\sum_s \nu^0_{csb}`.

--- a/docs/likelihood.rst
+++ b/docs/likelihood.rst
@@ -199,9 +199,9 @@ each sample would yield a very large number of nuisance parameters with limited
 utility. Therefore a set of bin-wise scale factors :math:`\gamma_{cb}` is
 introduced to model the overall uncertainty in the bin due to MC statistics.
 The constraint term is constructed as a set of constraints with a
-central value equal to unity (e.g. Gauss(:math:`\mu` = 1, :math:`\sigma_{cb}`) for 
-each bin in the channel). The scales :math:`\sigma_{cb}` of the 
-constraints are computed from the individual uncertainties of samples 
+central value equal to unity (e.g. Gauss(:math:`\mu` = 1, :math:`\sigma_{cb}`) for
+each bin in the channel). The scales :math:`\sigma_{cb}` of the
+constraints are computed from the individual uncertainties of samples
 defined within the channel relative to the total event rate of all samples:
 :math:`\sigma_{cb} = \sqrt{\sum_s\delta_{csb}}/\sum_s \nu^0_{csb}`.
 Where :math:`\delta_{csb}` is the absolute yield uncertainty in each bin.

--- a/docs/likelihood.rst
+++ b/docs/likelihood.rst
@@ -207,7 +207,7 @@ uncertainties of samples defined within the channel relative to the total event 
 of all samples: :math:`\sigma_{cb} = \sqrt{\sum_s\delta_{csb}}/\sum_s \nu^0_{csb}`,
 where :math:`\delta_{csb}` is the absolute yield uncertainty in each bin.
 
-As not all samples are within a channel are estimated from MC simulations, only
+As not all samples within a channel are estimated from MC simulations, only
 the samples with a declared statistical uncertainty modifier enter the sum.
 An example of a statistical uncertainty modifier for a single bin channel is
 shown below:

--- a/docs/likelihood.rst
+++ b/docs/likelihood.rst
@@ -198,9 +198,9 @@ As explained in detail in :cite:`likelihood-Cranmer:1456844`, adding uncertaint
 each sample would yield a very large number of nuisance parameters with limited
 utility. Therefore a set of bin-wise scale factors :math:`\gamma_b` is
 introduced to model the overall uncertainty in the bin due to MC statistics.
-The constraint term is constructed as a set of Gaussian constraints with a
-central value equal to unity (one Gaussian for each bin). The scales
-:math:`\sigma_b` of the Gaussian are computed from the individual
+The constraint term is constructed as a set of constraints with a
+central value equal to unity (e.g. `Gauss(:math:`\mu` = 1, :math:`\sigma_b`)` for each bin). The scales
+:math:`\sigma_b` of the constraints are computed from the individual
 uncertainties of samples defined within the channel relative to the total event
 rate of all samples: :math:`\sigma_{csb} = \delta_{csb}/\sum_s \nu^0_{scb}`.
 Where :math:`\delta_{csb}` is the absolute yield uncertainty in each bin.

--- a/docs/likelihood.rst
+++ b/docs/likelihood.rst
@@ -196,14 +196,15 @@ As the sample counts are often derived from Monte Carlo (MC) datasets, they
 necessarily carry an uncertainty due to the finite sample size of the datasets.
 As explained in detail in :cite:`likelihood-Cranmer:1456844`, adding uncertainties for
 each sample would yield a very large number of nuisance parameters with limited
-utility. Therefore a set of bin-wise scale factors :math:`\gamma_b` is
+utility. Therefore a set of bin-wise scale factors :math:`\gamma_{cb}` is
 introduced to model the overall uncertainty in the bin due to MC statistics.
 The constraint term is constructed as a set of constraints with a
-central value equal to unity (e.g. `Gauss(:math:`\mu` = 1, :math:`\sigma_b`)` for each bin). The scales
-:math:`\sigma_b` of the constraints are computed from the individual
-uncertainties of samples defined within the channel relative to the total event
-rate of all samples: :math:`\sigma_{b} = \sqrt{\sum_s\delta_{sb}}/\sum_s \nu^0_{sb}`.
-Where :math:`\delta_{sb}` is the absolute yield uncertainty in each bin, each sample.
+central value equal to unity (e.g. Gauss(:math:`\mu` = 1, :math:`\sigma_{cb}`) for 
+each bin in the channel). The scales :math:`\sigma_{cb}` of the 
+constraints are computed from the individual uncertainties of samples 
+defined within the channel relative to the total event rate of all samples:
+:math:`\sigma_{cb} = \sqrt{\sum_s\delta_{csb}}/\sum_s \nu^0_{csb}`.
+Where :math:`\delta_{csb}` is the absolute yield uncertainty in each bin.
 
 As not all samples are within a channel are estimated from MC simulations, only
 the samples with a declared statistical uncertainty modifier enter the sum.

--- a/docs/likelihood.rst
+++ b/docs/likelihood.rst
@@ -204,8 +204,8 @@ central value equal to unity, e.g. :math:`\mathrm{Gauss} (\mu = 1, \sigma_{cb})`
 each bin in the channel.
 The scales :math:`\sigma_{cb}` of the constraints are computed from the individual
 uncertainties of samples defined within the channel relative to the total event rate
-of all samples: :math:`\sigma_{cb} = \sqrt{\sum_s\delta_{csb}}/\sum_s \nu^0_{csb}`.
-Where :math:`\delta_{csb}` is the absolute yield uncertainty in each bin.
+of all samples: :math:`\sigma_{cb} = \sqrt{\sum_s\delta_{csb}}/\sum_s \nu^0_{csb}`,
+where :math:`\delta_{csb}` is the absolute yield uncertainty in each bin.
 
 As not all samples are within a channel are estimated from MC simulations, only
 the samples with a declared statistical uncertainty modifier enter the sum.

--- a/docs/likelihood.rst
+++ b/docs/likelihood.rst
@@ -194,7 +194,7 @@ MC Statistical Uncertainty (staterror)
 
 As the sample counts are often derived from Monte Carlo (MC) datasets, they
 necessarily carry an uncertainty due to the finite sample size of the datasets.
-As explained in detail in :cite:`likelihood-Cranmer:1456844`, adding uncertainties for
+As explained in detail in :cite:`likelihood-Cranmer:1456844`, adding uncertainties for
 each sample would yield a very large number of nuisance parameters with limited
 utility.
 Therefore a set of bin-wise scale factors :math:`\gamma_{cb}` is

--- a/docs/likelihood.rst
+++ b/docs/likelihood.rst
@@ -200,7 +200,7 @@ utility.
 Therefore a set of bin-wise scale factors :math:`\gamma_{cb}` is
 introduced to model the overall uncertainty in the bin due to MC statistics.
 The constraint term is constructed as a set of constraints with a
-central value equal to unity (e.g. Gauss(:math:`\mu` = 1, :math:`\sigma_{cb}`) for
+central value equal to unity (e.g. :math:`\mathrm{Gauss} (\mu = 1, \sigma_{cb}`) for
 each bin in the channel).
 The scales :math:`\sigma_{cb}` of the constraints are computed from the individual
 uncertainties of samples defined within the channel relative to the total event rate


### PR DESCRIPTION
clarify and fix typo for `Staterror` modifier.

# Description
The `\delta` parameter is the absolute error in each bin due to MC Stat at +/- 1 sigma. Thus, the `\sigma` of the Gaussian constraint term should have `\delta / nominal` value not the other way around.

And by play around with the `logpdf()` output, I'm convinced that the input in JSON is `\delta` rather than `\delta^2` (https://scikit-hep.org/pyhf/intro.html#id25)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Correct the description of the calculation of the scale of the constraint
to indicate it is calculated from the relative statistical uncertainty from the
channel's event rate.
* Add additional channel subscripts to make the notation be more explicit that
staterror is per-channel.
* Remove typo of additional 'are'.
* Add Jerry Ling to contributor list.
```