### PR TITLE
fix: Disallow ipython v8.7.0 to avoid Pygments lexer warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ extras_require['docs'] = sorted(
             'sphinx-issues',
             'sphinx-copybutton>=0.3.2',
             'sphinx-togglebutton>=0.3.0',
+            'ipython!=8.7.0',  # c.f. https://github.com/scikit-hep/pyhf/pull/2068
         ]
     )
 )


### PR DESCRIPTION
# Description

Resolves #2067 

Disallow `ipython` `v8.7.0` to avoid Pygments warning

```pytb
WARNING: Pygments lexer name 'ipython3' is not known
```

which arises during the docs build. This is a stopgap measure and this line should be removed as soon as there is a resolution and new `ipython` release.

c.f. https://github.com/ipython/ipython/issues/13845

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Disallow ipython v8.7.0 to avoid Pygments warning

> WARNING: Pygments lexer name 'ipython3' is not known

which arises during the docs build. This is a stopgap measure and this
line should be removed as soon as there is a resolution and new ipython
release.
   - c.f. https://github.com/ipython/ipython/issues/13845
```