### PR TITLE
fix: Coverage for importing XML channels with no data

### DIFF
--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -79,7 +79,7 @@ def import_root_histogram(rootdir, filename, path, name, filecache=None):
 
 
 def process_sample(
-    sample, rootdir, inputfile, histopath, channelname, track_progress=False
+    sample, rootdir, inputfile, histopath, channel_name, track_progress=False
 ):
     if 'InputFile' in sample.attrib:
         inputfile = sample.attrib.get('InputFile')
@@ -164,7 +164,7 @@ def process_sample(
                 raise RuntimeError('cannot determine stat error.')
             modifiers.append(
                 {
-                    'name': f'staterror_{channelname}',
+                    'name': f'staterror_{channel_name}',
                     'type': 'staterror',
                     'data': staterr,
                 }
@@ -226,24 +226,25 @@ def process_channel(channelxml, rootdir, track_progress=False):
         channel.findall('Sample'), unit='sample', disable=not (track_progress)
     )
 
+    channel_name = channel.attrib['Name']
+
     data = channel.findall('Data')
     if data:
         parsed_data = process_data(data[0], rootdir, inputfile, histopath)
     else:
-        parsed_data = None
-    channelname = channel.attrib['Name']
+        raise RuntimeError(f"Channel {channel_name} is missing data. See issue #1911.")
 
     results = []
     channel_parameter_configs = []
     for sample in samples:
         samples.set_description(f"  - sample {sample.attrib.get('Name')}")
         result = process_sample(
-            sample, rootdir, inputfile, histopath, channelname, track_progress
+            sample, rootdir, inputfile, histopath, channel_name, track_progress
         )
         channel_parameter_configs.extend(result.pop('parameter_configs'))
         results.append(result)
 
-    return channelname, parsed_data, results, channel_parameter_configs
+    return channel_name, parsed_data, results, channel_parameter_configs
 
 
 def process_measurements(toplvl, other_parameter_configs=None):

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -474,3 +474,12 @@ def test_import_validation_exception(mocker, caplog):
             'validation/xmlimport_input2',
             validation_as_error=True,
         )
+
+
+def test_import_noChannelData(mocker, datadir):
+    mocker.patch('pyhf.readxml.process_data', return_value=[])
+
+    basedir = datadir.joinpath("xmlimport_noChannelData")
+    with pytest.raises(RuntimeError) as excinfo:
+        pyhf.readxml.parse(basedir.joinpath("config/example.xml"), basedir)
+        assert 'Channel channel1 is missing data. See issue #1911' in str(excinfo.value)

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -477,7 +477,9 @@ def test_import_validation_exception(mocker, caplog):
 
 
 def test_import_noChannelData(mocker, datadir):
-    mocker.patch('pyhf.readxml.process_data', return_value=[])
+    _data = [0.0]
+    _err = [1.0]
+    mocker.patch('pyhf.readxml.import_root_histogram', return_value=(_data, _err))
 
     basedir = datadir.joinpath("xmlimport_noChannelData")
     with pytest.raises(RuntimeError) as excinfo:

--- a/tests/test_import/xmlimport_noChannelData/config/HistFactorySchema.dtd
+++ b/tests/test_import/xmlimport_noChannelData/config/HistFactorySchema.dtd
@@ -1,0 +1,160 @@
+
+<!-- The top level combination spec -->
+<!-- OutputFilePrefix: Prefix to the output root file to be created (inspection histograms) -->
+<!-- Mode: Type of the analysis -->
+<!ELEMENT Combination (Function*,Input+,Measurement*)>
+<!ATTLIST Combination
+        OutputFilePrefix         CDATA            #REQUIRED
+        Mode                     CDATA            #IMPLIED
+>
+
+<!-- Input files detailing the channels. One channel per file -->
+<!ELEMENT Function  EMPTY>
+<!ATTLIST Function
+     Name                 CDATA         #REQUIRED
+     Expression           CDATA         #REQUIRED
+     Dependents           CDATA         #REQUIRED
+>
+
+<!-- Input files detailing the channels. One channel per file -->
+<!ELEMENT Input (#PCDATA) >
+
+<!-- Configuration for each measurement -->
+<!-- Name: to be used as the heading in the table -->
+<!-- Lumi: the luminosity of the measurement -->
+<!-- LumiRelErr: the relative error known for the lumi -->
+<!-- BinLow: the lowest bin number used for the measurement (inclusive) -->
+<!-- BinHigh: the highest bin number used for the measurement (exclusive) -->
+<!-- Mode: type of the measurement (a closed list of ...) -->
+<!-- ExportOnly: if "True" skip fit, only export model -->
+<!ELEMENT Measurement (POI,ParamSetting*,ConstraintTerm*) >
+<!ATTLIST Measurement
+        Name              CDATA            #REQUIRED
+        Lumi              CDATA            #REQUIRED
+        LumiRelErr        CDATA            #REQUIRED
+        BinLow            CDATA            #IMPLIED
+        BinHigh           CDATA            #IMPLIED
+        Mode              CDATA            #IMPLIED
+        ExportOnly        CDATA            #IMPLIED
+>
+
+<!-- Specify what you are measuring. Corresponds to the name specified in the construction
+of the model in the channel setup. Typically the NormFactor for xsec measurements -->
+<!ELEMENT POI (#PCDATA) >
+
+<!-- Specify what parameters are fixed, or have particular value -->
+<!-- Val: set the value of the parameter -->
+<!-- Const: set this parameter constant -->
+<!ELEMENT ParamSetting (#PCDATA)>
+<!ATTLIST ParamSetting
+        Val               CDATA           #IMPLIED
+        Const             CDATA           #IMPLIED
+>
+
+<!-- Specify an alternative shape to use for given constraint terms (Gaussian is used if this is not specified) -->
+<!-- Type: can be Gamma or Uniform -->
+<!-- RelativeUncertainty: relative uncertainty on the shape -->
+<!ELEMENT ConstraintTerm (#PCDATA)>
+<!ATTLIST ConstraintTerm
+        Type                  CDATA       #REQUIRED
+        RelativeUncertainty   CDATA       #IMPLIED
+>
+
+<!-- Top element for channels. InputFile, HistoName and HistoPath
+can be set at this level in which case they will become defaul to
+all subsequent elements. Otherwise they can be set in individual
+subelements -->
+<!ELEMENT Channel (Data*,StatErrorConfig*,Sample+)>
+<!-- InputFile: input file where the input histogram can be found (use abs path) -->
+<!-- HistoPath: the path (within the root file) where the histogram can be found -->
+<!-- HistoName: the name of the histogram to be used for this (and following in not overridden) item -->
+<!ATTLIST Channel
+        Name              CDATA            #REQUIRED
+        InputFile         CDATA            #IMPLIED
+        HistoPath         CDATA            #IMPLIED
+        HistoName         CDATA            #IMPLIED
+>
+
+<!-- Data to be fit. If you don't provide it, Asimov data will be created -->
+<!-- InputFile: any item set here will override the configuration for the subelements.
+For this element there is no sublemenents so the setting will only have local effects -->
+<!ELEMENT Data EMPTY>
+<!ATTLIST Data
+        InputFile         CDATA            #IMPLIED
+        HistoPath         CDATA            #IMPLIED
+        HistoName         CDATA            #IMPLIED
+>
+
+<!ELEMENT StatErrorConfig EMPTY>
+<!ATTLIST StatErrorConfig
+        RelErrorThreshold      CDATA            #IMPLIED
+        ConstraintType         CDATA            #IMPLIED
+>
+
+
+<!-- Sample elements are made up of systematic variations -->
+<!ELEMENT Sample (StatError | HistoSys | OverallSys | ShapeSys | NormFactor | ShapeFactor)*>
+<!ATTLIST Sample
+        Name              CDATA            #REQUIRED
+        InputFile         CDATA            #IMPLIED
+        HistoName         CDATA            #IMPLIED
+        HistoPath         CDATA            #IMPLIED
+        NormalizeByTheory      CDATA       #IMPLIED
+>
+
+<!-- Systematics for which the variation is provided by histograms -->
+<!ELEMENT StatError EMPTY>
+<!ATTLIST StatError
+     Activate          CDATA            #REQUIRED
+          HistoName         CDATA            #IMPLIED
+          InputFile         CDATA            #IMPLIED
+          HistoPath         CDATA            #IMPLIED
+>
+
+<!ELEMENT HistoSys EMPTY>
+<!ATTLIST HistoSys
+        Name              CDATA            #REQUIRED
+        InputFile         CDATA            #IMPLIED
+        HistoFileHigh     CDATA            #IMPLIED
+        HistoPathHigh     CDATA            #IMPLIED
+        HistoNameHigh     CDATA            #IMPLIED
+        HistoFileLow      CDATA            #IMPLIED
+        HistoPathLow      CDATA            #IMPLIED
+        HistoNameLow      CDATA            #IMPLIED
+>
+
+<!-- Systematics for which the variation is provided by simple overall scaling -->
+<!ELEMENT OverallSys EMPTY>
+<!ATTLIST OverallSys
+        Name              CDATA            #REQUIRED
+        High              CDATA            #REQUIRED
+        Low               CDATA            #REQUIRED
+>
+
+<!-- Systematics for which the variation is provided by simple overall scaling -->
+<!ELEMENT ShapeSys EMPTY>
+<!ATTLIST ShapeSys
+          Name              CDATA            #REQUIRED
+          HistoName         CDATA            #REQUIRED
+          HistoPath         CDATA            #IMPLIED
+          InputFile         CDATA            #IMPLIED
+          ConstraintType    CDATA            #IMPLIED
+>
+
+<!-- Scaling factor, which may be the parameter of interest for cross section measurements-->
+<!ELEMENT NormFactor EMPTY>
+<!ATTLIST NormFactor
+        Name              CDATA            #REQUIRED
+        Val               CDATA            #REQUIRED
+        High              CDATA            #REQUIRED
+        Low               CDATA            #REQUIRED
+        Const             CDATA            #IMPLIED
+>
+
+
+<!-- Systematics for which the variation is provided by simple overall scaling -->
+<!ELEMENT ShapeFactor EMPTY>
+<!ATTLIST ShapeFactor
+          Name              CDATA            #REQUIRED
+>
+

--- a/tests/test_import/xmlimport_noChannelData/config/example.xml
+++ b/tests/test_import/xmlimport_noChannelData/config/example.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE Combination  SYSTEM 'HistFactorySchema.dtd'>
+<Combination OutputFilePrefix="./results/example" >
+  <Input>./config/example_channel.xml</Input>
+  <Measurement Name="GaussExample" Lumi="1." LumiRelErr="0.1" >
+    <POI>SigXsecOverSM</POI>
+    <ParamSetting Const="True">Lumi alpha_syst1</ParamSetting>
+  </Measurement>
+</Combination>

--- a/tests/test_import/xmlimport_noChannelData/config/example_channel.xml
+++ b/tests/test_import/xmlimport_noChannelData/config/example_channel.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE Channel  SYSTEM 'HistFactorySchema.dtd'>
+<Channel Name="channel1" InputFile="./data/example.root" >
+  <!--<Data HistoName="data" HistoPath="" />-->
+  <Sample Name="signal" HistoPath="" HistoName="signal">
+    <OverallSys Name="syst1" High="1.05" Low="0.95"/>
+    <NormFactor Name="SigXsecOverSM" Val="1" Low="0." High="3."  />
+  </Sample>
+  <Sample Name="background1" HistoPath="" NormalizeByTheory="True" HistoName="background1">
+    <StatError Activate="True" HistoName="background1_statUncert"  />
+    <OverallSys Name="syst2" Low="0.95" High="1.05"/>
+  </Sample>
+  <Sample Name="background2" HistoPath="" NormalizeByTheory="True" HistoName="background2">
+    <StatError Activate="True" /> <!-- Use Default Histogram Errors as input to StatError -->
+    <OverallSys Name="syst3" Low="0.95" High="1.05"/>
+  </Sample>
+</Channel>


### PR DESCRIPTION
# Description

Handle cases where channel is missing data in the XML configuration (associated with Asimov). c.f. Issue #1911

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Raise RuntimeError for cases where channel is missing data in the XML configuration
(associated with Asimov).
   - c.f. Issue #1911
* Add tests and test XML files.
```
