### PR TITLE
refactor: Use urllib.parse.urlsplit over urlparse

### DIFF
--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -6,7 +6,7 @@ import zipfile
 from io import BytesIO
 from pathlib import Path
 from shutil import rmtree
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 from pyhf import exceptions
 
@@ -50,7 +50,7 @@ try:
         """
         if not force:
             valid_hosts = ["www.hepdata.net", "doi.org"]
-            netloc = urlparse(archive_url).netloc
+            netloc = urlsplit(archive_url).netloc
             if netloc not in valid_hosts:
                 raise exceptions.InvalidArchiveHost(
                     f"{netloc} is not an approved archive host: {', '.join(str(host) for host in valid_hosts)}\n"


### PR DESCRIPTION
# Description

Use [`urllib.parse.urlsplit`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlsplit) over [`urllib.parse.urlparse`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlparse) to avoid having to deal with `urlparse`'s `params` argument which incurs a performance cost.

This isn't strictly needed, but it came up in the "Anthony Explains" video [python: don't use urlparse! (beginner - intermediate) anthony explains 474](https://youtu.be/ABJvdsIANds).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use urllib.parse.urlsplit over urllib.parse.urlparse to avoid having to deal with
  urlparse's 'params' argument which incurs a performance cost.
   - c.f. https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlsplit
   - c.f. https://youtu.be/ABJvdsIANds
```