### PR TITLE
docs: Use 'req@url' syntax to install from remote VCS

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -32,28 +32,28 @@ Install latest stable release from `PyPI <https://pypi.org/project/pyhf/>`__...
 
 .. code-block:: console
 
-    python -m pip install pyhf[tensorflow]
+    python -m pip install 'pyhf[tensorflow]'
 
 ... with PyTorch backend
 ++++++++++++++++++++++++
 
 .. code-block:: console
 
-    python -m pip install pyhf[torch]
+    python -m pip install 'pyhf[torch]'
 
 ... with JAX backend
 ++++++++++++++++++++
 
 .. code-block:: console
 
-    python -m pip install pyhf[jax]
+    python -m pip install 'pyhf[jax]'
 
 ... with all backends
 +++++++++++++++++++++
 
 .. code-block:: console
 
-    python -m pip install pyhf[backends]
+    python -m pip install 'pyhf[backends]'
 
 
 ... with xml import/export functionality
@@ -61,7 +61,7 @@ Install latest stable release from `PyPI <https://pypi.org/project/pyhf/>`__...
 
 .. code-block:: console
 
-    python -m pip install pyhf[xmlio]
+    python -m pip install 'pyhf[xmlio]'
 
 
 Install latest development version from `GitHub <https://github.com/scikit-hep/pyhf>`__...

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -72,35 +72,35 @@ Install latest development version from `GitHub <https://github.com/scikit-hep/p
 
 .. code-block:: console
 
-    python -m pip install --upgrade "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf"
+    python -m pip install --upgrade 'pyhf@git+https://github.com/scikit-hep/pyhf.git'
 
 ... with TensorFlow backend
 +++++++++++++++++++++++++++
 
 .. code-block:: console
 
-    python -m pip install --upgrade "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf[tensorflow]"
+    python -m pip install --upgrade 'pyhf[tensorflow]@git+https://github.com/scikit-hep/pyhf.git'
 
 ... with PyTorch backend
 ++++++++++++++++++++++++
 
 .. code-block:: console
 
-    python -m pip install --upgrade "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf[torch]"
+    python -m pip install --upgrade 'pyhf[torch]@git+https://github.com/scikit-hep/pyhf.git'
 
 ... with JAX backend
 ++++++++++++++++++++++
 
 .. code-block:: console
 
-    python -m pip install --upgrade "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf[jax]"
+    python -m pip install --upgrade 'pyhf[jax]@git+https://github.com/scikit-hep/pyhf.git'
 
 ... with all backends
 +++++++++++++++++++++
 
 .. code-block:: console
 
-    python -m pip install --upgrade "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf[backends]"
+    python -m pip install --upgrade 'pyhf[backends]@git+https://github.com/scikit-hep/pyhf.git'
 
 
 ... with xml import/export functionality
@@ -108,7 +108,7 @@ Install latest development version from `GitHub <https://github.com/scikit-hep/p
 
 .. code-block:: console
 
-    python -m pip install --upgrade "git+https://github.com/scikit-hep/pyhf.git#egg=pyhf[xmlio]"
+    python -m pip install --upgrade 'pyhf[xmlio]@git+https://github.com/scikit-hep/pyhf.git'
 
 
 Updating :code:`pyhf`

--- a/src/pyhf/cli/complete.py
+++ b/src/pyhf/cli/complete.py
@@ -21,9 +21,9 @@ except ImportError:
     @click.command(help='Generate shell completion code.', name='completions')
     @click.argument('shell', default=None)
     def cli(shell):
-        '''Placeholder for shell completion code generatioon function if necessary dependency is missing.'''
+        """Placeholder for shell completion code generatioon function if necessary dependency is missing."""
         click.secho(
-            'This requires the click_completion module.\n'
-            'You can install it with the shellcomplete extra:\n'
-            'python -m pip install pyhf[shellcomplete]'
+            "This requires the click_completion module.\n"
+            "You can install it with the shellcomplete extra:\n"
+            "python -m pip install 'pyhf[shellcomplete]'"
         )

--- a/src/pyhf/cli/rootio.py
+++ b/src/pyhf/cli/rootio.py
@@ -50,7 +50,7 @@ def xml2json(
     except ImportError:
         log.error(
             "xml2json requires uproot, please install pyhf using the "
-            "xmlio extra: python -m pip install pyhf[xmlio]",
+            "xmlio extra: python -m pip install 'pyhf[xmlio]'",
             exc_info=True,
         )
     from pyhf import readxml
@@ -86,7 +86,7 @@ def json2xml(workspace, output_dir, specroot, dataroot, resultprefix, patch):
     except ImportError:
         log.error(
             "json2xml requires uproot, please install pyhf using the "
-            "xmlio extra: python -m pip install pyhf[xmlio]",
+            "xmlio extra: python -m pip install 'pyhf[xmlio]'",
             exc_info=True,
         )
     from pyhf import writexml

--- a/src/pyhf/contrib/cli.py
+++ b/src/pyhf/contrib/cli.py
@@ -24,7 +24,7 @@ def cli():
 
         .. code-block:: shell
 
-            $ python -m pip install pyhf[contrib]
+            $ python -m pip install 'pyhf[contrib]'
     """
     from pyhf.contrib import utils  # Guard CLI from missing extra # noqa: F401
 
@@ -72,6 +72,6 @@ def download(archive_url, output_directory, verbose, force, compress):
     except AttributeError:
         log.error(
             "\nInstallation of the contrib extra is required to use the contrib CLI API"
-            + "\nPlease install with: python -m pip install pyhf[contrib]\n",
+            + "\nPlease install with: python -m pip install 'pyhf[contrib]'\n",
             exc_info=True,
         )

--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -128,6 +128,6 @@ try:
 except ModuleNotFoundError:
     log.error(
         "\nInstallation of the contrib extra is required to use pyhf.contrib.utils.download"
-        + "\nPlease install with: python -m pip install pyhf[contrib]\n",
+        + "\nPlease install with: python -m pip install 'pyhf[contrib]'\n",
         exc_info=True,
     )

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -632,7 +632,7 @@ def test_missing_contrib_extra(caplog):
         for line in [
             "import of requests halted; None in sys.modules",
             "Installation of the contrib extra is required to use pyhf.contrib.utils.download",
-            "Please install with: python -m pip install pyhf[contrib]",
+            "Please install with: python -m pip install 'pyhf[contrib]'",
         ]:
             assert line in caplog.text
         caplog.clear()
@@ -672,7 +672,7 @@ def test_missing_contrib_download(caplog):
             for line in [
                 "module 'pyhf.contrib.utils' has no attribute 'download'",
                 "Installation of the contrib extra is required to use the contrib CLI API",
-                "Please install with: python -m pip install pyhf[contrib]",
+                "Please install with: python -m pip install 'pyhf[contrib]'",
             ]:
                 assert line in caplog.text
             caplog.clear()


### PR DESCRIPTION
# Description

Resolves #2114

* Use `req@url` syntax when using `pip` to install from a remote Git repository over `url#egg=req` to avoid the use of `#egg=` fragments with a non-PEP 508 name. This will be required in `pip` `v25.0+`. c.f. https://github.com/pypa/pip/pull/11617 for more details. This avoids `pip` throwing the following warning:

> DEPRECATION: git+https://github.com/scikit-hep/pyhf.git#egg=pyhf[all] contains an egg fragment with a non-PEP 508 name pip 25.0 will enforce this behaviour change. A possible replacement is to use the req @ url syntax, and remove the egg fragment. Discussion can be found at pypa/pip#11617

* For best practice, quote the use of extras for compatibility across all shells.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use 'req@url' syntax when using pip to install from a remote git
  repository over 'url#egg=req' to avoid the use of #egg= fragments
  with a non-PEP 508 name. This will be required in pip v25.0+.
   - c.f. https://github.com/pypa/pip/pull/11617 for more details.
* For best practice, quote the use of extras for compatibility across all shells.
```