### PR TITLE
test: Discover pytest fixtures during doctest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 prune **
 graft src
-exlucde src/conftest.py
+exclude src/conftest.py
 
 include setup.py
 include setup.cfg

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 prune **
 graft src
+exlucde src/conftest.py
 
 include setup.py
 include setup.cfg

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,0 +1,1 @@
+../tests/conftest.py


### PR DESCRIPTION
# Description

* Resolves #2015
* Needed for PR #1274

Symlink the `tests/conftest.py` under the `src` tree to allow for the autouse pytest fixtures to be discovered and used during doctest. This is needed as the backends are not currently being automatically reset between doctests and the fixtures will not be discovered during doctest runs invoked with `pytest src/` as noted in the [pytest docs](https://docs.pytest.org/en/7.1.x/how-to/doctest.html#doctest-namespace-fixture):

> Note that like the normal `conftest.py`, the fixtures are discovered in the directory tree conftest is in. Meaning that if you put your doctest with your source code, the relevant `conftest.py` needs to be in the same directory tree. Fixtures will not be discovered in a sibling directory tree!

   - c.f. https://docs.pytest.org/en/7.1.x/how-to/doctest.html#doctest-namespace-fixture
   - https://docs.pytest.org/en/7.1.x/explanation/pythonpath.html

Exclude `src/conftest.py` from the `MANIFEST.in` so as to not include it in the sdist build.


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Symlink the tests/conftest.py under the src/ tree to allow for the
  autouse pytest fixtures to be discovered and used during doctest.
  This is needed as the backends are not currently being automatically
  reset between doctests and the fixtures will not be discovered during
  doctest runs invoked with `pytest src/` as noted in the pytest docs:

> Note that like the normal conftest.py, the fixtures are discovered in the
> directory tree conftest is in. Meaning that if you put your doctest with
> your source code, the relevant conftest.py needs to be in the same directory
> tree. Fixtures will not be discovered in a sibling directory tree!

   - c.f. https://docs.pytest.org/en/7.1.x/how-to/doctest.html#doctest-namespace-fixture
   - https://docs.pytest.org/en/7.1.x/explanation/pythonpath.html

* Exclude src/conftest.py from the MANIFEST.in so as to not include it
  in the sdist build.
```