### PR TITLE
ci: Make `build` error on warnings

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Build a wheel and a sdist
       run: |
-        PYTHONWARNINGS=error python -m build .
+        PYTHONWARNINGS=error,ignore::DeprecationWarning python -m build .
 
     - name: Verify untagged commits have dev versions
       if: "!startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Build a wheel and a sdist
       run: |
-        PYTHONWARNINGS=error python -m build --outdir dist/ .
+        PYTHONWARNINGS=error python -m build .
 
     - name: Verify untagged commits have dev versions
       if: "!startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Build a wheel and a sdist
       run: |
-        PYTHONWARNINGS=error,ignore::DeprecationWarning python -m build .
+        PYTHONWARNINGS=error,default::DeprecationWarning python -m build .
 
     - name: Verify untagged commits have dev versions
       if: "!startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Build a wheel and a sdist
       run: |
-        python -m build --outdir dist/ .
+        PYTHONWARNINGS=error python -m build --outdir dist/ .
 
     - name: Verify untagged commits have dev versions
       if: "!startsWith(github.ref, 'refs/tags/')"


### PR DESCRIPTION
# Description

Add `PYTHONWARNINGS=error,default::DeprecationWarning` to the environment to cause Python to treat warnings as errors (but use default for `DeprecationWarning` as probably internal to build tools) during the package build to ensure that the build configuration conforms to the latest standards. Use the ['PYTHONWARNINGS' environment variable](https://docs.python.org/3/library/warnings.html#describing-warning-filters) as `build` runs in a new process and so something like `python -Werror -m build .` won't be able to pass the flags into the new process, but the shell environment will be picked up. c.f. https://github.com/pypa/build/issues/482

Thanks to @agoose77 for their help pointing out that `PYTHONWARNINGS` should be used. :+1: 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add `PYTHONWARNINGS=error,default::DeprecationWarning` to the environment to cause
Python to treat warnings as errors (but use default for DeprecationWarning as probably
internal to build tools) during the package build to ensure that the build configuration
conforms to the latest standards. Use the 'PYTHONWARNINGS' environment variable as `build` runs in a new process and so something like `python -Werror -m build .` won't be able to
pass the flags into the new process, but the shell environment will be picked up.
   - c.f. https://docs.python.org/3/library/warnings.html#describing-warning-filters
   - c.f. https://github.com/pypa/build/issues/482
* Remove `--outdir` option from `build` to use default.
```