### PR TITLE
docs: Add GitHub Releases page to project url metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ Documentation = "https://pyhf.readthedocs.io/"
 Homepage = "https://github.com/scikit-hep/pyhf"
 "Issue Tracker" = "https://github.com/scikit-hep/pyhf/issues"
 "Release Notes" = "https://pyhf.readthedocs.io/en/stable/release-notes.html"
+"Releases" = "https://github.com/scikit-hep/pyhf/releases"
 "Source Code" = "https://github.com/scikit-hep/pyhf"
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Description

Add https://github.com/scikit-hep/pyhf/releases to 'Project links' section on PyPI webpage.

Inspired by [Awkward's use](https://github.com/scikit-hep/awkward/blob/e81128ad63ad5fbf4c8943ec6abacc7ddea9ec08/pyproject.toml#L62), which was added in https://github.com/scikit-hep/awkward/commit/0a80b2a09f8ae81264d1fa214c4b3c7df7fef88c.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add https://github.com/scikit-hep/pyhf/releases to 'Project links' section
  on PyPI webpage.
```