### PR TITLE
fix: Raise error when converting xml workspaces without data

### DIFF
--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -279,7 +279,7 @@ def process_data(
     histopath = sample.attrib.get('HistoPath', histopath)
     histoname = sample.attrib['HistoName']
 
-    if inputfile == "" or histopath == "" or histoname == "":
+    if inputfile == "" or histoname == "":
         raise NotImplementedError(
             "conversion of workspaces without data is currently not supported, see issue #566"
         )

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -281,7 +281,7 @@ def process_data(
 
     if inputfile == "" or histopath == "" or histoname == "":
         raise NotImplementedError(
-            "conversion of workspaces without data is not currently supported, see issue #566"
+            "conversion of workspaces without data is currently not supported, see issue #566"
         )
 
     data, _ = import_root_histogram(resolver, inputfile, histopath, histoname)

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -279,6 +279,11 @@ def process_data(
     histopath = sample.attrib.get('HistoPath', histopath)
     histoname = sample.attrib['HistoName']
 
+    if inputfile == "" or histopath == "" or histoname == "":
+        raise NotImplementedError(
+            "conversion of workspaces without data is not currently supported, see issue #566"
+        )
+
     data, _ = import_root_histogram(resolver, inputfile, histopath, histoname)
     return data
 

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -281,7 +281,7 @@ def process_data(
 
     if inputfile == "" or histoname == "":
         raise NotImplementedError(
-            "conversion of workspaces without data is currently not supported, see issue #566"
+            "Conversion of workspaces without data is currently not supported.\nSee https://github.com/scikit-hep/pyhf/issues/566"
         )
 
     data, _ = import_root_histogram(resolver, inputfile, histopath, histoname)

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -500,7 +500,7 @@ def test_import_noChannelDataPaths(mocker, datadir):
     with pytest.raises(NotImplementedError) as excinfo:
         pyhf.readxml.parse(basedir.joinpath("config/example.xml"), basedir)
     assert (
-        'conversion of workspaces without data is currently not supported, see issue #566'
+        "Conversion of workspaces without data is currently not supported.\nSee https://github.com/scikit-hep/pyhf/issues/566"
         in str(excinfo.value)
     )
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -497,12 +497,11 @@ def test_import_noChannelDataPaths(mocker, datadir):
     mocker.patch('pyhf.readxml.import_root_histogram', return_value=(_data, _err))
 
     basedir = datadir.joinpath("xmlimport_noChannelDataPaths")
-    with pytest.raises(NotImplementedError) as excinfo:
+    with pytest.raises(
+        NotImplementedError,
+        match="Conversion of workspaces without data is currently not supported.\nSee https://github.com/scikit-hep/pyhf/issues/566",
+    ):
         pyhf.readxml.parse(basedir.joinpath("config/example.xml"), basedir)
-    assert (
-        "Conversion of workspaces without data is currently not supported.\nSee https://github.com/scikit-hep/pyhf/issues/566"
-        in str(excinfo.value)
-    )
 
 
 def test_import_missingPOI(mocker, datadir):

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -491,6 +491,20 @@ def test_import_noChannelData(mocker, datadir):
         pyhf.readxml.parse(basedir.joinpath("config/example.xml"), basedir)
 
 
+def test_import_noChannelDataPaths(mocker, datadir):
+    _data = [0.0]
+    _err = [1.0]
+    mocker.patch('pyhf.readxml.import_root_histogram', return_value=(_data, _err))
+
+    basedir = datadir.joinpath("xmlimport_noChannelDataPaths")
+    with pytest.raises(NotImplementedError) as excinfo:
+        pyhf.readxml.parse(basedir.joinpath("config/example.xml"), basedir)
+    assert (
+        'conversion of workspaces without data is currently not supported, see issue #566'
+        in str(excinfo.value)
+    )
+
+
 def test_import_missingPOI(mocker, datadir):
     _data = [0.0]
     _err = [1.0]

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -494,7 +494,7 @@ def test_import_noChannelData(mocker, datadir):
 def test_import_noChannelDataPaths(mocker, datadir):
     _data = [0.0]
     _err = [1.0]
-    mocker.patch('pyhf.readxml.import_root_histogram', return_value=(_data, _err))
+    mocker.patch("pyhf.readxml.import_root_histogram", return_value=(_data, _err))
 
     basedir = datadir.joinpath("xmlimport_noChannelDataPaths")
     with pytest.raises(

--- a/tests/test_import/xmlimport_noChannelDataPaths/config/HistFactorySchema.dtd
+++ b/tests/test_import/xmlimport_noChannelDataPaths/config/HistFactorySchema.dtd
@@ -1,0 +1,160 @@
+
+<!-- The top level combination spec -->
+<!-- OutputFilePrefix: Prefix to the output root file to be created (inspection histograms) -->
+<!-- Mode: Type of the analysis -->
+<!ELEMENT Combination (Function*,Input+,Measurement*)>
+<!ATTLIST Combination
+        OutputFilePrefix         CDATA            #REQUIRED
+        Mode                     CDATA            #IMPLIED
+>
+
+<!-- Input files detailing the channels. One channel per file -->
+<!ELEMENT Function  EMPTY>
+<!ATTLIST Function
+     Name                 CDATA         #REQUIRED
+     Expression           CDATA         #REQUIRED
+     Dependents           CDATA         #REQUIRED
+>
+
+<!-- Input files detailing the channels. One channel per file -->
+<!ELEMENT Input (#PCDATA) >
+
+<!-- Configuration for each measurement -->
+<!-- Name: to be used as the heading in the table -->
+<!-- Lumi: the luminosity of the measurement -->
+<!-- LumiRelErr: the relative error known for the lumi -->
+<!-- BinLow: the lowest bin number used for the measurement (inclusive) -->
+<!-- BinHigh: the highest bin number used for the measurement (exclusive) -->
+<!-- Mode: type of the measurement (a closed list of ...) -->
+<!-- ExportOnly: if "True" skip fit, only export model -->
+<!ELEMENT Measurement (POI,ParamSetting*,ConstraintTerm*) >
+<!ATTLIST Measurement
+        Name              CDATA            #REQUIRED
+        Lumi              CDATA            #REQUIRED
+        LumiRelErr        CDATA            #REQUIRED
+        BinLow            CDATA            #IMPLIED
+        BinHigh           CDATA            #IMPLIED
+        Mode              CDATA            #IMPLIED
+        ExportOnly        CDATA            #IMPLIED
+>
+
+<!-- Specify what you are measuring. Corresponds to the name specified in the construction
+of the model in the channel setup. Typically the NormFactor for xsec measurements -->
+<!ELEMENT POI (#PCDATA) >
+
+<!-- Specify what parameters are fixed, or have particular value -->
+<!-- Val: set the value of the parameter -->
+<!-- Const: set this parameter constant -->
+<!ELEMENT ParamSetting (#PCDATA)>
+<!ATTLIST ParamSetting
+        Val               CDATA           #IMPLIED
+        Const             CDATA           #IMPLIED
+>
+
+<!-- Specify an alternative shape to use for given constraint terms (Gaussian is used if this is not specified) -->
+<!-- Type: can be Gamma or Uniform -->
+<!-- RelativeUncertainty: relative uncertainty on the shape -->
+<!ELEMENT ConstraintTerm (#PCDATA)>
+<!ATTLIST ConstraintTerm
+        Type                  CDATA       #REQUIRED
+        RelativeUncertainty   CDATA       #IMPLIED
+>
+
+<!-- Top element for channels. InputFile, HistoName and HistoPath
+can be set at this level in which case they will become defaul to
+all subsequent elements. Otherwise they can be set in individual
+subelements -->
+<!ELEMENT Channel (Data*,StatErrorConfig*,Sample+)>
+<!-- InputFile: input file where the input histogram can be found (use abs path) -->
+<!-- HistoPath: the path (within the root file) where the histogram can be found -->
+<!-- HistoName: the name of the histogram to be used for this (and following in not overridden) item -->
+<!ATTLIST Channel
+        Name              CDATA            #REQUIRED
+        InputFile         CDATA            #IMPLIED
+        HistoPath         CDATA            #IMPLIED
+        HistoName         CDATA            #IMPLIED
+>
+
+<!-- Data to be fit. If you don't provide it, Asimov data will be created -->
+<!-- InputFile: any item set here will override the configuration for the subelements.
+For this element there is no sublemenents so the setting will only have local effects -->
+<!ELEMENT Data EMPTY>
+<!ATTLIST Data
+        InputFile         CDATA            #IMPLIED
+        HistoPath         CDATA            #IMPLIED
+        HistoName         CDATA            #IMPLIED
+>
+
+<!ELEMENT StatErrorConfig EMPTY>
+<!ATTLIST StatErrorConfig
+        RelErrorThreshold      CDATA            #IMPLIED
+        ConstraintType         CDATA            #IMPLIED
+>
+
+
+<!-- Sample elements are made up of systematic variations -->
+<!ELEMENT Sample (StatError | HistoSys | OverallSys | ShapeSys | NormFactor | ShapeFactor)*>
+<!ATTLIST Sample
+        Name              CDATA            #REQUIRED
+        InputFile         CDATA            #IMPLIED
+        HistoName         CDATA            #IMPLIED
+        HistoPath         CDATA            #IMPLIED
+        NormalizeByTheory      CDATA       #IMPLIED
+>
+
+<!-- Systematics for which the variation is provided by histograms -->
+<!ELEMENT StatError EMPTY>
+<!ATTLIST StatError
+     Activate          CDATA            #REQUIRED
+          HistoName         CDATA            #IMPLIED
+          InputFile         CDATA            #IMPLIED
+          HistoPath         CDATA            #IMPLIED
+>
+
+<!ELEMENT HistoSys EMPTY>
+<!ATTLIST HistoSys
+        Name              CDATA            #REQUIRED
+        InputFile         CDATA            #IMPLIED
+        HistoFileHigh     CDATA            #IMPLIED
+        HistoPathHigh     CDATA            #IMPLIED
+        HistoNameHigh     CDATA            #IMPLIED
+        HistoFileLow      CDATA            #IMPLIED
+        HistoPathLow      CDATA            #IMPLIED
+        HistoNameLow      CDATA            #IMPLIED
+>
+
+<!-- Systematics for which the variation is provided by simple overall scaling -->
+<!ELEMENT OverallSys EMPTY>
+<!ATTLIST OverallSys
+        Name              CDATA            #REQUIRED
+        High              CDATA            #REQUIRED
+        Low               CDATA            #REQUIRED
+>
+
+<!-- Systematics for which the variation is provided by simple overall scaling -->
+<!ELEMENT ShapeSys EMPTY>
+<!ATTLIST ShapeSys
+          Name              CDATA            #REQUIRED
+          HistoName         CDATA            #REQUIRED
+          HistoPath         CDATA            #IMPLIED
+          InputFile         CDATA            #IMPLIED
+          ConstraintType    CDATA            #IMPLIED
+>
+
+<!-- Scaling factor, which may be the parameter of interest for cross section measurements-->
+<!ELEMENT NormFactor EMPTY>
+<!ATTLIST NormFactor
+        Name              CDATA            #REQUIRED
+        Val               CDATA            #REQUIRED
+        High              CDATA            #REQUIRED
+        Low               CDATA            #REQUIRED
+        Const             CDATA            #IMPLIED
+>
+
+
+<!-- Systematics for which the variation is provided by simple overall scaling -->
+<!ELEMENT ShapeFactor EMPTY>
+<!ATTLIST ShapeFactor
+          Name              CDATA            #REQUIRED
+>
+

--- a/tests/test_import/xmlimport_noChannelDataPaths/config/example.xml
+++ b/tests/test_import/xmlimport_noChannelDataPaths/config/example.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE Combination  SYSTEM 'HistFactorySchema.dtd'>
+<Combination OutputFilePrefix="./results/example" >
+  <Input>./config/example_channel.xml</Input>
+  <Measurement Name="GaussExample" Lumi="1." LumiRelErr="0.1" >
+    <POI>SigXsecOverSM</POI>
+    <ParamSetting Const="True">Lumi alpha_syst1</ParamSetting>
+  </Measurement>
+</Combination>

--- a/tests/test_import/xmlimport_noChannelDataPaths/config/example_channel.xml
+++ b/tests/test_import/xmlimport_noChannelDataPaths/config/example_channel.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE Channel  SYSTEM 'HistFactorySchema.dtd'>
+<Channel Name="channel1" InputFile="./data/example.root" >
+  <Data HistoName="" InputFile="" HistoPath=""/>
+  <Sample Name="signal" HistoPath="" HistoName="signal">
+    <OverallSys Name="syst1" High="1.05" Low="0.95"/>
+    <NormFactor Name="SigXsecOverSM" Val="1" Low="0." High="3."  />
+  </Sample>
+  <Sample Name="background1" HistoPath="" NormalizeByTheory="True" HistoName="background1">
+    <StatError Activate="True" HistoName="background1_statUncert"  />
+    <OverallSys Name="syst2" Low="0.95" High="1.05"/>
+  </Sample>
+  <Sample Name="background2" HistoPath="" NormalizeByTheory="True" HistoName="background2">
+    <StatError Activate="True" /> <!-- Use Default Histogram Errors as input to StatError -->
+    <OverallSys Name="syst3" Low="0.95" High="1.05"/>
+  </Sample>
+</Channel>


### PR DESCRIPTION
# Description

Raise an error when attempting to convert an xml workspace that contains no data, i.e. looks like this:
```xml
<Data HistoName="" InputFile="" HistoPath=""/>
```

Previously this would raise an `IsADirectoryError` via `uproot`, which is confusing to users. See #566 for context.

I have not added any new test for this, as I haven't seen anything specifically targeting that API at the moment. I confirmed it raises as expected, an example is linked in https://github.com/scikit-hep/pyhf/issues/566#issuecomment-700573969.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Raise NotImplementedError when attempting to convert an xml workspace that
  contains no data. The previous behavior was uproot raising IsADirectoryError,
  which is confusing.
* Add a test for raising NotImplementedError in tests/test_import.py and add the
  test files.
```