### PR TITLE
fix: Add filterwarnings ignore for protobuf DeprecationWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ filterwarnings = [
     'ignore:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with:UserWarning',  #FIXME: tests/test_optim.py::test_minimize[no_grad-scipy-pytorch-no_stitch]
     'ignore:divide by zero encountered in (true_)?divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]
     'ignore:[A-Z]+ is deprecated and will be removed in Pillow 10:DeprecationWarning',  # keras
-    'ignore:Call to deprecated create function FileDescriptor().:DeprecationWarning',  # protobuf via tensorflow
+    'ignore:Call to deprecated create function:DeprecationWarning',  # protobuf via tensorflow
 ]
 
 [tool.nbqa.mutate]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ filterwarnings = [
     'ignore:Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with:UserWarning',  #FIXME: tests/test_optim.py::test_minimize[no_grad-scipy-pytorch-no_stitch]
     'ignore:divide by zero encountered in (true_)?divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]
     'ignore:[A-Z]+ is deprecated and will be removed in Pillow 10:DeprecationWarning',  # keras
+    'ignore:Call to deprecated create function FileDescriptor().:DeprecationWarning',  # protobuf via tensorflow
 ]
 
 [tool.nbqa.mutate]


### PR DESCRIPTION
# Description

Add a ignore to filterwarnings to avoid a protobuf DeprecationWarning

> DeprecationWarning: Call to deprecated create function FileDescriptor(). Note: Create unlinked descriptors is going to go away. Please use get/find descriptors from generated code or query the descriptor_pool.

from TensorFlow's use of protobuf.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add a ignore to filterwarnings to avoid a protobuf DeprecationWarning

> DeprecationWarning: Call to deprecated create function FileDescriptor().
> Note: Create unlinked descriptors is going to go away. Please use get/find
> descriptors from generated code or query the descriptor_pool.

from TensorFlow's use of protobuf.
```