### PR TITLE
docs: Add use citations from ICHEP 2022 proceedings

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,4 +1,16 @@
 % 2022-11-26
+@article{Feickert:2022lzh,
+    author = "Feickert, Matthew and Heinrich, Lukas and Stark, Giordon",
+    title = "{pyhf: a pure-Python statistical fitting library with tensors and automatic differentiation}",
+    doi = "10.22323/1.414.0245",
+    journal = "PoS",
+    volume = "ICHEP2022",
+    pages = "245",
+    month = "11",
+    year = "2022"
+}
+
+% 2022-11-26
 @article{Held:2022sfw,
     author = "Held, Alexander and Shadura, Oksana",
     title = "{The IRIS-HEP Analysis Grand Challenge}",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,15 @@
+% 2022-11-26
+@article{Held:2022sfw,
+    author = "Held, Alexander and Shadura, Oksana",
+    title = "{The IRIS-HEP Analysis Grand Challenge}",
+    doi = "10.22323/1.414.0235",
+    journal = "PoS",
+    volume = "ICHEP2022",
+    pages = "235",
+    month = "11",
+    year = "2022"
+}
+
 % 2022-10-06
 @phdthesis{Biswas:2022vtp,
     author = "Biswas, Diptaparna",


### PR DESCRIPTION
# Description

Add use citation from [The IRIS-HEP Analysis Grand Challenge](https://inspirehep.net/literature/2598292) (by @alexander-held and @oshadura) and [pyhf: a pure-Python statistical fitting library with tensors and automatic differentiation](https://inspirehep.net/literature/2598491) (by the pyhf dev team) which both appear in the ICHEP 2022 proceedings.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'The IRIS-HEP Analysis Grand Challenge' and
 'pyhf: a pure-Python statistical fitting library with tensors and
  automatic differentiation' which both appear in the ICHEP 2022
  proceedings.
   - https://inspirehep.net/literature/2598292
   - https://inspirehep.net/literature/2598491
```