### PR TITLE
fix: Skip ReadTheDocs verions during Sphinx link check

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,10 +13,6 @@ build:
   apt_packages:
     - curl
     - jq
-  # https://docs.readthedocs.io/en/latest/build-customization.html
-  jobs:
-    pre_build:
-      - python -m sphinx -b linkcheck docs/ _build/linkcheck
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -500,7 +500,9 @@ linkcheck_ignore = [
     r'https://doi\.org/10\.31526/.*',
     # https://doi.org/10.1051/epjconf/x DOI URLs will periodically generate 500 Server Error
     r'https://doi\.org/10\.1051/epjconf/.*',
-    # tags for a release won't exist until it is made, but the release notes need to reference them
+    # tags for a release won't exist until it is made, but the release notes
+    # and ReadTheDocs need to reference them
     r'https://github.com/scikit-hep/pyhf/releases/tag/.*',
+    r'https://pyhf.readthedocs.io/en/.*',
 ]
 linkcheck_retries = 50


### PR DESCRIPTION
# Description

Resolves #2029 

* Add 'https://pyhf.readthedocs.io/en/.*' to the linkcheck ignore as tags for a release won't exist until it is made, but ReadTheDocs needs to reference them.
* Remove linkcheck from ReadTheDocs config.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add 'https://pyhf.readthedocs.io/en/.*' to the linkcheck ignore as tags
 for a release won't exist until it is made, but ReadTheDocs needs to reference them.
* Remove linkcheck from ReadTheDocs config.
```