### PR TITLE
ci: Enable multiplatform builds for amd64 and arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -120,6 +120,7 @@ jobs:
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
           push: true
+          platforms: linux/amd64,linux/arm64
 
       - name: Build and publish to registry with release tag
         if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf'
@@ -134,3 +135,4 @@ jobs:
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
           push: true
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
# Description

Add the `platforms` argument to the `docker/build-push-action` GitHub Action and pass the platform names to enable build for both amd64 and arm64 architectures. This will enable Apple M1 and M2 machines to run the `pyhf/pyhf` Docker images without emulation which will significantly improve runtime performance.

While this hasn't been run through the CI, this has been tested locally with

```console
$ docker buildx build --file docker/Dockerfile --platform linux/arm64 --tag pyhf/pyhf:debug-arm64 --load .
$ docker image inspect pyhf/pyhf:debug-arm64 | jq '.[] | with_entries(select(.key == "Architecture"))'
{
  "Architecture": "arm64"
}
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add the 'platforms' argument to the docker/build-push-action GitHub
  Action and pass the platform names to enable build for both amd64 and
  arm64 architectures. This will enable Apple M1 and M2 machines to run
  the pyhf/pyhf Docker images without emulation which will significantly
  improve runtime performance.
```