### PR TITLE
Feat: model building (and gradients thereof) with jax as the default backend

### DIFF
--- a/src/pyhf/constraints.py
+++ b/src/pyhf/constraints.py
@@ -10,6 +10,7 @@ __all__ = ["gaussian_constraint_combined", "poisson_constraint_combined"]
 def __dir__():
     return __all__
 
+
 class gaussian_constraint_combined:
     def __init__(self, pdfconfig, batch_size=None):
         default_backend = pyhf.default_backend
@@ -44,9 +45,7 @@ class gaussian_constraint_combined:
             if not parset.pdf_type == 'normal':
                 continue
 
-            normal_constraint_data.append(
-                default_backend.astensor(thisauxdata)
-            )
+            normal_constraint_data.append(default_backend.astensor(thisauxdata))
 
             # many constraints are defined on a unit gaussian
             # but we reserved the possibility that a paramset
@@ -54,9 +53,7 @@ class gaussian_constraint_combined:
             # by the paramset associated to staterror modifiers.
             # Such parsets define a 'sigmas' attribute
             try:
-                normal_constraint_sigmas.append(
-                    default_backend.astensor(parset.sigmas)
-                )
+                normal_constraint_sigmas.append(default_backend.astensor(parset.sigmas))
             except AttributeError:
                 normal_constraint_sigmas.append(
                     default_backend.astensor([1.0] * len(thisauxdata))

--- a/src/pyhf/constraints.py
+++ b/src/pyhf/constraints.py
@@ -10,7 +10,6 @@ __all__ = ["gaussian_constraint_combined", "poisson_constraint_combined"]
 def __dir__():
     return __all__
 
-
 class gaussian_constraint_combined:
     def __init__(self, pdfconfig, batch_size=None):
         default_backend = pyhf.default_backend
@@ -45,7 +44,9 @@ class gaussian_constraint_combined:
             if not parset.pdf_type == 'normal':
                 continue
 
-            normal_constraint_data.append(thisauxdata)
+            normal_constraint_data.append(
+                default_backend.astensor(thisauxdata)
+            )
 
             # many constraints are defined on a unit gaussian
             # but we reserved the possibility that a paramset
@@ -53,9 +54,13 @@ class gaussian_constraint_combined:
             # by the paramset associated to staterror modifiers.
             # Such parsets define a 'sigmas' attribute
             try:
-                normal_constraint_sigmas.append(parset.sigmas)
+                normal_constraint_sigmas.append(
+                    default_backend.astensor(parset.sigmas)
+                )
             except AttributeError:
-                normal_constraint_sigmas.append([1.0] * len(thisauxdata))
+                normal_constraint_sigmas.append(
+                    default_backend.astensor([1.0] * len(thisauxdata))
+                )
 
         self._normal_data = None
         self._sigmas = None

--- a/src/pyhf/modifiers/histosys.py
+++ b/src/pyhf/modifiers/histosys.py
@@ -31,11 +31,17 @@ class histosys_builder:
         self.required_parsets = {}
 
     def collect(self, thismod, nom):
+        default_backend = pyhf.default_backend
         lo_data = thismod['data']['lo_data'] if thismod else nom
         hi_data = thismod['data']['hi_data'] if thismod else nom
         maskval = bool(thismod)
         mask = [maskval] * len(nom)
-        return {'lo_data': lo_data, 'hi_data': hi_data, 'mask': mask, 'nom_data': nom}
+        return {
+            'lo_data': default_backend.astensor(lo_data),
+            'hi_data': default_backend.astensor(hi_data),
+            'mask': default_backend.astensor(mask, dtype = 'bool'),
+            'nom_data': default_backend.astensor(nom)
+        }
 
     def append(self, key, channel, sample, thismod, defined_samp):
         self.builder_data.setdefault(key, {}).setdefault(sample, {}).setdefault(

--- a/src/pyhf/modifiers/histosys.py
+++ b/src/pyhf/modifiers/histosys.py
@@ -39,8 +39,8 @@ class histosys_builder:
         return {
             'lo_data': default_backend.astensor(lo_data),
             'hi_data': default_backend.astensor(hi_data),
-            'mask': default_backend.astensor(mask, dtype = 'bool'),
-            'nom_data': default_backend.astensor(nom)
+            'mask': default_backend.astensor(mask, dtype='bool'),
+            'nom_data': default_backend.astensor(nom),
         }
 
     def append(self, key, channel, sample, thismod, defined_samp):

--- a/src/pyhf/modifiers/shapefactor.py
+++ b/src/pyhf/modifiers/shapefactor.py
@@ -142,9 +142,17 @@ class shapefactor_combined:
             for m in keys
         ]
 
-        global_concatenated_bin_indices = default_backend.astensor([
-            [[j for c in pdfconfig.channels for j in range(pdfconfig.channel_nbins[c])]]
-        ])
+        global_concatenated_bin_indices = default_backend.astensor(
+            [
+                [
+                    [
+                        j
+                        for c in pdfconfig.channels
+                        for j in range(pdfconfig.channel_nbins[c])
+                    ]
+                ]
+            ]
+        )
 
         self._access_field = default_backend.tile(
             global_concatenated_bin_indices,

--- a/src/pyhf/modifiers/shapefactor.py
+++ b/src/pyhf/modifiers/shapefactor.py
@@ -182,8 +182,8 @@ class shapefactor_combined:
             for t, batch_access in enumerate(syst_access):
                 selection = self.param_viewer.index_selection[s][t]
                 for b, bin_access in enumerate(batch_access):
-                    self._access_field[s, t, b] = (
-                        selection[bin_access] if bin_access < len(selection) else 0
+                    self._access_field = self._access_field.at[s, t, b].set(
+                        selection[int(bin_access)] if bin_access < len(selection) else 0
                     )
 
         self._precompute()

--- a/src/pyhf/modifiers/shapefactor.py
+++ b/src/pyhf/modifiers/shapefactor.py
@@ -142,9 +142,9 @@ class shapefactor_combined:
             for m in keys
         ]
 
-        global_concatenated_bin_indices = [
+        global_concatenated_bin_indices = default_backend.astensor([
             [[j for c in pdfconfig.channels for j in range(pdfconfig.channel_nbins[c])]]
-        ]
+        ])
 
         self._access_field = default_backend.tile(
             global_concatenated_bin_indices,

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -171,10 +171,12 @@ class shapesys_combined:
                 )
 
                 sample_mask = self._shapesys_mask[syst_index][singular_sample_index][0]
-                access_field_for_syst_and_batch[sample_mask] = selection
-                self._access_field[
-                    syst_index, batch_index
-                ] = access_field_for_syst_and_batch
+                access_field_for_syst_and_batch = access_field_for_syst_and_batch.at[
+                    sample_mask
+                ].set(selection)
+                self._access_field = self._access_field.at[syst_index, batch_index].set(
+                    access_field_for_syst_and_batch
+                )
 
     def _precompute(self):
         tensorlib, _ = get_backend()

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -128,9 +128,9 @@ class shapesys_combined:
                 for m in keys
             ]
         )
-        global_concatenated_bin_indices = [
+        global_concatenated_bin_indices = default_backend.astensor([
             [[j for c in pdfconfig.channels for j in range(pdfconfig.channel_nbins[c])]]
-        ]
+        ])
 
         self._access_field = default_backend.tile(
             global_concatenated_bin_indices,

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -128,9 +128,17 @@ class shapesys_combined:
                 for m in keys
             ]
         )
-        global_concatenated_bin_indices = default_backend.astensor([
-            [[j for c in pdfconfig.channels for j in range(pdfconfig.channel_nbins[c])]]
-        ])
+        global_concatenated_bin_indices = default_backend.astensor(
+            [
+                [
+                    [
+                        j
+                        for c in pdfconfig.channels
+                        for j in range(pdfconfig.channel_nbins[c])
+                    ]
+                ]
+            ]
+        )
 
         self._access_field = default_backend.tile(
             global_concatenated_bin_indices,

--- a/src/pyhf/modifiers/staterror.py
+++ b/src/pyhf/modifiers/staterror.py
@@ -117,9 +117,9 @@ class staterror_builder:
                 modifier_data['data']['mask'] = masks[modname]
             sigmas = relerrs[masks[modname]]
             # list of bools, consistent with other modifiers (no numpy.bool_)
-            fixed = default_backend.tolist(sigmas == 0)
+            fixed = sigmas == 0
             # ensures non-Nan constraint term, but in a future PR we need to remove constraints for these
-            sigmas[fixed] = 1.0
+            sigmas = sigmas.at[fixed].set(1.0)
             self.required_parsets.setdefault(parname, [required_parset(sigmas, fixed)])
         return self.builder_data
 
@@ -197,10 +197,12 @@ class staterror_combined:
                 )
 
                 sample_mask = self._staterror_mask[syst_index][singular_sample_index][0]
-                access_field_for_syst_and_batch[sample_mask] = selection
-                self._access_field[
-                    syst_index, batch_index
-                ] = access_field_for_syst_and_batch
+                access_field_for_syst_and_batch = access_field_for_syst_and_batch.at[
+                    sample_mask
+                ].set(selection)
+                self._access_field = self._access_field.at[syst_index, batch_index].set(
+                    access_field_for_syst_and_batch
+                )
 
     def _precompute(self):
         if not self.param_viewer.index_selection:

--- a/src/pyhf/modifiers/staterror.py
+++ b/src/pyhf/modifiers/staterror.py
@@ -157,9 +157,17 @@ class staterror_combined:
                 for m in keys
             ]
         )
-        global_concatenated_bin_indices = default_backend.astensor([
-            [[j for c in pdfconfig.channels for j in range(pdfconfig.channel_nbins[c])]]
-        ])
+        global_concatenated_bin_indices = default_backend.astensor(
+            [
+                [
+                    [
+                        j
+                        for c in pdfconfig.channels
+                        for j in range(pdfconfig.channel_nbins[c])
+                    ]
+                ]
+            ]
+        )
 
         self._access_field = default_backend.tile(
             global_concatenated_bin_indices,

--- a/src/pyhf/modifiers/staterror.py
+++ b/src/pyhf/modifiers/staterror.py
@@ -157,9 +157,9 @@ class staterror_combined:
                 for m in keys
             ]
         )
-        global_concatenated_bin_indices = [
+        global_concatenated_bin_indices = default_backend.astensor([
             [[j for c in pdfconfig.channels for j in range(pdfconfig.channel_nbins[c])]]
-        ]
+        ])
 
         self._access_field = default_backend.tile(
             global_concatenated_bin_indices,

--- a/src/pyhf/parameters/utils.py
+++ b/src/pyhf/parameters/utils.py
@@ -37,7 +37,9 @@ def reduce_paramsets_requirements(paramsets_requirements, paramsets_user_configs
             for paramset_requirement in paramset_requirements:
                 # undefined: the modifier does not support configuring that property
                 v = paramset_requirement.get(k, 'undefined')
-                combined_paramset.setdefault(k, list()).append(v)
+                # differentiable models mean that v could contain jax arrays/tracers
+                # neither of these are hashable, so the set-based logic here needs changing
+                combined_paramset.setdefault(k, set()).add(v)
 
             if len(combined_paramset[k]) != 1:
                 raise exceptions.InvalidNameReuse(

--- a/src/pyhf/parameters/utils.py
+++ b/src/pyhf/parameters/utils.py
@@ -37,7 +37,7 @@ def reduce_paramsets_requirements(paramsets_requirements, paramsets_user_configs
             for paramset_requirement in paramset_requirements:
                 # undefined: the modifier does not support configuring that property
                 v = paramset_requirement.get(k, 'undefined')
-                combined_paramset.setdefault(k, set()).add(v)
+                combined_paramset.setdefault(k, list()).append(v)
 
             if len(combined_paramset[k]) != 1:
                 raise exceptions.InvalidNameReuse(

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -49,8 +49,10 @@ def _create_parameters_from_spec(_reqs):
         paramset_type = getattr(pyhf.parameters, paramset_requirements['paramset_type'])
         paramset = paramset_type(**paramset_requirements)
         if paramset.constrained:  # is constrained
-            auxdata += paramset.auxdata
-            auxdata_order.append(param_name)
+            print(paramset.auxdata)
+            if paramset.auxdata is not None:
+                auxdata += paramset.auxdata
+                auxdata_order.append(param_name)
         _sets[param_name] = paramset
 
     return _sets, auxdata, auxdata_order
@@ -261,7 +263,8 @@ class _ModelConfig(_ChannelSummaryMixin):
         """
         init = []
         for name in self.par_order:
-            init = init + self.par_map[name]['paramset'].suggested_init
+            if self.par_map[name]['paramset'].suggested_init is not None:
+                init = init + self.par_map[name]['paramset'].suggested_init
         return init
 
     def suggested_bounds(self):

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -49,10 +49,8 @@ def _create_parameters_from_spec(_reqs):
         paramset_type = getattr(pyhf.parameters, paramset_requirements['paramset_type'])
         paramset = paramset_type(**paramset_requirements)
         if paramset.constrained:  # is constrained
-            print(paramset.auxdata)
-            if paramset.auxdata is not None:
-                auxdata += paramset.auxdata
-                auxdata_order.append(param_name)
+            auxdata += paramset.auxdata
+            auxdata_order.append(param_name)
         _sets[param_name] = paramset
 
     return _sets, auxdata, auxdata_order
@@ -263,8 +261,7 @@ class _ModelConfig(_ChannelSummaryMixin):
         """
         init = []
         for name in self.par_order:
-            if self.par_map[name]['paramset'].suggested_init is not None:
-                init = init + self.par_map[name]['paramset'].suggested_init
+            init = init + self.par_map[name]['paramset'].suggested_init
         return init
 
     def suggested_bounds(self):

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -453,18 +453,18 @@ class jax_backend:
         lam = jnp.asarray(lam)
         return jnp.exp(xlogy(n, lam) - lam - gammaln(n + 1.0))
 
-    def normal_logpdf(self, x, mu, sigma):
-        # this is much faster than
-        # norm.logpdf(x, loc=mu, scale=sigma)
-        # https://codereview.stackexchange.com/questions/69718/fastest-computation-of-n-likelihoods-on-normal-distributions
-        root2 = jnp.sqrt(2)
-        root2pi = jnp.sqrt(2 * jnp.pi)
-        prefactor = -jnp.log(sigma * root2pi)
-        summand = -jnp.square(jnp.divide((x - mu), (root2 * sigma)))
-        return prefactor + summand
-
     # def normal_logpdf(self, x, mu, sigma):
-    #     return norm.logpdf(x, loc=mu, scale=sigma)
+    #     # this is much faster than
+    #     # norm.logpdf(x, loc=mu, scale=sigma)
+    #     # https://codereview.stackexchange.com/questions/69718/fastest-computation-of-n-likelihoods-on-normal-distributions
+    #     root2 = jnp.sqrt(2)
+    #     root2pi = jnp.sqrt(2 * jnp.pi)
+    #     prefactor = -jnp.log(sigma * root2pi)
+    #     summand = -jnp.square(jnp.divide((x - mu), (root2 * sigma)))
+    #     return prefactor + summand
+
+    def normal_logpdf(self, x, mu, sigma):
+        return norm.logpdf(x, loc=mu, scale=sigma)
 
     def normal(self, x, mu, sigma):
         r"""

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -230,7 +230,7 @@ class jax_backend:
         return jnp.asarray(tensor_in, dtype=dtype)
 
     def sum(self, tensor_in, axis=None):
-        return jnp.sum(tensor_in, axis=axis)
+        return jnp.sum(jnp.asarray(tensor_in), axis=axis)
 
     def product(self, tensor_in, axis=None):
         return jnp.prod(tensor_in, axis=axis)
@@ -334,7 +334,7 @@ class jax_backend:
             output: the concatenated tensor
 
         """
-        return jnp.concatenate(sequence, axis=axis)
+        return jnp.concatenate([jnp.array(x) for x in sequence], axis=axis)
 
     def simple_broadcast(self, *args):
         """

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -453,18 +453,18 @@ class jax_backend:
         lam = jnp.asarray(lam)
         return jnp.exp(xlogy(n, lam) - lam - gammaln(n + 1.0))
 
-    # def normal_logpdf(self, x, mu, sigma):
-    #     # this is much faster than
-    #     # norm.logpdf(x, loc=mu, scale=sigma)
-    #     # https://codereview.stackexchange.com/questions/69718/fastest-computation-of-n-likelihoods-on-normal-distributions
-    #     root2 = jnp.sqrt(2)
-    #     root2pi = jnp.sqrt(2 * jnp.pi)
-    #     prefactor = -jnp.log(sigma * root2pi)
-    #     summand = -jnp.square(jnp.divide((x - mu), (root2 * sigma)))
-    #     return prefactor + summand
-
     def normal_logpdf(self, x, mu, sigma):
-        return norm.logpdf(x, loc=mu, scale=sigma)
+        # this is much faster than
+        # norm.logpdf(x, loc=mu, scale=sigma)
+        # https://codereview.stackexchange.com/questions/69718/fastest-computation-of-n-likelihoods-on-normal-distributions
+        root2 = jnp.sqrt(2)
+        root2pi = jnp.sqrt(2 * jnp.pi)
+        prefactor = -jnp.log(sigma * root2pi)
+        summand = -jnp.square(jnp.divide((x - mu), (root2 * sigma)))
+        return prefactor + summand
+
+    # def normal_logpdf(self, x, mu, sigma):
+    #     return norm.logpdf(x, loc=mu, scale=sigma)
 
     def normal(self, x, mu, sigma):
         r"""

--- a/tests/test_differentiable_model_construction.py
+++ b/tests/test_differentiable_model_construction.py
@@ -1,0 +1,115 @@
+import pyhf
+from jax import numpy as jnp
+import jax
+
+
+def test_model_building_grad():
+    pyhf.set_backend('jax', default=True)
+
+    def make_model(
+        nominal,
+        corrup_data,
+        corrdn_data,
+        stater_data,
+        normsys_up,
+        normsys_dn,
+        uncorr_data,
+    ):
+        return {
+            "channels": [
+                {
+                    "name": "achannel",
+                    "samples": [
+                        {
+                            "name": "background",
+                            "data": nominal,
+                            "modifiers": [
+                                {"name": "mu", "type": "normfactor", "data": None},
+                                {"name": "lumi", "type": "lumi", "data": None},
+                                {
+                                    "name": "mod_name",
+                                    "type": "shapefactor",
+                                    "data": None,
+                                },
+                                {
+                                    "name": "corr_bkguncrt2",
+                                    "type": "histosys",
+                                    "data": {
+                                        'hi_data': corrup_data,
+                                        'lo_data': corrdn_data,
+                                    },
+                                },
+                                {
+                                    "name": "staterror2",
+                                    "type": "staterror",
+                                    "data": stater_data,
+                                },
+                                {
+                                    "name": "norm",
+                                    "type": "normsys",
+                                    "data": {'hi': normsys_up, 'lo': normsys_dn},
+                                },
+                            ],
+                        }
+                    ],
+                },
+                {
+                    "name": "secondchannel",
+                    "samples": [
+                        {
+                            "name": "background",
+                            "data": nominal,
+                            "modifiers": [
+                                {"name": "mu", "type": "normfactor", "data": None},
+                                {"name": "lumi", "type": "lumi", "data": None},
+                                {
+                                    "name": "mod_name",
+                                    "type": "shapefactor",
+                                    "data": None,
+                                },
+                                {
+                                    "name": "uncorr_bkguncrt2",
+                                    "type": "shapesys",
+                                    "data": uncorr_data,
+                                },
+                                {
+                                    "name": "corr_bkguncrt2",
+                                    "type": "histosys",
+                                    "data": {
+                                        'hi_data': corrup_data,
+                                        'lo_data': corrdn_data,
+                                    },
+                                },
+                                {
+                                    "name": "staterror",
+                                    "type": "staterror",
+                                    "data": stater_data,
+                                },
+                                {
+                                    "name": "norm",
+                                    "type": "normsys",
+                                    "data": {'hi': normsys_up, 'lo': normsys_dn},
+                                },
+                            ],
+                        }
+                    ],
+                },
+            ],
+        }
+
+    def pipe(x):
+        spec = make_model(
+            x * jnp.asarray([60.0, 62.0]),
+            x * jnp.asarray([60.0, 62.0]),
+            x * jnp.asarray([60.0, 62.0]),
+            x * jnp.asarray([5.0, 5.0]),
+            x * jnp.asarray(0.95),
+            x * jnp.asarray(1.05),
+            x * jnp.asarray([5.0, 5.0]),
+        )
+        model = pyhf.Model(spec, validate=False)
+        nominal = jnp.array(model.config.suggested_init())
+        data = model.expected_data(nominal)
+        return model.logpdf(nominal, data)[0]
+
+    jax.grad(pipe)(3.4)  # should work without error


### PR DESCRIPTION
# Description

Building on work by @lukasheinrich in #1676 to address #882, this PR attempts to keep going down the debugging rabbit hole to make pyhf model construction properly differentiable for all modifier types.

Right now, there is some jax-only syntax that I plan to refactor for all tensor backends if we get this working, e.g. `array = array.at[index].set(value)`, which is the jax equivalent of `array[index] = value` since jax arrays are immutable.

A notable other addition is the changing of the jax concatenate implementation as referenced in #1655 to something many factors slower, but it's necessary to match numpy's behaviour. It also doesn't produce a user-facing slowdown that I experience, since the arrays involved are small and the operation is infrequent.

One roadblock right now as discussed offline with @kratsg concerns the following logic in the parameter "finalize" step: https://github.com/scikit-hep/pyhf/blob/acde7f4ff8d0db2351f5d6e31ff5584e34da0cf0/src/pyhf/parameters/utils.py#L37-L40

When building models with arrays in them, the `v` here can contain jax arrays, which are not hashable. I tried patching in a hashable construct, but this also failed -- when taking gradients, these values will become `JVPTracer` objects that I don't know a good way to hash (I was using `jax.numpy.array_str` then).

To add some optimism though: when I bypassed this logic by incorrectly using a list here, I seemed to be able to run the new test that this PR adds, which really would make model construction differentiable for all modifiers. That would mitigate the need from my standpoint to work on #1894, which was my most recent attempt in bypassing the model building logic for the sake of gradient calculations, though it may have other utility.

So: if we can get that logic re-written with collections that don't require hashable elements, then we could be good to go here! :) 

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
- [ ] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR
