### PR TITLE
fix: Base URI for jsonschema.RefResolver has better behavior

### DIFF
--- a/src/pyhf/schema/validator.py
+++ b/src/pyhf/schema/validator.py
@@ -27,8 +27,8 @@ def validate(spec: Mapping, schema_name: str, version: Union[str, None] = None):
 
     # note: trailing slash needed for RefResolver to resolve correctly
     resolver = jsonschema.RefResolver(
-        base_uri=f"file://{variables.schemas}/",
-        referrer=f"{version}/{schema_name}",
+        base_uri=f"file://{variables.schemas}/{version}/",
+        referrer=f"{schema_name}",
         store=variables.SCHEMA_CACHE,
     )
     validator = jsonschema.Draft6Validator(


### PR DESCRIPTION
# Pull Request Description

`jsonschema` has traditionally been not the greatest with resolving references. More recent development has definitely aimed to improve this behavior (thanks to @Julian) and it seems it highlighted an issue with how we defined our `RefResolver`. This PR moves the `version` up to the `baseuri` instead of being part of the document name.

Resolves #1975.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* update baseuri to include the version of the HiFa JSON schema to provide forward-compatibility for jsonschema>=4.15.0
```
