### PR TITLE
test: Use coverage over pytest-cov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,0 @@
-[report]
-omit =
-    src/pyhf/typing.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        coverage run --module pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+        coverage run --module pytest --ignore tests/contrib --ignore tests/benchmarks --ignore tests/test_notebooks.py
 
     - name: Launch a tmate session if tests fail
       if: failure() && github.event_name == 'workflow_dispatch'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,9 @@ jobs:
       uses: mxschmitt/action-tmate@v3
 
     - name: Coverage report for core project
-      run: coverage report
+      run: |
+        coverage report
+        coverage xml
 
       # Report coverage for oldest and newest Python tested to deal with version differences
     - name: Report core project coverage with Codecov
@@ -73,7 +75,9 @@ jobs:
         coverage run --append --module pytest tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
 
     - name: Coverage report with contrib
-      run: coverage report
+      run: |
+        coverage report
+        coverage xml
 
     - name: Report contrib coverage with Codecov
       if: github.event_name != 'schedule' && matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+        coverage run --module pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
 
     - name: Launch a tmate session if tests fail
       if: failure() && github.event_name == 'workflow_dispatch'
@@ -67,7 +67,7 @@ jobs:
 
     - name: Test Contrib module with pytest
       run: |
-        pytest tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
+        coverage run --append --module pytest tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
 
     - name: Report contrib coverage with Codecov
       if: github.event_name != 'schedule' && matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
@@ -78,7 +78,7 @@ jobs:
 
     - name: Test docstring examples with doctest
       if: matrix.python-version == '3.10'
-      run: pytest src/ README.rst
+      run: coverage run --append --module pytest src/ README.rst
 
     - name: Report doctest coverage with Codecov
       if: github.event_name != 'schedule' && matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,9 @@ jobs:
 
     - name: Test docstring examples with doctest
       if: matrix.python-version == '3.10'
-      run: coverage run --append --module pytest src/ README.rst
+      run: coverage run --module pytest src/ README.rst
 
-    - name: Coverage report with doctest
+    - name: Coverage report for doctest only
       run: coverage report
 
     - name: Report doctest coverage with Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       if: failure() && github.event_name == 'workflow_dispatch'
       uses: mxschmitt/action-tmate@v3
 
+    - name: Coverage report with default tests
+      run: coverage report
+
       # Report coverage for oldest and newest Python tested to deal with version differences
     - name: Report core project coverage with Codecov
       if: >-
@@ -69,6 +72,9 @@ jobs:
       run: |
         coverage run --append --module pytest tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
 
+    - name: Coverage report with default tests and contrib
+      run: coverage report
+
     - name: Report contrib coverage with Codecov
       if: github.event_name != 'schedule' && matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v3
@@ -79,6 +85,9 @@ jobs:
     - name: Test docstring examples with doctest
       if: matrix.python-version == '3.10'
       run: coverage run --append --module pytest src/ README.rst
+
+    - name: Coverage report with default tests, contrib, and doctest
+      run: coverage report
 
     - name: Report doctest coverage with Codecov
       if: github.event_name != 'schedule' && matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       if: failure() && github.event_name == 'workflow_dispatch'
       uses: mxschmitt/action-tmate@v3
 
-    - name: Coverage report with default tests
+    - name: Coverage report for core project
       run: coverage report
 
       # Report coverage for oldest and newest Python tested to deal with version differences
@@ -72,7 +72,7 @@ jobs:
       run: |
         coverage run --append --module pytest tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
 
-    - name: Coverage report with default tests and contrib
+    - name: Coverage report with contrib
       run: coverage report
 
     - name: Report contrib coverage with Codecov
@@ -86,7 +86,7 @@ jobs:
       if: matrix.python-version == '3.10'
       run: coverage run --append --module pytest src/ README.rst
 
-    - name: Coverage report with default tests, contrib, and doctest
+    - name: Coverage report with doctest
       run: coverage report
 
     - name: Report doctest coverage with Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,16 +88,18 @@ jobs:
 
     - name: Test docstring examples with doctest
       if: matrix.python-version == '3.10'
-      run: coverage run --module pytest src/ README.rst
+      run: coverage run --data-file=.coverage-doctest --module pytest src/ README.rst
 
     - name: Coverage report for doctest only
-      run: coverage report
+      run: |
+        coverage report --data-file=.coverage-doctest
+        coverage xml --data-file=.coverage-doctest -o doctest-coverage.xml
 
     - name: Report doctest coverage with Codecov
       if: github.event_name != 'schedule' && matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v3
       with:
-        files: ./coverage.xml
+        files: doctest-coverage.xml
         flags: doctest
 
     - name: Run benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
       run: coverage run --data-file=.coverage-doctest --module pytest src/ README.rst
 
     - name: Coverage report for doctest only
+      if: matrix.python-version == '3.10'
       run: |
         coverage report --data-file=.coverage-doctest
         coverage xml --data-file=.coverage-doctest -o doctest-coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     - name: List installed Python packages
       run: python -m pip list
 
-    - name: Test with pytest
+    - name: Test with pytest and coverage
       run: |
         coverage run --module pytest --ignore tests/contrib --ignore tests/benchmarks --ignore tests/test_notebooks.py
 

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+        pytest --ignore tests/contrib --ignore tests/benchmarks --ignore tests/test_notebooks.py
 
   scipy:
 
@@ -65,7 +65,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+        pytest --ignore tests/contrib --ignore tests/benchmarks --ignore tests/test_notebooks.py
 
   iminuit:
 
@@ -91,7 +91,7 @@ jobs:
         python -m pip list
     - name: Test with pytest
       run: |
-        pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+        pytest --ignore tests/contrib --ignore tests/benchmarks --ignore tests/test_notebooks.py
 
   uproot4:
 
@@ -116,7 +116,7 @@ jobs:
         python -m pip list
     - name: Test with pytest
       run: |
-        pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+        pytest --ignore tests/contrib --ignore tests/benchmarks --ignore tests/test_notebooks.py
 
   matplotlib:
 
@@ -177,4 +177,4 @@ jobs:
         python -m pip list
     - name: Test with pytest
       run: |
-        pytest --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py
+        pytest --ignore tests/contrib --ignore tests/benchmarks --ignore tests/test_notebooks.py

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -93,7 +93,7 @@ jobs:
       run: |
         pytest --ignore tests/contrib --ignore tests/benchmarks --ignore tests/test_notebooks.py
 
-  uproot5:
+  uproot4:
 
     runs-on: ${{ matrix.os }}
     strategy:
@@ -112,7 +112,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade .[test]
         python -m pip uninstall --yes uproot
-        python -m pip install --upgrade git+https://github.com/scikit-hep/uproot5.git
+        python -m pip install --upgrade git+https://github.com/scikit-hep/uproot4.git
         python -m pip list
     - name: Test with pytest
       run: |

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -93,7 +93,7 @@ jobs:
       run: |
         pytest --ignore tests/contrib --ignore tests/benchmarks --ignore tests/test_notebooks.py
 
-  uproot4:
+  uproot5:
 
     runs-on: ${{ matrix.os }}
     strategy:
@@ -112,7 +112,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade .[test]
         python -m pip uninstall --yes uproot
-        python -m pip install --upgrade git+https://github.com/scikit-hep/uproot4.git
+        python -m pip install --upgrade git+https://github.com/scikit-hep/uproot5.git
         python -m pip list
     - name: Test with pytest
       run: |

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -39,4 +39,4 @@ jobs:
         # free. Though still show warnings by setting warning control to 'default'.
         export PYTHONWARNINGS='default'
         # Run on tests/ to skip doctests of src given examples are for latest APIs
-        pytest --override-ini filterwarnings= --ignore tests/benchmarks/ --ignore tests/contrib --ignore tests/test_notebooks.py tests/
+        pytest --override-ini filterwarnings= --ignore tests/contrib --ignore tests/benchmarks --ignore tests/test_notebooks.py tests/

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --pre pyhf[backends,xmlio]
-        python -m pip install pytest pytest-cov
+        python -m pip install pytest
         python -m pip list
 
     - name: Canary test public API

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -128,6 +128,36 @@ For example, to run ``doctest`` on the JAX backend run
 
     pytest src/pyhf/tensor/jax_backend.py
 
+Coverage
+~~~~~~~~
+
+To measure coverage for the codebase run the tests under ``coverage`` with
+
+.. code-block:: console
+
+    coverage run --module pytest
+
+or pass ``coverage`` as a positional argument to the ``nox`` ``tests`` session
+
+.. code-block:: console
+
+    nox --session tests --python 3.10 -- coverage
+
+Coverage Report
+^^^^^^^^^^^^^^^
+
+To generate a coverage report after running the tests under ``coverage`` run
+
+.. code-block:: console
+
+    coverage
+
+or to also generate XML and HTML versions of the report run the coverage ``nox`` session
+
+.. code-block:: console
+
+    nox --session coverage
+
 Documentation
 -------------
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -88,20 +88,6 @@ def coverage(session):
     session.install("--upgrade", "pip")
     session.install("--upgrade", "coverage[toml]")
 
-    # session.run(
-    #     "coverage",
-    #     "run",
-    #     "-m",
-    #     "pytest",
-    #     "--ignore",
-    #     "tests/benchmarks/",
-    #     "--ignore",
-    #     "tests/test_notebooks.py",
-    #     "--mpl",
-    #     "--mpl-baseline-path",
-    #     "tests/contrib/baseline",
-    # )
-
     session.run("coverage", "report")
     session.run("coverage", "xml")
     htmlcov_path = DIR / "htmlcov"

--- a/noxfile.py
+++ b/noxfile.py
@@ -43,7 +43,7 @@ def tests(session):
                 "coverage",
                 "run",
                 "--append",
-                "-m",
+                "--module",
                 "pytest",
                 "tests/contrib",
                 "--mpl",
@@ -62,13 +62,13 @@ def tests(session):
         return
 
     if session.posargs:
-        session.run("coverage", "run", "-m", "pytest", *session.posargs)
+        session.run("coverage", "run", "--module", "pytest", *session.posargs)
     else:
         # defaults
         session.run(
             "coverage",
             "run",
-            "-m",
+            "--module",
             "pytest",
             "--ignore",
             "tests/benchmarks/",

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,17 +33,18 @@ def tests(session):
         $ nox --session tests --python 3.10
         $ nox --session tests --python 3.10 -- contrib  # run the contrib module tests
         $ nox --session tests --python 3.10 -- tests/test_tensor.py  # run specific tests
-        $ nox --session tests --python 3.10 -- nocov  # run without coverage but faster
+        $ nox --session tests --python 3.10 -- coverage  # run with coverage but slower
     """
     session.install("--upgrade", "--editable", ".[test]")
-    session.install("--upgrade", "pytest", "coverage[toml]")
+    session.install("--upgrade", "pytest")
 
     # Allow tests to be run without coverage
-    if "nocov" in session.posargs:
-        runner_commands = ["pytest"]
-        session.posargs.pop(session.posargs.index("nocov"))
-    else:
+    if "coverage" in session.posargs:
         runner_commands = ["coverage", "run", "--append", "--module", "pytest"]
+        session.posargs.pop(session.posargs.index("coverage"))
+        session.install("--upgrade", "coverage[toml]")
+    else:
+        runner_commands = ["pytest"]
 
     def _contrib(session):
         if sys.platform.startswith("linux"):

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,11 +35,14 @@ def tests(session):
         $ nox --session tests --python 3.10 -- tests/test_tensor.py
     """
     session.install("--upgrade", "--editable", ".[test]")
-    session.install("--upgrade", "pytest")
+    session.install("--upgrade", "pytest", "coverage")
 
     def _contrib(session):
         if sys.platform.startswith("linux"):
             session.run(
+                "coverage",
+                "run",
+                "-m",
                 "pytest",
                 "tests/contrib",
                 "--mpl",
@@ -58,10 +61,13 @@ def tests(session):
         return
 
     if session.posargs:
-        session.run("pytest", *session.posargs)
+        session.run("coverage", "run", "-m", "pytest", *session.posargs)
     else:
         # defaults
         session.run(
+            "coverage",
+            "run",
+            "-m",
             "pytest",
             "--ignore",
             "tests/benchmarks/",
@@ -76,28 +82,28 @@ def tests(session):
 @nox.session(reuse_venv=True)
 def coverage(session):
     """
-    Generate coverage and report
+    Generate coverage report
     """
-    session.install("--upgrade", "pip", "wheel")
-    session.install("--upgrade", ".[test]")
-    session.install("--upgrade", "pytest", "coverage")
+    session.install("--upgrade", "pip")
+    session.install("--upgrade", "coverage")
 
-    session.run(
-        "coverage",
-        "run",
-        "-m",
-        "pytest",
-        "--ignore",
-        "tests/benchmarks/",
-        "--ignore",
-        "tests/test_notebooks.py",
-        "--mpl",
-        "--mpl-baseline-path",
-        "tests/contrib/baseline",
-    )
+    # session.run(
+    #     "coverage",
+    #     "run",
+    #     "-m",
+    #     "pytest",
+    #     "--ignore",
+    #     "tests/benchmarks/",
+    #     "--ignore",
+    #     "tests/test_notebooks.py",
+    #     "--mpl",
+    #     "--mpl-baseline-path",
+    #     "tests/contrib/baseline",
+    # )
 
     session.run("coverage", "report")
     session.run("coverage", "xml")
+    session.run("coverage", "html")
 
 
 @nox.session(reuse_venv=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -69,9 +69,11 @@ def tests(session):
         session.run(*runner_commands, *session.posargs)
     else:
         # defaults
-        runner_commands.pop(runner_commands.index("--append"))
+        default_runner_commands = runner_commands.copy()
+        if "--append" in default_runner_commands:
+            default_runner_commands.pop(default_runner_commands.index("--append"))
         session.run(
-            *runner_commands,
+            *default_runner_commands,
             "--ignore",
             "tests/contrib",
             "--ignore",

--- a/noxfile.py
+++ b/noxfile.py
@@ -104,6 +104,10 @@ def coverage(session):
 
     session.run("coverage", "report")
     session.run("coverage", "xml")
+    htmlcov_path = DIR / "htmlcov"
+    if htmlcov_path.exists():
+        session.log(f"rm -r {htmlcov_path}")
+        shutil.rmtree(htmlcov_path)
     session.run("coverage", "html")
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -74,6 +74,33 @@ def tests(session):
 
 
 @nox.session(reuse_venv=True)
+def coverage(session):
+    """
+    Generate coverage and report
+    """
+    session.install("--upgrade", "pip", "wheel")
+    session.install("--upgrade", ".[test]")
+    session.install("--upgrade", "pytest", "coverage")
+
+    session.run(
+        "coverage",
+        "run",
+        "-m",
+        "pytest",
+        "--ignore",
+        "tests/benchmarks/",
+        "--ignore",
+        "tests/test_notebooks.py",
+        "--mpl",
+        "--mpl-baseline-path",
+        "tests/contrib/baseline",
+    )
+
+    session.run("coverage", "report")
+    session.run("coverage", "xml")
+
+
+@nox.session(reuse_venv=True)
 def regenerate(session):
     """
     Regenerate Matplotlib images.

--- a/noxfile.py
+++ b/noxfile.py
@@ -42,6 +42,7 @@ def tests(session):
             session.run(
                 "coverage",
                 "run",
+                "--append",
                 "-m",
                 "pytest",
                 "tests/contrib",

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,9 +31,9 @@ def tests(session):
     Examples:
 
         $ nox --session tests --python 3.10
-        $ nox --session tests --python 3.10 -- contrib
-        $ nox --session tests --python 3.10 -- tests/test_tensor.py
-        $ nox --session tests --python 3.10 -- nocov
+        $ nox --session tests --python 3.10 -- contrib  # run the contrib module tests
+        $ nox --session tests --python 3.10 -- tests/test_tensor.py  # run specific tests
+        $ nox --session tests --python 3.10 -- nocov  # run without coverage but faster
     """
     session.install("--upgrade", "--editable", ".[test]")
     session.install("--upgrade", "pytest", "coverage[toml]")
@@ -74,9 +74,9 @@ def tests(session):
         session.run(
             *runner_commands,
             "--ignore",
-            "tests/benchmarks/",
-            "--ignore",
             "tests/contrib",
+            "--ignore",
+            "tests/benchmarks",
             "--ignore",
             "tests/test_notebooks.py",
         )

--- a/noxfile.py
+++ b/noxfile.py
@@ -43,12 +43,10 @@ def tests(session):
         runner_commands = ["pytest"]
         session.posargs.pop(session.posargs.index("nocov"))
     else:
-        runner_commands = ["coverage", "run", "--module", "pytest"]
+        runner_commands = ["coverage", "run", "--append", "--module", "pytest"]
 
     def _contrib(session):
         if sys.platform.startswith("linux"):
-            if "coverage" in runner_commands:
-                runner_commands.insert(runner_commands.index("run") + 1, "--append")
             session.run(
                 *runner_commands,
                 "tests/contrib",
@@ -71,6 +69,7 @@ def tests(session):
         session.run(*runner_commands, *session.posargs)
     else:
         # defaults
+        runner_commands.pop(runner_commands.index("--append"))
         session.run(
             *runner_commands,
             "--ignore",

--- a/noxfile.py
+++ b/noxfile.py
@@ -38,7 +38,7 @@ def tests(session):
     session.install("--upgrade", "--editable", ".[test]")
     session.install("--upgrade", "pytest")
 
-    # Allow tests to be run without coverage
+    # Allow tests to be run with coverage
     if "coverage" in session.posargs:
         runner_commands = ["coverage", "run", "--append", "--module", "pytest"]
         session.posargs.pop(session.posargs.index("coverage"))

--- a/noxfile.py
+++ b/noxfile.py
@@ -86,7 +86,7 @@ def coverage(session):
     Generate coverage report
     """
     session.install("--upgrade", "pip")
-    session.install("--upgrade", "coverage")
+    session.install("--upgrade", "coverage[toml]")
 
     # session.run(
     #     "coverage",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ branch = true
 
 [tool.coverage.report]
 show_missing = true
+precision = 1
 
 [tool.nbqa.mutate]
 pyupgrade = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,14 +44,9 @@ minversion = "6.0"
 xfail_strict = true
 addopts = [
     "-ra",
-    "--cov=pyhf",
-    "--cov-branch",
     "--showlocals",
     "--strict-markers",
     "--strict-config",
-    "--cov-report=term-missing",
-    "--cov-report=xml",
-    "--cov-report=html",
     "--doctest-modules",
     "--doctest-glob='*.rst'",
 ]
@@ -95,6 +90,7 @@ filterwarnings = [
 
 [tool.coverage.run]
 addopts = [
+    "--source=pyhf",
     "--append",
     "--branch",
     "--showlocals",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,11 +93,10 @@ source = ["src", "*/site-packages"]
 
 [tool.coverage.run]
 source = ["pyhf"]
-append = true
 branch = true
 
 [tool.coverage.report]
-show-missing = true
+show_missing = true
 
 [tool.nbqa.mutate]
 pyupgrade = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,17 +88,16 @@ filterwarnings = [
     'ignore:Call to deprecated create function:DeprecationWarning',  # protobuf via tensorflow
 ]
 
+[tool.coverage.paths]
+source = ["src", "*/site-packages"]
+
 [tool.coverage.run]
-addopts = [
-    "--source=pyhf",
-    "--append",
-    "--branch",
-    "--showlocals",
-]
+source = ["pyhf"]
+append = true
+branch = true
+
 [tool.coverage.report]
-addopts = [
-    "--show-missing",
-]
+show-missing = true
 
 [tool.nbqa.mutate]
 pyupgrade = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,17 @@ filterwarnings = [
     'ignore:Call to deprecated create function:DeprecationWarning',  # protobuf via tensorflow
 ]
 
+[tool.coverage.run]
+addopts = [
+    "--append",
+    "--branch",
+    "--showlocals",
+]
+[tool.coverage.report]
+addopts = [
+    "--show-missing",
+]
+
 [tool.nbqa.mutate]
 pyupgrade = 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ source = ["src", "*/site-packages"]
 [tool.coverage.run]
 source = ["pyhf"]
 branch = true
+omit = ["*/pyhf/typing.py"]
 
 [tool.coverage.report]
 precision = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,9 +88,6 @@ filterwarnings = [
     'ignore:Call to deprecated create function:DeprecationWarning',  # protobuf via tensorflow
 ]
 
-[tool.coverage.paths]
-source = ["src", "*/site-packages"]
-
 [tool.coverage.run]
 source = ["pyhf"]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,8 +96,9 @@ source = ["pyhf"]
 branch = true
 
 [tool.coverage.report]
-show_missing = true
 precision = 1
+sort = "cover"
+show_missing = true
 
 [tool.nbqa.mutate]
 pyupgrade = 1

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ extras_require['test'] = sorted(
         + [
             'scikit-hep-testdata>=0.4.11',
             'pytest>=6.0',
-            'coverage>=6.0.0',
+            'coverage[toml]>=6.0.0',
             'pytest-mock',
             'requests-mock>=1.9.0',
             'pytest-benchmark[histogram]',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ extras_require['test'] = sorted(
         + [
             'scikit-hep-testdata>=0.4.11',
             'pytest>=6.0',
-            'pytest-cov>=2.5.1',
+            'coverage>=6.0.0',
             'pytest-mock',
             'requests-mock>=1.9.0',
             'pytest-benchmark[histogram]',


### PR DESCRIPTION
# Description

Following Anthony Sottile's video [I don't use pytest-cov (intermediate) anthony explains 489](https://youtu.be/sPgvHGkmd0U), this PR drops `pytest-cov` in favor of just managing coverage ourselves with `coverage[toml]`. This implements running the tests with coverage as and **optional** part of the `tests` `nox` session (enabled with adding `coverage` as a positional argument) and adds generating the coverage report as a separate step with `nox -s coverage`:

* Simplifies the reporting of pytest runs to show the information that is most relevant.
* Speeds up running the pytest tests as coverage takes additional time to properly check all branches. For the full test suite the result is a speed up of about a minute.

`pytest` with `coverage`: `03:54`
```console
$ nox -s tests-3.10 -- coverage
...
================================================================== 1435 passed, 43 skipped, 12 xfailed in 234.80s (0:03:54) ==================================================================

```

vs.

`pytest` without `coverage`: `03:04`
```console
$ nox -s tests-3.10
...
================================================================== 1435 passed, 43 skipped, 12 xfailed in 184.05s (0:03:04) ==================================================================

```

* Removes `.coveragerc` in favor of placing the information in `pyproject.toml` with the `coverage run --omit` option via

```
omit = ["*/pyhf/typing.py"]
```

* Sort the coverage report in ascending order of coverage, making it easier to visually group the files that need improved coverage.

* Add coverage report viewing steps to the CI.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove 'pytest-cov' in favor of 'coverage[toml]' in 'test' extra.
* Remove .coveragerc in favor of setting coverage options in pyproject.toml.
* Make running without coverage the default for the tests nox session. Running under coverage
  can be enabled with an optional 'coverage' positional argument.
* Add coverage session to nox that displays a coverage report sorted by ascending coverage
  and generates XML and HTML versions of the report.
* Update CI workflows to run with coverage only if needed. 
   - Apply stylistic changes to the order of arguments to pytest to match across the codebase.
* Add steps to CI to generate the stdout coverage report and XML report after each segment
  of the tests.
* Add section to development docs on coverage.
```