### PR TITLE
docs: Add use citation from Audrey Kvam's Ph.D. thesis

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,4 @@
+% 2022-04-19
 @phdthesis{Kvam:2022vgy,
     author = "Kvam, Audrey",
     title = "{Search for Events with Two Displaced Vertices from Pair-Produced Neutral Long-Lived Particles Decaying to Hadronic Jets in the Muon Spectrometer of the ATLAS Detector with Full Run 2 Data}",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,11 @@
+@phdthesis{Kvam:2022vgy,
+    author = "Kvam, Audrey",
+    title = "{Search for Events with Two Displaced Vertices from Pair-Produced Neutral Long-Lived Particles Decaying to Hadronic Jets in the Muon Spectrometer of the ATLAS Detector with Full Run 2 Data}",
+    school = "Washington U., Seattle",
+    year = "2022",
+    url = "https://cds.cern.ch/record/2812260"
+}
+
 % 2022-05-12
 @article{ATLAS:2022pib,
     author = "{ATLAS Collaboration}",


### PR DESCRIPTION
# Description

Add use citation from Audrey Kvam's Ph.D. thesis: [Search for Events with Two Displaced Vertices from Pair-Produced Neutral Long-Lived Particles Decaying to Hadronic Jets in the Muon Spectrometer of the ATLAS Detector with Full Run 2 Data](https://inspirehep.net/literature/2086276). The document exists on CDS at https://cds.cern.ch/record/2812260.

Congratulations Dr. Kvam! :rocket: 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Search for Events with Two Displaced Vertices from
Pair-Produced Neutral Long-Lived Particles Decaying to Hadronic Jets in the
Muon Spectrometer of the ATLAS Detector with Full Run 2 Data'.
   - c.f. https://inspirehep.net/literature/2086276
   - c.f. https://cds.cern.ch/record/2812260
   - Ph.D. dissertation of Audrey Kvam
```