### PR TITLE
test: Ignore EPJ Web of Conferences DOI URLs during Sphinx linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -468,5 +468,6 @@ linkcheck_ignore = [
     'cli.html#pyhf-xml2json',
     # https://doi.org/10.31526/lhep.2020.158 is causing linkcheck connection timeouts in CI
     r'https://doi\.org/10\.31526/.*',
+    r'https://doi\.org/10\.1051/epjconf/.*',
 ]
 linkcheck_retries = 50

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -468,6 +468,7 @@ linkcheck_ignore = [
     'cli.html#pyhf-xml2json',
     # https://doi.org/10.31526/lhep.2020.158 is causing linkcheck connection timeouts in CI
     r'https://doi\.org/10\.31526/.*',
+    # https://doi.org/10.1051/epjconf/x DOI URLs will periodically generate 500 Server Error
     r'https://doi\.org/10\.1051/epjconf/.*',
 ]
 linkcheck_retries = 50


### PR DESCRIPTION
# Description

DOI URLs for EPJ Web of Conferences proceedings will periodically fail to resolve given '500 Server Error' as the result of EPJ backend problems.

Example:
```
(       citations: line   25) broken    https://doi.org/10.1051/epjconf/202024506017 - 500 Server Error: Internal Server Error for url: https://www.epj-conferences.org/10.1051/epjconf/202024506017
(           index: line  309) ok        https://github.com/scikit-hep/pyhf/pull/1000
(   release-notes: line   19) ok        https://github.com/scikit-hep/pyhf/pull/1001
(       citations: line   25) broken    https://doi.org/10.1051/epjconf/20212[510](https://github.com/scikit-hep/pyhf/runs/6603171789?check_suite_focus=true#step:7:511)2070 - 500 Server Error: Internal Server Error for url: https://www.epj-conferences.org/10.1051/epjconf/202125102070
(   release-notes: line   45) ok        https://github.com/scikit-hep/pyhf/pull/1369
(   release-notes: line   17) ok        https://github.com/scikit-hep/pyhf/pull/1382
(   release-notes: line   73) ok        https://github.com/scikit-hep/pyhf/pull/1377
(       citations: line   25) broken    https://doi.org/10.1051/epjconf/202125103067 - 500 Server Error: Internal Server Error for url: https://www.epj-conferences.org/10.1051/epjconf/202125103067
```

![epj-error](https://user-images.githubusercontent.com/5142394/170404300-c2b8d655-52d0-48cd-9edb-4d8e363632f8.png)


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Ignore DOI URLs for EPJ Web of Conferences from Sphinx linkcheck tests as the DOI
URLs will periodically fail to resolve given '500 Server Error' as the result of
EPJ backend problems.
```