### PR TITLE
build: Update lower bound on iminuit to v2.7.0 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require = {
     'torch': ['torch>=1.10.0'],  # c.f. PR #1657
     'jax': ['jax>=0.2.10', 'jaxlib>=0.1.60,!=0.1.68'],  # c.f. Issue 1501
     'xmlio': ['uproot>=4.1.1'],  # c.f. PR #1567
-    'minuit': ['iminuit>=2.7.0'],  # c.f. PR #1893
+    'minuit': ['iminuit>=2.7.0'],  # c.f. PR #1895
 }
 extras_require['backends'] = sorted(
     set(

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require = {
     'torch': ['torch>=1.10.0'],  # c.f. PR #1657
     'jax': ['jax>=0.2.10', 'jaxlib>=0.1.60,!=0.1.68'],  # c.f. Issue 1501
     'xmlio': ['uproot>=4.1.1'],  # c.f. PR #1567
-    'minuit': ['iminuit>=2.4.0'],  # c.f. PR #1306
+    'minuit': ['iminuit>=2.7.0'],  # c.f. PR #1893
 }
 extras_require['backends'] = sorted(
     set(

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -9,7 +9,7 @@ importlib_resources==1.3.0
 # xmlio
 uproot==4.1.1
 # minuit
-iminuit==2.4.0
+iminuit==2.7.0
 # tensorflow
 tensorflow==2.6.5  # c.f. PR #1874
 tensorflow-probability==0.11.0  # c.f. PR #1657

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -9,7 +9,7 @@ importlib_resources==1.3.0
 # xmlio
 uproot==4.1.1
 # minuit
-iminuit==2.7.0  # c.f. PR #1893
+iminuit==2.7.0  # c.f. PR #1895
 # tensorflow
 tensorflow==2.6.5  # c.f. PR #1874
 tensorflow-probability==0.11.0  # c.f. PR #1657

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -9,7 +9,7 @@ importlib_resources==1.3.0
 # xmlio
 uproot==4.1.1
 # minuit
-iminuit==2.7.0
+iminuit==2.7.0  # c.f. PR #1893
 # tensorflow
 tensorflow==2.6.5  # c.f. PR #1874
 tensorflow-probability==0.11.0  # c.f. PR #1657


### PR DESCRIPTION
# Description

This was caught in the [Minimum supported dependencies workflow](https://github.com/scikit-hep/pyhf/blob/2411ed32e4077259a6676bd95f3e381e1b5b3507/.github/workflows/lower-bound-requirements.yml) after PR #1845 was merged.

Update lower bound on `iminuit` to `v2.7.0` as it is the 'oldest' SemVer release that has the behavior (as described in the [`iminiuit` `v2.7.0` changelog](https://iminuit.readthedocs.io/en/stable/changelog.html#july-4-2021)):
> `Minuit.hesse` no longer sets the status of the `FunctionMinimum` unconditionally to valid if it was invalid before.

Without this fix, the situation can arise where `Minuit.hesse()` can cause `Minuit.valid` to be `True` when it should be `False`. Specifically in 

https://github.com/scikit-hep/pyhf/blob/2411ed32e4077259a6676bd95f3e381e1b5b3507/src/pyhf/optimize/opt_minuit.py#L135-L140

during

```
pytest tests/test_pdf.py -k test_pdf_clipping[numpy_minuit]
```

https://github.com/scikit-hep/pyhf/blob/2411ed32e4077259a6676bd95f3e381e1b5b3507/tests/test_pdf.py#L1075

Also update `tests/constraints.txt` to use `iminuit==2.7.0`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update lower bound on iminuit to v2.7.0 as it is the 'oldest' SemVer release
that has the behavior:
> Minuit.hesse no longer sets the status of the FunctionMinimum unconditionally
> to valid if it was invalid before.

Without this fix, the situation can arise where `Minuit.hesse()` can cause
`Minuit.valid` to be True when it should be False.
* Update tests/constraints.txt to use iminuit==2.7.0.
* Amends PR #1845
```