### PR TITLE
ci: Use 'strict' option for twine check

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -81,7 +81,7 @@ jobs:
         echo "python-build named built distribution: ${wheel_name}"
 
     - name: Verify the distribution
-      run: twine check dist/*
+      run: twine check --strict dist/*
 
     - name: List contents of sdist
       run: python -m tarfile --list dist/pyhf-*.tar.gz


### PR DESCRIPTION
# Description

Use `twine check --strict` to fail on warnings.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use `twine check --strict` to fail on warnings.
```