### PR TITLE
feat: Drop Python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
         include:
           - os: macos-latest
             python-version: '3.10'

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # minimum supported Python
-        python-version: ['3.7']
+        python-version: ['3.8']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
         include:
           - os: macos-latest
             python-version: '3.10'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,11 +66,11 @@ repos:
     hooks:
       - &mypy
         id: mypy
-        name: mypy with Python 3.7
+        name: mypy with Python 3.8
         files: src
         additional_dependencies:
           ['numpy', 'types-tqdm', 'click', 'types-jsonpatch', 'types-pyyaml', 'types-jsonschema', 'importlib_metadata', 'packaging']
-        args: ["--python-version=3.7"]
+        args: ["--python-version=3.8"]
       - <<: *mypy
         name: mypy with Python 3.10
         args: ["--python-version=3.10"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     rev: v2.38.2
     hooks:
     - id: pyupgrade
-      args: ["--py37-plus"]
+      args: ["--py38-plus"]
 
 -   repo: https://github.com/MarcoGorelli/absolufy-imports
     rev: v0.3.1

--- a/codemeta.json
+++ b/codemeta.json
@@ -58,7 +58,6 @@
         "Python 3",
         "Python 3 Only",
         "Python 3.10",
-        "Python 3.7",
         "Python 3.8",
         "Python 3.9",
         "Python Implementation CPython"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ local_scheme = "no-local-version"
 
 [tool.black]
 line-length = 88
-target-version = ['py37', 'py38']
+target-version = ['py38', 'py39', 'py310']
 skip-string-normalization = true
 include = '\.pyi?$'
 exclude = '''
@@ -96,7 +96,7 @@ filterwarnings = [
 pyupgrade = 1
 
 [tool.nbqa.addopts]
-pyupgrade = ["--py37-plus"]
+pyupgrade = ["--py38-plus"]
 
 [tool.mypy]
 files = "src"

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ package_dir =
 include_package_data = True
 python_requires = >=3.8
 install_requires =
-    scipy>=1.2.0 # requires numpy, which is required by pyhf and tensorflow
+    scipy>=1.3.2 # requires numpy, which is required by pyhf and tensorflow
     click>=8.0.0  # for console scripts
     tqdm>=4.56.0  # for readxml
     jsonschema>=4.15.0  # for utils

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ classifiers =
     Topic :: Scientific/Engineering :: Physics
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -33,7 +32,7 @@ packages = find_namespace:
 package_dir =
     = src
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     scipy>=1.2.0 # requires numpy, which is required by pyhf and tensorflow
     click>=8.0.0  # for console scripts

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     jsonpatch>=1.15
     pyyaml>=5.1  # for parsing CLI equal-delimited options
     importlib_resources>=1.4.0; python_version < "3.9"  # for resources in schema
-    typing_extensions>=3.7.4.3; python_version == "3.7"  # for SupportsIndex
     numpy  # compatible versions controlled through scipy
 
 [options.packages.find]

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -81,7 +81,7 @@ try:
                     archive.write(response.content)
             else:
                 # Support for file-like objects for tarfile.is_tarfile was added
-                # in Python 3.9, so as pyhf is currently Python 3.7+ then can't
+                # in Python 3.9, so as pyhf is currently Python 3.8+ then can't
                 # do tarfile.is_tarfile(BytesIO(response.content)).
                 # Instead, just use a 'try except' block to determine if the
                 # archive is a valid tarfile.

--- a/src/pyhf/typing.py
+++ b/src/pyhf/typing.py
@@ -1,7 +1,15 @@
 import os
-from typing import Any, MutableSequence, Sequence, Tuple, Union
-
-from typing import Literal, Protocol, SupportsIndex, TypedDict
+from typing import (
+    Any,
+    Literal,
+    MutableSequence,
+    Protocol,
+    Sequence,
+    SupportsIndex,
+    Tuple,
+    TypedDict,
+    Union,
+)
 
 __all__ = (
     "PathOrStr",

--- a/src/pyhf/typing.py
+++ b/src/pyhf/typing.py
@@ -1,11 +1,7 @@
 import os
-import sys
 from typing import Any, MutableSequence, Sequence, Tuple, Union
 
-if sys.version_info >= (3, 8):
-    from typing import Literal, Protocol, SupportsIndex, TypedDict
-else:
-    from typing_extensions import Literal, Protocol, SupportsIndex, TypedDict
+from typing import Literal, Protocol, SupportsIndex, TypedDict
 
 __all__ = (
     "PathOrStr",

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,5 +1,5 @@
 # core
-scipy==1.2.0  # c.f. PR #1274
+scipy==1.3.2  # c.f. PR #???
 click==8.0.0  # c.f. PR #1958, #1909
 tqdm==4.56.0
 jsonschema==4.15.0  # c.f. PR #1979

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -6,7 +6,6 @@ jsonschema==4.15.0  # c.f. PR #1979
 jsonpatch==1.15
 pyyaml==5.1
 importlib_resources==1.4.0  # c.f. PR #1979
-typing-extensions==3.7.4.3  # c.f. PR #1961, #1940
 # xmlio
 uproot==4.1.1
 # minuit

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,5 +1,5 @@
 # core
-scipy==1.3.2  # c.f. PR #???
+scipy==1.3.2  # c.f. PR #2044
 click==8.0.0  # c.f. PR #1958, #1909
 tqdm==4.56.0
 jsonschema==4.15.0  # c.f. PR #1979

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -515,8 +515,7 @@ def test_init_pars_sync_fixed_values_minuit(mocker):
     minuit = mocker.patch.object(getattr(opt_minuit, 'iminuit'), 'Minuit')
     minimizer = opt._get_minimizer(None, [9, 9, 9], [(0, 10)] * 3, fixed_vals=[(0, 1)])
     assert minuit.called
-    # python 3.7 does not have ::args attribute on ::call_args
-    # assert minuit.call_args.args[1] == [1, 9, 9]
+    assert minuit.call_args.args[1] == [1, 9, 9]
     assert minuit.call_args[0][1] == [1, 9, 9]
     assert minimizer.fixed == [True, False, False]
 


### PR DESCRIPTION
# Description

Following Discussion #2042, drop Python 3.7 support to follow NEP 29 development recommendations. As a result, drop the requirement of `typing_extensions` as that is needed for Python 3.7 only and update the lower bound on SciPy to v1.3.2 &mdash; the first release with Python 3.8 wheels.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Drop Python 3.7 support to follow NEP 29 development recommendations.
   - c.f. https://github.com/scikit-hep/pyhf/discussions/2042
* Drop typing_extensions as a requirement as that is needed by Python 3.7 only.
* Update lower bound of the supported scipy versions to v1.3.2, the first scipy release
  with Python 3.8 wheels.
* Update pre-commit hooks to use Python 3.8.
```