### PR TITLE
ci: Use `github.workflow` property to ensure unique concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: codeql-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: dependencies-head-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: docker-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: docs-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: lint-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: notebooks-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -18,7 +18,7 @@ on:
         - true
 
 concurrency:
-  group: package-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: release-tests-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 concurrency:
-  group: semantic-pr-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
# Description

Use `github.workflow` property to ensure that the concurrency group id from `${{ github.workflow }}-${{ github.ref }}` is unique to the workflow.
c.f. [Example: Only cancel in-progress jobs or runs for the current workflow](https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow)

This also simplifies maintenance as it is removes unique names that need to be manually searched for.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use github.workflow property to ensure that the concurrency group id from
`${{ github.workflow }}-${{ github.ref }}` is unique to the workflow.
   - c.f. https://docs.github.com/en/actions/using-jobs/using-concurrency
```