### PR TITLE
fix: Use `jax.errors` API as `jax._src` removed from public namespace

### DIFF
--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -62,7 +62,7 @@ def test_diffable_backend_failure():
     with pytest.raises(
         (
             ValueError,
-            jax._src.errors.TracerArrayConversionError,
+            jax.errors.TracerArrayConversionError,
             jax.errors.ConcretizationTypeError,
         )
     ):
@@ -73,7 +73,7 @@ def test_diffable_backend_failure():
         z = pyhf.tensorlib.sum(y)
         return z
 
-    with pytest.raises(jax._src.errors.TracerArrayConversionError):
+    with pytest.raises(jax.errors.TracerArrayConversionError):
         jax.jacrev(example_op2)(pyhf.tensorlib.astensor([2.0, 3.0]))
 
 


### PR DESCRIPTION
# Description

Resolves #2033

This only affects the tests as `jax.errors.TracerArrayConversionError` works in the JAX `v0.2.10` API, so nothing needs to be altered elsewhere.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use jax.errors API over jax._src.errors as jax._src is removed from the
  jax public namespace in jax v0.3.18.
   - c.f. https://github.com/google/jax/releases/tag/jax-v0.3.18
```