### PR TITLE
feat: Promote `validate` kwarg to top-level functions in `pyhf.simplemodels`

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -28,3 +28,4 @@ Contributors include:
 - Lars Henkelmann
 - Aryan Roy
 - Jerry Ling
+- Nathan Simpson

--- a/src/pyhf/simplemodels.py
+++ b/src/pyhf/simplemodels.py
@@ -9,7 +9,7 @@ def __dir__():
     return __all__
 
 
-def correlated_background(signal, bkg, bkg_up, bkg_down, batch_size=None):
+def correlated_background(signal, bkg, bkg_up, bkg_down, batch_size=None, validate=True):
     r"""
     Construct a simple single channel :class:`~pyhf.pdf.Model` with a
     :class:`~pyhf.modifiers.histosys` modifier representing a background
@@ -23,6 +23,8 @@ def correlated_background(signal, bkg, bkg_up, bkg_down, batch_size=None):
         bkg_down (:obj:`list`): The background sample under a downward variation
          corresponding to :math:`\alpha=-1`.
         batch_size (:obj:`None` or :obj:`int`): Number of simultaneous (batched) Models to compute.
+        validate (:obj:`bool`): If :obj:`True`, validate the model before returning. 
+         Only set this to :obj:`False` if you have an experimental use case and know what you're doing.
 
     Returns:
         ~pyhf.pdf.Model: The statistical model adhering to the :obj:`model.json` schema.
@@ -75,10 +77,10 @@ def correlated_background(signal, bkg, bkg_up, bkg_down, batch_size=None):
             }
         ]
     }
-    return Model(spec, batch_size=batch_size)
+    return Model(spec, batch_size=batch_size, validate=validate)
 
 
-def uncorrelated_background(signal, bkg, bkg_uncertainty, batch_size=None):
+def uncorrelated_background(signal, bkg, bkg_uncertainty, batch_size=None, validate=True):
     """
     Construct a simple single channel :class:`~pyhf.pdf.Model` with a
     :class:`~pyhf.modifiers.shapesys` modifier representing an uncorrelated
@@ -106,6 +108,8 @@ def uncorrelated_background(signal, bkg, bkg_uncertainty, batch_size=None):
         bkg (:obj:`list`): The data in the background sample
         bkg_uncertainty (:obj:`list`): The statistical uncertainty on the background sample counts
         batch_size (:obj:`None` or :obj:`int`): Number of simultaneous (batched) Models to compute
+        validate (:obj:`bool`): If :obj:`True`, validate the model before returning.
+         Only set this to :obj:`False` if you have an experimental use case and know what you're doing.
 
     Returns:
         ~pyhf.pdf.Model: The statistical model adhering to the :obj:`model.json` schema
@@ -138,7 +142,7 @@ def uncorrelated_background(signal, bkg, bkg_uncertainty, batch_size=None):
             }
         ]
     }
-    return Model(spec, batch_size=batch_size)
+    return Model(spec, batch_size=batch_size, validate=validate)
 
 
 # Deprecated APIs

--- a/src/pyhf/simplemodels.py
+++ b/src/pyhf/simplemodels.py
@@ -9,7 +9,9 @@ def __dir__():
     return __all__
 
 
-def correlated_background(signal, bkg, bkg_up, bkg_down, batch_size=None, validate=True):
+def correlated_background(
+    signal, bkg, bkg_up, bkg_down, batch_size=None, validate=True
+):
     r"""
     Construct a simple single channel :class:`~pyhf.pdf.Model` with a
     :class:`~pyhf.modifiers.histosys` modifier representing a background
@@ -23,7 +25,7 @@ def correlated_background(signal, bkg, bkg_up, bkg_down, batch_size=None, valida
         bkg_down (:obj:`list`): The background sample under a downward variation
          corresponding to :math:`\alpha=-1`.
         batch_size (:obj:`None` or :obj:`int`): Number of simultaneous (batched) Models to compute.
-        validate (:obj:`bool`): If :obj:`True`, validate the model before returning. 
+        validate (:obj:`bool`): If :obj:`True`, validate the model before returning.
          Only set this to :obj:`False` if you have an experimental use case and know what you're doing.
 
     Returns:
@@ -80,7 +82,9 @@ def correlated_background(signal, bkg, bkg_up, bkg_down, batch_size=None, valida
     return Model(spec, batch_size=batch_size, validate=validate)
 
 
-def uncorrelated_background(signal, bkg, bkg_uncertainty, batch_size=None, validate=True):
+def uncorrelated_background(
+    signal, bkg, bkg_uncertainty, batch_size=None, validate=True
+):
     """
     Construct a simple single channel :class:`~pyhf.pdf.Model` with a
     :class:`~pyhf.modifiers.shapesys` modifier representing an uncorrelated


### PR DESCRIPTION
When doing experiments for differentiable models (#882), it's sometimes been easier to just skip validation with `simplemodels`, which I've been writing out specs for. This just reduces a bit of code overhead for me when I do that ;)

Made sure to highlight in the docstring that this should probably never be touched if one doesn't know why.

This is also partially because #1665 isn't fully done yet, which would probably make this redundant in some ways.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add `validate` kwarg to pyhf.simplemodels.uncorrelated_background and
pyhf.simplemodels.correlated_background API. This allows expert users to avoid
validating their models in specific circumstances.
* Add Nathan Simpson to contributors list.
```