### PR TITLE
chore: Remove 'lint' extra from setup.py

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,21 +16,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install --upgrade .[lint]
-        python -m pip list
-    - name: Lint with flake8
-      run: |
-        python -m flake8 .
-    - name: Lint with Black
-      run: |
-        black --check --diff --verbose .
 
     - name: Lint Dockerfile
       uses: hadolint/hadolint-action@v2.1.0

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,6 @@ extras_require['backends'] = sorted(
     )
 )
 extras_require['contrib'] = sorted({'matplotlib', 'requests'})
-extras_require['lint'] = sorted({'flake8', 'black>=22.1.0'})
-
 extras_require['test'] = sorted(
     set(
         extras_require['backends']
@@ -65,7 +63,6 @@ extras_require['docs'] = sorted(
 extras_require['develop'] = sorted(
     set(
         extras_require['docs']
-        + extras_require['lint']
         + extras_require['test']
         + [
             'nbdime',


### PR DESCRIPTION
# Description

* Remove the 'lint' extra. All linting should be done through pre-commit now and so there is no need to have a specific lint extra.
* Remove the flake8 and black components of the lint workflow, as these are redundant to pre-commit.ci.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove the 'lint' extra. All linting should be done through pre-commit now
and so there is no need to have a specific lint extra.
* Remove the flake8 and black components of the lint workflow, as these are
redundant to pre-commit.ci.
```