### PR TITLE
fix: Add PR number to Semantic PR Title Check concurrency group

### DIFF
--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
# Pull Request Description

The Semantic PR Check is cancelling itself on other PRs because the concurrency is based on target branch only, rather than the PR number as well.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add PR number to Semantic PR Title Check concurrency to avoid unintended cancellation.
```
