### PR TITLE
docs: Set English as language for Sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,7 +122,7 @@ version = '.'.join(release.split('.')[:3])
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
# Description

Set 'en' - English as the language for the docs. In [Sphinx v5.0.0+](https://github.com/sphinx-doc/sphinx/releases/tag/v5.0.0) setting a language is required to avoid:

```pytb
WARNING: Invalid configuration value found: 'language = None'
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Set 'en' - English as the language for the docs. In Sphinx v5.0.0+ setting
a language is required to avoid:
> WARNING: Invalid configuration value found: 'language = None'
```