### PR TITLE
chore: Update referenced to default branch to 'main'

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -141,7 +141,7 @@ body:
     description: |
       Read the [`pyhf` Code of Conduct][CoC] first.
 
-      [CoC]: https://github.com/scikit-hep/pyhf/blob/master/CODE_OF_CONDUCT.md
+      [CoC]: https://github.com/scikit-hep/pyhf/blob/main/CODE_OF_CONDUCT.md
     options:
     - label: I agree to follow the Code of Conduct
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -11,5 +11,5 @@ contact_links:
     The pyhf tutorial is continually updated and provides an in depth walkthrough
     of how to use the latest release of pyhf.
 - name: 📝  pyhf Code of Conduct
-  url: https://github.com/scikit-hep/pyhf/blob/master/CODE_OF_CONDUCT.md
+  url: https://github.com/scikit-hep/pyhf/blob/main/CODE_OF_CONDUCT.md
   about: Expectations for how people will interact with each other on pyhf's GitHub.

--- a/.github/ISSUE_TEMPLATE/documentation-report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-report.yml
@@ -45,7 +45,7 @@ body:
     description: |
       Read the [`pyhf` Code of Conduct][CoC] first.
 
-      [CoC]: https://github.com/scikit-hep/pyhf/blob/master/CODE_OF_CONDUCT.md
+      [CoC]: https://github.com/scikit-hep/pyhf/blob/main/CODE_OF_CONDUCT.md
     options:
     - label: I agree to follow the Code of Conduct
       required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -73,7 +73,7 @@ body:
     description: |
       Read the [`pyhf` Code of Conduct][CoC] first.
 
-      [CoC]: https://github.com/scikit-hep/pyhf/blob/master/CODE_OF_CONDUCT.md
+      [CoC]: https://github.com/scikit-hep/pyhf/blob/main/CODE_OF_CONDUCT.md
     options:
     - label: I agree to follow the Code of Conduct
       required: true

--- a/.github/ISSUE_TEMPLATE/~release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/~release-checklist.md
@@ -8,10 +8,10 @@ about: Checklist for core developers to complete as part of making a release
 ## Before Release
 
 * [ ] Migrate any unresolved Issues or PRs from the [release GitHub project board](https://github.com/scikit-hep/pyhf/projects/) to a new project board.
-* [ ] Verify that there is a release notes file for the release under [``docs/release-notes``](https://github.com/scikit-hep/pyhf/tree/master/docs/release-notes).
+* [ ] Verify that there is a release notes file for the release under [``docs/release-notes``](https://github.com/scikit-hep/pyhf/tree/main/docs/release-notes).
 * [ ] Verify that the release notes files correctly summarize all development changes since the last release.
 * [ ] Draft email to [``pyhf-announcements`` mailing list](https://groups.google.com/group/pyhf-announcements/subscribe) that summarizes the main points of the release notes and circulate it for development team approval.
-* [ ] Update the checklist Issue template in the [``.github/ISSUE_TEMPLATE``](https://github.com/scikit-hep/pyhf/tree/master/.github/ISSUE_TEMPLATE) directory if there are revisions.
+* [ ] Update the checklist Issue template in the [``.github/ISSUE_TEMPLATE``](https://github.com/scikit-hep/pyhf/tree/main/.github/ISSUE_TEMPLATE) directory if there are revisions.
 * [ ] Make a release to [TestPyPI][TestPyPI_pyhf] using the [workflow dispatch event trigger](https://github.com/scikit-hep/pyhf/actions/workflows/publish-package.yml).
 * [ ] Verify that the project README is displaying correctly on [TestPyPI][TestPyPI_pyhf].
 * [ ] Add any new use citations or published statistical models to the [Use and Citations page][citations_page].
@@ -28,7 +28,7 @@ about: Checklist for core developers to complete as part of making a release
 * [ ] Create a [GitHub release](https://github.com/scikit-hep/pyhf/releases) from the generated PR tag and copy the release notes published to the GitHub release page. The creation of the GitHub release triggers all other release related activities.
    - [ ] Before pasting in the release notes copy the changes that the GitHub bot has already queued up and pasted into the tag and place them in the "Changes" section of the release notes. If the release notes are published before these are copied then they will be overwritten and you'll have to add them back in by hand.
 * [ ] Verify there is a new [Zenodo DOI](https://doi.org/10.5281/zenodo.1169739) minted for the release.
-   - [ ] Verify that the new release archive metadata on Zenodo matches is being picked up as expected from [`CITATION.cff`](https://github.com/scikit-hep/pyhf/blob/master/CITATION.cff).
+   - [ ] Verify that the new release archive metadata on Zenodo matches is being picked up as expected from [`CITATION.cff`](https://github.com/scikit-hep/pyhf/blob/main/CITATION.cff).
 * [ ] Verify that a Binder has properly built for the new release.
 * [ ] Watch for a GitHub notification that there is an automatic PR to the
   [Conda-forge feedstock](https://github.com/conda-forge/pyhf-feedstock). This may take multiple hours to happen. If there are any changes needed to the Conda-forge release make them **from a personal account** and not from an organization account to have workflows properly trigger.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 # Description
 
-Please first read [CONTRIBUTING.md](https://github.com/scikit-hep/pyhf/tree/master/CONTRIBUTING.md).
+Please first read [CONTRIBUTING.md](https://github.com/scikit-hep/pyhf/tree/main/CONTRIBUTING.md).
 
 Please describe the purpose of this pull request in some detail. Reference and link to any relevant issues or pull requests.
 

--- a/.github/PULL_REQUEST_TEMPLATE/Bug-Fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Bug-Fix.md
@@ -1,6 +1,6 @@
 # Pull Request Description
 
-Please first read [CONTRIBUTING.md](https://github.com/scikit-hep/pyhf/tree/master/CONTRIBUTING.md).
+Please first read [CONTRIBUTING.md](https://github.com/scikit-hep/pyhf/tree/main/CONTRIBUTING.md).
 
 Please describe the purpose of this pull request in some detail and what bug it fixes. Reference and link to any relevant issues or pull requests (such as the issue in which this bug was first discussed).
 

--- a/.github/PULL_REQUEST_TEMPLATE/Feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Feature.md
@@ -1,6 +1,6 @@
 # Pull Request Description
 
-Please first read [CONTRIBUTING.md](https://github.com/scikit-hep/pyhf/tree/master/CONTRIBUTING.md).
+Please first read [CONTRIBUTING.md](https://github.com/scikit-hep/pyhf/tree/main/CONTRIBUTING.md).
 
 Please describe the purpose of this pull request in some detail and what the specific feature being added will do. Reference and link to any relevant issues or pull requests (such as the issue in which this feature was first suggested).
 

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -240,5 +240,5 @@ jobs:
         if [ ${{ github.event.inputs.dry_run }} == 'true' ]; then
             echo "# DRY RUN"
         else
-            git push origin master --tags
+            git push origin main --tags
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
     branches:
-    - master
+    - main
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'
@@ -18,11 +18,11 @@ jobs:
   test:
 
     runs-on: ${{ matrix.os }}
-    # On push events run the CI only on master by default, but run on any branch if the commit message contains '[ci all]'
+    # On push events run the CI only on main by default, but run on any branch if the commit message contains '[ci all]'
     if: >-
       github.event_name != 'push'
-      || (github.event_name == 'push' && github.ref == 'refs/heads/master')
-      || (github.event_name == 'push' && github.ref != 'refs/heads/master' && contains(github.event.head_commit.message, '[ci all]'))
+      || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      || (github.event_name == 'push' && github.ref != 'refs/heads/main' && contains(github.event.head_commit.message, '[ci all]'))
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     # branches must be a subset of push branches
-    branches: [master]
+    branches: [main]
   # Run weekly on Sundays at 0:01 UTC
   schedule:
     - cron: '1 0 * * 0'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,12 +3,12 @@ name: Docker Images
 on:
   push:
     branches:
-    - master
+    - main
     tags:
     - v*
   pull_request:
     branches:
-    - master
+    - main
   schedule:
     - cron:  '1 0 * * *'
   release:
@@ -107,8 +107,8 @@ jobs:
           -c "which curl; which tar"
 
       - name: Build and publish to registry
-        # every PR will trigger a push event on master, so check the push event is actually coming from master
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pyhf'
+        # every PR will trigger a push event on main, so check the push event is actually coming from main
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'scikit-hep/pyhf'
         id: docker_build_latest
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Docs
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
   workflow_dispatch:
 
@@ -86,7 +86,7 @@ jobs:
 
   deploy:
     name: Deploy docs to GitHub Pages
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     # Set permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
     permissions:

--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -15,5 +15,5 @@ jobs:
     - name: Trigger Binder build
       run: |
         # Use Binder build API to trigger repo2docker to build image on Google Cloud and Turing Institute Binder Federation clusters
-        bash binder/trigger_binder.sh https://gke.mybinder.org/build/gh/scikit-hep/pyhf/master
-        bash binder/trigger_binder.sh https://turing.mybinder.org/build/gh/scikit-hep/pyhf/master
+        bash binder/trigger_binder.sh https://gke.mybinder.org/build/gh/scikit-hep/pyhf/main
+        bash binder/trigger_binder.sh https://turing.mybinder.org/build/gh/scikit-hep/pyhf/main

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -2,12 +2,12 @@ name: publish distributions
 on:
   push:
     branches:
-    - master
+    - main
     tags:
     - v*
   pull_request:
     branches:
-    - master
+    - main
   release:
     types: [published]
   workflow_dispatch:
@@ -56,9 +56,9 @@ jobs:
       run: |
         latest_tag=$(git describe --tags)
         latest_tag_revlist_SHA=$(git rev-list -n 1 ${latest_tag})
-        master_SHA="$(git rev-parse --verify origin/master)"
+        main_SHA="$(git rev-parse --verify origin/main)"
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
-        if [[ "${latest_tag_revlist_SHA}" != "${master_SHA}" ]]; then # don't check master push events coming from tags
+        if [[ "${latest_tag_revlist_SHA}" != "${main_SHA}" ]]; then # don't check main push events coming from tags
           if [[ "${wheel_name}" == *"pyhf-0.1.dev"* || "${wheel_name}" != *"dev"* ]]; then
             echo "python-build incorrectly named built distribution: ${wheel_name}"
             echo "python-build is lacking the history and tags required to determine version number"
@@ -66,7 +66,7 @@ jobs:
             return 1
           fi
         else
-          echo "Push event to origin/master was triggered by push of tag ${latest_tag}"
+          echo "Push event to origin/main was triggered by push of tag ${latest_tag}"
         fi
         echo "python-build named built distribution: ${wheel_name}"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ If you would like to make a pull request please:
 3. Commit your changes to a feature branch on your fork and push to your branch.
 4. Start a pull request to let the project maintainers know you're working on it.
 5. Test your changes with `pytest`.
-6. Update your fork to make sure your changes don't conflict with the current state of the master branch.
+6. Update your fork to make sure your changes don't conflict with the current state of the main branch.
 7. Make sure that you've added your name to `docs/contributors.rst`.
 If you haven't **please** do so by simply appending your name to the bottom of the list.
 We are thankful for and value your contributions to `pyhf`, not matter the size.

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/_static/img/pyhf-logo-small.png
+.. image:: https://raw.githubusercontent.com/scikit-hep/pyhf/main/docs/_static/img/pyhf-logo-small.png
    :alt: pyhf logo
    :width: 320
    :align: center
@@ -8,7 +8,7 @@ pure-python fitting/limit-setting/interval estimation HistFactory-style
 
 |GitHub Project| |DOI| |JOSS DOI| |Scikit-HEP| |NSF Award Number|
 
-|Docs from latest| |Docs from master| |Jupyter Book tutorial| |Binder|
+|Docs from latest| |Docs from main| |Jupyter Book tutorial| |Binder|
 
 |PyPI version| |Conda-forge version| |Supported Python versions| |Docker Hub pyhf| |Docker Hub pyhf CUDA|
 
@@ -70,7 +70,7 @@ Alternatively the statistical model and observational data can be read from its 
    >>> import pyhf
    >>> import requests
    >>> pyhf.set_backend("numpy")
-   >>> url = "https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/examples/json/2-bin_1-channel.json"
+   >>> url = "https://raw.githubusercontent.com/scikit-hep/pyhf/main/docs/examples/json/2-bin_1-channel.json"
    >>> wspace = pyhf.Workspace(requests.get(url).json())
    >>> model = wspace.model()
    >>> data = wspace.data(model)
@@ -194,14 +194,14 @@ A one bin example
 
 **pyhf**
 
-.. image:: https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/_static/img/README_1bin_example.png
+.. image:: https://raw.githubusercontent.com/scikit-hep/pyhf/main/docs/_static/img/README_1bin_example.png
    :alt: manual
    :width: 500
    :align: center
 
 **ROOT**
 
-.. image:: https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/_static/img/hfh_1bin_55_50_7.png
+.. image:: https://raw.githubusercontent.com/scikit-hep/pyhf/main/docs/_static/img/hfh_1bin_55_50_7.png
    :alt: manual
    :width: 500
    :align: center
@@ -238,14 +238,14 @@ A two bin example
 
 **pyhf**
 
-.. image:: https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/_static/img/README_2bin_example.png
+.. image:: https://raw.githubusercontent.com/scikit-hep/pyhf/main/docs/_static/img/README_2bin_example.png
    :alt: manual
    :width: 500
    :align: center
 
 **ROOT**
 
-.. image:: https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/_static/img/hfh_2_bin_100.0_145.0_100.0_150.0_15.0_20.0_30.0_45.0.png
+.. image:: https://raw.githubusercontent.com/scikit-hep/pyhf/main/docs/_static/img/hfh_2_bin_100.0_145.0_100.0_150.0_15.0_20.0_30.0_45.0.png
    :alt: manual
    :width: 500
    :align: center
@@ -363,12 +363,12 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
    :target: https://nsf.gov/awardsearch/showAward?AWD_ID=1836650
 .. |Docs from latest| image:: https://img.shields.io/badge/docs-v0.7.0rc4-blue.svg
    :target: https://pyhf.readthedocs.io/
-.. |Docs from master| image:: https://img.shields.io/badge/docs-master-blue.svg
+.. |Docs from main| image:: https://img.shields.io/badge/docs-main-blue.svg
    :target: https://scikit-hep.github.io/pyhf
 .. |Jupyter Book tutorial| image:: https://jupyterbook.org/_images/badge.svg
    :target: https://pyhf.github.io/pyhf-tutorial/
 .. |Binder| image:: https://mybinder.org/badge_logo.svg
-   :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/master?filepath=docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
+   :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/main?filepath=docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
 
 .. |PyPI version| image:: https://badge.fury.io/py/pyhf.svg
    :target: https://badge.fury.io/py/pyhf
@@ -381,21 +381,21 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
 .. |Docker Hub pyhf CUDA| image:: https://img.shields.io/badge/pyhf-CUDA-blue?logo=Docker
    :target: https://hub.docker.com/r/pyhf/cuda/tags
 
-.. |Code Coverage| image:: https://codecov.io/gh/scikit-hep/pyhf/graph/badge.svg?branch=master
-   :target: https://codecov.io/gh/scikit-hep/pyhf?branch=master
+.. |Code Coverage| image:: https://codecov.io/gh/scikit-hep/pyhf/graph/badge.svg?branch=main
+   :target: https://codecov.io/gh/scikit-hep/pyhf?branch=main
 .. |CodeFactor| image:: https://www.codefactor.io/repository/github/scikit-hep/pyhf/badge
    :target: https://www.codefactor.io/repository/github/scikit-hep/pyhf
-.. |pre-commit.ci Status| image:: https://results.pre-commit.ci/badge/github/scikit-hep/pyhf/master.svg
-  :target: https://results.pre-commit.ci/latest/github/scikit-hep/pyhf/master
+.. |pre-commit.ci Status| image:: https://results.pre-commit.ci/badge/github/scikit-hep/pyhf/main.svg
+  :target: https://results.pre-commit.ci/latest/github/scikit-hep/pyhf/main
   :alt: pre-commit.ci status
 .. |Code style: black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :target: https://github.com/psf/black
 
-.. |GitHub Actions Status: CI| image:: https://github.com/scikit-hep/pyhf/workflows/CI/CD/badge.svg?branch=master
-   :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3ACI%2FCD+branch%3Amaster
-.. |GitHub Actions Status: Docs| image:: https://github.com/scikit-hep/pyhf/workflows/Docs/badge.svg?branch=master
-   :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3ADocs+branch%3Amaster
-.. |GitHub Actions Status: Publish| image:: https://github.com/scikit-hep/pyhf/workflows/publish%20distributions/badge.svg?branch=master
-   :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3A%22publish+distributions%22+branch%3Amaster
-.. |GitHub Actions Status: Docker| image:: https://github.com/scikit-hep/pyhf/actions/workflows/docker.yml/badge.svg?branch=master
-   :target: https://github.com/scikit-hep/pyhf/actions/workflows/docker.yml?query=branch%3Amaster
+.. |GitHub Actions Status: CI| image:: https://github.com/scikit-hep/pyhf/workflows/CI/CD/badge.svg?branch=main
+   :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3ACI%2FCD+branch%3Amain
+.. |GitHub Actions Status: Docs| image:: https://github.com/scikit-hep/pyhf/workflows/Docs/badge.svg?branch=main
+   :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3ADocs+branch%3Amain
+.. |GitHub Actions Status: Publish| image:: https://github.com/scikit-hep/pyhf/workflows/publish%20distributions/badge.svg?branch=main
+   :target: https://github.com/scikit-hep/pyhf/actions?query=workflow%3A%22publish+distributions%22+branch%3Amain
+.. |GitHub Actions Status: Docker| image:: https://github.com/scikit-hep/pyhf/actions/workflows/docker.yml/badge.svg?branch=main
+   :target: https://github.com/scikit-hep/pyhf/actions/workflows/docker.yml?query=branch%3Amain

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -103,7 +103,7 @@ Publishing
 Publishing to TestPyPI_ and PyPI_ is automated through the `PyPA's PyPI publish
 GitHub Action <https://github.com/pypa/gh-action-pypi-publish>`__
 and the ``pyhf`` `bump version GitHub Actions workflow
-<https://github.com/scikit-hep/pyhf/blob/master/.github/workflows/bump-version.yml>`__.
+<https://github.com/scikit-hep/pyhf/blob/main/.github/workflows/bump-version.yml>`__.
 
 Release Checklist
 ~~~~~~~~~~~~~~~~~
@@ -131,8 +131,8 @@ The maintainer needs to:
 The maintainer **should do a dry run first to make sure everything looks reasonable**.
 Once they have done that, they can run the `bump version GitHub Actions workflow`_ which
 will produce a new tag, bump the version of all files defined in `tbump.toml
-<https://github.com/scikit-hep/pyhf/blob/master/tbump.toml>`__, and then commit and
-push these changes and the tag back to the ``master`` branch.
+<https://github.com/scikit-hep/pyhf/blob/main/tbump.toml>`__, and then commit and
+push these changes and the tag back to the ``main`` branch.
 
 Deployment
 ~~~~~~~~~~

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -4,7 +4,7 @@ Examples
 Try out in Binder! |Binder|
 
 .. |Binder| image:: https://mybinder.org/badge_logo.svg
-    :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/master?filepath=docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
+    :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/main?filepath=docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
 
 Notebooks:
 

--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -63,7 +63,7 @@ def fit(
 
     .. code-block:: shell
 
-        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/examples/json/2-bin_1-channel.json | pyhf fit --value
+        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/main/docs/examples/json/2-bin_1-channel.json | pyhf fit --value
 
         \b
         {
@@ -179,7 +179,7 @@ def cls(
 
     .. code-block:: shell
 
-        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/examples/json/2-bin_1-channel.json | pyhf cls
+        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/main/docs/examples/json/2-bin_1-channel.json | pyhf cls
 
         \b
         {

--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -33,7 +33,7 @@ def inspect(workspace, output_file, measurement):
 
     .. code-block:: shell
 
-        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/examples/json/2-bin_1-channel.json | pyhf inspect
+        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/main/docs/examples/json/2-bin_1-channel.json | pyhf inspect
                   Summary
             ------------------
                channels  1
@@ -344,7 +344,7 @@ def digest(workspace, algorithm, output_json):
 
     .. code-block:: shell
 
-        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/examples/json/2-bin_1-channel.json | pyhf digest
+        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/main/docs/examples/json/2-bin_1-channel.json | pyhf digest
         sha256:dad8822af55205d60152cbe4303929042dbd9d4839012e055e7c6b6459d68d73
     """
     with click.open_file(workspace, "r", encoding="utf-8") as specstream:
@@ -383,12 +383,12 @@ def sort(workspace, output_file):
 
     .. code-block:: shell
 
-        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/examples/json/2-bin_1-channel.json | pyhf sort | jq '.' | md5
+        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/main/docs/examples/json/2-bin_1-channel.json | pyhf sort | jq '.' | md5
         8be5186ec249d2704e14dd29ef05ffb0
 
     .. code-block:: shell
 
-        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/master/docs/examples/json/2-bin_1-channel.json | jq -S '.channels|=sort_by(.name)|.channels[].samples|=sort_by(.name)|.channels[].samples[].modifiers|=sort_by(.name,.type)|.observations|=sort_by(.name)' | md5
+        $ curl -sL https://raw.githubusercontent.com/scikit-hep/pyhf/main/docs/examples/json/2-bin_1-channel.json | jq -S '.channels|=sort_by(.name)|.channels[].samples|=sort_by(.name)|.channels[].samples[].modifiers|=sort_by(.name,.type)|.observations|=sort_by(.name)' | md5
         8be5186ec249d2704e14dd29ef05ffb0
 
 


### PR DESCRIPTION
# Description

Join most of the rest of Scikit-HEP and use 'main' as the default branch. This has already been done in GitHub's settings, but this updates all reference to the default branch from 'master' to 'main. The remaining instances of 'master' in the repo are the following which are fine to keep:

```console
$ git grep "master"
docs/conf.py:# The master toctree document.
docs/conf.py:master_doc = 'index'
docs/conf.py:        master_doc,
docs/conf.py:man_pages = [(master_doc, 'pyhf', 'pyhf Documentation', [author], 1)]
docs/conf.py:        master_doc,
docs/conf.py:# c.f. https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder
docs/index.rst:.. pyhf documentation master file, created by
```

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update all references to the default repository branch from 'master' to 'main.
```