### PR TITLE
ci: Deploy GitHub Pages docs directly using GitHub Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -78,8 +78,6 @@ jobs:
         python -m doctest README.rst
         pushd docs
         make html
-        popd
-        touch docs/_build/html/.nojekyll
 
     - name: Check schemas are copied over
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,12 +35,15 @@ jobs:
       with:
         python-version: '3.10'
 
-    - name: Install dependencies
+    - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip --quiet install --upgrade .[docs,test]
         python -m pip install yq
         python -m pip list
+
+    - name: Install apt-get dependencies
+      run: |
         sudo apt-get update
         sudo apt-get -qq install pandoc
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Set permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -89,7 +89,6 @@ jobs:
         [ "$(ls -A docs/_build/html/schemas)" ]
 
     - name: Setup Pages
-      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: actions/configure-pages@v2
 
     - name: Upload artifact
@@ -98,5 +97,6 @@ jobs:
         path: 'docs/_build/html'
 
     - name: Deploy to GitHub Pages
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       id: deployment
       uses: actions/deploy-pages@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,10 +25,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        python-version: ['3.10']
-
     steps:
     - uses: actions/checkout@v3
       with:
@@ -37,7 +33,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,8 +19,12 @@ concurrency:
 
 jobs:
   docs:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
         python-version: ['3.10']
@@ -87,13 +91,15 @@ jobs:
         # is not empty
         [ "$(ls -A docs/_build/html/schemas)" ]
 
-    - name: Deploy docs to GitHub Pages
+    - name: Setup Pages
       if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
-      uses: peaceiris/actions-gh-pages@v3
+      uses: actions/configure-pages@v1
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/_build/html
-        force_orphan: true
-        user_name: 'github-actions[bot]'
-        user_email: 'github-actions[bot]@users.noreply.github.com'
-        commit_message: Deploy to GitHub pages
+        path: 'docs/_build/html'
+
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,10 +23,12 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up Python 3.10
+
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
@@ -35,6 +37,7 @@ jobs:
         python -m pip list
         sudo apt-get update
         sudo apt-get -qq install pandoc
+
     - name: Check docstrings
       run: |
         # Group 1 is related to docstrings
@@ -48,9 +51,11 @@ jobs:
                                src/pyhf/optimize \
                                src/pyhf/contrib \
                                src/pyhf/cli
+
     - name: Verify CITATION.cff schema
       run: |
         jsonschema <(curl -sL "https://citation-file-format.github.io/1.2.0/schema.json") --instance <(cat CITATION.cff | yq)
+
     - name: Check for broken links
       run: |
         pushd docs
@@ -58,6 +63,7 @@ jobs:
         # Don't ship the linkcheck
         rm -r _build/linkcheck
         popd
+
     - name: Test and build docs
       run: |
         python -m doctest README.rst
@@ -65,6 +71,7 @@ jobs:
         make html
         popd
         touch docs/_build/html/.nojekyll
+
     - name: Check schemas are copied over
       run: |
         # is a directory
@@ -73,6 +80,7 @@ jobs:
         [ ! -L "docs/_build/html/schemas" ]
         # is not empty
         [ "$(ls -A docs/_build/html/schemas)" ]
+
     - name: Deploy docs to GitHub Pages
       if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -90,7 +90,7 @@ jobs:
 
     - name: Setup Pages
       if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
-      uses: actions/configure-pages@v1
+      uses: actions/configure-pages@v2
 
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v1


### PR DESCRIPTION
# Description

Following the blog announcement [GitHub Pages: Custom GitHub Actions Workflows (beta)](https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/), publish the GitHub Pages docs directly from the repository using GitHub Actions, without needing to set up a [publishing source](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site) like a branch.

This also restricts deployments to happening in specific environments (c.f. https://github.com/scikit-hep/pyhf/settings/environments).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use the GitHub Actions:
   - actions/configure-pages@v2
   - actions/upload-pages-artifact@v1
   - actions/deploy-pages@v1
  over the peaceiris/actions-gh-pages@v3 to deploy the GitHub Pages docs website.
  This additionally uses the `permissions` and `environment` settings to restrict
  the deployment to specific environments.
   - c.f. https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/
* Remove unused strategy matrix as only one Python version is ever setup.
* Remove creation of `.nojekyll` file as the website is created without the
  use of Jekyll (Jekyll was the previous default assumption from GitHub pages).
```