### PR TITLE
docs: Update list of statistical models for 2022

### DIFF
--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -1,3 +1,13 @@
+% 2022-04-27
+@misc{ins2072870,
+    title = "{Searches for new phenomena in events with two leptons, jets, and missing transverse momentum in $139~\text{fb}^{-1}$ of $\sqrt{s}=13~$TeV $pp$ collisions with the ATLAS detector}",
+    doi = "10.17182/hepdata.116034",
+    url = "https://doi.org/10.17182/hepdata.116034",
+    year = "2022",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
 @misc{ins1995886,
     title = "{Search for Higgs boson pair production in the two bottom quarks plus two photons final state in $pp$ collisions at $\sqrt{s}=13$ TeV with the ATLAS detector}",
     doi = "10.17182/hepdata.105864",

--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -1,3 +1,12 @@
+@misc{ins1995886,
+    title = "{Search for Higgs boson pair production in the two bottom quarks plus two photons final state in $pp$ collisions at $\sqrt{s}=13$ TeV with the ATLAS detector}",
+    doi = "10.17182/hepdata.105864",
+    url = "https://doi.org/10.17182/hepdata.105864",
+    year = "2022",
+    type = "Data Collection",
+    collaboration = "ATLAS"
+}
+
 @misc{ins1906174,
     title = "{Search for charginos and neutralinos in final states with two boosted hadronically decaying bosons and missing transverse momentum in $pp$ collisions at $\sqrt{s}=13$ TeV with the ATLAS detector}",
     doi = "10.17182/hepdata.104458",

--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -160,6 +160,16 @@
     collaboration = "ATLAS",
 }
 
+% 2020-07-29
+@misc{1809244,
+    title = "{Evidence for $t\bar{t}t\bar{t}$ production in the multilepton final state in proton-proton collisions at $\sqrt{s}=13$ $\text {TeV}$ with the ATLAS detector}",
+    doi = "10.17182/hepdata.100170",
+    url = "https://doi.org/10.17182/hepdata.100170",
+    year = "2020",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
 % 2020-06-24
 @misc{ins1802524,
     title = "{Measurement of the $t\bar{t}$ production cross-section in the lepton+jets channel at $\sqrt{s}=13$ TeV with the ATLAS experiment}",

--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -1,3 +1,13 @@
+% 2022-05-05
+@misc{ins2077557,
+    title = "{Search for flavour-changing neutral-current couplings between the top quark and the photon with the ATLAS detector at $\sqrt{s} = 13$ TeV}",
+    doi = "10.17182/hepdata.129959",
+    url = "https://doi.org/10.17182/hepdata.129959",
+    year = "2022",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
 % 2022-04-27
 @misc{ins2072870,
     title = "{Searches for new phenomena in events with two leptons, jets, and missing transverse momentum in $139~\text{fb}^{-1}$ of $\sqrt{s}=13~$TeV $pp$ collisions with the ATLAS detector}",

--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -18,15 +18,17 @@
     collaboration = "ATLAS",
 }
 
+% 2021-12-22
 @misc{ins1995886,
     title = "{Search for Higgs boson pair production in the two bottom quarks plus two photons final state in $pp$ collisions at $\sqrt{s}=13$ TeV with the ATLAS detector}",
     doi = "10.17182/hepdata.105864",
     url = "https://doi.org/10.17182/hepdata.105864",
-    year = "2022",
+    year = "2021",
     type = "Data Collection",
     collaboration = "ATLAS"
 }
 
+% 2021-08-17
 @misc{ins1906174,
     title = "{Search for charginos and neutralinos in final states with two boosted hadronically decaying bosons and missing transverse momentum in $pp$ collisions at $\sqrt{s}=13$ TeV with the ATLAS detector}",
     doi = "10.17182/hepdata.104458",
@@ -36,6 +38,7 @@
     collaboration = "ATLAS",
 }
 
+% 2021-06-22
 @misc{ins1869695,
     title = "{Measurement of the $t\bar{t}t\bar{t}$ production cross section in $pp$ collisions at $\sqrt{s}$=13 TeV with the ATLAS detector}",
     doi = "10.17182/hepdata.105039",
@@ -45,6 +48,7 @@
     collaboration = "ATLAS",
 }
 
+% 2021-06-17
 @misc{ins1869040,
     title = "{Search for R-parity violating supersymmetry in a final state containing leptons and many jets with the ATLAS experiment using $\sqrt{s} = 13$ TeV proton-proton collision data}",
     doi = "10.17182/hepdata.104860",
@@ -54,6 +58,7 @@
     collaboration = "ATLAS",
 }
 
+% 2021-06-03
 @misc{ins1866951,
     title = "{Search for chargino--neutralino pair production in final states with three leptons and missing transverse momentum in $\sqrt{s} = 13$ TeV $pp$ collisions with the ATLAS detector}",
     doi = "10.17182/hepdata.95751",
@@ -63,6 +68,7 @@
     collaboration = "ATLAS",
 }
 
+% 2021-03-23
 @misc{ins1853014,
     title = "{Measurements of the inclusive and differential production cross sections of a top-quark-antiquark pair in association with a $Z$ boson at $\sqrt{s} = 13$ TeV with the ATLAS detector}",
     doi = "10.17182/hepdata.100351",
@@ -72,6 +78,7 @@
     collaboration = "ATLAS",
 }
 
+% 2021-01-27
 @misc{ins1843001,
     title = "{Search for pair production of third-generation scalar leptoquarks decaying into a top quark and a $\tau$-lepton in $pp$ collisions at $ \sqrt{s} $ = 13 TeV with the ATLAS detector}",
     doi = "10.17182/hepdata.100174",
@@ -81,6 +88,7 @@
     collaboration = "ATLAS",
 }
 
+% 2021-01-05
 @misc{ins1839446,
     title = "{Search for squarks and gluinos in final states with one isolated lepton, jets, and missing transverse momentum at $\sqrt{s}=13$  with the ATLAS detector}",
     doi = "10.17182/hepdata.97041",
@@ -90,6 +98,7 @@
     collaboration = "ATLAS",
 }
 
+% 2020-11-20
 @misc{ins1831992,
     title = "{Search for trilepton resonances from chargino and neutralino pair production in $\sqrt{s}$ = 13 TeV $pp$ collisions with the ATLAS detector}",
     doi = "10.17182/hepdata.99806",
@@ -129,6 +138,7 @@
     collaboration = "ATLAS",
 }
 
+% 2020-03-26
 @misc{ins1788448,
     title = "{Search for long-lived, massive particles in events with a displaced vertex and a muon with large impact parameter in $pp$ collisions at $\sqrt{s} = 13$ TeV with the ATLAS detector}",
     doi = "10.17182/hepdata.91760",
@@ -138,6 +148,7 @@
     collaboration = "ATLAS",
 }
 
+% 2019-12-18
 @misc{ins1771533,
     title = "{Search for chargino-neutralino production with mass splittings near the electroweak scale in three-lepton final states in $\sqrt{s}$ = 13 TeV $pp$ collisions with the ATLAS detector}",
     doi = "10.17182/hepdata.91127",
@@ -147,15 +158,17 @@
     collaboration = "ATLAS",
 }
 
+% 2019-11-28
 @misc{ins1767649,
     title = "{Searches for electroweak production of supersymmetric particles with compressed mass spectra in $\sqrt{s}=$ 13 TeV $pp$ collisions with the ATLAS detector}",
     doi = "10.17182/hepdata.91374",
     url = "https://doi.org/10.17182/hepdata.91374",
-    year = "2020",
+    year = "2019",
     type = "Data Collection",
     collaboration = "ATLAS",
 }
 
+% 2019-11-15
 @misc{ins1765529,
     title = "{Search for direct stau production in events with two hadronic $\tau$-leptons in $\sqrt{s} = 13$ TeV $pp$ collisions with the ATLAS detector}",
     doi = "10.17182/hepdata.92006",
@@ -165,20 +178,22 @@
     collaboration = "ATLAS",
 }
 
+% 2019-09-19
 @misc{ins1755298,
     title = "{Search for direct production of electroweakinos in final states with one lepton, missing transverse momentum and a Higgs boson decaying into two $b$-jets in (pp) collisions at $\sqrt{s}=13$ TeV with the ATLAS detector}",
     doi = "10.17182/hepdata.90607.v2",
     url = "https://doi.org/10.17182/hepdata.90607.v2",
-    year = "2020",
+    year = "2019",
     type = "Data Collection",
     collaboration = "ATLAS",
 }
 
+% 2019-09-18
 @misc{ins1754675,
     title = "{Search for squarks and gluinos in final states with same-sign leptons and jets using 139 fb$^{-1}$ of data collected with the ATLAS detector}",
     doi = "10.17182/hepdata.91214.v3",
     url = "https://doi.org/10.17182/hepdata.91214.v3",
-    year = "2020",
+    year = "2019",
     type = "Data Collection",
     collaboration = "ATLAS",
 }
@@ -213,6 +228,7 @@
     collaboration = "ATLAS",
 }
 
+% 2019-08-08
 @misc{ins1748602,
     title = "{Search for bottom-squark pair production with the ATLAS detector in final states containing Higgs bosons, $b$-jets and missing transverse momentum}",
     doi = "10.17182/hepdata.89408",

--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -160,6 +160,16 @@
     collaboration = "ATLAS",
 }
 
+% 2019-08-21
+@misc{ins1750597,
+    title = "{Search for electroweak production of charginos and sleptons decaying into final states with two leptons and missing transverse momentum in $\sqrt{s}=13$ TeV $pp$ collisions using the ATLAS detector}",
+    doi = "10.17182/hepdata.89413",
+    url = "https://doi.org/10.17182/hepdata.89413",
+    year = "2019",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
 @misc{ins1748602,
     title = "{Search for bottom-squark pair production with the ATLAS detector in final states containing Higgs bosons, $b$-jets and missing transverse momentum}",
     doi = "10.17182/hepdata.89408",

--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -160,6 +160,16 @@
     collaboration = "ATLAS",
 }
 
+% 2020-06-24
+@misc{ins1802524,
+    title = "{Measurement of the $t\bar{t}$ production cross-section in the lepton+jets channel at $\sqrt{s}=13$ TeV with the ATLAS experiment}",
+    doi = "10.17182/hepdata.95748",
+    url = "https://doi.org/10.17182/hepdata.95748",
+    year = "2020",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
 % 2019-08-21
 @misc{ins1750597,
     title = "{Search for electroweak production of charginos and sleptons decaying into final states with two leptons and missing transverse momentum in $\sqrt{s}=13$ TeV $pp$ collisions using the ATLAS detector}",

--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -99,8 +99,9 @@
     collaboration = "ATLAS",
 }
 
+% 2020-11-13
 @misc{ins1831504,
-    title = "{Search for displaced leptons in $\sqrt{s} = 13$ TeV $pp$ collisions with the ATLAS detector}",
+    title = "{Search for Displaced Leptons in $\sqrt{s} = 13$ TeV $pp$ Collisions with the ATLAS Detector}",
     doi = "10.17182/hepdata.98796",
     url = "https://doi.org/10.17182/hepdata.98796",
     year = "2020",
@@ -108,15 +109,17 @@
     collaboration = "ATLAS",
 }
 
+% 2020-10-27
 @misc{ins1827025,
     title = "{Search for squarks and gluinos in final states with jets and missing transverse momentum using 139 fb$^{-1}$ of $\sqrt{s}$ =13 TeV $pp$ collision data with the ATLAS detector}",
     doi = "10.17182/hepdata.95664",
     url = "https://doi.org/10.17182/hepdata.95664",
-    year = "2021",
+    year = "2020",
     type = "Data Collection",
     collaboration = "ATLAS",
 }
 
+% 2020-06-24
 @misc{ins1802524,
     title = "{Measurement of the $t\bar{t}$ production cross-section in the lepton+jets channel at $\sqrt{s}=13$ TeV with the ATLAS experiment}",
     doi = "10.17182/hepdata.95748",
@@ -190,31 +193,11 @@
     collaboration = "ATLAS",
 }
 
-% 2020-10-27
-@misc{ins1827025,
-    title = "{Search for squarks and gluinos in final states with jets and missing transverse momentum using 139 fb$^{-1}$ of $\sqrt{s}$ =13 TeV $pp$ collision data with the ATLAS detector}",
-    doi = "10.17182/hepdata.95664",
-    url = "https://doi.org/10.17182/hepdata.95664",
-    year = "2020",
-    type = "Data Collection",
-    collaboration = "ATLAS",
-}
-
 % 2020-07-29
 @misc{ins1809244,
     title = "{Evidence for $t\bar{t}t\bar{t}$ production in the multilepton final state in proton-proton collisions at $\sqrt{s}=13$ $\text {TeV}$ with the ATLAS detector}",
     doi = "10.17182/hepdata.100170",
     url = "https://doi.org/10.17182/hepdata.100170",
-    year = "2020",
-    type = "Data Collection",
-    collaboration = "ATLAS",
-}
-
-% 2020-06-24
-@misc{ins1802524,
-    title = "{Measurement of the $t\bar{t}$ production cross-section in the lepton+jets channel at $\sqrt{s}=13$ TeV with the ATLAS experiment}",
-    doi = "10.17182/hepdata.95748",
-    url = "https://doi.org/10.17182/hepdata.95748",
     year = "2020",
     type = "Data Collection",
     collaboration = "ATLAS",

--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -160,6 +160,16 @@
     collaboration = "ATLAS",
 }
 
+% 2020-11-13
+@misc{ins1831504,
+    title = "{Search for Displaced Leptons in $\sqrt{s} = 13$ TeV $pp$ Collisions with the ATLAS Detector}",
+    doi = "10.17182/hepdata.98796",
+    url = "https://doi.org/10.17182/hepdata.98796",
+    year = "2020",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
 % 2020-10-27
 @misc{ins1827025,
     title = "{Search for squarks and gluinos in final states with jets and missing transverse momentum using 139 fb$^{-1}$ of $\sqrt{s}$ =13 TeV $pp$ collision data with the ATLAS detector}",

--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -128,6 +128,16 @@
     collaboration = "ATLAS",
 }
 
+% 2020-07-29
+@misc{ins1809244,
+    title = "{Evidence for $t\bar{t}t\bar{t}$ production in the multilepton final state in proton-proton collisions at $\sqrt{s}=13$ $\text {TeV}$ with the ATLAS detector}",
+    doi = "10.17182/hepdata.100170",
+    url = "https://doi.org/10.17182/hepdata.100170",
+    year = "2020",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
 % 2020-06-24
 @misc{ins1802524,
     title = "{Measurement of the $t\bar{t}$ production cross-section in the lepton+jets channel at $\sqrt{s}=13$ TeV with the ATLAS experiment}",
@@ -194,26 +204,6 @@
     doi = "10.17182/hepdata.91214.v3",
     url = "https://doi.org/10.17182/hepdata.91214.v3",
     year = "2019",
-    type = "Data Collection",
-    collaboration = "ATLAS",
-}
-
-% 2020-11-13
-@misc{ins1831504,
-    title = "{Search for Displaced Leptons in $\sqrt{s} = 13$ TeV $pp$ Collisions with the ATLAS Detector}",
-    doi = "10.17182/hepdata.98796",
-    url = "https://doi.org/10.17182/hepdata.98796",
-    year = "2020",
-    type = "Data Collection",
-    collaboration = "ATLAS",
-}
-
-% 2020-07-29
-@misc{ins1809244,
-    title = "{Evidence for $t\bar{t}t\bar{t}$ production in the multilepton final state in proton-proton collisions at $\sqrt{s}=13$ $\text {TeV}$ with the ATLAS detector}",
-    doi = "10.17182/hepdata.100170",
-    url = "https://doi.org/10.17182/hepdata.100170",
-    year = "2020",
     type = "Data Collection",
     collaboration = "ATLAS",
 }

--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -160,8 +160,18 @@
     collaboration = "ATLAS",
 }
 
+% 2020-10-27
+@misc{ins1827025,
+    title = "{Search for squarks and gluinos in final states with jets and missing transverse momentum using 139 fb$^{-1}$ of $\sqrt{s}$ =13 TeV $pp$ collision data with the ATLAS detector}",
+    doi = "10.17182/hepdata.95664",
+    url = "https://doi.org/10.17182/hepdata.95664",
+    year = "2020",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
 % 2020-07-29
-@misc{1809244,
+@misc{ins1809244,
     title = "{Evidence for $t\bar{t}t\bar{t}$ production in the multilepton final state in proton-proton collisions at $\sqrt{s}=13$ $\text {TeV}$ with the ATLAS detector}",
     doi = "10.17182/hepdata.100170",
     url = "https://doi.org/10.17182/hepdata.100170",


### PR DESCRIPTION
# Description

Update the list of the published statistical models to include those from 2022 and those from previously published analyses that ATLAS has made public. Following https://pyhf.github.io/public-probability-models

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update the list of published statistical models to include new ones analyses in 2022
  and previous analyses that have had their models made public. Information is gathered
  from https://github.com/pyhf/public-probability-models which queries
  https://twiki.cern.ch/twiki/bin/view/AtlasPublic.
* Reorder the list by analysis publication date as given by ATLAS.
```