### PR TITLE
fix: Use non-gui matplotlib backend for tests to avoid hanging on ipywidgets interact

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -39,4 +39,4 @@ jobs:
         # Override the ini option for filterwarnings with an empty list to disable error
         # on filterwarnings as testing for notebooks to run with the latest API, not if
         # Jupyter infrastructure is warning free.
-        pytest --override-ini filterwarnings= tests/test_notebooks.py
+        pytest --verbose --override-ini filterwarnings= tests/test_notebooks.py

--- a/docs/examples/notebooks/learn/InterpolationCodes.ipynb
+++ b/docs/examples/notebooks/learn/InterpolationCodes.ipynb
@@ -4,15 +4,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Populating the interactive namespace from numpy and matplotlib\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/docs/examples/notebooks/learn/InterpolationCodes.ipynb
+++ b/docs/examples/notebooks/learn/InterpolationCodes.ipynb
@@ -14,9 +14,9 @@
     }
    ],
    "source": [
-    "%pylab inline\n",
-    "from ipywidgets import interact\n",
     "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from ipywidgets import interact\n",
     "from mpl_toolkits.mplot3d import Axes3D"
    ]
   },

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,7 +1,7 @@
 import sys
 from pathlib import Path
 
-import matplotlib as mpl
+import matplotlib
 import papermill as pm
 import pytest
 import scrapbook as sb
@@ -78,10 +78,11 @@ def test_toys(common_kwargs):
 
 
 def test_learn_interpolationcodes(common_kwargs):
-    with mpl.rc_context({"backend": "agg"}):
-        pm.execute_notebook(
-            'docs/examples/notebooks/learn/InterpolationCodes.ipynb', **common_kwargs
-        )
+    # Avoid problems with interact by using non-gui backend
+    matplotlib.use("agg")
+    pm.execute_notebook(
+        'docs/examples/notebooks/learn/InterpolationCodes.ipynb', **common_kwargs
+    )
 
 
 def test_learn_tensorizinginterpolations(common_kwargs):

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,10 +1,13 @@
+import os
 import sys
 from pathlib import Path
 
-import matplotlib
 import papermill as pm
 import pytest
 import scrapbook as sb
+
+# Avoid problems with interact by using non-gui backend
+os.environ["MPLBACKEND"] = "agg"
 
 
 @pytest.fixture()
@@ -78,8 +81,6 @@ def test_toys(common_kwargs):
 
 
 def test_learn_interpolationcodes(common_kwargs):
-    # Avoid problems with interact by using non-gui backend
-    matplotlib.use("agg")
     pm.execute_notebook(
         'docs/examples/notebooks/learn/InterpolationCodes.ipynb', **common_kwargs
     )

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -6,7 +6,7 @@ import papermill as pm
 import pytest
 import scrapbook as sb
 
-# Avoid problems with interact by using non-gui backend
+# Avoid hanging on with ipywidgets interact by using non-gui backend
 os.environ["MPLBACKEND"] = "agg"
 
 

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+import matplotlib as mpl
 import papermill as pm
 import pytest
 import scrapbook as sb
@@ -77,9 +78,10 @@ def test_toys(common_kwargs):
 
 
 def test_learn_interpolationcodes(common_kwargs):
-    pm.execute_notebook(
-        'docs/examples/notebooks/learn/InterpolationCodes.ipynb', **common_kwargs
-    )
+    with mpl.rc_context({"backend": "agg"}):
+        pm.execute_notebook(
+            'docs/examples/notebooks/learn/InterpolationCodes.ipynb', **common_kwargs
+        )
 
 
 def test_learn_tensorizinginterpolations(common_kwargs):


### PR DESCRIPTION
# Description

* To avoid having the notebook tests hang on the `ipywidgets` `interact` sections of `InterpolationCodes.ipynb` set the matplotlib backend to the non-gui Agg which disallows the creation of the gui elements that are causing the problem. This also speeds up runtime as no gui-elements are created for the notebook tests now.
* Remove '%pylab inline' from InterpolationCodes.ipynb as pylab is very deprecated.
* Add --verobse flag to notebook tests to make it easier to track the progress of the notebooks in the CI logs.


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Avoid the notebook tests hanging on the ipywidgets interact sections of `InterpolationCodes.ipynb`
  by setting the matplotlib backend to the non-gui Agg which disallows the creation of the gui elements
  that are causing the problem.
* Remove '%pylab inline' from InterpolationCodes.ipynb as pylab is very deprecated.
* Add --verobse flag to notebook tests to make it easier to track the progress of the notebooks in the
  CI logs.
```