### PR TITLE
build: Add numpy as a dependency explicitly

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     pyyaml>=5.1  # for parsing CLI equal-delimited options
     importlib_resources>=1.4.0; python_version < "3.9"  # for resources in schema
     typing_extensions>=3.7.4.3; python_version == "3.7"  # for SupportsIndex
+    numpy  # compatible versions controlled through scipy
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
# Description

Add numpy explicitly as a dependency of pyhf. As the lower bound (and upper bound) of numpy is tightly controlled by scipy a lower bound is not given to avoid potential future confusion for pip's dependency resolver. Explicitly adding numpy as a dependency improves the metadata for packaging. e.g. `pip show` will now list numpy under the 'Requires' output.

Note that no more information is contained with this addition, but it provides additional context to metadata inspection.

**Before**

```console
$ python -m pip show pyhf             
Name: pyhf
Version: 0.7.1.dev5
Summary: pure-Python HistFactory implementation with tensors and autodiff
Home-page: https://github.com/scikit-hep/pyhf
Author: Lukas Heinrich, Matthew Feickert, Giordon Stark
Author-email: lukas.heinrich@cern.ch, matthew.feickert@cern.ch, gstark@cern.ch
License: Apache
Location: /home/feickert/.pyenv/versions/3.10.6/envs/pyhf-dev-CPU/lib/python3.10/site-packages
Requires: click, jsonpatch, jsonschema, pyyaml, scipy, tqdm
Required-by: 
```

**This PR**

```console
$ python -m pip show pyhf    
Name: pyhf
Version: 0.7.1.dev6
Summary: pure-Python HistFactory implementation with tensors and autodiff
Home-page: https://github.com/scikit-hep/pyhf
Author: Lukas Heinrich, Matthew Feickert, Giordon Stark
Author-email: lukas.heinrich@cern.ch, matthew.feickert@cern.ch, gstark@cern.ch
License: Apache
Location: /home/feickert/.pyenv/versions/3.10.6/envs/pyhf-dev-CPU/lib/python3.10/site-packages
Requires: click, jsonpatch, jsonschema, numpy, pyyaml, scipy, tqdm
Required-by: 
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add numpy explicitly as a dependency of pyhf. As the lower bound (and upper bound)
  of numpy is tightly controlled by scipy a lower bound is not given to avoid potential
  future confusion for pip's dependency resolver. Explicitly adding numpy as a dependency
  improves the metadata for packaging. e.g. `pip show` will now list numpy under the
  'Requires' output.
```