### PR TITLE
docs: Add use citation from ATLAS dE/dX long-lived particle paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,4 @@
+% 2022-05-12
 @article{ATLAS:2022pib,
     author = "{ATLAS Collaboration}",
     title = "{Search for heavy, long-lived, charged particles with large ionisation energy loss in $pp$ collisions at $\sqrt{s} = 13~\text{TeV}$ using the ATLAS experiment and the full Run 2 dataset}",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,15 @@
+@article{ATLAS:2022pib,
+    author = "{ATLAS Collaboration}",
+    title = "{Search for heavy, long-lived, charged particles with large ionisation energy loss in $pp$ collisions at $\sqrt{s} = 13~\text{TeV}$ using the ATLAS experiment and the full Run 2 dataset}",
+    eprint = "2205.06013",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    reportNumber = "CERN-EP-2022-029",
+    month = "5",
+    year = "2022",
+    journal = ""
+}
+
 % 2022-03-14
 @inproceedings{Albert:2022mpk,
     author = "Albert, Alexander and others",


### PR DESCRIPTION
# Description

Add use citation from ATLAS paper [Search for heavy, long-lived, charged particles with large ionisation energy loss in pp collisions at s√=13 TeV using the ATLAS experiment and the full Run 2 dataset](https://inspirehep.net/literature/2080541).


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Search for heavy, long-lived, charged particles with
large ionisation energy loss in pp collisions at s√=13 TeV using the ATLAS
experiment and the full Run 2 dataset'.
   - ATLAS paper: SUSY-2018-42
   - c.f. https://inspirehep.net/literature/2080541
```