### PR TITLE
docs: Add FAQ on backend support on Apple silicon Macs 

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -33,15 +33,15 @@ For more information see :code:`pyhf cls --help`.
 Why can't ``pip`` find compatible backends on PyPI for Apple silicon Macs?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Unfortunately, at this time |tensorflow Issue 57185|_ of ``pyhf``'s backends support
-wheels for Apple silicon Macs (``osx-arm64``).
-So if you are installing wheels from PyPI on an ``osx-arm64`` machine, you will
-only be able to use a subset of all the backends.
+Unfortunately, at this time |tensorflow Issue 57185|_ of ``pyhf``'s backends
+support wheels for Apple silicon Macs (``osx-arm64``).
+If you are installing wheels from PyPI on an ``osx-arm64`` machine, you will only
+be able to use a subset of all the backends.
 
 An alternative would be to create a |micromamba|_ environment and install the
 backends individually from `conda-forge <https://prefix.dev/channels/conda-forge/>`__
-as all the backends have conda-forge releases compatible with ``linux-64`` and
-``osx-arm64``.
+as all the backends have conda-forge releases compatible with ``linux-64``,
+``osx-64``, and ``osx-arm64``.
 
 .. |tensorflow Issue 57185| replace:: not all
 .. _`tensorflow Issue 57185`: https://github.com/tensorflow/tensorflow/issues/57185

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -30,6 +30,25 @@ Use the :code:`--backend` option for :code:`pyhf cls` to specify a tensor backen
 The default backend is NumPy.
 For more information see :code:`pyhf cls --help`.
 
+Why can't ``pip`` find compatible backends on PyPI for Apple silicon Macs?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unfortunately, at this time |tensorflow Issue 57185|_ of ``pyhf``'s backends support
+wheels for Apple silicon Macs (``osx-arm64``).
+So if you are installing wheels from PyPI on an ``osx-arm64`` machine, you will
+only be able to use a subset of all the backends.
+
+An alternative would be to create a |micromamba|_ environment and install the
+backends individually from `conda-forge <https://prefix.dev/channels/conda-forge/>`__
+as all the backends have conda-forge releases compatible with ``linux-64`` and
+``osx-arm64``.
+
+.. |tensorflow Issue 57185| replace:: not all
+.. _`tensorflow Issue 57185`: https://github.com/tensorflow/tensorflow/issues/57185
+
+.. |micromamba| replace:: ``micromamba``
+.. _`micromamba`: https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html
+
 I installed an old ``pyhf`` release from PyPI, why am I getting an error from a dependency?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -34,9 +34,24 @@ Why can't ``pip`` find compatible backends on PyPI for Apple silicon Macs?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Unfortunately, at this time |tensorflow Issue 57185|_ of ``pyhf``'s backends
-support wheels for Apple silicon Macs (``osx-arm64``).
+support wheels for Apple silicon Macs (``osx-arm64``) under common names on PyPI.
 If you are installing wheels from PyPI on an ``osx-arm64`` machine, you will only
-be able to use a subset of all the backends.
+be able to use a subset of all the backends through the provided extras.
+
+To install the dependencies for the TensorFlow backend you'll need to manually
+specify that ``tensorflow-macos`` is required
+
+    .. code-block:: console
+
+        python -m pip install pyhf tensorflow-macos tensorflow-probability
+
+Similarly, if you want to install the TensorFlow backend dependencies along with the
+other backends included in the ``[backends]`` extra you'll need to specify the extras
+as well
+
+    .. code-block:: console
+
+        python -m pip install 'pyhf[torch,jax,minuit]' tensorflow-macos tensorflow-probability
 
 An alternative would be to create a |micromamba|_ environment and install the
 backends individually from `conda-forge <https://prefix.dev/channels/conda-forge/>`__


### PR DESCRIPTION
# Description

Superseded by PR #2119

---

Resolves #2111

At the moment, [TensorFlow does not have Apple silicon compatible wheels on PyPI](https://github.com/tensorflow/tensorflow/issues/57185) under the `tensorflow` project namespace, though it does under `tensorflow-macos`. As an alternative, note that conda-forge has `linux-64`, `osx-64`, and `osx-arm64` compatible releases for all of pyhf's backends.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* At the moment, TensorFlow does not have Apple silicon compatible
  wheels on PyPI. As an alternative, note that conda-forge has linux-64,
  osx-64, and osx-arm64 compatible releases for all of pyhf's backends.
   - c.f. https://github.com/tensorflow/tensorflow/issues/57185
```