### PR TITLE
build: Update lower bound of typing-extensions to v3.7.4.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     jsonpatch>=1.15
     pyyaml>=5.1  # for parsing CLI equal-delimited options
     importlib_resources>=1.3.0; python_version < "3.9"  # for resources in schema
-    typing_extensions>=3.7.4; python_version == "3.7"  # for TypedDict, Literal
+    typing_extensions>=3.7.4.3; python_version == "3.7"  # for SupportsIndex
 
 [options.packages.find]
 where = src

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -6,7 +6,7 @@ jsonschema==3.0.0
 jsonpatch==1.15
 pyyaml==5.1
 importlib_resources==1.3.0
-typing-extensions==3.7.4  # c.f. PR #1938
+typing-extensions==3.7.4.3  # c.f. PR #UPDATE, #1940
 # xmlio
 uproot==4.1.1
 # minuit

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -6,7 +6,7 @@ jsonschema==3.0.0
 jsonpatch==1.15
 pyyaml==5.1
 importlib_resources==1.3.0
-typing-extensions==3.7.4.3  # c.f. PR #UPDATE, #1940
+typing-extensions==3.7.4.3  # c.f. PR #1961, #1940
 # xmlio
 uproot==4.1.1
 # minuit


### PR DESCRIPTION
# Description

Update lower bound of the supported typing-extensions versions to `v3.7.4.3` to ensure `SupportsIndex` is available, which is used as of PR #1940.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update lower bound of the supported typing-extensions versions to v3.7.4.3
  to ensure SupportsIndex is available, which is used as of PR #1940.
   - Amends PR #1940.
* Update tests/constraints.txt to use typing-extensions==3.7.4.3.
```