### PR TITLE
fix: Use codemetapy v2.2.2+ API

### DIFF
--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -45,6 +45,6 @@ jobs:
       # FIXME: c.f. https://github.com/proycon/codemetapy/issues/24
     - name: Verify requirements in codemeta.json
       run: |
-        python -m pip install jq "codemetapy==0.3.5"
+        python -m pip install jq "codemetapy>=2.2.1"
         codemetapy --no-extras pyhf > codemeta_generated.json
         diff <(jq -S .softwareRequirements codemeta.json) <(jq -S .softwareRequirements codemeta_generated.json)

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -45,6 +45,6 @@ jobs:
       # FIXME: c.f. https://github.com/proycon/codemetapy/issues/24
     - name: Verify requirements in codemeta.json
       run: |
-        python -m pip install jq "codemetapy>=2.2.1"
+        python -m pip install jq "codemetapy>=2.2.2"
         codemetapy --inputtype python --no-extras pyhf > codemeta_generated.json
         diff <(jq -S .softwareRequirements codemeta.json) <(jq -S .softwareRequirements codemeta_generated.json)

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -46,5 +46,5 @@ jobs:
     - name: Verify requirements in codemeta.json
       run: |
         python -m pip install jq "codemetapy>=2.2.1"
-        codemetapy --no-extras pyhf > codemeta_generated.json
+        codemetapy --inputtype python --no-extras pyhf > codemeta_generated.json
         diff <(jq -S .softwareRequirements codemeta.json) <(jq -S .softwareRequirements codemeta_generated.json)

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,8 +8,8 @@
     "@id": "https://github.com/scikit-hep/pyhf",
     "@type": "SoftwareSourceCode",
     "applicationCategory": [
-        "Scientific/Engineering > Physics",
-        "Scientific/Engineering"
+        "Scientific/Engineering",
+        "Scientific/Engineering > Physics"
     ],
     "audience": {
         "@id": "/audience/science-research",
@@ -51,22 +51,38 @@
     "license": "http://spdx.org/licenses/Apache-2.0",
     "name": "pyhf",
     "runtimePlatform": [
-        "Python 3",
-        "Python 3.10",
-        "Python 3.7",
         "Python 3.9",
         "Python 3.8",
         "Python 3 Only",
-        "Python Implementation CPython"
+        "Python Implementation CPython",
+        "Python 3.10",
+        "Python 3",
+        "Python 3.7"
     ],
     "softwareRequirements": [
         {
-            "@id": "/dependency/jsonschema-ge-3.0.0",
+            "@id": "/dependency/click-ge-8.0.0",
+            "@type": "SoftwareApplication",
+            "identifier": "click",
+            "name": "click",
+            "runtimePlatform": "Python 3",
+            "version": ">=8.0.0"
+        },
+        {
+            "@id": "/dependency/jsonschema-ge-4.15.0",
             "@type": "SoftwareApplication",
             "identifier": "jsonschema",
             "name": "jsonschema",
             "runtimePlatform": "Python 3",
-            "version": ">=3.0.0"
+            "version": ">=4.15.0"
+        },
+        {
+            "@id": "/dependency/importlib-resources-ge-1.4.0",
+            "@type": "SoftwareApplication",
+            "identifier": "importlib-resources",
+            "name": "importlib-resources",
+            "runtimePlatform": "Python 3",
+            "version": ">=1.4.0"
         },
         {
             "@id": "/dependency/scipy-ge-1.1.0",
@@ -85,22 +101,6 @@
             "version": ">=3.7.4.3"
         },
         {
-            "@id": "/dependency/click-ge-8.0.0",
-            "@type": "SoftwareApplication",
-            "identifier": "click",
-            "name": "click",
-            "runtimePlatform": "Python 3",
-            "version": ">=8.0.0"
-        },
-        {
-            "@id": "/dependency/jsonpatch-ge-1.15",
-            "@type": "SoftwareApplication",
-            "identifier": "jsonpatch",
-            "name": "jsonpatch",
-            "runtimePlatform": "Python 3",
-            "version": ">=1.15"
-        },
-        {
             "@id": "/dependency/pyyaml-ge-5.1",
             "@type": "SoftwareApplication",
             "identifier": "pyyaml",
@@ -109,12 +109,12 @@
             "version": ">=5.1"
         },
         {
-            "@id": "/dependency/importlib-resources-ge-1.3.0",
+            "@id": "/dependency/jsonpatch-ge-1.15",
             "@type": "SoftwareApplication",
-            "identifier": "importlib-resources",
-            "name": "importlib-resources",
+            "identifier": "jsonpatch",
+            "name": "jsonpatch",
             "runtimePlatform": "Python 3",
-            "version": ">=1.3.0"
+            "version": ">=1.15"
         },
         {
             "@id": "/dependency/tqdm-ge-4.56.0",

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,159 +1,138 @@
 {
     "@context": [
-        "https://doi.org/10.5063/schema/codemeta-2.0",
-        "http://schema.org"
+        "https://raw.githubusercontent.com/codemeta/codemeta/2.0/codemeta.jsonld",
+        "https://raw.githubusercontent.com/schemaorg/schemaorg/main/data/releases/13.0/schemaorgcontext.jsonld",
+        "https://w3id.org/software-types",
+        "https://w3id.org/software-iodata"
     ],
+    "@id": "https://github.com/scikit-hep/pyhf",
     "@type": "SoftwareSourceCode",
-    "identifier": "pyhf",
-    "name": "pyhf",
-    "version": "0.7.0rc4",
-    "description": "pure-Python HistFactory implementation with tensors and autodiff",
-    "license": "Apache, OSI Approved :: Apache Software License",
+    "applicationCategory": [
+        "Scientific/Engineering > Physics",
+        "Scientific/Engineering"
+    ],
+    "audience": {
+        "@id": "/audience/science-research",
+        "@type": "Audience",
+        "audienceType": "Science/Research"
+    },
     "author": [
         {
-            "@id": "https://orcid.org/0000-0002-4048-7584",
+            "@id": "/person/lukas-heinrich",
             "@type": "Person",
-            "givenName": "Lukas",
+            "email": "lukas.heinrich@cern.ch",
             "familyName": "Heinrich",
-            "email": "lukas.heinrich@cern.ch"
+            "givenName": "Lukas",
+            "position": 1
         },
         {
-            "@id": "https://orcid.org/0000-0003-4124-7862",
+            "@id": "/person/matthew-feickert",
             "@type": "Person",
-            "givenName": "Matthew",
+            "email": " matthew.feickert@cern.ch",
             "familyName": "Feickert",
-            "email": "matthew.feickert@cern.ch"
+            "givenName": "Matthew",
+            "position": 2
         },
         {
-            "@id": "https://orcid.org/0000-0001-6616-3433",
+            "@id": "/person/giordon-stark",
             "@type": "Person",
-            "givenName": "Giordon",
+            "email": " gstark@cern.ch",
             "familyName": "Stark",
-            "email": "gstark@cern.ch"
+            "givenName": "Giordon",
+            "position": 3
         }
+    ],
+    "codeRepository": "https://github.com/scikit-hep/pyhf",
+    "description": "pure-Python HistFactory implementation with tensors and autodiff",
+    "developmentStatus": "https://www.repostatus.org/#wip",
+    "identifier": "pyhf",
+    "issueTracker": "https://github.com/scikit-hep/pyhf/issues",
+    "keywords": "physics fitting numpy scipy tensorflow pytorch jax",
+    "license": "http://spdx.org/licenses/Apache-2.0",
+    "name": "pyhf",
+    "runtimePlatform": [
+        "Python 3",
+        "Python 3.10",
+        "Python 3.7",
+        "Python 3.9",
+        "Python 3.8",
+        "Python 3 Only",
+        "Python Implementation CPython"
     ],
     "softwareRequirements": [
         {
+            "@id": "/dependency/jsonschema-ge-3.0.0",
+            "@type": "SoftwareApplication",
+            "identifier": "jsonschema",
+            "name": "jsonschema",
+            "runtimePlatform": "Python 3",
+            "version": ">=3.0.0"
+        },
+        {
+            "@id": "/dependency/scipy-ge-1.1.0",
             "@type": "SoftwareApplication",
             "identifier": "scipy",
             "name": "scipy",
-            "provider": {
-                "@id": "https://pypi.org",
-                "@type": "Organization",
-                "name": "The Python Package Index",
-                "url": "https://pypi.org"
-            },
             "runtimePlatform": "Python 3",
             "version": ">=1.1.0"
         },
         {
+            "@id": "/dependency/typing-extensions-ge-3.7.4.3",
+            "@type": "SoftwareApplication",
+            "identifier": "typing-extensions",
+            "name": "typing-extensions",
+            "runtimePlatform": "Python 3",
+            "version": ">=3.7.4.3"
+        },
+        {
+            "@id": "/dependency/click-ge-8.0.0",
             "@type": "SoftwareApplication",
             "identifier": "click",
             "name": "click",
-            "provider": {
-                "@id": "https://pypi.org",
-                "@type": "Organization",
-                "name": "The Python Package Index",
-                "url": "https://pypi.org"
-            },
             "runtimePlatform": "Python 3",
             "version": ">=8.0.0"
         },
         {
-            "@type": "SoftwareApplication",
-            "identifier": "tqdm",
-            "name": "tqdm",
-            "provider": {
-                "@id": "https://pypi.org",
-                "@type": "Organization",
-                "name": "The Python Package Index",
-                "url": "https://pypi.org"
-            },
-            "runtimePlatform": "Python 3",
-            "version": ">=4.56.0"
-        },
-        {
-            "@type": "SoftwareApplication",
-            "identifier": "jsonschema",
-            "name": "jsonschema",
-            "provider": {
-                "@id": "https://pypi.org",
-                "@type": "Organization",
-                "name": "The Python Package Index",
-                "url": "https://pypi.org"
-            },
-            "runtimePlatform": "Python 3",
-            "version": ">=4.15.0"
-        },
-        {
+            "@id": "/dependency/jsonpatch-ge-1.15",
             "@type": "SoftwareApplication",
             "identifier": "jsonpatch",
             "name": "jsonpatch",
-            "provider": {
-                "@id": "https://pypi.org",
-                "@type": "Organization",
-                "name": "The Python Package Index",
-                "url": "https://pypi.org"
-            },
             "runtimePlatform": "Python 3",
             "version": ">=1.15"
         },
         {
+            "@id": "/dependency/pyyaml-ge-5.1",
             "@type": "SoftwareApplication",
             "identifier": "pyyaml",
             "name": "pyyaml",
-            "provider": {
-                "@id": "https://pypi.org",
-                "@type": "Organization",
-                "name": "The Python Package Index",
-                "url": "https://pypi.org"
-            },
             "runtimePlatform": "Python 3",
             "version": ">=5.1"
         },
         {
+            "@id": "/dependency/importlib-resources-ge-1.3.0",
             "@type": "SoftwareApplication",
             "identifier": "importlib-resources",
             "name": "importlib-resources",
-            "provider": {
-                "@id": "https://pypi.org",
-                "@type": "Organization",
-                "name": "The Python Package Index",
-                "url": "https://pypi.org"
-            },
             "runtimePlatform": "Python 3",
-            "version": ">=1.4.0"
+            "version": ">=1.3.0"
         },
         {
+            "@id": "/dependency/tqdm-ge-4.56.0",
             "@type": "SoftwareApplication",
-            "identifier": "typing-extensions",
-            "name": "typing-extensions",
-            "provider": {
-                "@id": "https://pypi.org",
-                "@type": "Organization",
-                "name": "The Python Package Index",
-                "url": "https://pypi.org"
-            },
+            "identifier": "tqdm",
+            "name": "tqdm",
             "runtimePlatform": "Python 3",
-            "version": ">=3.7.4.3"
+            "version": ">=4.56.0"
         }
     ],
-    "audience": [
-        {
-            "@type": "Audience",
-            "audienceType": "Science/Research"
-        }
-    ],
-    "provider": {
-        "@id": "https://pypi.org",
-        "@type": "Organization",
-        "name": "The Python Package Index",
-        "url": "https://pypi.org"
+    "targetProduct": {
+        "@id": "/commandlineapplication/pyhf",
+        "@type": "CommandLineApplication",
+        "description": "The pyhf command line interface.",
+        "executableName": "pyhf",
+        "name": "pyhf",
+        "runtimePlatform": "Python 3"
     },
-    "runtimePlatform": "Python 3",
-    "url": "https://github.com/scikit-hep/pyhf",
-    "keywords": "physics fitting numpy scipy tensorflow pytorch jax",
-    "developmentStatus": "4 - Beta",
-    "applicationCategory": "Scientific/Engineering, Scientific/Engineering :: Physics",
-    "programmingLanguage": "Python 3, Python 3 Only, Python 3.7, Python 3.8, Python 3.9, Python 3.10, Python Implementation CPython"
+    "url": "https://pyhf.readthedocs.io/en/stable/release-notes.html",
+    "version": "0.7.0rc4"
 }

--- a/codemeta.json
+++ b/codemeta.json
@@ -23,6 +23,7 @@
             "email": "lukas.heinrich@cern.ch",
             "familyName": "Heinrich",
             "givenName": "Lukas",
+            "identifier": "https://orcid.org/0000-0002-4048-7584",
             "position": 1
         },
         {
@@ -31,6 +32,7 @@
             "email": "matthew.feickert@cern.ch",
             "familyName": "Feickert",
             "givenName": "Matthew",
+            "identifier": "https://orcid.org/0000-0003-4124-7862",
             "position": 2
         },
         {
@@ -39,6 +41,7 @@
             "email": "gstark@cern.ch",
             "familyName": "Stark",
             "givenName": "Giordon",
+            "identifier": "https://orcid.org/0000-0001-6616-3433",
             "position": 3
         }
     ],

--- a/codemeta.json
+++ b/codemeta.json
@@ -47,7 +47,7 @@
     ],
     "codeRepository": "https://github.com/scikit-hep/pyhf",
     "description": "pure-Python HistFactory implementation with tensors and autodiff",
-    "developmentStatus": "https://www.repostatus.org/#wip",
+    "developmentStatus": "4 - Beta",
     "identifier": "pyhf",
     "issueTracker": "https://github.com/scikit-hep/pyhf/issues",
     "keywords": "physics fitting numpy scipy tensorflow pytorch jax",

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,9 +1,9 @@
 {
     "@context": [
         "https://raw.githubusercontent.com/codemeta/codemeta/2.0/codemeta.jsonld",
+        "https://w3id.org/software-iodata",
         "https://raw.githubusercontent.com/schemaorg/schemaorg/main/data/releases/13.0/schemaorgcontext.jsonld",
-        "https://w3id.org/software-types",
-        "https://w3id.org/software-iodata"
+        "https://w3id.org/software-types"
     ],
     "@id": "https://github.com/scikit-hep/pyhf",
     "@type": "SoftwareSourceCode",
@@ -28,7 +28,7 @@
         {
             "@id": "/person/matthew-feickert",
             "@type": "Person",
-            "email": " matthew.feickert@cern.ch",
+            "email": "matthew.feickert@cern.ch",
             "familyName": "Feickert",
             "givenName": "Matthew",
             "position": 2
@@ -36,7 +36,7 @@
         {
             "@id": "/person/giordon-stark",
             "@type": "Person",
-            "email": " gstark@cern.ch",
+            "email": "gstark@cern.ch",
             "familyName": "Stark",
             "givenName": "Giordon",
             "position": 3
@@ -50,15 +50,19 @@
     "keywords": "physics fitting numpy scipy tensorflow pytorch jax",
     "license": "http://spdx.org/licenses/Apache-2.0",
     "name": "pyhf",
+    "releaseNotes": "https://pyhf.readthedocs.io/en/stable/release-notes.html",
     "runtimePlatform": [
-        "Python 3.9",
-        "Python 3.8",
-        "Python 3 Only",
-        "Python Implementation CPython",
-        "Python 3.10",
         "Python 3",
-        "Python 3.7"
+        "Python 3 Only",
+        "Python 3.10",
+        "Python 3.7",
+        "Python 3.8",
+        "Python 3.9",
+        "Python Implementation CPython"
     ],
+    "softwareHelp": {
+        "@id": "https://pyhf.readthedocs.io/"
+    },
     "softwareRequirements": [
         {
             "@id": "/dependency/click-ge-8.0.0",
@@ -69,44 +73,12 @@
             "version": ">=8.0.0"
         },
         {
-            "@id": "/dependency/jsonschema-ge-4.15.0",
-            "@type": "SoftwareApplication",
-            "identifier": "jsonschema",
-            "name": "jsonschema",
-            "runtimePlatform": "Python 3",
-            "version": ">=4.15.0"
-        },
-        {
             "@id": "/dependency/importlib-resources-ge-1.4.0",
             "@type": "SoftwareApplication",
             "identifier": "importlib-resources",
             "name": "importlib-resources",
             "runtimePlatform": "Python 3",
             "version": ">=1.4.0"
-        },
-        {
-            "@id": "/dependency/scipy-ge-1.1.0",
-            "@type": "SoftwareApplication",
-            "identifier": "scipy",
-            "name": "scipy",
-            "runtimePlatform": "Python 3",
-            "version": ">=1.1.0"
-        },
-        {
-            "@id": "/dependency/typing-extensions-ge-3.7.4.3",
-            "@type": "SoftwareApplication",
-            "identifier": "typing-extensions",
-            "name": "typing-extensions",
-            "runtimePlatform": "Python 3",
-            "version": ">=3.7.4.3"
-        },
-        {
-            "@id": "/dependency/pyyaml-ge-5.1",
-            "@type": "SoftwareApplication",
-            "identifier": "pyyaml",
-            "name": "pyyaml",
-            "runtimePlatform": "Python 3",
-            "version": ">=5.1"
         },
         {
             "@id": "/dependency/jsonpatch-ge-1.15",
@@ -117,12 +89,44 @@
             "version": ">=1.15"
         },
         {
+            "@id": "/dependency/jsonschema-ge-4.15.0",
+            "@type": "SoftwareApplication",
+            "identifier": "jsonschema",
+            "name": "jsonschema",
+            "runtimePlatform": "Python 3",
+            "version": ">=4.15.0"
+        },
+        {
+            "@id": "/dependency/pyyaml-ge-5.1",
+            "@type": "SoftwareApplication",
+            "identifier": "pyyaml",
+            "name": "pyyaml",
+            "runtimePlatform": "Python 3",
+            "version": ">=5.1"
+        },
+        {
+            "@id": "/dependency/scipy-ge-1.1.0",
+            "@type": "SoftwareApplication",
+            "identifier": "scipy",
+            "name": "scipy",
+            "runtimePlatform": "Python 3",
+            "version": ">=1.1.0"
+        },
+        {
             "@id": "/dependency/tqdm-ge-4.56.0",
             "@type": "SoftwareApplication",
             "identifier": "tqdm",
             "name": "tqdm",
             "runtimePlatform": "Python 3",
             "version": ">=4.56.0"
+        },
+        {
+            "@id": "/dependency/typing-extensions-ge-3.7.4.3",
+            "@type": "SoftwareApplication",
+            "identifier": "typing-extensions",
+            "name": "typing-extensions",
+            "runtimePlatform": "Python 3",
+            "version": ">=3.7.4.3"
         }
     ],
     "targetProduct": {
@@ -133,6 +137,6 @@
         "name": "pyhf",
         "runtimePlatform": "Python 3"
     },
-    "url": "https://pyhf.readthedocs.io/en/stable/release-notes.html",
+    "url": "https://github.com/scikit-hep/pyhf",
     "version": "0.7.0rc4"
 }


### PR DESCRIPTION
# Description

Following the release of [`codemetapy` `v2.2.1`](https://github.com/proycon/codemetapy/releases/tag/v2.2.1) which resolved https://github.com/proycon/codemetapy/issues/24, `codemetapy` `v2.2.2+` releases have the `--no-extras` CLI API option restored. Release `v2.2.2` then made it possible for reproducible runs (c.f. https://github.com/proycon/codemetapy/issues/26). Update the current release check workflow to use this new API.

Amends PR #1995

Many thanks @proycon for being so responsive and helpful on `codemetapy`!

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update codemetapy to v2.2.2+ in 'current release' workflow to have access to
  the `--no-extras` CLI API in v2.0+ and reproducible runs.
   - c.f. https://github.com/proycon/codemetapy/issues/24
   - c.f. https://github.com/proycon/codemetapy/issues/26
   - Amends PR #1995
* Use the codemetapy v2.0 API which requires `--inputtype python` to be added.
* Update codemeta.json to follow codemetapy v2.0+ general spec.
```