### PR TITLE
docs: Add use citation from Anomalous Hadronic Higgs at the LHeC paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,15 @@
+% 2023-02-24
+@article{Behera:2023eeo,
+    author = "Behera, Subhasish and Hageluken, Manuel and Schott, Matthias",
+    title = "{Prospects of Searches for Anomalous Hadronic Higgs Boson Decays at the LHeC}",
+    eprint = "2302.12885",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    month = "2",
+    year = "2023"
+    journal = ""
+}
+
 % 2023-02-10
 @article{Chan:2023tbf,
     author = "Chan, Jay and Nachman, Benjamin",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -6,7 +6,7 @@
     archivePrefix = "arXiv",
     primaryClass = "hep-ex",
     month = "2",
-    year = "2023"
+    year = "2023",
     journal = ""
 }
 


### PR DESCRIPTION
# Description

Add use citation from [Prospects of Searches for Anomalous Hadronic Higgs Boson Decays at the LHeC](https://inspirehep.net/literature/2636748) by Subhasish Behera, Manuel Hageluken, and Matthias Schott.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Prospects of Searches for Anomalous Hadronic
  Higgs Boson Decays at the LHeC'.
   - c.f. https://inspirehep.net/literature/2636748
```