### PR TITLE
docs: Add milestone for 2000 project GitHub items

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -340,6 +340,7 @@ contributors <https://github.com/scikit-hep/pyhf/graphs/contributors>`__.
 Milestones
 ----------
 
+- 2022-09-12: 2000 GitHub issues and pull requests. (See PR `#2000 <https://github.com/scikit-hep/pyhf/pull/2000>`__)
 - 2021-12-09: 1000 commits to the project. (See PR `#1710 <https://github.com/scikit-hep/pyhf/pull/1710>`__)
 - 2020-07-28: 1000 GitHub issues and pull requests. (See PR `#1000 <https://github.com/scikit-hep/pyhf/pull/1000>`__)
 


### PR DESCRIPTION
# Description

Add milestone to README for 2000 project GitHub issues and pull requests.

For time context, PR #1000 came back in 2020-07-28. :slightly_smiling_face: 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add milestone to README for 2000 project GitHub issues and pull requests.
```