### PR TITLE
docs: Add Environment :: WebAssembly :: Emscripten PyPI trove classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ keywords = [
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
+    "Environment :: WebAssembly",
+    "Environment :: WebAssembly :: Emscripten",
+    "Environment :: WebAssembly :: WASI",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "hatchling>=1.0.0",
+    "hatchling>=1.13.0",
     "hatch-vcs>=0.3.0",
 ]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,7 @@ keywords = [
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
-    "Environment :: WebAssembly",
     "Environment :: WebAssembly :: Emscripten",
-    "Environment :: WebAssembly :: WASI",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["hatchling>=1.0.0", "hatch-vcs"]
+requires = [
+    "hatchling>=1.0.0",
+    "hatch-vcs>=0.3.0",
+]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
# Description

Add PyPI trove classifiers to the PyPI metadata for `Environment :: WebAssembly :: Emscripten` as pyhf can run on a WASM build of CPython.
   - c.f. https://discuss.python.org/t/do-we-want-classifiers-for-webassembly-on-pypi/22712

Thanks to @treyhunner for [sharing this on Twitter](https://twitter.com/treyhunner/status/1616937929276022784?s=43&t=ExhFr34n5b725DwOITxJ6g) and to @brettcannon for adding them in https://github.com/pypa/trove-classifiers/pull/129. :+1: 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add the PyPI Environment :: WebAssembly :: Emscripten trove classifier
  to the PyPI metadata as pyhf can run on a WASM build of CPython.
   - c.f. https://discuss.python.org/t/do-we-want-classifiers-for-webassembly-on-pypi/22712
* Update hatchling lower bound to v1.13.0, the first version to support
  the Environment :: WebAssembly trove classifiers.
```