### PR TITLE
fix: Keep staterror from affecting multiple samples

### DIFF
--- a/src/pyhf/modifiers/staterror.py
+++ b/src/pyhf/modifiers/staterror.py
@@ -120,10 +120,11 @@ class staterror_builder:
             # extract sigmas using this modifiers mask
             sigmas = relerrs[masks[modname]]
 
-            # sigmas that are zero will be fixed to 1.0 arbitrarily
             # list of bools, consistent with other modifiers (no numpy.bool_)
-            # to ensure non-Nan constraint term, but in a future PR we need to remove constraints for these
             fixed = default_backend.tolist(sigmas == 0)
+            # FIXME: sigmas that are zero will be fixed to 1.0 arbitrarily to ensure
+            # non-Nan constraint term, but in a future PR need to remove constraints
+            # for these
             sigmas[fixed] = 1.0
             self.required_parsets.setdefault(parname, [required_parset(sigmas, fixed)])
         return self.builder_data

--- a/src/pyhf/modifiers/staterror.py
+++ b/src/pyhf/modifiers/staterror.py
@@ -117,7 +117,7 @@ class staterror_builder:
                     else:
                         assert (mask_this_sample == masks[modname]).all()
 
-            #extract sigmas using this modifiers mask
+            # extract sigmas using this modifiers mask
             sigmas = relerrs[masks[modname]]
 
             # sigmas that are zero will be fixed to 1.0 arbitrarily

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -193,3 +193,23 @@ def test_invalid_bin_wise_modifier(datadir, patch_file):
 
     with pytest.raises(pyhf.exceptions.InvalidModifier):
         pyhf.Model(bad_spec)
+
+
+@pytest.mark.parametrize(
+    "inits",
+    [[-2.0], [-1.0], [0.0], [1.0], [2.0]],
+)
+def test_issue1720_greedy_staterror(datadir, inits):
+    """
+    Test that the staterror does not affect more samples than shapesys equivalently.
+    """
+    spec = json.load(open(datadir.joinpath("issue1720_greedy_staterror.json")))
+
+    model_shapesys = pyhf.Workspace(spec).model()
+    expected_shapesys = model_shapesys.expected_actualdata(inits)
+
+    spec["channels"][0]["samples"][1]["modifiers"][0]["type"] = "staterror"
+    model_staterror = pyhf.Workspace(spec).model()
+    expected_staterror = model_staterror.expected_actualdata(inits)
+
+    assert expected_staterror == expected_shapesys

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -196,33 +196,34 @@ def test_invalid_bin_wise_modifier(datadir, patch_file):
 
 
 def test_issue1720_staterror_builder_mask(datadir):
-    spec = json.load(open(datadir.joinpath("issue1720_greedy_staterror.json")))
+    with open(datadir.joinpath("issue1720_greedy_staterror.json")) as spec_file:
+        spec = json.load(spec_file)
 
     spec["channels"][0]["samples"][1]["modifiers"][0]["type"] = "staterror"
     config = pyhf.pdf._ModelConfig(spec)
     builder = pyhf.modifiers.staterror.staterror_builder(config)
 
-    channel = spec['channels'][0]
-    sigsample = channel['samples'][0]
-    bkgsample = channel['samples'][1]
-    modifier = bkgsample['modifiers'][0]
+    channel = spec["channels"][0]
+    sigsample = channel["samples"][0]
+    bkgsample = channel["samples"][1]
+    modifier = bkgsample["modifiers"][0]
 
-    assert channel['name'] == 'channel'
-    assert sigsample['name'] == 'signal'
-    assert bkgsample['name'] == 'bkg'
-    assert modifier['type'] == 'staterror'
+    assert channel["name"] == "channel"
+    assert sigsample["name"] == "signal"
+    assert bkgsample["name"] == "bkg"
+    assert modifier["type"] == "staterror"
 
-    builder.append('staterror/NP', 'channel', 'bkg', modifier, bkgsample)
-    collected_bkg = builder.collect(modifier, bkgsample['data'])
-    assert collected_bkg == {'mask': [True], 'nom_data': [1], 'uncrt': [1.5]}
+    builder.append("staterror/NP", "channel", "bkg", modifier, bkgsample)
+    collected_bkg = builder.collect(modifier, bkgsample["data"])
+    assert collected_bkg == {"mask": [True], "nom_data": [1], "uncrt": [1.5]}
 
-    builder.append('staterror/NP', 'channel', 'signal', None, sigsample)
-    collected_sig = builder.collect(None, sigsample['data'])
-    assert collected_sig == {'mask': [False], 'nom_data': [5], 'uncrt': [0.0]}
+    builder.append("staterror/NP", "channel", "signal", None, sigsample)
+    collected_sig = builder.collect(None, sigsample["data"])
+    assert collected_sig == {"mask": [False], "nom_data": [5], "uncrt": [0.0]}
 
     finalized = builder.finalize()
-    assert finalized['staterror/NP']['bkg']['data']['mask'].tolist() == [True]
-    assert finalized['staterror/NP']['signal']['data']['mask'].tolist() == [False]
+    assert finalized["staterror/NP"]["bkg"]["data"]["mask"].tolist() == [True]
+    assert finalized["staterror/NP"]["signal"]["data"]["mask"].tolist() == [False]
 
 
 @pytest.mark.parametrize(
@@ -233,7 +234,8 @@ def test_issue1720_greedy_staterror(datadir, inits):
     """
     Test that the staterror does not affect more samples than shapesys equivalently.
     """
-    spec = json.load(open(datadir.joinpath("issue1720_greedy_staterror.json")))
+    with open(datadir.joinpath("issue1720_greedy_staterror.json")) as spec_file:
+        spec = json.load(spec_file)
 
     model_shapesys = pyhf.Workspace(spec).model()
     expected_shapesys = model_shapesys.expected_actualdata(inits)

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -195,6 +195,36 @@ def test_invalid_bin_wise_modifier(datadir, patch_file):
         pyhf.Model(bad_spec)
 
 
+def test_issue1720_staterror_builder_mask(datadir):
+    spec = json.load(open(datadir.joinpath("issue1720_greedy_staterror.json")))
+
+    spec["channels"][0]["samples"][1]["modifiers"][0]["type"] = "staterror"
+    config = pyhf.pdf._ModelConfig(spec)
+    builder = pyhf.modifiers.staterror.staterror_builder(config)
+
+    channel = spec['channels'][0]
+    sigsample = channel['samples'][0]
+    bkgsample = channel['samples'][1]
+    modifier = bkgsample['modifiers'][0]
+
+    assert channel['name'] == 'channel'
+    assert sigsample['name'] == 'signal'
+    assert bkgsample['name'] == 'bkg'
+    assert modifier['type'] == 'staterror'
+
+    builder.append('staterror/NP', 'channel', 'bkg', modifier, bkgsample)
+    collected_bkg = builder.collect(modifier, bkgsample['data'])
+    assert collected_bkg == {'mask': [True], 'nom_data': [1], 'uncrt': [1.5]}
+
+    builder.append('staterror/NP', 'channel', 'signal', None, sigsample)
+    collected_sig = builder.collect(None, sigsample['data'])
+    assert collected_sig == {'mask': [False], 'nom_data': [5], 'uncrt': [0.0]}
+
+    finalized = builder.finalize()
+    assert finalized['staterror/NP']['bkg']['data']['mask'].tolist() == [True]
+    assert finalized['staterror/NP']['signal']['data']['mask'].tolist() == [False]
+
+
 @pytest.mark.parametrize(
     "inits",
     [[-2.0], [-1.0], [0.0], [1.0], [2.0]],

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -204,21 +204,21 @@ def test_issue1720_staterror_builder_mask(datadir):
     builder = pyhf.modifiers.staterror.staterror_builder(config)
 
     channel = spec["channels"][0]
-    sigsample = channel["samples"][0]
-    bkgsample = channel["samples"][1]
-    modifier = bkgsample["modifiers"][0]
+    sig_sample = channel["samples"][0]
+    bkg_sample = channel["samples"][1]
+    modifier = bkg_sample["modifiers"][0]
 
     assert channel["name"] == "channel"
-    assert sigsample["name"] == "signal"
-    assert bkgsample["name"] == "bkg"
+    assert sig_sample["name"] == "signal"
+    assert bkg_sample["name"] == "bkg"
     assert modifier["type"] == "staterror"
 
-    builder.append("staterror/NP", "channel", "bkg", modifier, bkgsample)
-    collected_bkg = builder.collect(modifier, bkgsample["data"])
+    builder.append("staterror/NP", "channel", "bkg", modifier, bkg_sample)
+    collected_bkg = builder.collect(modifier, bkg_sample["data"])
     assert collected_bkg == {"mask": [True], "nom_data": [1], "uncrt": [1.5]}
 
-    builder.append("staterror/NP", "channel", "signal", None, sigsample)
-    collected_sig = builder.collect(None, sigsample["data"])
+    builder.append("staterror/NP", "channel", "signal", None, sig_sample)
+    collected_sig = builder.collect(None, sig_sample["data"])
     assert collected_sig == {"mask": [False], "nom_data": [5], "uncrt": [0.0]}
 
     finalized = builder.finalize()

--- a/tests/test_modifiers/issue1720_greedy_staterror.json
+++ b/tests/test_modifiers/issue1720_greedy_staterror.json
@@ -1,0 +1,49 @@
+{
+  "channels": [
+    {
+      "name": "channel",
+      "samples": [
+        {
+          "data": [
+            5
+          ],
+          "modifiers": [],
+          "name": "signal"
+        },
+        {
+          "data": [
+            1
+          ],
+          "modifiers": [
+            {
+              "data": [
+                1.5
+              ],
+              "name": "NP",
+              "type": "staterror"
+            }
+          ],
+          "name": "bkg"
+        }
+      ]
+    }
+  ],
+  "measurements": [
+    {
+      "config": {
+        "parameters": [],
+        "poi": "NP"
+      },
+      "name": ""
+    }
+  ],
+  "observations": [
+    {
+      "data": [
+        0
+      ],
+      "name": "channel"
+    }
+  ],
+  "version": "1.0.0"
+}

--- a/tests/test_modifiers/issue1720_greedy_staterror.json
+++ b/tests/test_modifiers/issue1720_greedy_staterror.json
@@ -20,7 +20,7 @@
                 1.5
               ],
               "name": "NP",
-              "type": "staterror"
+              "type": "shapesys"
             }
           ],
           "name": "bkg"

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -297,7 +297,7 @@ def test_testpoi(tmpdir, script_runner):
     command = f'pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {temp.strpath:s}'
     ret = script_runner.run(*shlex.split(command))
 
-    pois = [1.0, 0.5, 0.0]
+    pois = [1.0, 0.5, 0.001]
     results_exp = []
     results_obs = []
     for test_poi in pois:


### PR DESCRIPTION
# Pull Request Description

* Resolves #1720 
* Resolves #1945

This PR is supposed to fix the issue w/ staterrors which erroneously affected multiple samples. 

- [x] Would be great to get add. test coverage and cross-checks w/ real world models

@alexander-held @matthewfeickert @kratsg 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Fix staterror bug introduced after v0.6.3 where staterror erroneously affected
  multiple samples.
   - Amends PR #1639 which introduced regression.
   - c.f. Issue #1720
* Remove staterror_combined.__staterror_uncrt as it is unused by the codebase.
* Add test to verify that staterror does not affect more samples than shapesys equivalently.

Co-authored-by: Giordon Stark <kratsg@gmail.com>
```