### PR TITLE
ci: Restrict deployments of environments to PR merges

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -89,11 +89,9 @@ jobs:
         [ "$(ls -A docs/_build/html/schemas)" ]
 
     - name: Setup Pages
-      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: actions/configure-pages@v2
 
     - name: Upload artifact
-      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: actions/upload-pages-artifact@v1
       with:
         path: 'docs/_build/html'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -89,6 +89,7 @@ jobs:
         [ "$(ls -A docs/_build/html/schemas)" ]
 
     - name: Setup Pages
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: actions/configure-pages@v2
 
     - name: Upload artifact

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -92,6 +92,7 @@ jobs:
       uses: actions/configure-pages@v2
 
     - name: Upload artifact
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: actions/upload-pages-artifact@v1
       with:
         path: 'docs/_build/html'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   build:
+    name: Build docs
     runs-on: ubuntu-latest
 
     steps:
@@ -84,6 +85,7 @@ jobs:
         path: 'docs/_build/html'
 
   deploy:
+    name: Deploy docs to GitHub Pages
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: build
     # Set permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,22 +7,12 @@ on:
   pull_request:
   workflow_dispatch:
 
-# Set permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  docs:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -88,15 +78,30 @@ jobs:
         # is not empty
         [ "$(ls -A docs/_build/html/schemas)" ]
 
-    - name: Setup Pages
-      uses: actions/configure-pages@v2
-
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v1
       with:
         path: 'docs/_build/html'
 
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: build
+    # Set permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Setup Pages
+      uses: actions/configure-pages@v2
+
     - name: Deploy to GitHub Pages
-      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       id: deployment
       uses: actions/deploy-pages@v1


### PR DESCRIPTION
# Description

Split the docs workflow into a build and deploy jobs, where the deploy job requires the build job to succeed. This avoids unnecessary deployments by only having the github-pages environment exist in the deploy job.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Split the docs workflow into a build and deploy jobs, where the deploy
  job requires the build job to succeed. This avoids unnecessary deployments
  by only having the github-pages environment exist in the deploy job.
* Constrain the deployment of environments to PR merges by requiring push
  events on master to trigger the deploy job.

Co-authored-by: Giordon Stark <kratsg@gmail.com>
```