### PR TITLE
fix: Pin codemetapy to v0.3.5 for `--no-extras` functionality

### DIFF
--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -42,8 +42,9 @@ jobs:
       run: |
         pytest tests/test_public_api.py
 
+      # FIXME: c.f. https://github.com/proycon/codemetapy/issues/24
     - name: Verify requirements in codemeta.json
       run: |
         python -m pip install jq "codemetapy==0.3.5"
         codemetapy --no-extras pyhf > codemeta_generated.json
-        diff <(jq -S .softwareRequirements codemeta_generated.json) <(jq -S .softwareRequirements codemeta.json)
+        diff <(jq -S .softwareRequirements codemeta.json) <(jq -S .softwareRequirements codemeta_generated.json)

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -44,6 +44,6 @@ jobs:
 
     - name: Verify requirements in codemeta.json
       run: |
-        python -m pip install jq "codemetapy>=0.3.4"
+        python -m pip install jq "codemetapy==0.3.5"
         codemetapy --no-extras pyhf > codemeta_generated.json
         diff <(jq -S .softwareRequirements codemeta_generated.json) <(jq -S .softwareRequirements codemeta.json)

--- a/codemeta.json
+++ b/codemeta.json
@@ -44,7 +44,7 @@
                 "url": "https://pypi.org"
             },
             "runtimePlatform": "Python 3",
-            "version": ">=1.4.1"
+            "version": ">=1.1.0"
         },
         {
             "@type": "SoftwareApplication",
@@ -57,7 +57,7 @@
                 "url": "https://pypi.org"
             },
             "runtimePlatform": "Python 3",
-            "version": ">=7.0"
+            "version": ">=8.0.0"
         },
         {
             "@type": "SoftwareApplication",
@@ -110,6 +110,32 @@
             },
             "runtimePlatform": "Python 3",
             "version": ">=5.1"
+        },
+        {
+            "@type": "SoftwareApplication",
+            "identifier": "importlib-resources",
+            "name": "importlib-resources",
+            "provider": {
+                "@id": "https://pypi.org",
+                "@type": "Organization",
+                "name": "The Python Package Index",
+                "url": "https://pypi.org"
+            },
+            "runtimePlatform": "Python 3",
+            "version": ">=1.3.0"
+        },
+        {
+            "@type": "SoftwareApplication",
+            "identifier": "typing-extensions",
+            "name": "typing-extensions",
+            "provider": {
+                "@id": "https://pypi.org",
+                "@type": "Organization",
+                "name": "The Python Package Index",
+                "url": "https://pypi.org"
+            },
+            "runtimePlatform": "Python 3",
+            "version": ">=3.7.4.3"
         }
     ],
     "audience": [
@@ -129,5 +155,5 @@
     "keywords": "physics fitting numpy scipy tensorflow pytorch jax",
     "developmentStatus": "4 - Beta",
     "applicationCategory": "Scientific/Engineering, Scientific/Engineering :: Physics",
-    "programmingLanguage": "Python 3, Python 3.7, Python 3.8, Python 3.9, Python 3.10, Python Implementation CPython"
+    "programmingLanguage": "Python 3, Python 3 Only, Python 3.7, Python 3.8, Python 3.9, Python 3.10, Python Implementation CPython"
 }


### PR DESCRIPTION
# Description

Resolves #1990 by choosing to pin to `v0.3.5` until a viable solution to https://github.com/proycon/codemetapy/issues/24 is found.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Pin codemetapy to v0.3.5 in the 'current release' test workflow to keep the
  `--no-extras` CLI API option.
   - c.f. https://github.com/proycon/codemetapy/issues/24
* Update lower bounds for scipy and click in codemeta.json and add lower bounds
  for importlib-resources and typing-extensions.
```