### PR TITLE
refactor: Use string literal types of generic builtins for type checking

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,0 @@
-[report]
-exclude_lines =
-    if TYPE_CHECKING:

--- a/src/pyhf/typing.py
+++ b/src/pyhf/typing.py
@@ -27,7 +27,7 @@ __all__ = (
     "Workspace",
 )
 
-# TODO: Switch to os.PathLike[str] once Python 3.7 dropped
+# TODO: Switch to os.PathLike[str] once Python 3.8 support dropped
 PathOrStr = Union[str, "os.PathLike[str]"]
 
 

--- a/src/pyhf/typing.py
+++ b/src/pyhf/typing.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from typing import TYPE_CHECKING, MutableSequence, Sequence, Union
+from typing import MutableSequence, Sequence, Union
 
 if sys.version_info >= (3, 8):
     from typing import Literal, TypedDict
@@ -27,10 +27,8 @@ __all__ = (
     "Workspace",
 )
 
-if TYPE_CHECKING:
-    PathOrStr = Union[str, os.PathLike[str]]
-else:
-    PathOrStr = Union[str, "os.PathLike[str]"]
+# TODO: Switch to os.PathLike[str] once Python 3.7 dropped
+PathOrStr = Union[str, "os.PathLike[str]"]
 
 
 class ParameterBase(TypedDict, total=False):


### PR DESCRIPTION
# Description

Resolves #1941 

* Use [string literal types](https://mypy.readthedocs.io/en/stable/runtime_troubles.html#string-literal-types) of generic builtins for type checking until Python 3.8 support is dropped (so pyhf is Python 3.9+ only) to avoid having to check for `if typing.TYPE_CHECKING`.
   - c.f. https://mypy.readthedocs.io/en/stable/runtime_troubles.html#string-literal-types
   - c.f. https://mypy.readthedocs.io/en/stable/builtin_types.html#generic-types
   - c.f. https://mypy.readthedocs.io/en/stable/runtime_troubles.html#generic-builtins
   - c.f. https://peps.python.org/pep-0585/
* Remove `.coveragerc` as no longer needed.
   - Reverts PR #1937

Thanks @henryiii for the nudge on this.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use string literal types of generic builtins for type checking until Python
  3.8 support is dropped (so pyhf is Python 3.9+ only) to avoid having to
  check for `if typing.TYPE_CHECKING`.
   - c.f. https://mypy.readthedocs.io/en/stable/runtime_troubles.html#string-literal-types
   - c.f. https://mypy.readthedocs.io/en/stable/builtin_types.html#generic-types
   - c.f. https://mypy.readthedocs.io/en/stable/runtime_troubles.html#generic-builtins
   - c.f. https://peps.python.org/pep-0585/
* Remove .coveragerc as no longer needed.
   - Reverts PR #1937
```