### PR TITLE
feat: Allow failing toys

### DIFF
--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -703,6 +703,7 @@ class ToyCalculator:
         test_stat="qtilde",
         ntoys=2000,
         track_progress=True,
+        skip_failing_toys = False,
     ):
         r"""
         Toy-based Calculator.
@@ -733,6 +734,7 @@ class ToyCalculator:
             ~pyhf.infer.calculators.ToyCalculator: The calculator for toy-based quantities.
 
         """
+        self.skip_failing_toys = skip_failing_toys
         self.ntoys = ntoys
         self.data = data
         self.pdf = pdf
@@ -782,6 +784,9 @@ class ToyCalculator:
             Tuple (~pyhf.infer.calculators.EmpiricalDistribution): The distributions under the hypotheses.
 
         """
+
+        print('skip?',self.skip_failing_toys)
+
         tensorlib, _ = get_backend()
         sample_shape = (self.ntoys,)
 
@@ -827,8 +832,8 @@ class ToyCalculator:
             )
             signal_teststat = []
             for sample in signal_sample:
-                signal_teststat.append(
-                    teststat_func(
+                try:
+                    value = teststat_func(
                         poi_test,
                         sample,
                         self.pdf,
@@ -836,7 +841,16 @@ class ToyCalculator:
                         self.par_bounds,
                         self.fixed_params,
                     )
-                )
+                except RuntimeError:
+                    if self.skip_failing_toys:
+                        value = None
+                    else:
+                        raise
+
+                if (value is not None) and (tensorlib.isfinite(value)):
+                    signal_teststat.append(
+                        value
+                    )
                 progress.advance(signal_task, 1)
 
             bkg_task = progress.add_task(
@@ -844,16 +858,25 @@ class ToyCalculator:
             )
             bkg_teststat = []
             for sample in bkg_sample:
-                bkg_teststat.append(
-                    teststat_func(
+                try:
+                    value = teststat_func(
                         poi_test,
                         sample,
                         self.pdf,
                         self.init_pars,
                         self.par_bounds,
                         self.fixed_params,
-                    )
                 )
+                except RuntimeError:
+                    if self.skip_failing_toys:
+                        value = None
+                    else:
+                        raise
+
+                if (value is not None) and (tensorlib.isfinite(value)):
+                    bkg_teststat.append(
+                        value
+                    )
                 progress.advance(bkg_task, 1)
 
         s_plus_b = EmpiricalDistribution(tensorlib.astensor(signal_teststat))

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -27,6 +27,7 @@ from pyhf import get_backend
 from pyhf.exceptions import FailedMinimization
 from pyhf.infer import utils
 from pyhf.infer.mle import fixed_poi_fit
+from pyhf.tensor.numpy_backend import Tensor
 
 log = logging.getLogger(__name__)
 
@@ -227,12 +228,11 @@ class HypoTestFitResults:
     :py:meth:`AsymptoticCalculator.teststatistic <pyhf.infer.calculators.AsymptoticCalculator.teststatistic>`
     """
 
-    # ignore "F821 undefined name 'Tensor'" so as to avoid typing.Any
-    asimov_pars: Tensor  # noqa: F821
-    free_fit_to_data: Tensor  # noqa: F821
-    free_fit_to_asimov: Tensor  # noqa: F821
-    fixed_poi_fit_to_data: Tensor  # noqa: F821
-    fixed_poi_fit_to_asimov: Tensor  # noqa: F821
+    asimov_pars: Tensor
+    free_fit_to_data: Tensor
+    free_fit_to_asimov: Tensor
+    fixed_poi_fit_to_data: Tensor
+    fixed_poi_fit_to_asimov: Tensor
 
 
 class AsymptoticCalculator:
@@ -703,10 +703,9 @@ class ToyResult:
     <pyhf.infer.calculators.ToyCalculator.distributions>`.
     """
 
-    # ignore "F821 undefined name 'Tensor'" so as to avoid typing.Any
     successful: list[float]
     """Test statistic values for toys where the fit succeeded."""
-    failed: list[tuple[int, Tensor, FailedMinimization]]  # noqa: F821
+    failed: list[tuple[int, Tensor, FailedMinimization]]
     """
     Entries for each toy that raised :py:exc:`~pyhf.exceptions.FailedMinimization`.
     Each entry is a ``(toy_index, sample, exception)`` tuple so callers can

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -24,6 +24,7 @@ from rich.progress import (
 )
 
 from pyhf import get_backend
+from pyhf.exceptions import FailedMinimization
 from pyhf.infer import utils
 from pyhf.infer.mle import fixed_poi_fit
 
@@ -34,6 +35,7 @@ __all__ = [
     "AsymptoticTestStatDistribution",
     "EmpiricalDistribution",
     "ToyCalculator",
+    "ToyResult",
     "generate_asimov_data",
 ]
 
@@ -690,6 +692,28 @@ class EmpiricalDistribution:
         )
 
 
+@dataclass(frozen=True)
+class ToyResult:
+    """
+    Diagnostics from a single hypothesis toy loop.
+
+    Returned as part of :py:attr:`ToyCalculator.toy_results
+    <pyhf.infer.calculators.ToyCalculator.toy_results>` after calling
+    :py:meth:`ToyCalculator.distributions
+    <pyhf.infer.calculators.ToyCalculator.distributions>`.
+    """
+
+    # ignore "F821 undefined name 'Tensor'" so as to avoid typing.Any
+    successful: list[float]
+    """Test statistic values for toys where the fit succeeded."""
+    failed: list[tuple[int, Tensor, FailedMinimization]]  # noqa: F821
+    """
+    Entries for each toy that raised :py:exc:`~pyhf.exceptions.FailedMinimization`.
+    Each entry is a ``(toy_index, sample, exception)`` tuple so callers can
+    inspect the pseudo-data and the underlying fit result.
+    """
+
+
 class ToyCalculator:
     """The Toy-based Calculator."""
 
@@ -703,7 +727,7 @@ class ToyCalculator:
         test_stat="qtilde",
         ntoys=2000,
         track_progress=True,
-        skip_failing_toys=False,
+        failure_threshold=None,
     ):
         r"""
         Toy-based Calculator.
@@ -729,12 +753,18 @@ class ToyCalculator:
                 :math:`q_{0}` (:func:`~pyhf.infer.test_statistics.q0`).
             ntoys (:obj:`int`): Number of toys to use (how many times to sample the underlying distributions).
             track_progress (:obj:`bool`): Whether to display the progress bar or not (outputs to `stderr`).
+            failure_threshold (:obj:`float` or None): The maximum fraction of toys allowed to
+                fail before raising :py:exc:`~pyhf.exceptions.FailedMinimization`.
+                ``None`` (default) means any failure raises immediately.
+                A value of ``0.1`` allows up to 10% of toys to fail.
+                Failures and their details are always stored in
+                :py:attr:`toy_results <pyhf.infer.calculators.ToyCalculator.toy_results>`.
 
         Returns:
             ~pyhf.infer.calculators.ToyCalculator: The calculator for toy-based quantities.
 
         """
-        self.skip_failing_toys = skip_failing_toys
+        self.failure_threshold = failure_threshold
         self.ntoys = ntoys
         self.data = data
         self.pdf = pdf
@@ -743,6 +773,59 @@ class ToyCalculator:
         self.fixed_params = fixed_params or pdf.config.suggested_fixed()
         self.test_stat = test_stat
         self.track_progress = track_progress
+
+    def _collect_toy_teststats(
+        self, samples, poi_test, teststat_func, progress, task, label
+    ):
+        """
+        Run the test statistic over toy samples, collecting diagnostics.
+
+        Args:
+            samples: Pseudo-data samples to iterate over.
+            poi_test: POI value passed through to the test statistic function.
+            teststat_func: The test statistic function to call per toy.
+            progress: Rich :py:class:`Progress` instance for the progress bar.
+            task: Rich task ID to advance per toy.
+            label (:obj:`str`): Human-readable label for log messages (e.g. ``"Signal-like"``).
+
+        Returns:
+            ~pyhf.infer.calculators.ToyResult: Diagnostics including successful test
+            statistic values and details of any failed toys.
+        """
+        successful = []
+        failed = []
+
+        for idx, sample in enumerate(samples):
+            try:
+                value = teststat_func(
+                    poi_test,
+                    sample,
+                    self.pdf,
+                    self.init_pars,
+                    self.par_bounds,
+                    self.fixed_params,
+                )
+                successful.append(value)
+            except FailedMinimization as exc:
+                if self.failure_threshold is None:
+                    raise
+                failed.append((idx, sample, exc))
+                n_done = len(successful) + len(failed)
+                if len(failed) / n_done > self.failure_threshold:
+                    raise FailedMinimization(exc.result) from exc
+            progress.advance(task, 1)
+
+        if failed:
+            n_total = len(successful) + len(failed)
+            log.warning(
+                "%s: %d/%d toys failed (%.1f%%)",
+                label,
+                len(failed),
+                n_total,
+                100 * len(failed) / n_total,
+            )
+
+        return ToyResult(successful=successful, failed=failed)
 
     def distributions(self, poi_test, track_progress=None):
         """
@@ -756,6 +839,10 @@ class ToyCalculator:
 
         .. _LHC Higgs search combination procedure: https://inspirehep.net/literature/1196797
         .. |LHC Higgs search combination procedure| replace:: *Procedure for the LHC Higgs boson search combination in Summer 2011*
+
+        Toy failures are tracked in :py:attr:`toy_results` after this method returns.
+        Set ``failure_threshold`` on the calculator to allow a fraction of toys to fail
+        without aborting.
 
         Example:
 
@@ -784,10 +871,6 @@ class ToyCalculator:
             Tuple (~pyhf.infer.calculators.EmpiricalDistribution): The distributions under the hypotheses.
 
         """
-
-        # DEBUG
-        # print("skip?", self.skip_failing_toys)
-
         tensorlib, _ = get_backend()
         sample_shape = (self.ntoys,)
 
@@ -831,53 +914,34 @@ class ToyCalculator:
             signal_task = progress.add_task(
                 "[cyan]Signal-like", total=self.ntoys, visible=show_progress
             )
-            signal_teststat = []
-            for sample in signal_sample:
-                try:
-                    value = teststat_func(
-                        poi_test,
-                        sample,
-                        self.pdf,
-                        self.init_pars,
-                        self.par_bounds,
-                        self.fixed_params,
-                    )
-                except RuntimeError:
-                    if self.skip_failing_toys:
-                        value = None
-                    else:
-                        raise
-
-                if (value is not None) and (tensorlib.isfinite(value)):
-                    signal_teststat.append(value)
-                progress.advance(signal_task, 1)
+            signal_result = self._collect_toy_teststats(
+                signal_sample,
+                poi_test,
+                teststat_func,
+                progress,
+                signal_task,
+                "Signal-like",
+            )
 
             bkg_task = progress.add_task(
                 "[cyan]Background-like", total=self.ntoys, visible=show_progress
             )
-            bkg_teststat = []
-            for sample in bkg_sample:
-                try:
-                    value = teststat_func(
-                        poi_test,
-                        sample,
-                        self.pdf,
-                        self.init_pars,
-                        self.par_bounds,
-                        self.fixed_params,
-                    )
-                except RuntimeError:
-                    if self.skip_failing_toys:
-                        value = None
-                    else:
-                        raise
+            bkg_result = self._collect_toy_teststats(
+                bkg_sample,
+                poi_test,
+                teststat_func,
+                progress,
+                bkg_task,
+                "Background-like",
+            )
 
-                if (value is not None) and (tensorlib.isfinite(value)):
-                    bkg_teststat.append(value)
-                progress.advance(bkg_task, 1)
+        self.toy_results = {
+            "sig_plus_bkg": signal_result,
+            "bkg_only": bkg_result,
+        }
 
-        s_plus_b = EmpiricalDistribution(tensorlib.astensor(signal_teststat))
-        b_only = EmpiricalDistribution(tensorlib.astensor(bkg_teststat))
+        s_plus_b = EmpiricalDistribution(tensorlib.astensor(signal_result.successful))
+        b_only = EmpiricalDistribution(tensorlib.astensor(bkg_result.successful))
         return s_plus_b, b_only
 
     def pvalues(self, teststat, sig_plus_bkg_distribution, bkg_only_distribution):

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -785,7 +785,8 @@ class ToyCalculator:
 
         """
 
-        print('skip?', self.skip_failing_toys)
+        # DEBUG
+        # print("skip?", self.skip_failing_toys)
 
         tensorlib, _ = get_backend()
         sample_shape = (self.ntoys,)
@@ -848,9 +849,7 @@ class ToyCalculator:
                         raise
 
                 if (value is not None) and (tensorlib.isfinite(value)):
-                    signal_teststat.append(
-                        value
-                    )
+                    signal_teststat.append(value)
                 progress.advance(signal_task, 1)
 
             bkg_task = progress.add_task(
@@ -866,7 +865,7 @@ class ToyCalculator:
                         self.init_pars,
                         self.par_bounds,
                         self.fixed_params,
-                )
+                    )
                 except RuntimeError:
                     if self.skip_failing_toys:
                         value = None
@@ -874,9 +873,7 @@ class ToyCalculator:
                         raise
 
                 if (value is not None) and (tensorlib.isfinite(value)):
-                    bkg_teststat.append(
-                        value
-                    )
+                    bkg_teststat.append(value)
                 progress.advance(bkg_task, 1)
 
         s_plus_b = EmpiricalDistribution(tensorlib.astensor(signal_teststat))

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -703,7 +703,7 @@ class ToyCalculator:
         test_stat="qtilde",
         ntoys=2000,
         track_progress=True,
-        skip_failing_toys = False,
+        skip_failing_toys=False,
     ):
         r"""
         Toy-based Calculator.
@@ -785,7 +785,7 @@ class ToyCalculator:
 
         """
 
-        print('skip?',self.skip_failing_toys)
+        print('skip?', self.skip_failing_toys)
 
         tensorlib, _ = get_backend()
         sample_shape = (self.ntoys,)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1,3 +1,4 @@
+import types
 import warnings
 
 import numpy as np
@@ -681,8 +682,6 @@ def test_toy_calculator_default_raises_on_failure(hypotest_args, monkeypatch):
         call_count[0] += 1
         if call_count[0] == 3:
             # Simulate a failed fit result
-            import types
-
             fake_result = types.SimpleNamespace(
                 success=False, message="simulated failure"
             )
@@ -716,8 +715,6 @@ def test_toy_calculator_failure_threshold_allows_failures(hypotest_args, monkeyp
         idx = call_count[0]
         call_count[0] += 1
         if idx in fail_on:
-            import types
-
             fake_result = types.SimpleNamespace(
                 success=False, message="simulated failure"
             )
@@ -766,8 +763,6 @@ def test_toy_calculator_failure_threshold_exceeded_raises(hypotest_args, monkeyp
     def always_fails(*args, **kwargs):
         call_count[0] += 1
         if call_count[0] >= 2:
-            import types
-
             fake_result = types.SimpleNamespace(
                 success=False, message="simulated failure"
             )
@@ -799,8 +794,6 @@ def test_toy_calculator_failure_warning_logged(hypotest_args, monkeypatch, caplo
         idx = call_count[0]
         call_count[0] += 1
         if idx == 1:
-            import types
-
             fake_result = types.SimpleNamespace(
                 success=False, message="simulated failure"
             )
@@ -834,8 +827,6 @@ def test_toy_calculator_failure_threshold_via_hypotest(hypotest_args, monkeypatc
         # Fail on call 5 so at least 4 signal toys succeed first, keeping the
         # failure fraction at 1/5 = 20% well below failure_threshold=0.5.
         if idx == 5:
-            import types
-
             fake_result = types.SimpleNamespace(
                 success=False, message="simulated failure"
             )

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -637,6 +637,225 @@ def test_toy_calculator(hypotest_args):
     )
 
 
+def test_toy_calculator_toy_results_no_failures(hypotest_args):
+    """
+    Check that toy_results is populated after distributions() and reflects
+    all-successful toys when no failures occur.
+    """
+    np.random.seed(0)
+    mu_test, data, model = hypotest_args
+    calc = pyhf.infer.calculators.ToyCalculator(
+        data, model, ntoys=10, track_progress=False
+    )
+    calc.distributions(mu_test)
+
+    assert hasattr(calc, "toy_results")
+    assert set(calc.toy_results) == {"sig_plus_bkg", "bkg_only"}
+
+    sig_result = calc.toy_results["sig_plus_bkg"]
+    bkg_result = calc.toy_results["bkg_only"]
+
+    assert isinstance(sig_result, pyhf.infer.calculators.ToyResult)
+    assert isinstance(bkg_result, pyhf.infer.calculators.ToyResult)
+
+    assert len(sig_result.successful) == 10
+    assert len(sig_result.failed) == 0
+    assert len(bkg_result.successful) == 10
+    assert len(bkg_result.failed) == 0
+
+
+def test_toy_calculator_default_raises_on_failure(hypotest_args, monkeypatch):
+    """
+    With failure_threshold=None (default), any FailedMinimization propagates immediately.
+    """
+    np.random.seed(0)
+    mu_test, data, model = hypotest_args
+    calc = pyhf.infer.calculators.ToyCalculator(
+        data, model, ntoys=10, track_progress=False
+    )
+
+    original_func = pyhf.infer.test_statistics.qmu_tilde
+    call_count = [0]
+
+    def failing_teststat(*args, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 3:
+            # Simulate a failed fit result
+            import types
+
+            fake_result = types.SimpleNamespace(
+                success=False, message="simulated failure"
+            )
+            raise pyhf.exceptions.FailedMinimization(fake_result)
+        return original_func(*args, **kwargs)
+
+    monkeypatch.setattr(pyhf.infer.utils, "qmu_tilde", failing_teststat)
+
+    with pytest.raises(pyhf.exceptions.FailedMinimization):
+        calc.distributions(mu_test)
+
+
+def test_toy_calculator_failure_threshold_allows_failures(hypotest_args, monkeypatch):
+    """
+    With failure_threshold set, toys that fail are recorded in toy_results
+    and distributions() completes as long as the failure fraction stays below threshold.
+    """
+    np.random.seed(0)
+    mu_test, data, model = hypotest_args
+    ntoys = 10
+    # Allow up to 50% failures — we'll inject 2 out of 10 (20%)
+    calc = pyhf.infer.calculators.ToyCalculator(
+        data, model, ntoys=ntoys, track_progress=False, failure_threshold=0.5
+    )
+
+    original_func = pyhf.infer.test_statistics.qmu_tilde
+    fail_on = {2, 5}  # inject failures on calls 2 and 5 (0-indexed)
+    call_count = [0]
+
+    def patched_teststat(*args, **kwargs):
+        idx = call_count[0]
+        call_count[0] += 1
+        if idx in fail_on:
+            import types
+
+            fake_result = types.SimpleNamespace(
+                success=False, message="simulated failure"
+            )
+            raise pyhf.exceptions.FailedMinimization(fake_result)
+        return original_func(*args, **kwargs)
+
+    monkeypatch.setattr(pyhf.infer.utils, "qmu_tilde", patched_teststat)
+
+    sig_dist, bkg_dist = calc.distributions(mu_test)
+
+    # signal loop runs ntoys calls (indices 0-9), bkg loop runs ntoys more (10-19)
+    sig_result = calc.toy_results["sig_plus_bkg"]
+    bkg_result = calc.toy_results["bkg_only"]
+
+    # call index 2 lands in signal, call index 5 also in signal
+    assert len(sig_result.failed) == 2
+    assert len(sig_result.successful) == 8
+    assert len(bkg_result.failed) == 0
+    assert len(bkg_result.successful) == 10
+
+    # Each failed entry is (toy_index, sample, exception)
+    for toy_idx, _sample, exc in sig_result.failed:
+        assert isinstance(toy_idx, int)
+        assert isinstance(exc, pyhf.exceptions.FailedMinimization)
+        assert exc.result.success is False
+
+    # EmpiricalDistribution built from successful values only
+    assert len(sig_dist.samples) == 8
+    assert len(bkg_dist.samples) == 10
+
+
+def test_toy_calculator_failure_threshold_exceeded_raises(hypotest_args, monkeypatch):
+    """
+    With failure_threshold set, exceeding the allowed failure fraction raises FailedMinimization.
+    """
+    np.random.seed(0)
+    mu_test, data, model = hypotest_args
+    # Allow only 10% failures; we'll exceed that
+    calc = pyhf.infer.calculators.ToyCalculator(
+        data, model, ntoys=10, track_progress=False, failure_threshold=0.1
+    )
+
+    original_func = pyhf.infer.test_statistics.qmu_tilde
+    call_count = [0]
+
+    def always_fails(*args, **kwargs):
+        call_count[0] += 1
+        if call_count[0] >= 2:
+            import types
+
+            fake_result = types.SimpleNamespace(
+                success=False, message="simulated failure"
+            )
+            raise pyhf.exceptions.FailedMinimization(fake_result)
+        return original_func(*args, **kwargs)
+
+    monkeypatch.setattr(pyhf.infer.utils, "qmu_tilde", always_fails)
+
+    with pytest.raises(pyhf.exceptions.FailedMinimization):
+        calc.distributions(mu_test)
+
+
+def test_toy_calculator_failure_warning_logged(hypotest_args, monkeypatch, caplog):
+    """
+    When toys fail within the threshold, a warning is logged with the failure count.
+    """
+    import logging
+
+    np.random.seed(0)
+    mu_test, data, model = hypotest_args
+    calc = pyhf.infer.calculators.ToyCalculator(
+        data, model, ntoys=10, track_progress=False, failure_threshold=0.5
+    )
+
+    original_func = pyhf.infer.test_statistics.qmu_tilde
+    call_count = [0]
+
+    def one_failure(*args, **kwargs):
+        idx = call_count[0]
+        call_count[0] += 1
+        if idx == 1:
+            import types
+
+            fake_result = types.SimpleNamespace(
+                success=False, message="simulated failure"
+            )
+            raise pyhf.exceptions.FailedMinimization(fake_result)
+        return original_func(*args, **kwargs)
+
+    monkeypatch.setattr(pyhf.infer.utils, "qmu_tilde", one_failure)
+
+    with caplog.at_level(logging.WARNING, logger="pyhf.infer.calculators"):
+        calc.distributions(mu_test)
+
+    assert any(
+        "Signal-like" in r.message and "failed" in r.message for r in caplog.records
+    )
+
+
+def test_toy_calculator_failure_threshold_via_hypotest(hypotest_args, monkeypatch):
+    """
+    failure_threshold is forwarded through hypotest() kwargs to ToyCalculator.
+    """
+    np.random.seed(0)
+    mu_test, data, model = hypotest_args
+
+    original_func = pyhf.infer.test_statistics.qmu_tilde
+    call_count = [0]
+
+    def one_failure(*args, **kwargs):
+        idx = call_count[0]
+        call_count[0] += 1
+        # hypotest() calls teststatistic() first (call 0), then the toy loops start.
+        # Fail on call 5 so at least 4 signal toys succeed first, keeping the
+        # failure fraction at 1/5 = 20% well below failure_threshold=0.5.
+        if idx == 5:
+            import types
+
+            fake_result = types.SimpleNamespace(
+                success=False, message="simulated failure"
+            )
+            raise pyhf.exceptions.FailedMinimization(fake_result)
+        return original_func(*args, **kwargs)
+
+    monkeypatch.setattr(pyhf.infer.utils, "qmu_tilde", one_failure)
+
+    # Should not raise — failure_threshold=0.5 allows up to 50% failures
+    pyhf.infer.hypotest(
+        mu_test,
+        data,
+        model,
+        ntoys=10,
+        track_progress=False,
+        calctype="toybased",
+        failure_threshold=0.5,
+    )
+
+
 def test_fixed_poi(hypotest_args):
     """
     Check that the return structure of pyhf.infer.hypotest with the

--- a/tests/test_public_api_repr.py
+++ b/tests/test_public_api_repr.py
@@ -120,6 +120,7 @@ def test_infer_calculators_public_api():
         "AsymptoticTestStatDistribution",
         "EmpiricalDistribution",
         "ToyCalculator",
+        "ToyResult",
         "generate_asimov_data",
     ]
 


### PR DESCRIPTION
# Pull Request Description

Resolves #1427.

When running toy-based hypothesis tests with `ToyCalculator`, any single failed fit (raised as `FailedMinimization`) would abort the entire toy loop. For large `ntoys` runs this is extremely frustrating — all progress is lost with no information about which toys failed or why.

This PR adds two things:

1. **`ToyResult` dataclass** — a frozen public dataclass that captures per-hypothesis diagnostics from the toy loop, stored on the calculator as `toy_results` after `distributions()` returns:
   - `successful: list[float]` which is a list of test statistic values for toys where the fit converged
   - `failed: list[tuple[int, Tensor, FailedMinimization]]` which is a list of `(toy_index, sample, exception)` for each failed toy, giving callers full access to the pseudo-data and underlying fit result via `exception.result`

2. **`failure_threshold` parameter on `ToyCalculator`** which replaces the draft boolean `skip_failing_toys` with a float (or `None`):
   - `None` (default): any `FailedMinimization` propagates immediately, preserving existing behaviour
   - `[0.0, 1.0]`: fraction of toys allowed to fail before raising; e.g. `failure_threshold=0.1` permits up to 10% failures
   - When failures occur within the threshold, a `WARNING` is logged with the count and fraction
   - `failure_threshold` passes through `hypotest()` kwargs to the calculator automatically

The internal toy loop is also refactored into a private `_collect_toy_teststats()` method to eliminate the duplicated signal/background logic.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Replace the draft skip_failing_toys boolean with a failure_threshold (float | None)
  parameter on ToyCalculator. When None (default) any FailedMinimization propagates
  immediately, preserving existing behaviour. A float value sets the maximum fraction
  of toys allowed to fail before raising.
* Add ToyResult frozen dataclass to capture per-hypothesis diagnostics: successful 
  test statistic values and failed entries as (toy_index, sample, FailedMinimization)
  tuples. Stored on the calculator as toy_results after distributions() returns,
  giving callers full access to which toys failed and the underlying fit result.
* Refactor duplicated signal/background toy loops into a single private
  _collect_toy_teststats() method. Catches FailedMinimization specifically (not bare
  except or RuntimeError), logs a WARNING with failure count and fraction, and
  checks the running failure fraction against failure_threshold after each failure.
* Add ToyResult to the public API (__all__) of pyhf.infer.calculators.
* Add tests covering: no-failure baseline (toy_results populated correctly),
  default raises on first failure, threshold allows failures within limit, threshold
  exceeded raises, warning logged on failure, and failure_threshold forwarded
  through hypotest() kwargs to ToyCalculator.

Co-Authored-By: Giordon Stark <kratsg@gmail.com>
```
