### PR TITLE
ci: Report coverage for all Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
     - name: Report core project coverage with Codecov
       if: >-
         github.event_name != 'schedule' &&
-        (matrix.python-version == '3.7' || matrix.python-version == '3.10') &&
         matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v3
       with:


### PR DESCRIPTION
# Description

Remove check to only report coverage to Codecov for the oldest Python (Python 3.7) and newest (Python 3.10) tested

https://github.com/scikit-hep/pyhf/blob/97664bcfcef3b4a459a7f700b0703b40aec9b842/.github/workflows/ci.yml#L29

and instead report the coverage for all versions. The coverage flag for Codecov is `unittests-${{ matrix.python-version }}` and so the Codecov report will now show coverage for all versions and not just the 'bookend' versions.

https://github.com/scikit-hep/pyhf/blob/97664bcfcef3b4a459a7f700b0703b40aec9b842/.github/workflows/ci.yml#L64-L67

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove check to only report coverage to Codecov for the oldest Python
(Python 3.7) and newest (Python 3.10) tested and instead report
the coverage for all versions. The coverage flag for Codecov is
'unittests-${{ matrix.python-version }}' and so the Codecov report
will now show coverage for all versions and not just the 'bookend'
versions.
```