### PR TITLE
chore: Move to using Ruff for pre-commit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,0 @@
-[flake8]
-# E203: whitespace before ':'
-# E402: module level import not at top of file
-# E501: line too long
-extend-ignore = E203, E402, E501
-max-line-length = 88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,11 +26,6 @@ repos:
       # exclude generated files
       exclude: ^validation/|\.dtd$|\.xml$
 
--   repo: https://github.com/MarcoGorelli/absolufy-imports
-    rev: v0.3.1
-    hooks:
-    - id: absolufy-imports
-
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: "v0.0.253"
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,16 +26,16 @@ repos:
       # exclude generated files
       exclude: ^validation/|\.dtd$|\.xml$
 
--   repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
-    hooks:
-    - id: pyupgrade
-      args: ["--py38-plus"]
-
 -   repo: https://github.com/MarcoGorelli/absolufy-imports
     rev: v0.3.1
     hooks:
     - id: absolufy-imports
+
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: "v0.0.253"
+  hooks:
+    - id: ruff
+      args: ["--fix", "--show-fixes"]
 
 -   repo: https://github.com/psf/black
     rev: 23.1.0
@@ -47,18 +47,6 @@ repos:
     hooks:
     - id: blacken-docs
       additional_dependencies: [black==23.1.0]
-
--   repo: https://github.com/asottile/yesqa
-    rev: v1.4.0
-    hooks:
-    - id: yesqa
-
--   repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-    - id: flake8
-      args: ["--count", "--statistics"]
-      additional_dependencies: [flake8-encodings==0.5.0.post1]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.0.1
@@ -78,8 +66,9 @@ repos:
 -   repo: https://github.com/nbQA-dev/nbQA
     rev: 1.6.3
     hooks:
-    - id: nbqa-pyupgrade
-      additional_dependencies: [pyupgrade==3.3.1]
+    - id: nbqa-ruff
+      additional_dependencies: [ruff==0.0.253]
+      args: ["--extend-ignore=F821,F401,F841,F811"]
 
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.2.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       exclude: ^validation/|\.dtd$|\.xml$
 
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: "v0.0.253"
+  rev: "v0.0.255"
   hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,11 +277,14 @@ ignore_errors = true
 select = [
   "E", "F", "W", # flake8
   "UP",          # pyupgrade
+  "RUF",         # Ruff-specific
 ]
 line-length = 88
 ignore = [
-    "E402",
-    "E501",
+  "E402",
+  "E501",
+  "RUF001", # String contains ambiguous unicode character
+  "RUF005", # unpack-instead-of-concatenating-to-collection-literal
 ]
 target-version = "py38"
 src = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,12 +222,6 @@ precision = 1
 sort = "cover"
 show_missing = true
 
-[tool.nbqa.mutate]
-pyupgrade = 1
-
-[tool.nbqa.addopts]
-pyupgrade = ["--py38-plus"]
-
 [tool.mypy]
 files = "src"
 python_version = "3.10"
@@ -278,3 +272,20 @@ module = [
   'pyhf.tensor.pytorch_backend.*',
 ]
 ignore_errors = true
+
+[tool.ruff]
+select = [
+  "E", "F", "W", # flake8
+  "UP",          # pyupgrade
+]
+line-length = 88
+ignore = [
+    "E402",
+    "E501",
+]
+target-version = "py38"
+src = ["src"]
+typing-modules = ["pyhf.typing"]
+unfixable = [
+  "F841", # Removes unused variables
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,6 +278,7 @@ select = [
   "E", "F", "W", # flake8
   "UP",          # pyupgrade
   "RUF",         # Ruff-specific
+  "TID",         # flake8-tidy-imports
 ]
 line-length = 88
 ignore = [
@@ -292,3 +293,4 @@ typing-modules = ["pyhf.typing"]
 unfixable = [
   "F841", # Removes unused variables
 ]
+flake8-tidy-imports.ban-relative-imports = "all"

--- a/src/pyhf/cli/spec.py
+++ b/src/pyhf/cli/spec.py
@@ -108,7 +108,7 @@ def inspect(workspace, output_file, measurement):
     )
 
     # summary
-    fmtStr = '{{0: >{0:d}s}}  {{1:s}}'.format(maxlen + len('Summary'))
+    fmtStr = '{{: >{:d}s}}  {{:s}}'.format(maxlen + len('Summary'))
     click.echo(fmtStr.format('     Summary     ', ''))
     click.echo(fmtStr.format('-' * 18, ''))
     fmtStr = f'{{0: >{maxlen:d}s}}  {{1:s}}'


### PR DESCRIPTION
# Description

This moves the flake8 & pyupgrade checks into a single Ruff check, and moves the config to pyproject.toml. There are a lot of checks that could be added (see https://scikit-hep.org/developer/style#ruff), I've just stuck to replicating the current config. The one loss is flake8-encodings, someone could request this added to Ruff.

I've skipped the failing checks for notebooks, might be worth checking to see if they are valid.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Drop flake8, yesqa, pyupgrade, and nbqa-pyupgrade pre-commit hooks in favor of Ruff.
   - Remove .flake8 config file as no longer used.
   - Remove nbqa config options for pyupgrade in pyproject.toml and add ruff config options.
```