### PR TITLE
test: Restrict tf dependency protobuf to ABI compatible releases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 extras_require = {
     'shellcomplete': ['click_completion'],
     'tensorflow': [
-        'tensorflow>=2.3.1',  # c.f. https://github.com/tensorflow/tensorflow/pull/40789
+        'tensorflow>=2.6.5',  # c.f. PR #1869
         'tensorflow-probability>=0.11.0',  # c.f. PR #1657
     ],
     'torch': ['torch>=1.10.0'],  # c.f. PR #1657

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 extras_require = {
     'shellcomplete': ['click_completion'],
     'tensorflow': [
-        'tensorflow>=2.6.5',  # c.f. PR #1869
+        'tensorflow>=2.3.1',  # c.f. https://github.com/tensorflow/tensorflow/pull/40789
         'tensorflow-probability>=0.11.0',  # c.f. PR #1657
     ],
     'torch': ['torch>=1.10.0'],  # c.f. PR #1657

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -11,8 +11,7 @@ uproot==4.1.1
 # minuit
 iminuit==2.4.0
 # tensorflow
-tensorflow==2.3.1  # tensorflow-probability v0.11.0 requires tensorflow>=2.3
-protobuf<=3.20.1  # protobuf v4.21.0 breaks ABI compatability
+tensorflow==2.6.5  # c.f. PR #1869
 tensorflow-probability==0.11.0  # c.f. PR #1657
 # torch
 torch==1.10.0

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -11,7 +11,8 @@ uproot==4.1.1
 # minuit
 iminuit==2.4.0
 # tensorflow
-tensorflow==2.6.5  # c.f. PR #1869
+tensorflow==2.3.1  # tensorflow-probability v0.11.0 requires tensorflow>=2.3
+protobuf<=3.20.1  # protobuf v4.21.0 breaks ABI compatability
 tensorflow-probability==0.11.0  # c.f. PR #1657
 # torch
 torch==1.10.0

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -12,6 +12,7 @@ uproot==4.1.1
 iminuit==2.4.0
 # tensorflow
 tensorflow==2.3.1  # tensorflow-probability v0.11.0 requires tensorflow>=2.3
+protobuf<=3.20.1  # protobuf v4.21.0 breaks ABI compatability
 tensorflow-probability==0.11.0  # c.f. PR #1657
 # torch
 torch==1.10.0


### PR DESCRIPTION
# Description

`protobuf` `v3.20.1` is the last release to support ABI compatibility with `tensorflow` pre `tensorflow` `v2.9.1`. The next release of `protobuf`, [`v4.21.0`](https://pypi.org/project/protobuf/4.21.0/) (released 2022-05-25), breaks ABI compatibility and so requires an upper bound of `protobuf` `v3.20.1` for older `tensorflow` releases to not break.

`tensorflow` released a series of patch releases in response to `protobuf` `v4.21.0`: `v2.6.5`, `v2.7.3`, `v2.8.2`, `v2.9.1`. As the oldest `tensorflow` that `pyhf` supports API compatibility with is `tensorflow` `v2.3.1` add an upper bound of `protobuf<=3.20.1` to `ci/constraints.txt` ~update the lower bound to `tensorflow>=2.6.5`~.

c.f. https://github.com/tensorflow/tensorflow/issues/56077

~**edit**: Motivated by discussions below, this PR is now updating the lower bound on `tensorflow` to `v2.6.5+`. This is motivated primarily by the fact that this is significantly easier to maintain as a standard user is going to prefer a release of TensorFlow that works "out of the box" and doesn't require additional modification of the dependencies. The "oldest" (in the SemVer sense, not CalVer sense) release of TensorFlow that are not broken at install now is `v2.6.5`, so this will be the new lower bound. As~ 

https://github.com/scikit-hep/pyhf/blob/0409ab5977e1bea841d246691d295118d59ec0bf/setup.py#L7

~is still compatible with `tensorflow` `v2.6.5.` this seems pretty uncontroversial in terms of an API jump.~

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* protobuf v3.20.1 is the last release to support ABI compatibility
with tensorflow pre tensorflow 2.9.1. The next release of protobuf,
v4.21.0, breaks ABI compatibility and so requires an upper bound of
protobuf v3.20.1 for older tensorflow releases to not break. tensorflow
released a series of patch releases in response to protobuf v4.21.0:
v2.6.5, v2.7.3, v2.8.2, v2.9.1.
   - c.f. https://github.com/tensorflow/tensorflow/issues/56077
```