### PR TITLE
feat: Add type hints for tensor manager

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,6 @@ module = [
   'pyhf.simplemodels',
   'pyhf.probability',
   'pyhf.tensor.common.*',
-  'pyhf.tensor.manager.*',
   'pyhf.tensor',
   'pyhf.tensor.jax_backend.*',
   'pyhf.tensor.tensorflow_backend.*',

--- a/src/pyhf/events.py
+++ b/src/pyhf/events.py
@@ -1,25 +1,17 @@
 from __future__ import annotations
+
 import weakref
 from functools import wraps
+from typing import Callable, TypeVar, cast
 
-from typing import TypeVar, Callable, cast
-
-# see https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators
+# See https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators
 TCallable = TypeVar("TCallable", bound=Callable)
 
 
 __events = {}
 __disabled_events = set()
 
-__all__ = [
-    "Callables",
-    "disable",
-    "enable",
-    "noop",
-    "register",
-    "subscribe",
-    "trigger",
-]
+__all__ = ["Callables", "disable", "enable", "noop", "register", "subscribe", "trigger"]
 
 
 def __dir__():

--- a/src/pyhf/tensor/manager.py
+++ b/src/pyhf/tensor/manager.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
+
 import sys
 
-from pyhf.tensor import BackendRetriever
-from pyhf import exceptions
-from pyhf import events
+from pyhf import events, exceptions
 from pyhf.optimize import OptimizerRetriever
-from pyhf.typing import TensorBackend, Optimizer, TypedDict, Protocol
+from pyhf.tensor import BackendRetriever
+from pyhf.typing import Optimizer, Protocol, TensorBackend, TypedDict
 
 
 class State(TypedDict):

--- a/src/pyhf/tensor/manager.py
+++ b/src/pyhf/tensor/manager.py
@@ -43,10 +43,7 @@ def get_backend(default: bool = False) -> tuple[TensorBackend, Optimizer]:
     Returns:
         backend, optimizer
     """
-    if default:
-        return this.state['default']
-
-    return this.state['current']
+    return this.state["default"] if default else this.state["current"]
 
 
 _default_backend: TensorBackend = BackendRetriever.numpy_backend()

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -49,9 +49,9 @@ class numpy_backend(Generic[T]):
 
     __slots__ = ['name', 'precision', 'dtypemap', 'default_do_grad']
 
-    def __init__(self, **kwargs: dict[str, str]):
-        self.name = 'numpy'
-        self.precision = kwargs.get('precision', '64b')
+    def __init__(self, **kwargs: str):
+        self.name: str = 'numpy'
+        self.precision: str = kwargs.get('precision', '64b')
         self.dtypemap: Mapping[
             FloatIntOrBool,
             DTypeLike,  # Type[np.floating[T]] | Type[np.integer[T]] | Type[np.bool_],
@@ -60,7 +60,7 @@ class numpy_backend(Generic[T]):
             'int': np.int64 if self.precision == '64b' else np.int32,
             'bool': np.bool_,
         }
-        self.default_do_grad = False
+        self.default_do_grad: bool = False
 
     def _setup(self) -> None:
         """

--- a/src/pyhf/typing.py
+++ b/src/pyhf/typing.py
@@ -27,6 +27,7 @@ __all__ = (
     "Workspace",
     "Literal",
     "TypedDict",
+    "Protocol",
 )
 
 

--- a/src/pyhf/typing.py
+++ b/src/pyhf/typing.py
@@ -26,6 +26,7 @@ __all__ = (
     "Observation",
     "Workspace",
     "Literal",
+    "TypedDict",
 )
 
 

--- a/src/pyhf/typing.py
+++ b/src/pyhf/typing.py
@@ -140,7 +140,16 @@ class Workspace(TypedDict):
 
 
 class TensorBackend(Protocol):
-    ...
+    name: str
+    precision: str
+    default_do_grad: bool
+
+    def _setup(self) -> None:
+        ...
+
+
+class Optimizer(Protocol):
+    name: str
 
 
 class PDF(Protocol):


### PR DESCRIPTION
# Pull Request Description

See #1284.

This PR adds typing for `src/pyhf/tensor/manager.py` (and also adds some typing for the `src/pyhf/events.py` to make sure the decorators used are [forwarding their signatures](https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators)).

Additionally provides some minor fix on top of #1940 to get the NumPy backend more properly typed according to the expanded (stricter) `TensorBackend` `Protocol`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add type hints to the tensor manager.
* Add type hints to some of the events management code for the decorators used.
* Expand the TensorBackend protocol and fix up the NumPy backend type hints to align properly.
   - Amends PR #1940.
```
