### PR TITLE
build: Set lower bound of typing-extensions to v3.7.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     jsonpatch>=1.15
     pyyaml>=5.1  # for parsing CLI equal-delimited options
     importlib_resources>=1.3.0; python_version < "3.9"  # for resources in schema
-    typing_extensions; python_version == "3.7"  # for TypedDict, Literal
+    typing_extensions>=3.7.4; python_version == "3.7"  # for TypedDict, Literal
 
 [options.packages.find]
 where = src

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -6,6 +6,7 @@ jsonschema==3.0.0
 jsonpatch==1.15
 pyyaml==5.1
 importlib_resources==1.3.0
+typing-extensions==3.7.4  # c.f. PR #this-one
 # xmlio
 uproot==4.1.1
 # minuit

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -6,7 +6,7 @@ jsonschema==3.0.0
 jsonpatch==1.15
 pyyaml==5.1
 importlib_resources==1.3.0
-typing-extensions==3.7.4  # c.f. PR #this-one
+typing-extensions==3.7.4  # c.f. PR #1938
 # xmlio
 uproot==4.1.1
 # minuit


### PR DESCRIPTION
# Description

Add a lower bound of the supported `typing_extensions` version to `v3.7.4` as `TypedDict` was added in `v3.7.4`.

> The typing_extensions module contains both backports of these changes as well as experimental types that will eventually be added to the typing module, such as Protocol or TypedDict.
   - c.f. https://pypi.org/project/typing-extensions/3.7.4/

Amends PR #1934.

Example:

```console
(venv) $ python -m pip --quiet install 'typing-extensions==3.7.2' && python -c 'from typing_extensions import Literal, TypedDict' && echo $?
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name 'TypedDict' from 'typing_extensions' (/venv/lib/python3.7/site-packages/typing_extensions.py)
(venv) $ python -m pip --quiet install 'typing-extensions==3.7.4' && python -c 'from typing_extensions import Literal, TypedDict' && echo $?
0
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Set the lower bound of the supported typing_extensions versions to v3.7.4
  as TypedDict was added in v3.7.4.

  > The typing_extensions module contains both backports of these changes as
  > well as experimental types that will eventually be added to the typing module,
  > such as Protocol or TypedDict.
   - c.f. https://pypi.org/project/typing-extensions/3.7.4/

   - Amends PR #1934
* Add typing-extensions==3.7.4 to tests/constraints.txt.
```