### PR TITLE
chore: Update codemeta.json for numpy, scipy, and typing-extensions

### DIFF
--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -45,6 +45,6 @@ jobs:
       # FIXME: c.f. https://github.com/proycon/codemetapy/issues/24
     - name: Verify requirements in codemeta.json
       run: |
-        python -m pip install jq "codemetapy>=2.2.2"
+        python -m pip install jq "codemetapy>=2.3.0"
         codemetapy --inputtype python --no-extras pyhf > codemeta_generated.json
         diff <(jq -S .softwareRequirements codemeta.json) <(jq -S .softwareRequirements codemeta_generated.json)

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,48 +1,41 @@
 {
     "@context": [
-        "https://raw.githubusercontent.com/codemeta/codemeta/2.0/codemeta.jsonld",
+        "https://doi.org/10.5063/schema/codemeta-2.0",
         "https://w3id.org/software-iodata",
-        "https://raw.githubusercontent.com/schemaorg/schemaorg/main/data/releases/13.0/schemaorgcontext.jsonld",
+        "https://raw.githubusercontent.com/jantman/repostatus.org/master/badges/latest/ontology.jsonld",
+        "https://schema.org",
         "https://w3id.org/software-types"
     ],
-    "@id": "https://github.com/scikit-hep/pyhf",
     "@type": "SoftwareSourceCode",
     "applicationCategory": [
         "Scientific/Engineering",
         "Scientific/Engineering > Physics"
     ],
     "audience": {
-        "@id": "/audience/science-research",
         "@type": "Audience",
         "audienceType": "Science/Research"
     },
     "author": [
         {
-            "@id": "/person/lukas-heinrich",
             "@type": "Person",
             "email": "lukas.heinrich@cern.ch",
             "familyName": "Heinrich",
-            "givenName": "Lukas",
             "identifier": "https://orcid.org/0000-0002-4048-7584",
-            "position": 1
+            "givenName": "Lukas"
         },
         {
-            "@id": "/person/matthew-feickert",
             "@type": "Person",
             "email": "matthew.feickert@cern.ch",
             "familyName": "Feickert",
-            "givenName": "Matthew",
             "identifier": "https://orcid.org/0000-0003-4124-7862",
-            "position": 2
+            "givenName": "Matthew"
         },
         {
-            "@id": "/person/giordon-stark",
             "@type": "Person",
             "email": "gstark@cern.ch",
             "familyName": "Stark",
-            "givenName": "Giordon",
             "identifier": "https://orcid.org/0000-0001-6616-3433",
-            "position": 3
+            "givenName": "Giordon"
         }
     ],
     "codeRepository": "https://github.com/scikit-hep/pyhf",
@@ -62,12 +55,9 @@
         "Python 3.9",
         "Python Implementation CPython"
     ],
-    "softwareHelp": {
-        "@id": "https://pyhf.readthedocs.io/"
-    },
+    "softwareHelp": "https://pyhf.readthedocs.io/",
     "softwareRequirements": [
         {
-            "@id": "/dependency/click-ge-8.0.0",
             "@type": "SoftwareApplication",
             "identifier": "click",
             "name": "click",
@@ -75,7 +65,6 @@
             "version": ">=8.0.0"
         },
         {
-            "@id": "/dependency/importlib-resources-ge-1.4.0",
             "@type": "SoftwareApplication",
             "identifier": "importlib-resources",
             "name": "importlib-resources",
@@ -83,7 +72,6 @@
             "version": ">=1.4.0"
         },
         {
-            "@id": "/dependency/jsonpatch-ge-1.15",
             "@type": "SoftwareApplication",
             "identifier": "jsonpatch",
             "name": "jsonpatch",
@@ -91,7 +79,6 @@
             "version": ">=1.15"
         },
         {
-            "@id": "/dependency/jsonschema-ge-4.15.0",
             "@type": "SoftwareApplication",
             "identifier": "jsonschema",
             "name": "jsonschema",
@@ -99,7 +86,12 @@
             "version": ">=4.15.0"
         },
         {
-            "@id": "/dependency/pyyaml-ge-5.1",
+            "@type": "SoftwareApplication",
+            "identifier": "numpy",
+            "name": "numpy",
+            "runtimePlatform": "Python 3"
+        },
+        {
             "@type": "SoftwareApplication",
             "identifier": "pyyaml",
             "name": "pyyaml",
@@ -107,32 +99,21 @@
             "version": ">=5.1"
         },
         {
-            "@id": "/dependency/scipy-ge-1.2.0",
             "@type": "SoftwareApplication",
             "identifier": "scipy",
             "name": "scipy",
             "runtimePlatform": "Python 3",
-            "version": ">=1.2.0"
+            "version": ">=1.3.2"
         },
         {
-            "@id": "/dependency/tqdm-ge-4.56.0",
             "@type": "SoftwareApplication",
             "identifier": "tqdm",
             "name": "tqdm",
             "runtimePlatform": "Python 3",
             "version": ">=4.56.0"
-        },
-        {
-            "@id": "/dependency/typing-extensions-ge-3.7.4.3",
-            "@type": "SoftwareApplication",
-            "identifier": "typing-extensions",
-            "name": "typing-extensions",
-            "runtimePlatform": "Python 3",
-            "version": ">=3.7.4.3"
         }
     ],
     "targetProduct": {
-        "@id": "/commandlineapplication/pyhf",
         "@type": "CommandLineApplication",
         "description": "The pyhf command line interface.",
         "executableName": "pyhf",

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ extras_require['develop'] = sorted(
             'ipython',
             'pre-commit',
             'check-manifest',
-            'codemetapy>=0.3.4',
+            'codemetapy>=2.3.0',
             'twine',
         ]
     )


### PR DESCRIPTION
# Description

* Add `numpy` metadata information to `codemeta.json`.
   - Amends PR #2041
* Update lower bound on `scipy` to `v1.3.2` and remove `typing-extensions`.
   - Amends PR #2044
* Update `codemetapy` lower bound to `v2.3.0` to ensure consistency of output

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add numpy metadata information to codemeta.json.
   - Amends PR #2041
* Update lower bound on scipy to v1.3.2 and remove typing-extensions.
   - Amends PR #2044
* Update codemetapy lower bound to v2.3.0 to ensure consistency of output.
```