### PR TITLE
chore: Update uproot URL to uproot5

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -93,7 +93,7 @@ jobs:
       run: |
         pytest --ignore tests/contrib --ignore tests/benchmarks --ignore tests/test_notebooks.py
 
-  uproot4:
+  uproot5:
 
     runs-on: ${{ matrix.os }}
     strategy:
@@ -112,7 +112,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade .[test]
         python -m pip uninstall --yes uproot
-        python -m pip install --upgrade git+https://github.com/scikit-hep/uproot4.git
+        python -m pip install --upgrade git+https://github.com/scikit-hep/uproot5.git
         python -m pip list
     - name: Test with pytest
       run: |


### PR DESCRIPTION
# Description

* Update HEAD of dependencies workflow to use uproot5 URL. This is a purely cosmetic change as the uproot4 URL will resolve to the uproot5 URL.
   - c.f. https://github.com/scikit-hep/uproot5

Migrated from PR #2054.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update HEAD of dependencies workflow to use uproot5 URL. This is a purely cosmetic change
  as the uproot4 URL will resolve to the uproot5 URL.
   - c.f. https://github.com/scikit-hep/uproot5
```