### PR TITLE
docs: Add use citation from Belle II invisible Z' search

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -7,7 +7,8 @@
     primaryClass = "hep-ex",
     reportNumber = "Belle II Preprint 2022-008, KEK Preprint 2022-40",
     month = "12",
-    year = "2022"
+    year = "2022",
+    journal = ""
 }
 
 % 2022-11-26

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,15 @@
+% 2022-12-06
+@article{Belle-II:2022yaw,
+    author = "Belle II Collaboration",
+    title = "{Search for an invisible $Z^\prime$ in a final state with two muons and missing energy at Belle II}",
+    eprint = "2212.03066",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    reportNumber = "Belle II Preprint 2022-008, KEK Preprint 2022-40",
+    month = "12",
+    year = "2022"
+}
+
 % 2022-11-26
 @article{Feickert:2022lzh,
     author = "Feickert, Matthew and Heinrich, Lukas and Stark, Giordon",


### PR DESCRIPTION
# Description

Add use citation from [Search for an invisible Z' in a final state with two muons and missing energy at Belle II](https://inspirehep.net/literature/2611344). :rocket: 
  
# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Search for an invisible Z' in a final state with
  two muons and missing energy at Belle II'.
   - c.f. https://inspirehep.net/literature/2611344
```