### PR TITLE
build: Update lower bound on tensorflow to v2.6.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 extras_require = {
     'shellcomplete': ['click_completion'],
     'tensorflow': [
-        'tensorflow>=2.3.1',  # c.f. https://github.com/tensorflow/tensorflow/pull/40789
+        'tensorflow>=2.6.5',  # c.f. PR #1869
         'tensorflow-probability>=0.11.0',  # c.f. PR #1657
     ],
     'torch': ['torch>=1.10.0'],  # c.f. PR #1657

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 extras_require = {
     'shellcomplete': ['click_completion'],
     'tensorflow': [
-        'tensorflow>=2.6.5',  # c.f. PR #1869
+        'tensorflow>=2.6.5',  # c.f. PR #1874
         'tensorflow-probability>=0.11.0',  # c.f. PR #1657
     ],
     'torch': ['torch>=1.10.0'],  # c.f. PR #1657

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -11,8 +11,7 @@ uproot==4.1.1
 # minuit
 iminuit==2.4.0
 # tensorflow
-tensorflow==2.3.1  # tensorflow-probability v0.11.0 requires tensorflow>=2.3
-protobuf<=3.20.1  # protobuf v4.21.0 breaks ABI compatability
+tensorflow==2.6.5  # c.f. PR #1869
 tensorflow-probability==0.11.0  # c.f. PR #1657
 # torch
 torch==1.10.0

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -11,7 +11,7 @@ uproot==4.1.1
 # minuit
 iminuit==2.4.0
 # tensorflow
-tensorflow==2.6.5  # c.f. PR #1869
+tensorflow==2.6.5  # c.f. PR #1874
 tensorflow-probability==0.11.0  # c.f. PR #1657
 # torch
 torch==1.10.0


### PR DESCRIPTION
# Description

Amends PR #1869. Following Discussion #1871, bump tensorflow lower bound to the oldest supported version by the TensorFlow project following https://github.com/tensorflow/tensorflow/issues/56077.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update lower bound on tensorflow to v2.6.5 as it is the "oldest" SemVer release
that is not broken on install by protobuf v4.21.0 ABI incompatibility.
   - c.f. https://github.com/tensorflow/tensorflow/issues/56077
   - Amend PR #1869
* Update tests/constraints.txt to use tensorflow==2.6.5.
```