### PR TITLE
docs: Add use citation from strange quark probe Snowmass paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,14 @@
+@inproceedings{Albert:2022mpk,
+    author = "Albert, Alexander and others",
+    title = "{Strange quark as a probe for new physics in the Higgs sector}",
+    booktitle = "{2022 Snowmass Summer Study}",
+    eprint = "2203.07535",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    month = "3",
+    year = "2022"
+}
+
 % 2022-03-10
 @article{Simpson:2022suz,
     author = "Simpson, Nathan and Heinrich, Lukas",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,4 @@
+% 2022-03-14
 @inproceedings{Albert:2022mpk,
     author = "Albert, Alexander and others",
     title = "{Strange quark as a probe for new physics in the Higgs sector}",


### PR DESCRIPTION
# Description

Add use citation from [Strange quark as a probe for new physics in the Higgs sector](https://inspirehep.net/literature/2052514), by Alexander Albert, Matthew J. Basso, Samuel K. Bright-Thonney, Valentina M. M. Cairo, Chris Damerell, Daniel Egana-Ugrinovic, Ulrich Heintz, @shomiller, Shin-ichi Kawada, Jingyu Luo, Chester Mantel, Patrick Meade, Jose Monroy, Meenakshi Narain, Robert S. Orr, Joseph Reichert, Anders Ryd, Jan Strube, Dong Su, Ariel G. Schwartzman, Tomohiko Tanabe, Junping Tian, Emanuele Usai, Jerry Va'vra, Caterina Vernieri, Charles C. Young, Rui Zou. The paper was part of the Snowmass 2022 submissions.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Strange quark as a probe for new physics in the Higgs sector'.
   - c.f. https://inspirehep.net/literature/2052514
   - Contribution to 2022 Snowmass Summer Study
```
