### PR TITLE
build: Install tensorflow-macos on Apple silicon Macs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,8 @@ Homepage = "https://github.com/scikit-hep/pyhf"
 [project.optional-dependencies]
 shellcomplete = ["click_completion"]
 tensorflow = [
-    "tensorflow>=2.7.0 and platform_machine != 'arm64'",  # c.f. PR #1962
-    "tensorflow-macos>=2.7.0 and platform_machine == 'arm64' and platform_system == 'Darwin'",  # c.f. PR #1962
+    "tensorflow>=2.7.0; platform_machine != 'arm64'",  # c.f. PR #1962
+    "tensorflow-macos>=2.7.0; platform_machine == 'arm64' and platform_system == 'Darwin'",  # c.f. PR #1962
     "tensorflow-probability>=0.11.0",  # c.f. PR #1657
 ]
 torch = ["torch>=1.10.0"]  # c.f. PR #1657

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ Homepage = "https://github.com/scikit-hep/pyhf"
 shellcomplete = ["click_completion"]
 tensorflow = [
     "tensorflow>=2.7.0; platform_machine != 'arm64'",  # c.f. PR #1962
-    "tensorflow-macos>=2.7.0; platform_machine == 'arm64' and platform_system == 'Darwin'",  # c.f. PR #1962
+    "tensorflow-macos>=2.7.0; platform_machine == 'arm64' and platform_system == 'Darwin'",  # c.f. PR #2119
     "tensorflow-probability>=0.11.0",  # c.f. PR #1657
 ]
 torch = ["torch>=1.10.0"]  # c.f. PR #1657

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,8 @@ Homepage = "https://github.com/scikit-hep/pyhf"
 [project.optional-dependencies]
 shellcomplete = ["click_completion"]
 tensorflow = [
-    "tensorflow>=2.7.0",  # c.f. PR #1962
+    "tensorflow>=2.7.0 and platform_machine != 'arm64'",  # c.f. PR #1962
+    "tensorflow-macos>=2.7.0 and platform_machine == 'arm64' and platform_system == 'Darwin'",  # c.f. PR #1962
     "tensorflow-probability>=0.11.0",  # c.f. PR #1657
 ]
 torch = ["torch>=1.10.0"]  # c.f. PR #1657


### PR DESCRIPTION
# Description

* Resolves #2111
* Closes #2118

Use [`hatchling`'s environment markers](https://hatch.pypa.io/latest/config/dependency/#environment-markers) system to use platform information to determine when the installing machine is an Apple silicon Mac and install `tensorflow-macos` instead of `tensorflow` in this situation. This works because of the following:

* x86-64 Linux machine:

```python
>>> import platform
>>> platform.machine()
'x86_64'
>>> platform.system()
'Linux'
```

* x86-64 Apple machine:

```python
>>> import platform
>>> platform.machine()
'x86_64'
>>> platform.system()
'Darwin'
```

* AArch64 machine:

```python
>>> import platform
>>> platform.machine()
'aarch64'
>>> platform.system()
'Linux'
```

* Apple silicon machine:

```python
>>> import platform
>>> platform.machine()
'arm64'
>>> platform.system()
'Darwin'
```

This is a nice workaround for https://github.com/tensorflow/tensorflow/issues/57185.

The check for an Apple silicon Mac is purposefully over specified with both `platform_machine` and `platform_system` as I do not know for certain that `arm64` will be reserved for Apple silicon machines forever.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use hatchling's environment markers system to use platform information
  to determine when the installing machine is an Apple silicon Mac
  and install tensorflow-macos instead of tensorflow in this situation.
   - c.f. https://hatch.pypa.io/latest/config/dependency/#environment-markers
* This works because of the following:
   - x86-64 Linux machine:
     >>> import platform
     >>> platform.machine()
     'x86_64'
     >>> platform.system()
     'Linux'
   - x86-64 Apple machine:
     >>> import platform
     >>> platform.machine()
     'x86_64'
     >>> platform.system()
     'Darwin'
   - AArch64 machine:
     >>> import platform
     >>> platform.machine()
     'aarch64'
     >>> platform.system()
     'Linux'
   - Apple silicon machine:
     >>> import platform
     >>> platform.machine()
     'arm64'
     >>> platform.system()
     'Darwin'
```