### PR TITLE
fix: Add guards against shared shapesys paramsets

### DIFF
--- a/src/pyhf/modifiers/histosys.py
+++ b/src/pyhf/modifiers/histosys.py
@@ -13,7 +13,6 @@ def required_parset(sample_data, modifier_data):
     return {
         'paramset_type': 'constrained_by_normal',
         'n_parameters': 1,
-        'is_shared': True,
         'is_scalar': True,
         'inits': (0.0,),
         'bounds': ((-5.0, 5.0),),
@@ -24,6 +23,8 @@ def required_parset(sample_data, modifier_data):
 
 class histosys_builder:
     """Builder class for collecting histoys modifier data"""
+
+    is_shared = True
 
     def __init__(self, config):
         self.builder_data = {}

--- a/src/pyhf/modifiers/lumi.py
+++ b/src/pyhf/modifiers/lumi.py
@@ -10,7 +10,6 @@ def required_parset(sample_data, modifier_data):
     return {
         'paramset_type': 'constrained_by_normal',
         'n_parameters': 1,
-        'is_shared': True,
         'is_scalar': True,
         'inits': None,  # lumi
         'bounds': None,  # (0, 10*lumi)
@@ -22,6 +21,8 @@ def required_parset(sample_data, modifier_data):
 
 class lumi_builder:
     """Builder class for collecting lumi modiifier data"""
+
+    is_shared = True
 
     def __init__(self, config):
         self.builder_data = {}

--- a/src/pyhf/modifiers/normfactor.py
+++ b/src/pyhf/modifiers/normfactor.py
@@ -10,7 +10,6 @@ def required_parset(sample_data, modifier_data):
     return {
         'paramset_type': 'unconstrained',
         'n_parameters': 1,
-        'is_shared': True,
         'is_scalar': True,
         'inits': (1.0,),
         'bounds': ((0, 10),),
@@ -20,6 +19,8 @@ def required_parset(sample_data, modifier_data):
 
 class normfactor_builder:
     """Builder class for collecting normfactor modifier data"""
+
+    is_shared = True
 
     def __init__(self, config):
         self.builder_data = {}

--- a/src/pyhf/modifiers/normsys.py
+++ b/src/pyhf/modifiers/normsys.py
@@ -11,7 +11,6 @@ def required_parset(sample_data, modifier_data):
     return {
         'paramset_type': 'constrained_by_normal',
         'n_parameters': 1,
-        'is_shared': True,
         'is_scalar': True,
         'inits': (0.0,),
         'bounds': ((-5.0, 5.0),),
@@ -22,6 +21,8 @@ def required_parset(sample_data, modifier_data):
 
 class normsys_builder:
     """Builder class for collecting normsys modifier data"""
+
+    is_shared = True
 
     def __init__(self, config):
         self.builder_data = {}

--- a/src/pyhf/modifiers/shapefactor.py
+++ b/src/pyhf/modifiers/shapefactor.py
@@ -12,7 +12,6 @@ def required_parset(sample_data, modifier_data):
     return {
         'paramset_type': 'unconstrained',
         'n_parameters': len(sample_data),
-        'is_shared': True,
         'is_scalar': False,
         'inits': (1.0,) * len(sample_data),
         'bounds': ((0.0, 10.0),) * len(sample_data),
@@ -22,6 +21,8 @@ def required_parset(sample_data, modifier_data):
 
 class shapefactor_builder:
     """Builder class for collecting shapefactor modifier data"""
+
+    is_shared = True
 
     def __init__(self, config):
         self.builder_data = {}

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -25,7 +25,6 @@ def required_parset(sample_data, modifier_data):
     return {
         "paramset_type": "constrained_by_poisson",
         "n_parameters": n_parameters,
-        "is_shared": False,
         "is_scalar": False,
         "inits": (1.0,) * n_parameters,
         "bounds": ((1e-10, 10.0),) * n_parameters,
@@ -37,6 +36,8 @@ def required_parset(sample_data, modifier_data):
 
 class shapesys_builder:
     """Builder class for collecting shapesys modifier data"""
+
+    is_shared = False
 
     def __init__(self, config):
         self.builder_data = {}

--- a/src/pyhf/modifiers/staterror.py
+++ b/src/pyhf/modifiers/staterror.py
@@ -15,7 +15,6 @@ def required_parset(sigmas, fixed: List[bool]):
     return {
         'paramset_type': 'constrained_by_normal',
         'n_parameters': n_parameters,
-        'is_shared': True,
         'is_scalar': False,
         'inits': (1.0,) * n_parameters,
         'bounds': ((1e-10, 10.0),) * n_parameters,
@@ -27,6 +26,8 @@ def required_parset(sigmas, fixed: List[bool]):
 
 class staterror_builder:
     """Builder class for collecting staterror modifier data"""
+
+    is_shared = True
 
     def __init__(self, config):
         self.builder_data = {}

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -110,9 +110,9 @@ def _nominal_and_modifiers_from_spec(modifier_set, config, spec, batch_size):
     # 1. setup nominal & modifier builders
     nominal = _nominal_builder(config)
 
-    modifiers_builders = {}
-    for k, (builder, applier) in modifier_set.items():
-        modifiers_builders[k] = builder(config)
+    modifiers_builders = {
+        key: builder(config) for key, (builder, _) in modifier_set.items()
+    }
 
     # 2. make a helper that maps channel-name/sample-name to pairs of channel-sample structs
     helper = {}

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -126,7 +126,7 @@ def _nominal_and_modifiers_from_spec(modifier_set, config, spec, batch_size):
                     )
                 key = f"{x['type']}/{x['name']}"
                 # check if the modifier to be built is allowed to be shared
-                if not modifiers_builders[k].is_shared and key in moddict:
+                if not modifiers_builders[x['type']].is_shared and key in moddict:
                     raise exceptions.InvalidModel(
                         f"Trying to add paramset {key} on {s['name']} sample in {c['name']} channel but other paramsets exist with the same name."
                     )

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -127,10 +127,8 @@ def _nominal_and_modifiers_from_spec(modifier_set, config, spec, batch_size):
                     )
                 key = f"{x['type']}/{x['name']}"
                 # check if the modifier to be built is allowed to be shared
-                if (
-                    not modifiers_builders[x['type']].is_shared
-                    and key in moddict
-                    or key in _keys_seen
+                if not modifiers_builders[x['type']].is_shared and (
+                    key in _keys_seen or key in moddict
                 ):
                     raise exceptions.InvalidModel(
                         f"Trying to add paramset {key} on {s['name']} sample in {c['name']} channel but other paramsets exist with the same name."

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -107,7 +107,14 @@ def _nominal_and_modifiers_from_spec(modifier_set, config, spec, batch_size):
     # We don't actually set up the modifier data here for no-ops, but we do
     # set up the entire structure
 
-    # helper maps channel-name/sample-name to pairs of channel-sample structs
+    # 1. setup nominal & modifier builders
+    nominal = _nominal_builder(config)
+
+    modifiers_builders = {}
+    for k, (builder, applier) in modifier_set.items():
+        modifiers_builders[k] = builder(config)
+
+    # 2. make a helper that maps channel-name/sample-name to pairs of channel-sample structs
     helper = {}
     for c in spec['channels']:
         for s in c['samples']:
@@ -117,17 +124,17 @@ def _nominal_and_modifiers_from_spec(modifier_set, config, spec, batch_size):
                     raise exceptions.InvalidModifier(
                         f'{x["type"]} not among {list(modifier_set.keys())}'
                     )
-                moddict[f"{x['type']}/{x['name']}"] = x
+                key = f"{x['type']}/{x['name']}"
+                # check if the modifier to be built is allowed to be shared
+                if not modifiers_builders[k].is_shared and key in moddict:
+                    raise exceptions.InvalidModel(
+                        f"Trying to add paramset {key} on {s['name']} sample in {c['name']} channel but other paramsets exist with the same name."
+                    )
+
+                moddict[key] = x
             helper.setdefault(c['name'], {})[s['name']] = (s, moddict)
 
-    # 1. setup nominal & modifier builders
-    nominal = _nominal_builder(config)
-
-    modifiers_builders = {}
-    for k, (builder, applier) in modifier_set.items():
-        modifiers_builders[k] = builder(config)
-
-    # 2. walk spec and call builders
+    # 3. walk spec and call builders
     for c in config.channels:
         for s in config.samples:
             helper_data = helper.get(c, {}).get(s)
@@ -141,13 +148,13 @@ def _nominal_and_modifiers_from_spec(modifier_set, config, spec, batch_size):
                 thismod = defined_mods.get(key) if defined_mods else None
                 modifiers_builders[mtype].append(key, c, s, thismod, defined_samp)
 
-    # 3. finalize nominal & modifier builders
+    # 4. finalize nominal & modifier builders
     nominal_rates = nominal.finalize()
     finalizd_builder_data = {}
     for k, (builder, applier) in modifier_set.items():
         finalizd_builder_data[k] = modifiers_builders[k].finalize()
 
-    # 4. collect parameters from spec and from user.
+    # 5. collect parameters from spec and from user.
     # At this point we know all constraints and so forth
     _required_paramsets = {}
     for v in list(modifiers_builders.values()):

--- a/tests/test_custom_mods.py
+++ b/tests/test_custom_mods.py
@@ -4,6 +4,8 @@ import pytest
 
 
 class custom_builder:
+    is_shared = True
+
     def __init__(self, pdfconfig):
         self.config = pdfconfig
         self.required_parsets = {
@@ -12,7 +14,6 @@ class custom_builder:
                     'paramset_type': 'unconstrained',
                     'n_parameters': 1,
                     'is_constrained': False,
-                    'is_shared': True,
                     'inits': (1.0,),
                     'bounds': ((-5, 5),),
                     'fixed': False,

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1184,7 +1184,7 @@ def test_pdf_clipping(backend):
     pyhf.infer.mle.fit(data, model_clip_bin)
 
 
-def test_is_shared_paramset_shapesys_diff_sample():
+def test_is_shared_paramset_shapesys_diff_sample_diff_channel():
     spec = {
         "channels": [
             {
@@ -1227,7 +1227,52 @@ def test_is_shared_paramset_shapesys_diff_sample():
         pyhf.Workspace(spec).model()
 
 
-def test_is_shared_paramset_shapesys_same_sample():
+def test_is_shared_paramset_shapesys_diff_sample_same_channel():
+    spec = {
+        "channels": [
+            {
+                "name": "SR",
+                "samples": [
+                    {
+                        "data": [50],
+                        "modifiers": [
+                            {
+                                "data": [9],
+                                "name": "abc",
+                                "type": "shapesys",
+                            },
+                            {
+                                "data": None,
+                                "name": "Signal strength",
+                                "type": "normfactor",
+                            },
+                        ],
+                        "name": "Signal",
+                    },
+                    {
+                        "data": [150],
+                        "modifiers": [
+                            {
+                                "data": [7],
+                                "name": "abc",
+                                "type": "shapesys",
+                            }
+                        ],
+                        "name": "Background",
+                    },
+                ],
+            }
+        ],
+        "measurements": [{"config": {"parameters": [], "poi": ""}, "name": "meas"}],
+        "observations": [{"data": [160], "name": "SR"}],
+        "version": "1.0.0",
+    }
+
+    with pytest.raises(pyhf.exceptions.InvalidModel):
+        pyhf.Workspace(spec).model()
+
+
+def test_is_shared_paramset_shapesys_same_sample_same_channel():
     spec = {
         "channels": [
             {

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1182,3 +1182,46 @@ def test_pdf_clipping(backend):
     # We should be able to converge when clipping is enabled
     pyhf.infer.mle.fit(data, model_clip_sample)
     pyhf.infer.mle.fit(data, model_clip_bin)
+
+
+def test_is_shared_paramset():
+    spec = {
+        "channels": [
+            {
+                "name": "SR",
+                "samples": [
+                    {
+                        "data": [24.0, 25.0],
+                        "modifiers": [
+                            {"data": [0.1, 0.2], "name": "par", "type": "shapesys"},
+                            {"data": None, "name": "mu", "type": "normfactor"},
+                        ],
+                        "name": "Signal",
+                    }
+                ],
+            },
+            {
+                "name": "CR",
+                "samples": [
+                    {
+                        "data": [10.0],
+                        "modifiers": [
+                            {"data": [0.1], "name": "par", "type": "shapesys"}
+                        ],
+                        "name": "Background",
+                    }
+                ],
+            },
+        ],
+        "measurements": [
+            {"config": {"parameters": [], "poi": "mu"}, "name": "minimal_example"}
+        ],
+        "observations": [
+            {"data": [24.0, 24.0], "name": "SR"},
+            {"data": [10.0], "name": "CR"},
+        ],
+        "version": "1.0.0",
+    }
+
+    with pytest.raises(pyhf.exceptions.InvalidModel):
+        pyhf.Workspace(spec).model()

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1184,7 +1184,7 @@ def test_pdf_clipping(backend):
     pyhf.infer.mle.fit(data, model_clip_bin)
 
 
-def test_is_shared_paramset():
+def test_is_shared_paramset_shapesys_diff_sample():
     spec = {
         "channels": [
             {
@@ -1207,6 +1207,50 @@ def test_is_shared_paramset():
                         "data": [10.0],
                         "modifiers": [
                             {"data": [0.1], "name": "par", "type": "shapesys"}
+                        ],
+                        "name": "Background",
+                    }
+                ],
+            },
+        ],
+        "measurements": [
+            {"config": {"parameters": [], "poi": "mu"}, "name": "minimal_example"}
+        ],
+        "observations": [
+            {"data": [24.0, 24.0], "name": "SR"},
+            {"data": [10.0], "name": "CR"},
+        ],
+        "version": "1.0.0",
+    }
+
+    with pytest.raises(pyhf.exceptions.InvalidModel):
+        pyhf.Workspace(spec).model()
+
+
+def test_is_shared_paramset_shapesys_same_sample():
+    spec = {
+        "channels": [
+            {
+                "name": "SR",
+                "samples": [
+                    {
+                        "data": [24.0, 25.0],
+                        "modifiers": [
+                            {"data": [0.1, 0.2], "name": "par2", "type": "shapesys"},
+                            {"data": None, "name": "mu", "type": "normfactor"},
+                        ],
+                        "name": "Signal",
+                    }
+                ],
+            },
+            {
+                "name": "CR",
+                "samples": [
+                    {
+                        "data": [10.0],
+                        "modifiers": [
+                            {"data": [0.1], "name": "par", "type": "shapesys"},
+                            {"data": [0.5], "name": "par", "type": "shapesys"},
                         ],
                         "name": "Background",
                     }


### PR DESCRIPTION
# Pull Request Description

* Resolves #1908
* Resolves #1967 
* Resolves #1973
* Amends PR #1625

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add checks to determine if modifiers should be shared across channels when
  the modifier is being built. This guards against accidental correlations across
  channels. e.g. shared shapesys paramsets.
   - Amends PR #1625
* Add tests for raised pyhf.exceptions.InvalidModel in the event that a shared shapesys
  paramset is introduced in the model spec.
```
