### PR TITLE
test: Loosen tolerance for test_validation[1bin_normsys_mu1]

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -706,7 +706,7 @@ def validate_hypotest(
             {'init_pars': 2, 'par_bounds': 2},
             1.0,
             "q",
-            2e-9,
+            3e-6,
             "asymptotics",
         ),
         (


### PR DESCRIPTION
# Description

Loosen the relative tolerance from ~1e-9 to ~1e-6 to have comparisons with NumPy v1.24.0+ work. A relative tolerance of ~1e-6 is still fine and so this shouldn't be considered a regression.
 
# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Loosen the relative tolerance from ~1e-9 to ~1e-6 to have comparisons with
  NumPy v1.24.0+ work. A relative tolerance of ~1e-6 is still fine and so this
  shouldn't be considered a regression.
```