### PR TITLE
chore: Remove 'enable-recursive-aliases' from mypy checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,10 +70,10 @@ repos:
         files: src
         additional_dependencies:
           ['numpy', 'types-tqdm', 'click', 'types-jsonpatch', 'types-pyyaml', 'types-jsonschema', 'importlib_metadata', 'packaging']
-        args: ["--python-version=3.8", "--enable-recursive-aliases"]
+        args: ["--python-version=3.8"]
       - <<: *mypy
         name: mypy with Python 3.10
-        args: ["--python-version=3.10", "--enable-recursive-aliases"]
+        args: ["--python-version=3.10"]
 
 -   repo: https://github.com/nbQA-dev/nbQA
     rev: 1.5.3

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -203,10 +203,10 @@ class numpy_backend(Generic[T]):
         return np.outer(tensor_in_1, tensor_in_2)  # type: ignore[arg-type]
 
     def gather(self, tensor: Tensor[T], indices: NDArray[np.integer[T]]) -> ArrayLike:
-        return tensor[indices]  # type: ignore[no-any-return]
+        return tensor[indices]
 
     def boolean_mask(self, tensor: Tensor[T], mask: NDArray[np.bool_]) -> ArrayLike:
-        return tensor[mask]  # type: ignore[no-any-return]
+        return tensor[mask]
 
     def isfinite(self, tensor: Tensor[T]) -> NDArray[np.bool_]:
         return np.isfinite(tensor)


### PR DESCRIPTION
# Description

As prompted by pre-commit.ci, remove the `--enable-recursive-aliases` `mypy` option to avoid

> Warning: --enable-recursive-aliases is deprecated; recursive types are enabled by default

and remove `type: ignore[no-any-return]` to avoid

> error: Unused "type: ignore" comment

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove the `--enable-recursive-aliases` mypy option in pre-commit to avoid

> Warning: --enable-recursive-aliases is deprecated; recursive types are enabled by default

and remove `type: ignore[no-any-return]` to avoid

> error: Unused "type: ignore" comment

These changes are prompted from pre-commit.ci runs.
```