### PR TITLE
ci: Add 'name-tests-test' to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
       # exclude generated files
       exclude: ^validation/|\.dtd$|\.json$|\.xml$
     - id: mixed-line-ending
+    - id: name-tests-test
     - id: requirements-txt-fixer
     - id: trailing-whitespace
       # exclude generated files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
       exclude: ^validation/|\.dtd$|\.json$|\.xml$
     - id: mixed-line-ending
     - id: name-tests-test
+      args: ["--django"]
     - id: requirements-txt-fixer
     - id: trailing-whitespace
       # exclude generated files


### PR DESCRIPTION
# Description

`name-tests-test` verifies that test files under `tests/` conform to pytest naming conventions.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add the 'name-tests-test' pre-commit hooks which verifies that test files
under tests/ conform to pytest naming conventions.
   - Use the '--django' option to match the 'test*.py' naming convention.
```