### PR TITLE
fix: Disallow Sphinx v5.1.0 to avoid 'exception: pop from an empty deque'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ extras_require['docs'] = sorted(
         extras_require['xmlio']
         + extras_require['contrib']
         + [
-            'sphinx>=4.0.0,!=5.1.0',
+            'sphinx>=4.0.0,!=5.1.0',  # c.f. https://github.com/scikit-hep/pyhf/pull/1925
             'sphinxcontrib-bibtex~=2.1',
             'sphinx-click',
             'sphinx_rtd_theme',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ extras_require['docs'] = sorted(
         extras_require['xmlio']
         + extras_require['contrib']
         + [
-            'sphinx>=4.0.0',
+            'sphinx>=4.0.0,!=5.1.0',
             'sphinxcontrib-bibtex~=2.1',
             'sphinx-click',
             'sphinx_rtd_theme',


### PR DESCRIPTION
# Description

* Disallow Sphinx `v5.1.0` as it introduces an deque error that can be caused by `sphinx.ext.napoleon`:

```pytb
Extension error (sphinx.ext.napoleon):
Handler <function _process_docstring at 0x7f43e8361a20> for event 'autodoc-process-docstring' threw an exception (exception: pop from an empty deque)
```
   - This was fixed rapidly in https://github.com/sphinx-doc/sphinx/pull/10709 and
     so will not be a problem in Sphinx v5.1.1+. (Thanks again to the amazing Sphinx team for the super rapid work they do on patch releases!)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Disallow Sphinx v5.1.0 as it introduces an deque error that can be
  caused by sphinx.ext.napoleon:
> Extension error (sphinx.ext.napoleon):
> Handler <function _process_docstring at 0x7f43e8361a20> for event 'autodoc-process-docstring'
> threw an exception (exception: pop from an empty deque)
   - This was fixed rapidly in https://github.com/sphinx-doc/sphinx/pull/10709 and
     so will not be a problem in Sphinx v5.1.1+.
```