### PR TITLE
ci: Update ReadTheDocs build to Ubuntu 22.04

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.10"
   apt_packages:


### PR DESCRIPTION
# Description

Update the ReadTheDocs build image to use `ubuntu:22.04`

c.f. https://twitter.com/readthedocs/status/1522266722635436041

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use the Docker image ubuntu:22.04 to run the ReadTheDocs build.
   - c.f. https://twitter.com/readthedocs/status/1522266722635436041
```