### PR TITLE
docs: Update lower bound on Sphinx to v5.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ extras_require['docs'] = sorted(
         extras_require['xmlio']
         + extras_require['contrib']
         + [
-            'sphinx>=4.0.0,!=5.1.0',  # c.f. https://github.com/scikit-hep/pyhf/pull/1925
+            'sphinx>=5.1.1',  # c.f. https://github.com/scikit-hep/pyhf/pull/1925
             'sphinxcontrib-bibtex~=2.1',
             'sphinx-click',
             'sphinx_rtd_theme',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ extras_require['docs'] = sorted(
         extras_require['xmlio']
         + extras_require['contrib']
         + [
-            'sphinx>=5.1.1',  # c.f. https://github.com/scikit-hep/pyhf/pull/1925
+            'sphinx>=5.1.1',  # c.f. https://github.com/scikit-hep/pyhf/pull/1926
             'sphinxcontrib-bibtex~=2.1',
             'sphinx-click',
             'sphinx_rtd_theme',


### PR DESCRIPTION
# Description

* Update lower bound of `Sphinx` to `v5.1.1` to ensure consistent docs builds. This is simpler than disallowing particular problematic versions like `Sphinx` `v5.1.0` given that the documentation can be viewed as a deployment of an application and does not need to support as wide of a version range as possible.
* Amends PR #1925.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update lower bound of Sphinx to v5.1.1 to ensure consistent docs
builds. This is simpler than disallowing particular problematic versions
like Sphinx v5.1.0 given that the documentation can be viewed as a
deployment of an application and does not need to support as wide of a
version range as possible.
* Amends PR 1925.
```