### PR TITLE
docs: Remove requests install from JupyterLite REPL setup

### DIFF
--- a/docs/generate_jupyterlite_iframe.py
+++ b/docs/generate_jupyterlite_iframe.py
@@ -4,7 +4,7 @@ import urllib.parse
 def main():
     code = """\
 import piplite
-await piplite.install(["pyhf==0.7.0rc4", "requests"])
+await piplite.install(["pyhf==0.7.0rc4"])
 %matplotlib inline
 import pyhf\
 """

--- a/docs/jupyterlite.rst
+++ b/docs/jupyterlite.rst
@@ -21,7 +21,7 @@ Try out now with JupyterLite_
 .. raw:: html
 
    <iframe
-      src="https://jupyterlite.github.io/demo/repl/index.html?kernel=python&toolbar=1&code=import%20piplite%0Aawait%20piplite.install%28%5B%22pyhf%3D%3D0.7.0rc4%22%2C%20%22requests%22%5D%29%0A%25matplotlib%20inline%0Aimport%20pyhf"
+      src="https://jupyterlite.github.io/demo/repl/index.html?kernel=python&toolbar=1&code=import%20piplite%0Aawait%20piplite.install%28%5B%22pyhf%3D%3D0.7.0rc4%22%5D%29%0A%25matplotlib%20inline%0Aimport%20pyhf"
       width="100%"
       height="500px"
    ></iframe>


### PR DESCRIPTION
# Description

Given the async nature of the Pyodide kernel https://github.com/scikit-hep/pyhf/issues/1775#issuecomment-1079128954 `requests` isn't something we can usefully use for `pyhf.contrib.utils.download` in Pyodide examples. Given this, to simplify things as much as possible remove the install of `requests` from the setup of the JupyterLite REPL for the docs.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* To simplify things, remove the piplite install of requests from the JupyterLite REPL setup.
   - Given the async nature of Pyodide, requests isn't currently useful for examples using
     pyhf.contrib.utils.download. c.f. Issue #1775 for context.
```