### PR TITLE
ci: Add yesqa pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,7 @@ repos:
     rev: 5.0.2
     hooks:
     - id: flake8
+      args: ["--count", "--statistics"]
 
 -   repo: https://github.com/nbQA-dev/nbQA
     rev: 1.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,11 @@ repos:
     - id: blacken-docs
       additional_dependencies: [black==22.6.0]
 
+-   repo: https://github.com/asottile/yesqa
+    rev: v1.4.0
+    hooks:
+    - id: yesqa
+
 -   repo: https://github.com/PyCQA/flake8
     rev: 5.0.2
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,5 +56,3 @@ console_scripts =
 # E501: line too long
 extend-ignore = E203, E402, E501
 max-line-length = 88
-count = True
-statistics = True

--- a/src/pyhf/infer/__init__.py
+++ b/src/pyhf/infer/__init__.py
@@ -204,7 +204,7 @@ def hypotest(
     return tuple(_returns) if len(_returns) > 1 else _returns[0]
 
 
-from pyhf.infer import intervals  # noqa: F401
+from pyhf.infer import intervals
 
 __all__ = ["hypotest", "calculators", "intervals", "mle", "test_statistics", "utils"]
 


### PR DESCRIPTION
# Description

Add `yesqa` pre-commit hook and use it to remove an unused `noqa: F401` from

https://github.com/scikit-hep/pyhf/blob/1494b66ef4edbb2d76e982771523d8b94c2d73e4/src/pyhf/infer/__init__.py#L207

As the use of the `flake8` config options `count` and `statistics` in `setup.cfg` cause issues with `yesqa` (c.f. https://github.com/asottile/yesqa/issues/132, https://github.com/PyCQA/flake8/issues/1458) move them to the `flake8` pre-commit hook as `args`.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR
