### PR TITLE
ci: Install release candidates for 'current release' test workflow

### DIFF
--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --pre pyhf[backends,xmlio]
-        python -m pip install 'pytest~=7.0' pytest-cov
+        python -m pip install pytest pytest-cov
         python -m pip list
 
     - name: Canary test public API

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install from PyPI
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install pyhf[backends,xmlio]
+        python -m pip install --pre pyhf[backends,xmlio]
         python -m pip install 'pytest~=7.0' pytest-cov
         python -m pip list
 


### PR DESCRIPTION
# Description

Use release candidates that are on PyPI for verifiying that the public API passes tests. This verifies that the release candidates that users are being asked to test reflect the release API.


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use release candidates that are on PyPI for verifiying that the public API
  passes tests. This verifies that the release candidates that users are being
  asked to test reflect the release API.
* Use the latest version of pytest.
```