### PR TITLE
docs: Use prefix.dev as conda-forge package page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -373,7 +373,7 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
 .. |PyPI version| image:: https://badge.fury.io/py/pyhf.svg
    :target: https://badge.fury.io/py/pyhf
 .. |Conda-forge version| image:: https://img.shields.io/conda/vn/conda-forge/pyhf.svg
-   :target: https://github.com/conda-forge/pyhf-feedstock
+   :target: https://prefix.dev/channels/conda-forge/packages/pyhf
 .. |Supported Python versions| image:: https://img.shields.io/pypi/pyversions/pyhf.svg
    :target: https://pypi.org/project/pyhf/
 .. |Docker Hub pyhf| image:: https://img.shields.io/badge/pyhf-v0.7.0-blue?logo=Docker


### PR DESCRIPTION
# Description

https://prefix.dev provides a significantly nicer and faster browsing experience of packages on conda-forge with a UI that is more user focused. prefix.dev comes from the mamba-org team and so has backing support.
   - c.f. https://prefix.dev/channels/conda-forge/packages/pyhf

Big thanks to @agoose77 for sharing https://prefix.dev/ with us!

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* https://prefix.dev/ provides a significantly nicer and faster browsing
  experience of packages on conda-forge with a UI that is more user
  focused. prefix.dev comes from the mamba-org team and so has backing support.
   - c.f. https://prefix.dev/channels/conda-forge/packages/pyhf
```