### PR TITLE
feat: Validate workspace specification before accessing parts of it

### DIFF
--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -300,14 +300,15 @@ class Workspace(_ChannelSummaryMixin, dict):
 
         """
         spec = copy.deepcopy(spec)
-        super().__init__(spec, channels=spec['channels'])
         self.schema = config_kwargs.pop('schema', 'workspace.json')
         self.version = config_kwargs.pop('version', spec.get('version', None))
 
         # run jsonschema validation of input specification against the (provided) schema
         if validate:
             log.info(f"Validating spec against schema: {self.schema}")
-            schema.validate(self, self.schema, version=self.version)
+            schema.validate(spec, self.schema, version=self.version)
+
+        super().__init__(spec, channels=spec['channels'])
 
         self.measurement_names = []
         for measurement in self.get('measurements', []):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -914,6 +914,7 @@ def test_workspace_without_validation(mocker, simplemodels_model_data):
 
 def test_workspace_invalid_specification():
     spec = {"channels": [{"name": "SR", "samples_wrong_name": []}]}
-    # ensure that an invalid specifications gets caught as such
+    # Ensure that an invalid specifications gets caught as such
+    # before a KeyError: 'samples' could be reached.
     with pytest.raises(pyhf.exceptions.InvalidSpecification):
         pyhf.Workspace(spec)

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -910,3 +910,10 @@ def test_workspace_without_validation(mocker, simplemodels_model_data):
 
     pyhf.Workspace(dict(ws), validate=False)
     assert pyhf.schema.validate.called is False
+
+
+def test_workspace_invalid_specification():
+    spec = {"channels": [{"name": "SR", "samples_wrong_name": []}]}
+    # ensure that an invalid specifications gets caught as such
+    with pytest.raises(pyhf.exceptions.InvalidSpecification):
+        pyhf.Workspace(spec)


### PR DESCRIPTION
# Description

The validation of a workspace specification against the schema currently takes place after some aspects of the workspace are already accessed in the constructor of `_ChannelSummaryMixin`. This can lead to unintuitive error messages, which should instead be caught by the schema validation. This PR re-orders the logic such that validation takes place first, ensuring that the relevant information is available for subsequent steps (assuming validation succeeds).

resolves #1952

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Validate the workspace specification in Model construction before any spec information
  can be accessed in the constructor of _ChannelSummaryMixin.
* Add test that checks for an pyhf.exceptions.InvalidSpecification being raised, indicating
  that the invalid model spec has been caught before a KeyError would be raised later.
```