### PR TITLE
ci: Ignore Dependabot PRs to update tests/constraints.txt 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "github-actions"
+      - "dependencies"
+    reviewers:
+      - "matthewfeickert"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,11 @@ updates:
       - "dependencies"
     reviewers:
       - "matthewfeickert"
+
+  # Ignore all pip dependencies to avoid PRs to update tests/constraints.txt
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
# Description

Ignore all dependencies that are under the domain of pip in Dependabot's package ecosystems to avoid automatic security PRs that target `tests/constraints.txt`, which must remain static for lower bound constraints testing. This is designed to keep things like PR #2008 from ever happening.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Ignore all dependencies that are under the domain of pip in Dependabot's package
  ecosystems to avoid automatic security PRs that target tests/constraints.txt,
  which must remain static for lower bound constraints testing.
* Add default labels and reviewers to be applied to PRs from GHA updates from Dependabot.
```