### PR TITLE
fix: Guard against nan in test stat calculation

### DIFF
--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -418,8 +418,9 @@ class AsymptoticCalculator:
                 teststat = (qmu - qmu_A) / (2 * self.sqrtqmuA_v)
                 return teststat
 
+            # Use '<=' rather than '<' to avoid Issue #1992
             teststat = tensorlib.conditional(
-                (sqrtqmu_v < self.sqrtqmuA_v), _true_case, _false_case
+                (sqrtqmu_v <= self.sqrtqmuA_v), _true_case, _false_case
             )
         return tensorlib.astensor(teststat)
 

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -418,9 +418,11 @@ class AsymptoticCalculator:
                 teststat = (qmu - qmu_A) / (2 * self.sqrtqmuA_v)
                 return teststat
 
-            # Use '<=' rather than '<' to avoid Issue #1992
+            # Use '>' rather than reverse condition with '<=' to avoid
+            # equating floating point numbers.
+            # This comparison is done to avoid Issue #1992.
             teststat = tensorlib.conditional(
-                (sqrtqmu_v <= self.sqrtqmuA_v), _true_case, _false_case
+                (self.sqrtqmuA_v > sqrtqmu_v), _true_case, _false_case
             )
         return tensorlib.astensor(teststat)
 

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -418,11 +418,9 @@ class AsymptoticCalculator:
                 teststat = (qmu - qmu_A) / (2 * self.sqrtqmuA_v)
                 return teststat
 
-            # Use '>' rather than reverse condition with '<=' to avoid
-            # equating floating point numbers.
-            # This comparison is done to avoid Issue #1992.
+            # Use '<=' rather than '<' to avoid Issue #1992
             teststat = tensorlib.conditional(
-                (self.sqrtqmuA_v > sqrtqmu_v), _true_case, _false_case
+                (sqrtqmu_v <= self.sqrtqmuA_v), _true_case, _false_case
             )
         return tensorlib.astensor(teststat)
 

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -71,7 +71,7 @@ def qmu(mu, data, pdf, init_pars, par_bounds, fixed_params, return_fitted_pars=F
 
        \begin{equation}
           q_{\mu} = \left\{\begin{array}{ll}
-          -2\ln\lambda\left(\mu\right), &\hat{\mu} < \mu,\\
+          -2\ln\lambda\left(\mu\right), &\hat{\mu} \leq \mu,\\
           0, & \hat{\mu} > \mu
           \end{array}\right.
         \end{equation}
@@ -160,7 +160,7 @@ def qmu_tilde(
 
        \begin{equation}
           \tilde{q}_{\mu} = \left\{\begin{array}{ll}
-          -2\ln\tilde{\lambda}\left(\mu\right), &\hat{\mu} < \mu,\\
+          -2\ln\tilde{\lambda}\left(\mu\right), &\hat{\mu} \leq \mu,\\
           0, & \hat{\mu} > \mu
           \end{array}\right.
         \end{equation}


### PR DESCRIPTION
# Description

* Resolves #1992
* Resolves #529
* Resolves #1994

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Guard against nan from division by zero in pyhf.infer.calculators.AsymptoticCalculator.teststatistic.
* Add use of 'less than or equal to' to docs for tests stats to match equations 14
  and 16 of https://arxiv.org/abs/1007.1727.
* Add tests to ensure that nan conditions in Issue #529 and Issue #1992 are not possible.
```