### PR TITLE
fix: Add filterwarnings ignore for np.bool8 DeprecationWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ filterwarnings = [
     'ignore:divide by zero encountered in (true_)?divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]
     'ignore:[A-Z]+ is deprecated and will be removed in Pillow 10:DeprecationWarning',  # keras
     'ignore:Call to deprecated create function:DeprecationWarning',  # protobuf via tensorflow
+    'ignore:`np.bool8` is a deprecated alias for `np.bool_`:DeprecationWarning',  # numpy via tensorflow
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
# Description

Add a ignore to filterwarnings to avoid a numpy DeprecationWarning

> DeprecationWarning: `np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24)

from TensorFlow's use of numpy. This DeprecationWarning first appeared in numpy v1.24.0rc1, and so this ignore is being added in advance of v1.24.0 as a preventative measure for HEAD of dependencies testing.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add a ignore to filterwarnings to avoid a numpy DeprecationWarning

> DeprecationWarning: `np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24)

from TensorFlow's use of numpy. This DeprecationWarning first appeared in
numpy v1.24.0rc1, and so this ignore is being added in advance of
v1.24.0 as a preventative measure for HEAD of dependencies testing.
```