### PR TITLE
fix: Populate the schema cache with local `defs.json` again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ extras_require['test'] = sorted(
             'scrapbook~=0.5.0',
             'jupyter',
             'graphviz',
+            'pytest-socket>=0.2',
         ]
     )
 )

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ extras_require['test'] = sorted(
             'scrapbook~=0.5.0',
             'jupyter',
             'graphviz',
-            'pytest-socket>=0.2',
+            'pytest-socket>=0.2',  # 0.2 adds the socket_disabled fixture, cf. https://github.com/scikit-hep/pyhf/pull/1917#discussion_r951943084
         ]
     )
 )

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ extras_require['test'] = sorted(
             'scrapbook~=0.5.0',
             'jupyter',
             'graphviz',
-            'pytest-socket>=0.2',  # 0.2 adds the socket_disabled fixture, cf. https://github.com/scikit-hep/pyhf/pull/1917#discussion_r951943084
+            'pytest-socket>=0.2.0',  # c.f. PR #1917
         ]
     )
 )

--- a/src/pyhf/schema/__init__.py
+++ b/src/pyhf/schema/__init__.py
@@ -72,6 +72,7 @@ class Schema(sys.modules[__name__].__class__):
             self (pyhf.schema.Schema): Returns itself (for contextlib management)
         """
         self.orig_path, variables.schemas = variables.schemas, new_path
+        self.orig_cache = dict(variables.SCHEMA_CACHE)
         variables.SCHEMA_CACHE.clear()
         return self
 
@@ -86,6 +87,7 @@ class Schema(sys.modules[__name__].__class__):
             None
         """
         variables.schemas = self.orig_path
+        variables.SCHEMA_CACHE = self.orig_cache
 
     @property
     def path(self):

--- a/src/pyhf/schema/__init__.py
+++ b/src/pyhf/schema/__init__.py
@@ -72,6 +72,7 @@ class Schema(sys.modules[__name__].__class__):
             self (pyhf.schema.Schema): Returns itself (for contextlib management)
         """
         self.orig_path, variables.schemas = variables.schemas, new_path
+        variables.SCHEMA_CACHE.clear()
         return self
 
     def __enter__(self):

--- a/src/pyhf/schema/loader.py
+++ b/src/pyhf/schema/loader.py
@@ -39,3 +39,9 @@ def load_schema(schema_id: str):
             schema = json.load(json_schema)
             variables.SCHEMA_CACHE[schema['$id']] = schema
         return variables.SCHEMA_CACHE[schema['$id']]
+
+
+# pre-populate the cache to avoid network access
+# on first validation in standard usage
+# (not in pyhf.schema.variables to avoid circular imports)
+load_schema(f'{variables.SCHEMA_VERSION}/defs.json')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -620,10 +620,12 @@ def no_sockets(monkeypatch):
 
 @pytest.fixture
 def refresh_pyhf(monkeypatch):
+    global pyhf
     modules_to_clear = [name for name in sys.modules if name.split('.')[0] == 'pyhf']
     for module_name in modules_to_clear:
         monkeypatch.delitem(sys.modules, module_name)
-    importlib.import_module(pyhf.__name__)
+    pyhf = importlib.import_module(pyhf.__name__)
+    return pyhf
 
 
 def test_defs_always_cached(
@@ -639,6 +641,7 @@ def test_defs_always_cached(
     Otherwise using pyhf in contexts where the jsonschema.RefResolver cannot lookup the definition by the schema-id,
     it will crash (e.g. a cluster node without network access).
     """
+    pyhf = refresh_pyhf
     spec = {
         'channels': [
             {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -609,8 +609,8 @@ def test_defs_always_cached(
     """
     Schema definitions should always be loaded from the local files and cached at first import.
 
-    Otherwise using pyhf in contexts where the jsonschema.RefResolver cannot lookup the definition by the schema-id,
-    it will crash (e.g. a cluster node without network access).
+    Otherwise pyhf will crash in contexts where the jsonschema.RefResolver cannot lookup the definition by the schema-id
+    (e.g. a cluster node without network access).
     """
     pyhf = refresh_pyhf
     spec = {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,9 +1,11 @@
-import pyhf
-import pytest
-import json
 import importlib
+import json
 import sys
+
+import pytest
 from pytest_socket import socket_disabled  # noqa: F401
+
+import pyhf
 
 
 @pytest.mark.parametrize('version', ['1.0.0'])

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,7 +4,6 @@ import json
 import importlib
 import sys
 from pytest_socket import socket_disabled  # noqa: F401
-import unittest
 
 
 @pytest.mark.parametrize('version', ['1.0.0'])
@@ -593,15 +592,9 @@ def test_patchset_fail(datadir, patchset_file):
         pyhf.schema.validate(patchset, 'patchset.json')
 
 
-@pytest.fixture
-def monkeypatched_sys_modules():
-    with unittest.mock.patch.dict(sys.modules):
-        yield sys.modules
-
-
 def test_defs_always_cached(
     socket_disabled,  # noqa: F811
-    monkeypatched_sys_modules,
+    isolate_modules,
 ):
     """
     Schema definitions should always be loaded from the local files and cached at first import.
@@ -609,11 +602,10 @@ def test_defs_always_cached(
     Otherwise pyhf will crash in contexts where the jsonschema.RefResolver cannot lookup the definition by the schema-id
     (e.g. a cluster node without network access).
     """
-
     global pyhf
     modules_to_clear = [name for name in sys.modules if name.split('.')[0] == 'pyhf']
     for module_name in modules_to_clear:
-        del monkeypatched_sys_modules[module_name]
+        del sys.modules[module_name]
     pyhf = importlib.import_module(pyhf.__name__)
 
     spec = {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -594,7 +594,7 @@ def test_patchset_fail(datadir, patchset_file):
 
 def test_defs_always_cached(
     socket_disabled,  # noqa: F811
-    monkeypatch,  # ensure there is not a pre-existing cache hiding the issue
+    monkeypatch,
 ):
     """
     Schema definitions should always be loaded from the local files and cached at first import.

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,6 +4,7 @@ import json
 import importlib
 import sys
 from pytest_socket import socket_disabled  # noqa: F401
+import unittest
 
 
 @pytest.mark.parametrize('version', ['1.0.0'])
@@ -592,9 +593,15 @@ def test_patchset_fail(datadir, patchset_file):
         pyhf.schema.validate(patchset, 'patchset.json')
 
 
+@pytest.fixture
+def monkeypatched_sys_modules():
+    with unittest.mock.patch.dict(sys.modules):
+        yield sys.modules
+
+
 def test_defs_always_cached(
     socket_disabled,  # noqa: F811
-    monkeypatch,
+    monkeypatched_sys_modules,
 ):
     """
     Schema definitions should always be loaded from the local files and cached at first import.
@@ -606,7 +613,7 @@ def test_defs_always_cached(
     global pyhf
     modules_to_clear = [name for name in sys.modules if name.split('.')[0] == 'pyhf']
     for module_name in modules_to_clear:
-        monkeypatch.delitem(sys.modules, module_name)
+        del monkeypatched_sys_modules[module_name]
     pyhf = importlib.import_module(pyhf.__name__)
 
     spec = {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -592,19 +592,9 @@ def test_patchset_fail(datadir, patchset_file):
         pyhf.schema.validate(patchset, 'patchset.json')
 
 
-@pytest.fixture
-def refresh_pyhf(monkeypatch):
-    global pyhf
-    modules_to_clear = [name for name in sys.modules if name.split('.')[0] == 'pyhf']
-    for module_name in modules_to_clear:
-        monkeypatch.delitem(sys.modules, module_name)
-    pyhf = importlib.import_module(pyhf.__name__)
-    return pyhf
-
-
 def test_defs_always_cached(
     socket_disabled,  # noqa: F811
-    refresh_pyhf,  # ensure there is not a pre-existing cache hiding the issue
+    monkeypatch,  # ensure there is not a pre-existing cache hiding the issue
 ):
     """
     Schema definitions should always be loaded from the local files and cached at first import.
@@ -612,7 +602,13 @@ def test_defs_always_cached(
     Otherwise pyhf will crash in contexts where the jsonschema.RefResolver cannot lookup the definition by the schema-id
     (e.g. a cluster node without network access).
     """
-    pyhf = refresh_pyhf
+
+    global pyhf
+    modules_to_clear = [name for name in sys.modules if name.split('.')[0] == 'pyhf']
+    for module_name in modules_to_clear:
+        monkeypatch.delitem(sys.modules, module_name)
+    pyhf = importlib.import_module(pyhf.__name__)
+
     spec = {
         'channels': [
             {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -602,11 +602,10 @@ def test_defs_always_cached(
     Otherwise pyhf will crash in contexts where the jsonschema.RefResolver cannot lookup the definition by the schema-id
     (e.g. a cluster node without network access).
     """
-    global pyhf
     modules_to_clear = [name for name in sys.modules if name.split('.')[0] == 'pyhf']
     for module_name in modules_to_clear:
         del sys.modules[module_name]
-    pyhf = importlib.import_module(pyhf.__name__)
+    pyhf = importlib.import_module('pyhf')
 
     spec = {
         'channels': [


### PR DESCRIPTION
# Description

Resolves #1916 by re-introducing the pre-population of the schema cache that had been done before the re-write of the schema utilities in #1753. Since  `defs.json` is in the cache under its id, `jsonschema.RefResolver` will not attempt to connect to `"https://scikit-hep.org"` to find it, which can crash code using pyhf in environments where the resource is not reachable.

I also tried to include a test to avoid future regression, but I am not happy with it. 
A better/more robust test would be a dedicated run in a sandboxed (i.e. no internet access / relevant ports blocked) environment, e.g. as part of the CI. But I have no clue how to set that up. 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Load `defs.json` into `schema.variables.SCHEMA_CACHE` from the local file.
  - in line with what was done before in PR #1753
* Add pytest-socket as a dependency of the 'test' extra. `pytest_socket.socket_disabled`
  was added in pytest-socket v0.2.0.
   - c.f. https://github.com/miketheman/pytest-socket/releases/tag/0.2.0
* Add a unit test to catch this regression in the future.
* `pyhf.schema` clears the cache to avoid stale schemas (and restores the cache if used as a CM).
* Amend unit tests for `pyhf.schema` to test the correct treatment of the cache.
```
