### PR TITLE
test: Add constraint to protobuf for lower bound tests

### DIFF
--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -14,7 +14,7 @@ iminuit==2.7.0  # c.f. PR #1895
 # tensorflow
 tensorflow==2.7.0  # c.f. PR #1962
 tensorflow-probability==0.11.0  # c.f. PR #1657
-tensorboard<2.12.0  # c.f. PR #2117
+protobuf<4.21.0  # c.f. PR #2117
 # torch
 torch==1.10.0
 # jax

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -14,6 +14,7 @@ iminuit==2.7.0  # c.f. PR #1895
 # tensorflow
 tensorflow==2.7.0  # c.f. PR #1962
 tensorflow-probability==0.11.0  # c.f. PR #1657
+tensorboard<2.12.0
 # torch
 torch==1.10.0
 # jax

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -14,7 +14,7 @@ iminuit==2.7.0  # c.f. PR #1895
 # tensorflow
 tensorflow==2.7.0  # c.f. PR #1962
 tensorflow-probability==0.11.0  # c.f. PR #1657
-tensorboard<2.12.0
+tensorboard<2.12.0  # c.f. PR #2117
 # torch
 torch==1.10.0
 # jax


### PR DESCRIPTION
# Description

Constrain `protobuf` to be less than `4.21.0` for `tensorflow` to work in the minimum supported dependencies workflow test. For the version of `tensorflow` used, `protobuf` `v4.21.0+` results in a `protobuf` error of

```pytb
/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/google/protobuf/descriptor.py:560: in __new__
    _message.Message._CheckCalledFromGeneratedFile()
E   TypeError: Descriptors cannot not be created directly.
E   If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
E   If you cannot immediately regenerate your protos, some other possible workarounds are:
E    1. Downgrade the protobuf package to 3.20.x or lower.
E    2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add constraint of 'protobuf<4.21.0' for tensorflow==2.7.0 to work in the
  minimum supported dependencies workflow. Without this constraint on protobuf
  a 'TypeError: Descriptors cannot not be created directly' will occur:

   E   TypeError: Descriptors cannot not be created directly.
   E   If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
   E   If you cannot immediately regenerate your protos, some other possible workarounds are:
   E    1. Downgrade the protobuf package to 3.20.x or lower.
   E    2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```