### PR TITLE
fix: Update codemeta lower bounds for jsonschema, importlib-resources

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -83,7 +83,7 @@
                 "url": "https://pypi.org"
             },
             "runtimePlatform": "Python 3",
-            "version": ">=3.0.0"
+            "version": ">=4.15.0"
         },
         {
             "@type": "SoftwareApplication",

--- a/codemeta.json
+++ b/codemeta.json
@@ -122,7 +122,7 @@
                 "url": "https://pypi.org"
             },
             "runtimePlatform": "Python 3",
-            "version": ">=1.3.0"
+            "version": ">=1.4.0"
         },
         {
             "@type": "SoftwareApplication",


### PR DESCRIPTION
# Description

Resolves #1999

* jsonschema lower bound is v4.15.0
* importlib-resources lower bound is v1.4.0

Amends PR #1979.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update jsonschema lower bound to v4.15.0 and importlib-resources lower bound to v1.4.0
  to match their versions in setup.cfg.
   - Amends PR #1979
```