### PR TITLE
feat: Make `par_names` a _ModelConfig property attribute

### DIFF
--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -181,7 +181,7 @@ class OptimizerMixin:
 
         # handle non-pyhf ModelConfigs
         try:
-            par_names = pdf.config.par_names()
+            par_names = pdf.config.par_names
         except AttributeError:
             par_names = None
 

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -358,6 +358,7 @@ class _ModelConfig(_ChannelSummaryMixin):
         """
         return self.par_map[name]['slice']
 
+    @property
     def par_names(self):
         """
         The names of the parameters in the model including binned-parameter indexing.
@@ -370,7 +371,7 @@ class _ModelConfig(_ChannelSummaryMixin):
             >>> model = pyhf.simplemodels.uncorrelated_background(
             ...     signal=[12.0, 11.0], bkg=[50.0, 52.0], bkg_uncertainty=[3.0, 7.0]
             ... )
-            >>> model.config.par_names()
+            >>> model.config.par_names
             ['mu', 'uncorr_bkguncrt[0]', 'uncorr_bkguncrt[1]']
         """
         _names = []

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -373,6 +373,8 @@ class _ModelConfig(_ChannelSummaryMixin):
             ... )
             >>> model.config.par_names
             ['mu', 'uncorr_bkguncrt[0]', 'uncorr_bkguncrt[1]']
+
+        .. versionchanged:: 0.7.0 Changed from method to property attribute.
         """
         _names = []
         for name in self.par_order:

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch, PropertyMock
 import pyhf
 from pyhf.optimize.mixins import OptimizerMixin
 from pyhf.optimize.common import _get_tensor_shim, _make_stitch_pars
@@ -576,7 +577,10 @@ def test_minuit_param_names(mocker):
     assert 'minuit' in result
     assert result.minuit.parameters == ('mu', 'uncorr_bkguncrt[0]')
 
-    pdf.config.par_names = mocker.Mock(return_value=None)
-    _, result = pyhf.infer.mle.fit(data, pdf, return_result_obj=True)
-    assert 'minuit' in result
-    assert result.minuit.parameters == ('x0', 'x1')
+    with patch(
+        "pyhf.pdf._ModelConfig.par_names", new_callable=PropertyMock
+    ) as mock_par_names:
+        mock_par_names.return_value = None
+        _, result = pyhf.infer.mle.fit(data, pdf, return_result_obj=True)
+        assert "minuit" in result
+        assert result.minuit.parameters == ("x0", "x1")

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -957,7 +957,7 @@ def test_par_names_scalar_nonscalar():
 
     model = pyhf.Model(spec, poi_name="scalar")
     assert model.config.par_order == ["scalar", "nonscalar"]
-    assert model.config.par_names() == [
+    assert model.config.par_names == [
         'scalar',
         'nonscalar[0]',
     ]
@@ -1159,7 +1159,7 @@ def test_pdf_clipping(backend):
     model = ws.model()
     data = tensorlib.astensor([100.0, 100.0, 10.0, 0.0, 0.0])
 
-    for par_name in model.config.par_names():
+    for par_name in model.config.par_names:
         if "np" in par_name:
             par_values.append(-0.6)  # np_1 / np_2
         else:

--- a/tests/test_simplemodels.py
+++ b/tests/test_simplemodels.py
@@ -18,7 +18,7 @@ def test_correlated_background(backend):
     assert model.config.channels == ["single_channel"]
     assert model.config.samples == ["background", "signal"]
     assert model.config.par_order == ["correlated_bkg_uncertainty", "mu"]
-    assert model.config.par_names() == ['correlated_bkg_uncertainty', "mu"]
+    assert model.config.par_names == ["correlated_bkg_uncertainty", "mu"]
     assert model.config.suggested_init() == [0.0, 1.0]
 
 
@@ -29,7 +29,7 @@ def test_uncorrelated_background(backend):
     assert model.config.channels == ["singlechannel"]
     assert model.config.samples == ["background", "signal"]
     assert model.config.par_order == ["mu", "uncorr_bkguncrt"]
-    assert model.config.par_names() == [
+    assert model.config.par_names == [
         'mu',
         'uncorr_bkguncrt[0]',
         'uncorr_bkguncrt[1]',
@@ -52,7 +52,7 @@ def test_correlated_background_default_backend(default_backend):
     assert model.config.channels == ["single_channel"]
     assert model.config.samples == ["background", "signal"]
     assert model.config.par_order == ["correlated_bkg_uncertainty", "mu"]
-    assert model.config.par_names() == ['correlated_bkg_uncertainty', "mu"]
+    assert model.config.par_names == ["correlated_bkg_uncertainty", "mu"]
     assert model.config.suggested_init() == [0.0, 1.0]
 
 
@@ -68,7 +68,7 @@ def test_uncorrelated_background_default_backend(default_backend):
     assert model.config.channels == ["singlechannel"]
     assert model.config.samples == ["background", "signal"]
     assert model.config.par_order == ["mu", "uncorr_bkguncrt"]
-    assert model.config.par_names() == [
+    assert model.config.par_names == [
         'mu',
         'uncorr_bkguncrt[0]',
         'uncorr_bkguncrt[1]',


### PR DESCRIPTION
# Description

Resolves #1700

Make `pyhf.pdf._ModelConfig.par_names()` a property attribute to match the `pyhf.pdf._ModelConfig.par_order` API.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Make pyhf.pdf._ModelConfig.par_names() property attribute pyhf.pdf._ModelConfig.par_names,
  like the the pyhf.pdf._ModelConfig.par_order API.
* Update all usage of `.par_names()` to `par_names`.
* Use unittest.mock.PropertyMock to properly mock par_names return.
```