### PR TITLE
feat: Add support for `_ModelConfig.set_poi(None)` to unset model POI

### DIFF
--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -429,6 +429,8 @@ class _ModelConfig(_ChannelSummaryMixin):
         """
         Set the model parameter of interest to be model parameter ``name``.
 
+        If ``name`` is ``None``, this will reset the parameter of interest.
+
         Example:
             >>> import pyhf
             >>> model = pyhf.simplemodels.uncorrelated_background(
@@ -438,6 +440,11 @@ class _ModelConfig(_ChannelSummaryMixin):
             >>> model.config.poi_name
             'mu'
         """
+        if name is None:
+            self._poi_name = None
+            self._poi_index = None
+            return
+
         if name not in self.parameters:
             raise exceptions.InvalidModel(
                 f"The parameter of interest '{name:s}' cannot be fit as it is not declared in the model specification."

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -429,7 +429,7 @@ class _ModelConfig(_ChannelSummaryMixin):
         """
         Set the model parameter of interest to be model parameter ``name``.
 
-        If ``name`` is ``None``, this will reset the parameter of interest.
+        If ``name`` is ``None``, this will unset the parameter of interest.
 
         Example:
             >>> import pyhf

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -221,3 +221,15 @@ def test_set_schema_path_context(monkeypatch):
     new_path = pathlib.Path('a/new/path')
     with pyhf.schema(new_path):
         assert pyhf.schema.path == new_path
+
+
+def test_pdf_set_poi(backend):
+    model = pyhf.simplemodels.uncorrelated_background([5.0], [10.0], [2.5])
+    assert model.config.poi_index == 0
+    assert model.config.poi_name == 'mu'
+    model.config.set_poi('uncorr_bkguncrt')
+    assert model.config.poi_index == 1
+    assert model.config.poi_name == 'uncorr_bkguncrt'
+    model.config.set_poi(None)
+    assert model.config.poi_index is None
+    assert model.config.poi_name is None


### PR DESCRIPTION
# Pull Request Description

Resolves #1984 by allowing `_ModelConfig.set_poi(None)` to be allowed behavior to remove the POI from a model.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Allow for `_ModelConfig.set_poi(None)` as a way to unset the POI from a model.
* Add test of `model.config.set_poi` for value of the poi that are valid strings and None.
```
