### PR TITLE
perf: Remove instances of `.keys()` that are not needed

### DIFF
--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -178,7 +178,7 @@ def inspect(workspace, output_file, measurement):
     '--modifier-type',
     default=[],
     multiple=True,
-    type=click.Choice(modifiers.histfactory_set.keys()),
+    type=click.Choice(modifiers.histfactory_set),
 )
 @click.option('--measurement', default=[], multiple=True, metavar='<MEASUREMENT>...')
 def prune(

--- a/src/pyhf/infer/intervals/upper_limits.py
+++ b/src/pyhf/infer/intervals/upper_limits.py
@@ -99,7 +99,7 @@ def toms748_scan(
 
     def best_bracket(limit):
         # return best bracket
-        ks = np.asarray(list(cache.keys()))
+        ks = np.asarray(list(cache))
         vals = np.asarray(
             [
                 value[0] - level if limit == 0 else value[1][limit - 1] - level
@@ -136,7 +136,7 @@ def toms748_scan(
         for idx in range(1, 6)
     ]
     if from_upper_limit_fn:
-        return obs, exp, (list(cache.keys()), list(cache.values()))
+        return obs, exp, (list(cache), list(cache.values()))
     return obs, exp
 
 

--- a/src/pyhf/modifiers/staterror.py
+++ b/src/pyhf/modifiers/staterror.py
@@ -78,7 +78,7 @@ class staterror_builder:
                         + f" has 'data' of length {_uncrt_len}."
                     )
 
-        for modname in self.builder_data.keys():
+        for modname in self.builder_data:
             parname = modname.split('/')[1]
 
             nomsall = default_backend.sum(

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -28,7 +28,7 @@ class OptimizerMixin:
 
         if kwargs:
             raise exceptions.Unsupported(
-                f"Unsupported kwargs were passed in: {list(kwargs.keys())}."
+                f"Unsupported kwargs were passed in: {list(kwargs)}."
             )
 
     def _internal_minimize(

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -109,7 +109,7 @@ class minuit_optimizer(OptimizerMixin):
         tolerance = options.pop('tolerance', self.tolerance)
         if options:
             raise exceptions.Unsupported(
-                f"Unsupported options were passed in: {list(options.keys())}."
+                f"Unsupported options were passed in: {list(options)}."
             )
 
         minimizer.strategy = strategy

--- a/src/pyhf/optimize/opt_scipy.py
+++ b/src/pyhf/optimize/opt_scipy.py
@@ -76,7 +76,7 @@ class scipy_optimizer(OptimizerMixin):
         solver_options = options.pop('solver_options', self.solver_options)
         if options:
             raise exceptions.Unsupported(
-                f"Unsupported options were passed in: {list(options.keys())}."
+                f"Unsupported options were passed in: {list(options)}."
             )
 
         fixed_vals = fixed_vals or []

--- a/src/pyhf/parameters/utils.py
+++ b/src/pyhf/parameters/utils.py
@@ -28,7 +28,7 @@ def reduce_paramsets_requirements(paramsets_requirements, paramsets_user_configs
     # - if the paramset is unique, build the paramset using the set() defined on its options
     #   - if the value is a tuple, this came from default options so convert to a list and use it
     #   - if the value is a list, this came from user-define options, so use it
-    for paramset_name in list(paramsets_requirements.keys()):
+    for paramset_name in list(paramsets_requirements):
         paramset_requirements = paramsets_requirements[paramset_name]
         paramset_user_configs = paramsets_user_configs.get(paramset_name, {})
 

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -123,7 +123,7 @@ def _nominal_and_modifiers_from_spec(modifier_set, config, spec, batch_size):
             for x in s['modifiers']:
                 if x['type'] not in modifier_set:
                     raise exceptions.InvalidModifier(
-                        f'{x["type"]} not among {list(modifier_set.keys())}'
+                        f'{x["type"]} not among {list(modifier_set)}'
                     )
                 key = f"{x['type']}/{x['name']}"
                 # check if the modifier to be built is allowed to be shared
@@ -229,7 +229,7 @@ class _ModelConfig(_ChannelSummaryMixin):
 
         if config_kwargs:
             raise exceptions.Unsupported(
-                f"Unsupported options were passed in: {list(config_kwargs.keys())}."
+                f"Unsupported options were passed in: {list(config_kwargs)}."
             )
 
         # prefixed with underscore are documented via @property
@@ -291,7 +291,7 @@ class _ModelConfig(_ChannelSummaryMixin):
         """
         self._create_and_register_paramsets(_required_paramsets)
         self.npars = len(self.suggested_init())
-        self.parameters = sorted(k for k in self.par_map.keys())
+        self.parameters = sorted(k for k in self.par_map)
 
     def set_auxinfo(self, auxdata, auxdata_order):
         """

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -249,7 +249,7 @@ class jax_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.",
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap)}.",
                 exc_info=True,
             )
             raise
@@ -261,7 +261,7 @@ class jax_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.",
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap)}.",
                 exc_info=True,
             )
             raise

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -258,7 +258,7 @@ class numpy_backend(Generic[T]):
             dtype_obj = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.",
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap)}.",
                 exc_info=True,
             )
             raise
@@ -270,7 +270,7 @@ class numpy_backend(Generic[T]):
             dtype_obj = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.",
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap)}.",
                 exc_info=True,
             )
             raise

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -256,7 +256,7 @@ class pytorch_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.",
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap)}.",
                 exc_info=True,
             )
             raise
@@ -268,7 +268,7 @@ class pytorch_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.",
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap)}.",
                 exc_info=True,
             )
             raise

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -248,7 +248,7 @@ class tensorflow_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.",
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap)}.",
                 exc_info=True,
             )
             raise
@@ -260,7 +260,7 @@ class tensorflow_backend:
             dtype = self.dtypemap[dtype]
         except KeyError:
             log.error(
-                f"Invalid dtype: dtype must be one of {list(self.dtypemap.keys())}.",
+                f"Invalid dtype: dtype must be one of {list(self.dtypemap)}.",
                 exc_info=True,
             )
             raise

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -539,25 +539,25 @@ class Workspace(_ChannelSummaryMixin, dict):
                     f"{modifier_type} is not one of the modifier types in this workspace."
                 )
 
-        for modifier_name in (*prune_modifiers, *rename_modifiers.keys()):
+        for modifier_name in (*prune_modifiers, *rename_modifiers):
             if modifier_name not in dict(self.modifiers):
                 raise exceptions.InvalidWorkspaceOperation(
                     f"{modifier_name} is not one of the modifiers in this workspace."
                 )
 
-        for sample_name in (*prune_samples, *rename_samples.keys()):
+        for sample_name in (*prune_samples, *rename_samples):
             if sample_name not in self.samples:
                 raise exceptions.InvalidWorkspaceOperation(
                     f"{sample_name} is not one of the samples in this workspace."
                 )
 
-        for channel_name in (*prune_channels, *rename_channels.keys()):
+        for channel_name in (*prune_channels, *rename_channels):
             if channel_name not in self.channels:
                 raise exceptions.InvalidWorkspaceOperation(
                     f"{channel_name} is not one of the channels in this workspace."
                 )
 
-        for measurement_name in (*prune_measurements, *rename_measurements.keys()):
+        for measurement_name in (*prune_measurements, *rename_measurements):
             if measurement_name not in self.measurement_names:
                 raise exceptions.InvalidWorkspaceOperation(
                     f"{measurement_name} is not one of the measurements in this workspace."

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -320,7 +320,7 @@ class Workspace(_ChannelSummaryMixin, dict):
 
         if config_kwargs:
             raise exceptions.Unsupported(
-                f"Unsupported options were passed in: {list(config_kwargs.keys())}."
+                f"Unsupported options were passed in: {list(config_kwargs)}."
             )
 
     def __eq__(self, other):

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -11,7 +11,7 @@ from jsonschema import ValidationError
 
 def assert_equal_dictionary(d1, d2):
     "recursively compare 2 dictionaries"
-    for k in d1.keys():
+    for k in d1:
         assert k in d2
         if isinstance(d1[k], dict):
             assert_equal_dictionary(d1[k], d2[k])

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -44,4 +44,4 @@ def test_channel_nbins_sorted_as_channels(spec):
     spec["channels"][-1]["name"] = "a_make_first_in_sort_channel2"
     mixin = pyhf.mixins._ChannelSummaryMixin(channels=spec["channels"])
     assert mixin.channels == ["a_make_first_in_sort_channel2", "channel1"]
-    assert list(mixin.channel_nbins.keys()) == mixin.channels
+    assert list(mixin.channel_nbins) == mixin.channels

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -387,7 +387,7 @@ def test_inspect_outfile(tmpdir, script_runner):
         'parameters',
         'samples',
         'systematics',
-    ] == sorted(summary.keys())
+    ] == sorted(summary)
     assert len(summary['channels']) == 1
     assert len(summary['measurements']) == 4
     assert len(summary['modifiers']) == 6


### PR DESCRIPTION
# Description

Based [on this Tweet by Tim Head](https://twitter.com/betatim/status/1575020386411896832?s=20&t=WvZIENWyUdA7E_9q4AiDvg)

> In Python, is `some_key in d.keys()` as fast as `some_key in d`? Why wouldn't it be?
>
> TIL that the former takes about twice as long as the latter. (On Python 3.10)

Remove calls to `some_dict.keys()` when `some_dict` would work instead.

The remaining instances

```console
$ git grep ".keys()"     
src/pyhf/schema/loader.py:        >>> schema.keys()
tests/test_export.py:    assert sorted(modifier.keys()) == ['High', 'Low', 'Name', 'Val']
```

are needed.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove calls of `.keys()` when just using the dict by itself would work as
  .keys() incurrs extra overhead that makes it about twice as slow as using
  the dict.
   - c.f. https://twitter.com/betatim/status/1575020386411896832
```