### PR TITLE
test: Ignore TYPE_CHECKING for coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+exclude_lines =
+    if TYPE_CHECKING:


### PR DESCRIPTION
# Pull Request Description

As introduced in #1909, we had a drop in coverage due to the `TYPE_CHECKING` blocks. We'll ignore it to fix coverage as those blocks aren't meant to be seen during runtime.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add .coveragerc file with configuration to ignore TYPE_CHECKING.
  - ref: https://coverage.readthedocs.io/en/6.4.3/excluding.html#advanced-exclusion
```
