### PR TITLE
docs: Update use citations published in journals in June 2022

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -52,9 +52,11 @@
     archivePrefix = "arXiv",
     primaryClass  = "hep-ex",
     reportNumber  = "CERN-EP-2022-002",
-    month         = "3",
-    year          = "2022",
-    journal       = ""
+    doi           = "10.1007/JHEP06(2022)005",
+    journal       = "JHEP",
+    volume        = "06",
+    pages         = "005",
+    year          = "2022"
 }
 
 % 2022-03-01

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -73,13 +73,16 @@
 % 2021-12-29
 @article{Jaffredo:2021ymt,
     author = "Jaffredo, Florentin",
-    title = "{Revisiting mono-$\tau$ tails at the LHC}",
+    title = "{Revisiting mono-tau tails at the LHC}",
     eprint = "2112.14604",
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
-    month = "12",
-    year = "2021",
-    journal = ""
+    doi = "10.1140/epjc/s10052-022-10504-9",
+    journal = "Eur. Phys. J. C",
+    volume = "82",
+    number = "6",
+    pages = "541",
+    year = "2022"
 }
 
 % 2021-09-30


### PR DESCRIPTION
# Description

Update the use citation information for the following papers published in journals in June 2022:
* [Revisiting mono-tau tails at the LHC](https://inspirehep.net/literature/1998227) (published in [European Physical Journal C](https://doi.org/10.1140/epjc/s10052-022-10504-9))
* [Search for neutral long-lived particles in pp collisions at 𝑠√ = 13 TeV that decay into displaced hadronic jets in the ATLAS calorimeter](https://inspirehep.net/literature/2043503) (Published in [Journal of High Energy Physics](https://doi.org/10.1007/JHEP06(2022)005))

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update 'Revisiting mono-tau tails at the LHC' reference for publication in European
Physical Journal C.
   - c.f. https://doi.org/10.1140/epjc/s10052-022-10504-9
* Update 'Search for neutral long-lived particles in pp collisions at \sqrt{s} = 13 TeV
that decay into displaced hadronic jets in the ATLAS calorimeter' reference for
publication in Journal of High Energy Physics.
   - c.f. https://doi.org/10.1007/JHEP06(2022)005
```
