### PR TITLE
build: Update lower bounds of scipy to v1.5.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ package_dir =
 include_package_data = True
 python_requires = >=3.8
 install_requires =
-    scipy>=1.5.0 # requires numpy, which is required by pyhf and tensorflow
+    scipy>=1.5.1 # requires numpy, which is required by pyhf and tensorflow
     click>=8.0.0  # for console scripts
     tqdm>=4.56.0  # for readxml
     jsonschema>=4.15.0  # for utils

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,5 +1,5 @@
 # core
-scipy==1.5.0  # c.f. PR #2079
+scipy==1.5.1  # c.f. PR #2080
 click==8.0.0  # c.f. PR #1958, #1909
 tqdm==4.56.0
 jsonschema==4.15.0  # c.f. PR #1979

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,5 +1,5 @@
 # core
-scipy==1.5.1  # c.f. PR #2080
+scipy==1.5.1  # c.f. PR #2081
 click==8.0.0  # c.f. PR #1958, #1909
 tqdm==4.56.0
 jsonschema==4.15.0  # c.f. PR #1979


### PR DESCRIPTION
# Description

Following PR #2079 there were _some_ (but not all!) runs of the minimum supported dependencies workflow that failed with `scipy` `v1.5.0`. However, all runs passed with `v1.5.1` so as this is just a patch release bump (from a release in 2020) this should be an uncontroversial fix.

Amends PR #2079.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update lower bounds of scipy to v1.5.1 to ensure that the minimum supported dependencies
  workflow passes, as it failed nondeterministically for v1.5.0.
* Amends PR #2079.
```