### PR TITLE
fix: Use function scope to avoid altering hypotest_args fixture

### DIFF
--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1,13 +1,10 @@
-from copy import deepcopy
-
-import numpy as np
 import pytest
+import pyhf
+import numpy as np
 import scipy.stats
 
-import pyhf
 
-
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="function")
 def hypotest_args():
     pdf = pyhf.simplemodels.uncorrelated_background(
         signal=[12.0, 11.0], bkg=[50.0, 52.0], bkg_uncertainty=[3.0, 7.0]
@@ -469,17 +466,16 @@ def test_toy_calculator(tmpdir, hypotest_args):
     )
 
 
-def test_fixed_poi(hypotest_args):
+def test_fixed_poi(tmpdir, hypotest_args):
     """
     Check that the return structure of pyhf.infer.hypotest with the
     addition of the return_expected keyword arg is as expected
     """
 
-    test_poi, data, pdf = hypotest_args
-    pdf = deepcopy(pdf)  # deepcopy to avoid altering hypotest_args fixture
-    pdf.config.param_set("mu").suggested_fixed = [True]
+    _, _, pdf = hypotest_args
+    pdf.config.param_set('mu').suggested_fixed = [True]
     with pytest.raises(pyhf.exceptions.InvalidModel):
-        pyhf.infer.hypotest(test_poi, data, pdf)
+        pyhf.infer.hypotest(*hypotest_args)
 
 
 def test_teststat_nan_guard():

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1,7 +1,10 @@
-import pytest
-import pyhf
+from copy import deepcopy
+
 import numpy as np
+import pytest
 import scipy.stats
+
+import pyhf
 
 
 @pytest.fixture(scope='module')
@@ -466,16 +469,17 @@ def test_toy_calculator(tmpdir, hypotest_args):
     )
 
 
-def test_fixed_poi(tmpdir, hypotest_args):
+def test_fixed_poi(hypotest_args):
     """
     Check that the return structure of pyhf.infer.hypotest with the
     addition of the return_expected keyword arg is as expected
     """
 
-    _, _, pdf = hypotest_args
-    pdf.config.param_set('mu').suggested_fixed = [True]
+    test_poi, data, pdf = hypotest_args
+    pdf = deepcopy(pdf)  # deepcopy to avoid altering hypotest_args fixture
+    pdf.config.param_set("mu").suggested_fixed = [True]
     with pytest.raises(pyhf.exceptions.InvalidModel):
-        pyhf.infer.hypotest(*hypotest_args)
+        pyhf.infer.hypotest(test_poi, data, pdf)
 
 
 def test_teststat_nan_guard():

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -466,16 +466,16 @@ def test_toy_calculator(tmpdir, hypotest_args):
     )
 
 
-def test_fixed_poi(tmpdir, hypotest_args):
+def test_fixed_poi(hypotest_args):
     """
     Check that the return structure of pyhf.infer.hypotest with the
     addition of the return_expected keyword arg is as expected
     """
 
-    _, _, pdf = hypotest_args
-    pdf.config.param_set('mu').suggested_fixed = [True]
+    test_poi, data, model = hypotest_args
+    model.config.param_set("mu").suggested_fixed = [True]
     with pytest.raises(pyhf.exceptions.InvalidModel):
-        pyhf.infer.hypotest(*hypotest_args)
+        pyhf.infer.hypotest(test_poi, data, model)
 
 
 def test_teststat_nan_guard():


### PR DESCRIPTION
# Description

Needed for PR #1274 

* Use the 'function' scope for hypotest_args fixture. Fixing the POI in the model config changes it for the entire fixture if the fixture is 'module' scope, which would cause errors in other tests that later use it and defeats the point of the fixture.
* Remove unnecessary use of tmpdir fixture as no output is written.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use the 'function' scope for hypotest_args fixture. Fixing the POI in the model config
  changes it for the entire fixture if the fixture is 'module' scope, which would cause
  errors in other tests that later use it and defeats the point of the fixture.
* Remove unnecessary use of tmpdir fixture as no output is written.
```