### PR TITLE
build: Use `find_namespace:` to ensure discovery of package data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,9 +47,9 @@ install_requires =
 where = src
 
 [options.package_data]
-data =
+pyhf.data =
     *.bib
-schemas =
+pyhf.schemas =
     *
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,12 +46,6 @@ install_requires =
 [options.packages.find]
 where = src
 
-[options.package_data]
-pyhf.data =
-    *.bib
-pyhf.schemas =
-    *
-
 [options.entry_points]
 console_scripts =
     pyhf = pyhf.cli:cli

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,9 +29,9 @@ classifiers =
     Programming Language :: Python :: Implementation :: CPython
 
 [options]
+packages = find_namespace:
 package_dir =
     = src
-packages = find:
 include_package_data = True
 python_requires = >=3.7
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ where = src
 
 [options.package_data]
 data =
-    *
+    *.bib
 schemas =
     *
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,12 @@ install_requires =
 [options.packages.find]
 where = src
 
+[options.package_data]
+data =
+    *
+schemas =
+    *
+
 [options.entry_points]
 console_scripts =
     pyhf = pyhf.cli:cli


### PR DESCRIPTION
# Description

Resolves #1880

Use `find_namespace:` in conjunction with `include_package_data = True` in `setup.cfg` to properly find package data (`pyhf.data` and `pyhf.schemas`) during build of sdist and wheel. The [recommendation from `setuptools`](https://setuptools.pypa.io/en/stable/userguide/datafiles.html#subdirectory-for-data-files) is to treat the `data/` and `schemas/` subdirectories as namespace packages given [PEP 420](https://peps.python.org/pep-0420/).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use `find_namespace:` in conjunction with `include_package_data = True` in setup.cfg
to properly find package data (pyhf.data and pyhf.schemas) during build of sdist
and wheel.
   - The recommendation from setuptools is to treat the data/ and schemas/ subdirectories as
     namespace packages given PEP 420 (https://peps.python.org/pep-0420/).
   - c.f. https://setuptools.pypa.io/en/stable/userguide/datafiles.html#subdirectory-for-data-files
```