### PR TITLE
docs: Use 'develop' extra over removed 'complete'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ We recommend first reading the "[Developing](https://scikit-hep.org/pyhf/develop
 You can install the development environment (which includes a number of extra) libraries and all others needed to run the tests via `pip`:
 
 ```console
-python -m pip install --upgrade --editable .[complete]
+python -m pip install --upgrade --editable '.[develop]'
 ```
 
 To make the PR process much smoother we also strongly recommend that you setup the Git pre-commit hook for [Black](https://github.com/psf/black) by running

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,2 +1,2 @@
-python -m pip install --upgrade .[complete]
+python -m pip install --upgrade '.[backends]'
 python -m pip install altair

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,2 +1,2 @@
-python -m pip install --upgrade '.[backends]'
+python -m pip install --upgrade '.[all]'
 python -m pip install altair

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -20,7 +20,7 @@ and install all necessary packages for development
 
 .. code-block:: console
 
-    python -m pip install --upgrade --editable '.[complete]'
+    python -m pip install --upgrade --editable '.[develop]'
 
 Then setup the Git `pre-commit <https://pre-commit.com/>`__ hooks by running
 


### PR DESCRIPTION
# Description

Resolves #2110

* Update all uses of the removed 'complete' extra to 'develop'.
   - The 'complete' extra was removed when moving to `hatchling` in PR #2095, but the 'develop' extra retains most of that functionality.
   - Update the 'complete' extra to 'all' for the Binder postBuild to reduce the number of dependencies that need to be installed.
* Quote the extra for best practice to ensure compatibility across shells.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update all uses of the removed 'complete' extra to 'develop'.
   - The 'complete' extra was removed when moving to hatchling in
     PR #2095, but the 'develop' extra retains most of that functionality.
   - Update the 'complete' extra to 'all' for the Binder postBuild to
     reduce the number of dependencies that need to be installed.
* Quote the extra for best practice to ensure compatibility across shells.
```