### PR TITLE
docs: Add use citation from ATLAS displaced vertices and multiple jets paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -22,6 +22,19 @@
     journal = ""
 }
 
+% 2023-01-31
+@article{ATLAS:2023oti,
+    author = "{ATLAS Collaboration}",
+    title = "{Search for long-lived, massive particles in events with displaced vertices and multiple jets in $pp$ collisions at $\sqrt{s} = 13$ TeV with the ATLAS detector}",
+    eprint = "2301.13866",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    reportNumber = "CERN-EP-2023-002",
+    month = "1",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-01-13
 @article{Berger:2023bat,
     author = "Berger, Nicolas",


### PR DESCRIPTION
# Description

Add use citation from ATLAS paper [Search for long-lived, massive particles in events with displaced vertices and multiple jets in pp collisions at s√=13 TeV with the ATLAS detector](https://inspirehep.net/literature/2628398) ([SUSY-2018-13](http://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PAPERS/SUSY-2018-13/)).

Congratulations to the analysis team! :tada: 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Search for long-lived, massive particles in events
  with displaced vertices and multiple jets in pp collisions at s√=13 TeV
  with the ATLAS detector'.
   - ATLAS paper: SUSY-2018-13
   - c.f. https://inspirehep.net/literature/2628398
```