### PR TITLE
docs: Add July 2022 use citations

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,16 @@
+% 2022-07-15
+@article{Belle:2022gbl,
+    author = "{Belle Collaboration}",
+    title = "{Search for a dark leptophilic scalar produced in association with $\tau^+\tau^-$ pair in $e^+e^-$ annihilation at center-of-mass energies near 10.58 GeV}",
+    eprint = "2207.07476",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    reportNumber = "BELLE-CONF-2201",
+    month = "7",
+    year = "2022",
+    journal = ""
+}
+
 % 2022-06-29
 @article{Alguero:2022gwm,
     author = {Alguero, Ga\"el and Araz, Jack Y. and Fuks, Benjamin and Kraml, Sabine},

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,16 @@
+% 2022-06-29
+@article{Alguero:2022gwm,
+    author = {Alguero, Ga\"el and Araz, Jack Y. and Fuks, Benjamin and Kraml, Sabine},
+    title = "{Signal region combination with full and simplified likelihoods in MadAnalysis 5}",
+    eprint = "2206.14870",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "IPPP/22/41",
+    month = "6",
+    year = "2022",
+    journal = ""
+}
+
 % 2022-04-19
 @phdthesis{Kvam:2022vgy,
     author = "Kvam, Audrey",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,16 @@
+% 2022-07-21
+@article{Allwicher:2022mcg,
+    author = "Allwicher, Lukas and Faroughy, Darius. A. and Jaffredo, Florentin and Sumensari, Olcyr and Wilsch, Felix",
+    title = "{HighPT: A Tool for high-$p_T$ Drell-Yan Tails Beyond the Standard Model}",
+    eprint = "2207.10756",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "ZU-TH-29/22",
+    month = "7",
+    year = "2022",
+    journal = ""
+}
+
 % 2022-07-15
 @article{Belle:2022gbl,
     author = "{Belle Collaboration}",


### PR DESCRIPTION
# Description

* Add use citation from [Signal region combination with full and simplified likelihoods in MadAnalysis 5](https://inspirehep.net/literature/2103971) by @Ga0l, @jackaraz, @BFuks, and @sabinekraml. :tada:
* Add use citation from [Search for a dark leptophilic scalar produced in association with τ+τ− pair in e+e− annihilation at center-of-mass energies near 10.58 GeV](https://inspirehep.net/literature/2115280) by the Belle Collaboration.
* Add use citation from [HighPT: A Tool for high-pT Drell-Yan Tails Beyond the Standard Model](https://inspirehep.net/literature/2121076) by Lukas Allwicher, Darius. A. Faroughy, Florentin Jaffredo, Olcyr Sumensari, and Felix Wilsch.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Signal region combination with full and simplified likelihoods
in MadAnalysis 5'.
   - c.f. https://inspirehep.net/literature/2103971
* Add use citation from 'Search for a dark leptophilic scalar produced in association
with τ+τ− pair in e+e− annihilation at center-of-mass energies near 10.58 GeV'.
   - Belle Collaboration paper
   - c.f. https://inspirehep.net/literature/2115280
* Add use citation from 'HighPT: A Tool for high-pT Drell-Yan Tails Beyond the
Standard Model'.
   - c.f. https://inspirehep.net/literature/2121076
```