### PR TITLE
docs: Update use citations and general citations to latest distribution

### DIFF
--- a/docs/bib/general_citations.bib
+++ b/docs/bib/general_citations.bib
@@ -7,7 +7,8 @@
       reportNumber  = "ATL-PHYS-PUB-2022-017",
       month         = "Apr",
       year          = "2022",
-      url           = "https://cds.cern.ch/record/2805991"
+      url           = "https://cds.cern.ch/record/2805991",
+      doi           = "10.17181/CERN.R6S3.0QKV"
 }
 
 % 2022-03-22
@@ -70,9 +71,11 @@
     eprint = "2107.12980",
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
-    month = "7",
-    year = "2021",
-    journal = ""
+    doi = "10.1007/JHEP12(2021)182",
+    journal = "JHEP",
+    volume = "12",
+    pages = "182",
+    year = "2021"
 }
 
 % 2020-06-20

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -110,14 +110,17 @@
 % 2022-03-01
 @article{EXOT-2019-24,
     author        = "{ATLAS Collaboration}",
-    title         = "{Search for events with a pair of displaced vertices from long-lived neutral particles decaying into hadronic jets in the ATLAS muon spectrometer in pp collisions at $\sqrt{s}=13$ TeV}",
+    title         = "{Search for events with a pair of displaced vertices from long-lived neutral particles decaying into hadronic jets in the ATLAS muon spectrometer in pp collisions at $\sqrt s$=13\,\,TeV}",
     eprint        = "2203.00587",
     archivePrefix = "arXiv",
     primaryClass  = "hep-ex",
     reportNumber  = "CERN-EP-2021-195",
-    month         = "3",
-    year          = "2022",
-    journal       = ""
+    doi           = "10.1103/PhysRevD.106.032005",
+    journal       = "Phys. Rev. D",
+    volume        = "106",
+    number        = "3",
+    pages         = "032005",
+    year          = "2022"
 }
 
 % 2021-12-29

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -174,9 +174,12 @@
     eprint = "2109.04981",
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
-    month = "9",
-    year = "2021",
-    journal = ""
+    doi = "10.21468/SciPostPhys.12.1.037",
+    journal = "SciPost Phys.",
+    volume = "12",
+    number = "1",
+    pages = "037",
+    year = "2022"
 }
 
 % 2021-08-23


### PR DESCRIPTION
# Description

Update the use and general citations to reflect publications of preprints in journals.

- ATLAS publication ['Search for events with a pair of displaced vertices from long-lived neutral particles decaying into hadronic jets in the ATLAS muon spectrometer in pp collisions at \sqrt s =13  TeV'](https://inspirehep.net/literature/2040545) is published as Phys.Rev.D 106 (2022) 3, 032005. https://doi.org/10.1103/PhysRevD.106.032005
- ['Publishing statistical models'](https://inspirehep.net/literature/1919763) is published as SciPost Phys. 12 (2022) 1, 037. https://doi.org/10.21468/SciPostPhys.12.1.037
- ['Reinterpreting the ATLAS bounds on heavy neutral leptons in a realistic neutrino oscillation model'](https://inspirehep.net/literature/1893584) is published as JHEP 12 (2021) 182. https://doi.org/10.1007/JHEP12(2021)182

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update use citations and general citations references to include their journal
  publication information.
   - ATLAS publication https://inspirehep.net/literature/2040545 is published as
     Phys.Rev.D 106 (2022) 3, 032005. https://doi.org/10.1103/PhysRevD.106.032005
   - 'Publishing statistical models' https://inspirehep.net/literature/1919763 is
     published as SciPost Phys. 12 (2022) 1, 037. https://doi.org/10.21468/SciPostPhys.12.1.037
   - 'Reinterpreting the ATLAS bounds on heavy neutral leptons in a realistic neutrino oscillation model'
     https://inspirehep.net/literature/1893584 is published as JHEP 12 (2021) 182.
     https://doi.org/10.1007/JHEP12(2021)182
* Add DOI to SimpleAnalysis ATLAS PUB note. http://dx.doi.org/10.17181/CERN.R6S3.0QKV
```