### PR TITLE
test: Add lower bound on supported numpy versions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -208,26 +208,3 @@ def build(session):
 
     session.install("build")
     session.run("python", "-m", "build")
-
-
-@nox.session(python="3.8", reuse_venv=True)
-def minimum(session: nox.Session):
-    """
-    Run tests with minimum supported dependencies.
-    """
-    session.install("--upgrade", "pip", "setuptools", "wheel")
-    session.install("--constraint", "tests/constraints.txt", ".[test]")
-    session.run(
-        "PYTHONWARNINGS='default'",
-        "pytest",
-        "--override-ini",
-        "filterwarnings=",
-        "--ignore",
-        "tests/contrib",
-        "--ignore",
-        "tests/benchmarks",
-        "--ignore",
-        "tests/test_notebooks.py",
-        "tests/",
-        *session.posargs,
-    )

--- a/noxfile.py
+++ b/noxfile.py
@@ -208,3 +208,26 @@ def build(session):
 
     session.install("build")
     session.run("python", "-m", "build")
+
+
+@nox.session(python="3.8", reuse_venv=True)
+def minimum(session: nox.Session):
+    """
+    Run tests with minimum supported dependencies.
+    """
+    session.install("--upgrade", "pip", "setuptools", "wheel")
+    session.install("--constraint", "tests/constraints.txt", ".[test]")
+    session.run(
+        "PYTHONWARNINGS='default'",
+        "pytest",
+        "--override-ini",
+        "filterwarnings=",
+        "--ignore",
+        "tests/contrib",
+        "--ignore",
+        "tests/benchmarks",
+        "--ignore",
+        "tests/test_notebooks.py",
+        "tests/",
+        *session.posargs,
+    )

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -6,7 +6,7 @@ jsonschema==4.15.0  # c.f. PR #1979
 jsonpatch==1.15
 pyyaml==5.1
 importlib_resources==1.4.0  # c.f. PR #1979
-numpy==1.20.1 # constrained by jax v0.4.1
+numpy==1.21.0 # constrained by jax v0.4.1
 # xmlio
 uproot==4.1.1
 # minuit

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -6,7 +6,7 @@ jsonschema==4.15.0  # c.f. PR #1979
 jsonpatch==1.15
 pyyaml==5.1
 importlib_resources==1.4.0  # c.f. PR #1979
-numpy==1.14.5  # constrained by scipy v1.5.1
+numpy==1.20.0 # constrained by jax v0.4.1
 # xmlio
 uproot==4.1.1
 # minuit

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -6,7 +6,7 @@ jsonschema==4.15.0  # c.f. PR #1979
 jsonpatch==1.15
 pyyaml==5.1
 importlib_resources==1.4.0  # c.f. PR #1979
-numpy==1.20.0 # constrained by jax v0.4.1
+numpy==1.20.1 # constrained by jax v0.4.1
 # xmlio
 uproot==4.1.1
 # minuit

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -6,6 +6,7 @@ jsonschema==4.15.0  # c.f. PR #1979
 jsonpatch==1.15
 pyyaml==5.1
 importlib_resources==1.4.0  # c.f. PR #1979
+numpy==1.14.5  # constrained by scipy v1.5.1
 # xmlio
 uproot==4.1.1
 # minuit


### PR DESCRIPTION
# Description

Set lower bound on numpy to v1.21.0 as this is the lower bound required by JAX v0.4.1 in addition to the lower bound of numpy>=1.14.5 by scipy v1.5.1 (the current lowest supported version). Newer versions of scipy place an upper bound on numpy for compatibility reasons and so this is only required for older scipy releases.

Example: `scipy` `v1.9.3` requires `numpy<1.26.0,>=1.18.5`.

This needs to be bumped again for JAX 
```
jax 0.4.1 depends on numpy>=1.20
The user requested (constraint) numpy==1.14.5
```

Need `numpy` `v1.21.0` for

```python
from numpy.typing import ArrayLike, DTypeLike, NBitBase, NDArray
```

to not give

```pytb
ImportError: cannot import name 'NDArray' from 'numpy.typing'
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
Set lower bound on numpy to v1.21.0 as this is the lower bound required by JAX v0.4.1
in addition to the lower bound of numpy>=1.14.5 by scipy v1.5.1 (the current lowest
supported version). Newer versions of scipy place an upper bound on numpy for
compatibility reasons and so this is only required for older scipy releases.
```