### PR TITLE
docs: Add link to public-probability-models website

### DIFF
--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -46,7 +46,7 @@ The following is an updating list of HEPData entries for publications using ``Hi
 
    There is also an automatically generated list of statistical models that is updated
    nightly available at `pyhf.github.io/public-probability-models
-   <https://pyhf.github.io/public-probability-models>`.
+   <https://pyhf.github.io/public-probability-models>`__.
 
 .. bibliography:: bib/HEPData_likelihoods.bib
    :list: enumerated

--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -40,7 +40,13 @@ General Citations
 Published Statistical Models
 ----------------------------
 
-Updating list of HEPData entries for publications using ``HistFactory`` JSON statistical models:
+The following is an updating list of HEPData entries for publications using ``HistFactory`` JSON statistical models.
+
+.. note::
+
+   There is also an automatically generated list of statistical models that is updated
+   nightly available at `pyhf.github.io/public-probability-models
+   <https://pyhf.github.io/public-probability-models>`.
 
 .. bibliography:: bib/HEPData_likelihoods.bib
    :list: enumerated


### PR DESCRIPTION
# Description

Following up on PR #1688, add note in the docs about links to the public-probability-models website that generates a nightly list of all public probability models.
   - c.f. https://pyhf.github.io/public-probability-models

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add note that links to the public-probability-models website that
  generates a nightly list of all public probability models.
   - c.f. https://pyhf.github.io/public-probability-models
```