### PR TITLE
build: Update git archival options to support auto versioning

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,1 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
 ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-.git_archival.txt  export-subst
+.git_archival.txt export-subst
 *.py diff=python
 *.md diff=markdown

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-.git_archival.txt export-subst
+.git_archival.txt  export-subst
 *.py diff=python
 *.md diff=markdown

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools>=42.0.0", "setuptools_scm[toml]>=7.0.1"]
+requires = ["setuptools>=42.0.0", "setuptools_scm>=7.0.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools>=42.0.0", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=42.0.0", "setuptools_scm[toml]>=7.0.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools>=42.0.0", "setuptools_scm>=7.0.1"]
+requires = ["setuptools>=61.0.0", "setuptools_scm>=7.0.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
# Description

From the removed sections of https://github.com/scikit-hep/scikit-hep.github.io/pull/250/ I see that we should be updating the `.git_archival.txt` information to allow for Git archives (including the ones generated from GitHub) to also support versioning. c.f. https://github.com/pypa/setuptools_scm/tree/1b18371fc2fa672f39c758a103c4d12956b5964f#git-archives

In there it is additionally pointed out (in the removed section) that 

> If you are missing `setuptools_scm` or possibly the `toml` dependency on old versions of `setuptools_scm`, you will silently get version 0.0.0.
> ...
> This will only work with `setuptools_scm>=7`, which requires Python 3.7+ (though adding the files won't hurt older versions).

So additionally update `build-system` `requires` to have `setuptools_scm>=7.0.1` as `7.0.0` was yanked.

Require `setuptools>=61.0.0` for the build system as `v61.0.0` adds support for `pyproject.toml` configuration. This configuration is not currently used by pyhf, but it is updated given the recommendation by the Scikit-HEP developer guide.
   - c.f. https://setuptools.pypa.io/en/latest/history.html#v61-0-0

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update the options in .git_archival.txt to fully support to allow Git archives
  (including the ones generated from GitHub) to support versioning.
   - c.f. https://github.com/scikit-hep/scikit-hep.github.io/pull/250
   - c.f. https://github.com/pypa/setuptools_scm/tree/1b18371fc2fa672f39c758a103c4d12956b5964f#git-archives
* Require 'setuptools_scm>=7.0.1' for the build system to ensure support.
   - Drop addition of 'setuptools_scm[toml]' extra as no longer required.
* Require 'setuptools>=61.0.0' for the build system as v61.0.0 adds support for
  pyproject.toml configuration. This configuration is not currently used by pyhf, but
  it is updated given the recommendation by the Scikit-HEP developer guide.
   - c.f. https://setuptools.pypa.io/en/latest/history.html#v61-0-0
```