### PR TITLE
test: Ignore LHEP DOI URLs during Sphinx linkcheck

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -196,7 +196,6 @@ changes:
 
 .PHONY: linkcheck
 linkcheck:
-	# $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	$(SPHINXBUILD) -b linkcheck -W . $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -196,7 +196,8 @@ changes:
 
 .PHONY: linkcheck
 linkcheck:
-	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
+	# $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
+	$(SPHINXBUILD) -b linkcheck -W . $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -196,8 +196,7 @@ changes:
 
 .PHONY: linkcheck
 linkcheck:
-	# $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
-	$(SPHINXBUILD) -b linkcheck -W . $(BUILDDIR)/linkcheck
+	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -196,6 +196,7 @@ changes:
 
 .PHONY: linkcheck
 linkcheck:
+	# $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	$(SPHINXBUILD) -b linkcheck -W . $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -464,5 +464,9 @@ mathjax3_config = {
 }
 
 # c.f. https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder
-linkcheck_ignore = ['cli.html#pyhf-xml2json']
+linkcheck_ignore = [
+    'cli.html#pyhf-xml2json',
+    # https://doi.org/10.31526/lhep.2020.158 is causing linkcheck connection timeouts in CI
+    r'https://doi\.org/10\.31526/.*',
+]
 linkcheck_retries = 50

--- a/docs/governance/ROADMAP.rst
+++ b/docs/governance/ROADMAP.rst
@@ -118,8 +118,8 @@ Roadmap
 
 4. **Research**
 
-   -  |uncheck| Add pyfitcore/Statisfactory integrations (Issue #344, `zfit
-      Issue 120 <https://github.com/zfit/zfit/issues/120>`__) [2019-Q4]
+   -  |uncheck| Add pyfitcore/Statisfactory integrations (Issue #344, `zfit-development
+      Issue 56 <https://github.com/zfit/zfit-development/issues/56>`__) [2019-Q4]
    -  |uncheck| Hardware acceleration scaling studies (Issues #93, #301)
       [2019-Q4 → 2020-Q1]
    -  |uncheck| Speedup through Numba (Issue #364) [2019-Q3 → 2019-Q4]


### PR DESCRIPTION
# Description

~* Manually specify Sphinx options of `-W` and remove `--keep-going` to avoid hanging of completed Sphinx `linkcheck` Make target in GitHub Actions CI. I'm not sure why this is happening in CI, as I can't reproduce it locally, but this is perhaps the easiest step forward to get things working.~
* Ignore the DOI URL for [SModelS database update v1.2.3](https://inspirehep.net/literature/1794162)
https://github.com/scikit-hep/pyhf/blob/461d3685b88ad7cec6df684eefae9d44da275d2f/docs/JOSS/paper.bib#L104
during Sphinx's `linkcheck` as it is causing timeout errors in CI like
```
(       citations: line   25) broken    https://doi.org/10.31526/lhep.2020.158 - HTTPConnectionPool(host='journals.andromedapublisher.com', port=80): Max retries exceeded with url: /index.php/LHEP/article/download/158/86/ (Caused by ConnectTimeoutError(<urllib3.connection.HTTPConnection object at 0x7f4ba029d9c0>, 'Connection to journals.andromedapublisher.com timed out. (connect timeout=None)'))
```
* zfit Issue 120 was moved to https://github.com/zfit/zfit-development/issues/56 on 2020-03-12. Changing this keeps from getting a "broken" status in Sphinx's `linkcheck`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Ignore DOI URLs for LHEP from Sphinx linkcheck tests as the DOI for
'SModelS database update v1.2.3' (https://doi.org/10.31526/lhep.2020.158)
is causing 'ConnectTimeoutError's in CI.
   - This is only happening in GitHub Actions CI. It was not reproducible locally.
* zfit Issue 120 was moved to zfit-development Issue 56 on 2020-03-12. Updating
the Issue URL avoids a 404 status and a 'broken' linkcheck status.
```