### PR TITLE
feat: Allow readxml to demote validation exception to warning

### DIFF
--- a/src/pyhf/cli/rootio.py
+++ b/src/pyhf/cli/rootio.py
@@ -29,7 +29,8 @@ def cli():
     default=None,
 )
 @click.option('--track-progress/--hide-progress', default=True)
-def xml2json(entrypoint_xml, basedir, output_file, track_progress):
+@click.option('--validation-as-error/--validation-as-warning', default=True)
+def xml2json(entrypoint_xml, basedir, output_file, track_progress, validation_as_error):
     """Entrypoint XML: The top-level XML file for the PDF definition."""
     try:
         import uproot
@@ -43,7 +44,12 @@ def xml2json(entrypoint_xml, basedir, output_file, track_progress):
         )
     from pyhf import readxml
 
-    spec = readxml.parse(entrypoint_xml, basedir, track_progress=track_progress)
+    spec = readxml.parse(
+        entrypoint_xml,
+        basedir,
+        track_progress=track_progress,
+        validation_as_error=validation_as_error,
+    )
     if output_file is None:
         click.echo(json.dumps(spec, indent=4, sort_keys=True))
     else:

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -1,5 +1,6 @@
 from pyhf import schema
 from pyhf import compat
+from pyhf import exceptions
 
 import logging
 
@@ -333,7 +334,7 @@ def dedupe_parameters(parameters):
     return list({v['name']: v for v in parameters}.values())
 
 
-def parse(configfile, rootdir, track_progress=False, skip_validation=False):
+def parse(configfile, rootdir, track_progress=False, validation_exception=True):
     toplvl = ET.parse(configfile)
     inputs = tqdm.tqdm(
         [x.text for x in toplvl.findall('Input')],
@@ -366,9 +367,13 @@ def parse(configfile, rootdir, track_progress=False, skip_validation=False):
         ],
         'version': schema.version,
     }
-    if not skip_validation:
+    try:
         schema.validate(result, 'workspace.json')
-
+    except exceptions.InvalidSpecification as exc:
+        if validation_exception:
+            raise exc
+        else:
+            log.warning(exc)
     return result
 
 

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -334,7 +334,7 @@ def dedupe_parameters(parameters):
     return list({v['name']: v for v in parameters}.values())
 
 
-def parse(configfile, rootdir, track_progress=False, validation_exception=True):
+def parse(configfile, rootdir, track_progress=False, validation_as_error=True):
     toplvl = ET.parse(configfile)
     inputs = tqdm.tqdm(
         [x.text for x in toplvl.findall('Input')],
@@ -370,7 +370,7 @@ def parse(configfile, rootdir, track_progress=False, validation_exception=True):
     try:
         schema.validate(result, 'workspace.json')
     except exceptions.InvalidSpecification as exc:
-        if validation_exception:
+        if validation_as_error:
             raise exc
         else:
             log.warning(exc)

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -333,7 +333,7 @@ def dedupe_parameters(parameters):
     return list({v['name']: v for v in parameters}.values())
 
 
-def parse(configfile, rootdir, track_progress=False):
+def parse(configfile, rootdir, track_progress=False, skip_validation=False):
     toplvl = ET.parse(configfile)
     inputs = tqdm.tqdm(
         [x.text for x in toplvl.findall('Input')],
@@ -366,7 +366,8 @@ def parse(configfile, rootdir, track_progress=False):
         ],
         'version': schema.version,
     }
-    schema.validate(result, 'workspace.json')
+    if not skip_validation:
+        schema.validate(result, 'workspace.json')
 
     return result
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -467,3 +467,10 @@ def test_import_validation_exception(mocker, caplog):
             validation_as_error=False,
         )
         assert "this is an invalid specification" in caplog.text
+
+    with pytest.raises(pyhf.exceptions.InvalidSpecification):
+        pyhf.readxml.parse(
+            'validation/xmlimport_input2/config/example.xml',
+            'validation/xmlimport_input2',
+            validation_as_error=True,
+        )

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -464,6 +464,6 @@ def test_import_validation_exception(mocker, caplog):
         pyhf.readxml.parse(
             'validation/xmlimport_input2/config/example.xml',
             'validation/xmlimport_input2',
-            validation_exception=False,
+            validation_as_error=False,
         )
         assert "this is an invalid specification" in caplog.text

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -448,3 +448,22 @@ def test_process_modifiers(mocker, caplog):
     assert {'name': 'staterror_myChannel', 'type': 'staterror', 'data': _err} in result[
         'modifiers'
     ]
+
+
+def test_import_skip_validation(mocker):
+    spy = mocker.spy(pyhf.schema, 'validate')
+    assert spy.call_count == 0
+    pyhf.readxml.parse(
+        'validation/xmlimport_input2/config/example.xml',
+        'validation/xmlimport_input2',
+        skip_validation=False,
+    )
+    assert spy.call_count == 1
+    spy.reset_mock()
+
+    pyhf.readxml.parse(
+        'validation/xmlimport_input2/config/example.xml',
+        'validation/xmlimport_input2',
+        skip_validation=True,
+    )
+    assert spy.call_count == 0


### PR DESCRIPTION
# Pull Request Description

This resolves #1864. Added functionality `pyhf.readxml` to push the exception down to a warning if needed, so conversion still works for invalid XML workspaces, but will still warn that it is invalid. This also adds it to `pyhf xml2json` as well.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add ability to passing validation_as_error=False to readxml.parse to warn when the workspace
is invalid instead of just raising an exception (default is to raise exception).
* Add --validation-as-error/validation-as-warning flag to xml2json command line interface to
switch between the two (default is to raise exception).
```
