### PR TITLE
build: Update lower bound of click to v8.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ include_package_data = True
 python_requires = >=3.7
 install_requires =
     scipy>=1.1.0 # requires numpy, which is required by pyhf and tensorflow
-    click>=7.0  # for console scripts
+    click>=8.0.0  # for console scripts
     tqdm>=4.56.0  # for readxml
     jsonschema>=3.0.0  # for utils
     jsonpatch>=1.15

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,6 +1,6 @@
 # core
 scipy==1.1.0
-click==8.0.0
+click==8.0.0  # c.f. PR #1957, #1909
 tqdm==4.56.0
 jsonschema==3.0.0
 jsonpatch==1.15

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,6 +1,6 @@
 # core
 scipy==1.1.0
-click==7.0
+click==8.0.0
 tqdm==4.56.0
 jsonschema==3.0.0
 jsonpatch==1.15

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,6 +1,6 @@
 # core
 scipy==1.1.0
-click==8.0.0  # c.f. PR #1957, #1909
+click==8.0.0  # c.f. PR #1958, #1909
 tqdm==4.56.0
 jsonschema==3.0.0
 jsonpatch==1.15


### PR DESCRIPTION
# Description

Resolves #1957 

* Update lower bound of the supported `click` versions to `v8.0.0` as it is required to support behavior in PR #1909. I'm not actually sure what changed, but from empirical testing something in [`v8.0.0`](https://click.palletsprojects.com/en/8.1.x/changes/#version-8-0-0) is needed. :?

**edit**: @kratsg has found in https://github.com/scikit-hep/pyhf/issues/1957#issuecomment-1228782947 that Click v7 has a bug and didn't set the path type correctly.

* Update 

https://github.com/scikit-hep/pyhf/blob/f01dcf59da10ec9313345305efc49cfb7186bf99/tests/constraints.txt#L3

to use `click==8.0.0`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update lower bound of the supported click versions to v8.0.0 as it
is required to support behavior in PR #1909 due to click v7.x not
setting the type correctly for path type arguments.
   - c.f. https://github.com/scikit-hep/pyhf/issues/1957#issuecomment-1228782947
* Update tests/constraints.txt to use click==8.0.0.
```