### PR TITLE
ci: Use '--pytest-test-first' option for naming clarity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
     - id: check-added-large-files
     - id: check-case-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       exclude: ^validation/|\.dtd$|\.json$|\.xml$
     - id: mixed-line-ending
     - id: name-tests-test
-      args: ["--django"]
+      args: ["--pytest-test-first"]
     - id: requirements-txt-fixer
     - id: trailing-whitespace
       # exclude generated files


### PR DESCRIPTION
# Description

Following https://github.com/pre-commit/pre-commit-hooks/pull/779 and [pre-commit-hooks `v4.3.0`](https://github.com/pre-commit/pre-commit-hooks/releases/tag/v4.3.0) use the `--pytest-test-first` option of `name-tests-test` for clarity.

This amends PR #1877.

Related: https://github.com/scikit-hep/scikit-hep.github.io/pull/231

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update github.com/pre-commit/pre-commit-hooks: v4.2.0 → v4.3.0 to get
`--pytest-test-first` option for name-test-tests.
* Use `--pytest-test-first` option for name-test-tests for greater clarity of
convention.
* Amends PR #1877.
```