### PR TITLE
build: Update lower bounds to tensorflow v2.7.0, jaxlib v0.1.61

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     jsonpatch>=1.15
     pyyaml>=5.1  # for parsing CLI equal-delimited options
     importlib_resources>=1.3.0; python_version < "3.9"  # for resources in schema
-    typing_extensions>=3.7.4; python_version == "3.7"  # for TypedDict, Literal
+    typing_extensions>=3.7.4.3; python_version == "3.7"  # for SupportsIndex
 
 [options.packages.find]
 where = src

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 extras_require = {
     'shellcomplete': ['click_completion'],
     'tensorflow': [
-        'tensorflow>=2.6.5',  # c.f. PR #1874
+        'tensorflow>=2.7.0',  # c.f. PR #1874
         'tensorflow-probability>=0.11.0',  # c.f. PR #1657
     ],
     'torch': ['torch>=1.10.0'],  # c.f. PR #1657

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ extras_require = {
         'tensorflow-probability>=0.11.0',  # c.f. PR #1657
     ],
     'torch': ['torch>=1.10.0'],  # c.f. PR #1657
-    'jax': ['jax>=0.2.10', 'jaxlib>=0.1.60,!=0.1.68'],  # c.f. Issue 1501
+    'jax': ['jax>=0.2.10', 'jaxlib>=0.1.61,!=0.1.68'],  # c.f. Issue 1501
     'xmlio': ['uproot>=4.1.1'],  # c.f. PR #1567
     'minuit': ['iminuit>=2.7.0'],  # c.f. PR #1895
 }

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,11 @@ from setuptools import setup
 extras_require = {
     'shellcomplete': ['click_completion'],
     'tensorflow': [
-        'tensorflow>=2.7.0',  # c.f. PR #1874
+        'tensorflow>=2.7.0',  # c.f. PR #1962
         'tensorflow-probability>=0.11.0',  # c.f. PR #1657
     ],
     'torch': ['torch>=1.10.0'],  # c.f. PR #1657
-    'jax': ['jax>=0.2.10', 'jaxlib>=0.1.61,!=0.1.68'],  # c.f. Issue 1501
+    'jax': ['jax>=0.2.10', 'jaxlib>=0.1.61,!=0.1.68'],  # c.f. PR #1962, Issue #1501
     'xmlio': ['uproot>=4.1.1'],  # c.f. PR #1567
     'minuit': ['iminuit>=2.7.0'],  # c.f. PR #1895
 }

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -12,7 +12,7 @@ uproot==4.1.1
 # minuit
 iminuit==2.7.0  # c.f. PR #1895
 # tensorflow
-tensorflow==2.7.0  # c.f. PR #UPDATE, #1940
+tensorflow==2.7.0  # c.f. PR #1962, #1940
 tensorflow-probability==0.11.0  # c.f. PR #1657
 # torch
 torch==1.10.0
@@ -21,4 +21,4 @@ torch==1.10.0
 # c.f. https://github.com/google/jax/discussions/7608#discussioncomment-1269342
 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
 jax==0.2.10
-jaxlib==0.1.61  # jax v0.2.10 requires jaxlib>=0.1.60
+jaxlib==0.1.61  # c.f. PR #1962, #1940

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -21,4 +21,4 @@ torch==1.10.0
 # c.f. https://github.com/google/jax/discussions/7608#discussioncomment-1269342
 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
 jax==0.2.10
-jaxlib==0.1.60  # jax v0.2.10 requires jaxlib>=0.1.60
+jaxlib==0.1.61  # jax v0.2.10 requires jaxlib>=0.1.60

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -6,7 +6,7 @@ jsonschema==3.0.0
 jsonpatch==1.15
 pyyaml==5.1
 importlib_resources==1.3.0
-typing-extensions==3.7.4  # c.f. PR #1938
+typing-extensions==3.7.4.3  # c.f. PR #UPDATE, #1940
 # xmlio
 uproot==4.1.1
 # minuit

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -6,7 +6,7 @@ jsonschema==3.0.0
 jsonpatch==1.15
 pyyaml==5.1
 importlib_resources==1.3.0
-typing-extensions==3.7.4.3  # c.f. PR #UPDATE, #1940
+typing-extensions==3.7.4.3  # c.f. PR #1961, #1940
 # xmlio
 uproot==4.1.1
 # minuit

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -12,7 +12,7 @@ uproot==4.1.1
 # minuit
 iminuit==2.7.0  # c.f. PR #1895
 # tensorflow
-tensorflow==2.7.0  # c.f. PR #1962, #1940
+tensorflow==2.7.0  # c.f. PR #1962
 tensorflow-probability==0.11.0  # c.f. PR #1657
 # torch
 torch==1.10.0
@@ -21,4 +21,4 @@ torch==1.10.0
 # c.f. https://github.com/google/jax/discussions/7608#discussioncomment-1269342
 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
 jax==0.2.10
-jaxlib==0.1.61  # c.f. PR #1962, #1940
+jaxlib==0.1.61  # c.f. PR #1962

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -12,7 +12,7 @@ uproot==4.1.1
 # minuit
 iminuit==2.7.0  # c.f. PR #1895
 # tensorflow
-tensorflow==2.7.0  # c.f. PR #UPDATE
+tensorflow==2.7.0  # c.f. PR #UPDATE, #1940
 tensorflow-probability==0.11.0  # c.f. PR #1657
 # torch
 torch==1.10.0

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -12,7 +12,7 @@ uproot==4.1.1
 # minuit
 iminuit==2.7.0  # c.f. PR #1895
 # tensorflow
-tensorflow==2.6.5  # c.f. PR #1874
+tensorflow==2.7.0  # c.f. PR #UPDATE
 tensorflow-probability==0.11.0  # c.f. PR #1657
 # torch
 torch==1.10.0


### PR DESCRIPTION
# Description

* `tensorflow` `v2.6.5` restricts `numpy` to [`numpy~=1.19.2`](https://github.com/tensorflow/tensorflow/blob/6b54e9fa35d6261adae9565f18cde359003b551b/tensorflow/tools/pip_package/setup.py#L81) but `numpy.typing` was not added until `numpy` `v1.20.0`. For typing of the NumPy backend to work as added in PR #1940, `tensorflow` `v2.7.0+` is required, where `tensorflow` relaxes `numpy` constraints to [`numpy>=1.14.5`](https://github.com/tensorflow/tensorflow/blob/c256c071bb26e1e13b4666d1b3e229e110bc914a/tensorflow/tools/pip_package/setup.py#L81).

* `jaxlib` `v0.1.60` required [`numpy>=1.12,<1.20`](https://github.com/google/jax/blob/7495f71ea42db7b985427a12a1d366ed3cffda64/jaxlib/setup.py#L39) but `jaxlib` `v0.1.61` requires [`numpy>=1.16`](https://github.com/google/jax/blob/8c3371cae133e22c48eb420271ee64559358e417/jaxlib/setup.py#L39).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update lower bound of the supported tensorflow versions to v2.7.0 to ensure
  numpy v1.20.0+ is available.
   - numpy.typing is needed for PR #1940 and was added in numpy v1.20.0.
   - tensorflow v2.6.5 restricts numpy to 'numpy~=1.19.2' and tensorflow v2.7.0
     relaxes numpy constraints to 'numpy>=1.14.5'.
* Update lower bound of the supported jaxlib versions to v0.1.61.
   - jaxlib v0.1.60 required 'numpy>=1.12,<1.20' and jaxlib v0.1.61 relaxes this
     to 'numpy>=1.16'.
* Update tests/constraints.txt to use tensorflow==2.7.0 and jaxlib==0.1.61.
```