### PR TITLE
fix: Downgrade jupyter-client for papermill to work

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -29,7 +29,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade .[test]
+        # FIXME: c.f. https://github.com/scikit-hep/pyhf/issues/2104
+        python -m pip install --upgrade .[test] 'jupyter-client<8.0.0'
 
     - name: List installed Python packages
       run: python -m pip list


### PR DESCRIPTION
# Description

As a temporary fix to Issue #2104 (which is because of https://github.com/nteract/papermill/issues/711), downgrade `jupyter-client` to a version less than `v8.0.0` so that `papermill` is able to run. This is not a sufficient fix and an alternative to using `papermill` should be considered.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* As a temporary fix to Issue #2104, downgrade jupyter-client to a
  version less than v8.0.0 so that papermill is able to run.
  This is not a sufficient fix and an alternative to using papermill
  should be considered.
```