### PR TITLE
docs: Add typehint aliases

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,6 +141,38 @@ autodoc_mock_imports = [
     'tensorflow_probability',
 ]
 
+
+_type_aliases_inverted = {
+    'pyhf.typing': [
+        'PathOrStr',
+        'ParameterBase',
+        'Parameter',
+        'Measurement',
+        'ModifierBase',
+        'NormSys',
+        'NormFactor',
+        'HistoSys',
+        'StatError',
+        'ShapeSys',
+        'ShapeFactor',
+        'LumiSys',
+        'Modifier',
+        'Sample',
+        'Channel',
+        'Observation',
+        'Workspace',
+        'Literal',
+    ],
+    'numpy.typing': ['ArrayLike', 'DTypeLike', 'NBitBase', 'NDArray'],
+}
+autodoc_type_aliases = {
+    item: f'{k}.{item}' for k, v in _type_aliases_inverted.items() for item in v
+}
+
+autodoc_typehints_format = 'fully-qualified'
+
+print(autodoc_type_aliases)
+
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -171,8 +171,6 @@ autodoc_type_aliases = {
 
 autodoc_typehints_format = 'fully-qualified'
 
-print(autodoc_type_aliases)
-
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -15,7 +15,7 @@ from pyhf.typing import Literal, Shape
 T = TypeVar("T", bound=NBitBase)
 
 Tensor = Union["NDArray[np.number[T]]", "NDArray[np.bool_]"]
-
+FloatIntOrBool = Literal["float", "int", "bool"]
 log = logging.getLogger(__name__)
 
 
@@ -53,7 +53,7 @@ class numpy_backend(Generic[T]):
         self.name = 'numpy'
         self.precision = kwargs.get('precision', '64b')
         self.dtypemap: Mapping[
-            Literal['float', 'int', 'bool'],
+            FloatIntOrBool,
             DTypeLike,  # Type[np.floating[T]] | Type[np.integer[T]] | Type[np.bool_],
         ] = {
             'float': np.float64 if self.precision == '64b' else np.float32,
@@ -206,7 +206,7 @@ class numpy_backend(Generic[T]):
         return np.isfinite(tensor)
 
     def astensor(
-        self, tensor_in: ArrayLike, dtype: Literal['float'] = 'float'
+        self, tensor_in: ArrayLike, dtype: FloatIntOrBool = 'float'
     ) -> ArrayLike:
         """
         Convert to a NumPy array.
@@ -247,9 +247,7 @@ class numpy_backend(Generic[T]):
     def abs(self, tensor: Tensor[T]) -> ArrayLike:
         return np.abs(tensor)
 
-    def ones(
-        self, shape: Shape, dtype: Literal["float", "int", "bool"] = "float"
-    ) -> ArrayLike:
+    def ones(self, shape: Shape, dtype: FloatIntOrBool = "float") -> ArrayLike:
         try:
             dtype_obj = self.dtypemap[dtype]
         except KeyError:
@@ -261,9 +259,7 @@ class numpy_backend(Generic[T]):
 
         return np.ones(shape, dtype=dtype_obj)
 
-    def zeros(
-        self, shape: Shape, dtype: Literal["float", "int", "bool"] = "float"
-    ) -> ArrayLike:
+    def zeros(self, shape: Shape, dtype: FloatIntOrBool = "float") -> ArrayLike:
         try:
             dtype_obj = self.dtypemap[dtype]
         except KeyError:


### PR DESCRIPTION
# Pull Request Description

Resolves #1964.

Link to docs render: https://pyhf--1969.org.readthedocs.build/en/1969/_generated/pyhf.tensor.numpy_backend.numpy_backend.html#pyhf.tensor.numpy_backend.numpy_backend

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Use Sphinx autodoc typehint aliases to improve readability of documentation.
   - c.f. https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_type_aliases
```
