### PR TITLE
chore: List release candidates, alpha, and beta releases

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: List release candidates and alphas
       run: |
-        python -m pip list | grep '[0-9]rc[0-9]\|[0-9]a[0-9]'
+        python -m pip list | grep '[0-9]rc[0-9]\|[0-9]a[0-9]\|[0-9]b[0-9]'
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -33,9 +33,9 @@ jobs:
         python -m pip --no-cache-dir --quiet install --upgrade --pre .[test]
         python -m pip list
 
-    - name: List release candidates and alphas
+    - name: List release candidates, alpha, and beta releases
       run: |
-        python -m pip list | grep '[0-9]rc[0-9]\|[0-9]a[0-9]\|[0-9]b[0-9]'
+        python -m pip list | egrep '[0-9](rc|[ab])[0-9]'
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -33,6 +33,10 @@ jobs:
         python -m pip --no-cache-dir --quiet install --upgrade --pre .[test]
         python -m pip list
 
+    - name: List release candidates and alphas
+      run: |
+        python -m pip list | grep '[0-9]rc[0-9]\|[0-9]a[0-9]'
+
     - name: Test with pytest
       run: |
         pytest --ignore tests/contrib --ignore tests/benchmarks --ignore tests/test_notebooks.py


### PR DESCRIPTION
# Description

List the release candidates, alpha releases, and beta releases that are installed as part of testing against dependencies with the '--pre' pip flag to help make it easier to visually identify them in the CI logs

This comes up when the release candidate workflows fail and we want to try to identify what might be coming down the line easier.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* List the release candidates, alpha releases, and beta releases that are
  installed as part of testing against dependencies with the '--pre' pip flag
  to help make it easier to visually identify them in the CI logs.
```