### PR TITLE
feat: Add environment information CLI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -32,34 +32,22 @@ body:
   attributes:
     label: OS / Environment
     description: >-
-      Provide information on your operating system.
-      Something like the output of `cat /etc/os-release` on Linux or
+      Provide information on your operating system and Python environment.
+      If you have pyhf installed, paste the output of `pyhf utils environment`.
+      Otherwise, something like the output of `cat /etc/os-release` on Linux or
       `system_profiler -detailLevel mini SPSoftwareDataType` on macOS.
     render: console
     placeholder: |
-      # Linux
-      $ cat /etc/os-release
-      NAME="Ubuntu"
-      VERSION="20.04.2 LTS (Focal Fossa)"
-      ID=ubuntu
-      ID_LIKE=debian
-      PRETTY_NAME="Ubuntu 20.04.2 LTS"
-      VERSION_ID="20.04"
-      HOME_URL="https://www.ubuntu.com/"
-      SUPPORT_URL="https://help.ubuntu.com/"
-      BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
-      PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
-      VERSION_CODENAME=focal
-      UBUNTU_CODENAME=focal
-
-      # macOS
-      $ system_profiler -detailLevel mini SPSoftwareDataType | head -n 6
-      Software:
-
-          System Software Overview:
-
-            System Version: macOS 10.15.7 (19H1323)
-            Kernel Version: Darwin 19.6.0
+      $ pyhf utils environment
+      * os version: Ubuntu 22.04.4 LTS (Jammy Jellyfish)
+      * kernel version: Linux 6.8.0-79-generic x86_64
+      * python version: CPython 3.12.7 [GCC 13.2.0]
+      * pyhf version: 0.7.6
+      * numpy version: 2.1.3
+      * scipy version: 1.14.1
+      * iminuit version: 2.30.1
+      * jax version: not installed
+      * jaxlib version: not installed
   validations:
     required: true
 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -39,13 +39,13 @@ body:
     render: console
     placeholder: |
       $ pyhf utils environment
-      * os version: Ubuntu 22.04.4 LTS (Jammy Jellyfish)
+      * os version: Ubuntu 24.04.4 LTS (Noble Numbat)
       * kernel version: Linux 6.8.0-79-generic x86_64
-      * python version: CPython 3.12.7 [GCC 13.2.0]
+      * python version: CPython 3.14.6 [GCC 14.3.0]
       * pyhf version: 0.7.6
-      * numpy version: 2.1.3
-      * scipy version: 1.14.1
-      * iminuit version: 2.30.1
+      * numpy version: 2.5.2
+      * scipy version: 1.18.0
+      * iminuit version: 2.32.0
       * jax version: not installed
       * jaxlib version: not installed
   validations:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -42,7 +42,7 @@ body:
       * os version: Ubuntu 24.04.4 LTS (Noble Numbat)
       * kernel version: Linux 6.8.0-79-generic x86_64
       * python version: CPython 3.14.6 [GCC 14.3.0]
-      * pyhf version: 0.7.6
+      * pyhf version: 0.8.0
       * numpy version: 2.5.2
       * scipy version: 1.18.0
       * iminuit version: 2.32.0

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -223,6 +223,7 @@ Utilities
    options_from_eqdelimstring
    digest
    citation
+   environment_info
 
 Contrib
 -------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -169,6 +169,10 @@ invitation for community contributions and new developers.
 Troubleshooting
 ---------------
 
+When reporting an issue, include the output of :code:`pyhf utils environment`,
+which summarizes your operating system and the versions of pyhf and its
+dependencies in a Markdown-friendly format.
+
 - :code:`import pyhf` causes a :code:`Segmentation fault (core dumped)`
 
     This is may be the result of a conflict with the NVIDIA drivers that you

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -170,7 +170,7 @@ Troubleshooting
 ---------------
 
 When reporting an issue, include the output of :code:`pyhf utils environment`,
-which summarizes your operating system and the versions of pyhf and its
+which summarizes your operating system and the versions of ``pyhf`` and its
 dependencies in a Markdown-friendly format.
 
 - :code:`import pyhf` causes a :code:`Segmentation fault (core dumped)`

--- a/src/pyhf/cli/cli.py
+++ b/src/pyhf/cli/cli.py
@@ -5,7 +5,7 @@ import logging
 import click
 
 from pyhf import __version__
-from pyhf.cli import rootio, spec, infer, patchset, utils, complete
+from pyhf.cli import complete, infer, patchset, rootio, spec, utils
 from pyhf.contrib import cli as contrib
 from pyhf.utils import citation
 

--- a/src/pyhf/cli/cli.py
+++ b/src/pyhf/cli/cli.py
@@ -22,7 +22,7 @@ def _print_citation(ctx, param, value):  # noqa: ARG001
 def _debug(ctx, param, value):
     if not value or ctx.resilient_parsing:
         return
-    click.echo(utils.debug_os_info())
+    click.echo(utils.debug_info())
     ctx.exit()
 
 

--- a/src/pyhf/cli/cli.py
+++ b/src/pyhf/cli/cli.py
@@ -19,6 +19,13 @@ def _print_citation(ctx, param, value):  # noqa: ARG001
     ctx.exit()
 
 
+def _debug(ctx, param, value):
+    if not value or ctx.resilient_parsing:
+        return
+    click.echo(utils.debug_os_info())
+    ctx.exit()
+
+
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(version=__version__)
 @click.option(
@@ -28,6 +35,15 @@ def _print_citation(ctx, param, value):  # noqa: ARG001
     default=False,
     is_flag=True,
     callback=_print_citation,
+    expose_value=False,
+    is_eager=True,
+)
+@click.option(
+    "--debug",
+    help="Produce OS / environment information useful for filing a bug report",
+    default=False,
+    is_flag=True,
+    callback=_debug,
     expose_value=False,
     is_eager=True,
 )
@@ -56,3 +72,5 @@ pyhf.add_command(patchset.cli)
 pyhf.add_command(complete.cli)
 
 pyhf.add_command(contrib.cli)
+
+# pyhf.add_command(utils.cli)

--- a/src/pyhf/cli/cli.py
+++ b/src/pyhf/cli/cli.py
@@ -4,9 +4,10 @@ import logging
 
 import click
 
-from pyhf import __version__, utils
-from pyhf.cli import complete, infer, patchset, rootio, spec
+from pyhf import __version__
+from pyhf.cli import rootio, spec, infer, patchset, utils, complete
 from pyhf.contrib import cli as contrib
+from pyhf.utils import citation
 
 logging.basicConfig()
 log = logging.getLogger(__name__)
@@ -15,14 +16,7 @@ log = logging.getLogger(__name__)
 def _print_citation(ctx, param, value):  # noqa: ARG001
     if not value or ctx.resilient_parsing:
         return
-    click.echo(utils.citation())
-    ctx.exit()
-
-
-def _debug(ctx, param, value):
-    if not value or ctx.resilient_parsing:
-        return
-    click.echo(utils.debug_info())
+    click.echo(citation())
     ctx.exit()
 
 
@@ -35,15 +29,6 @@ def _debug(ctx, param, value):
     default=False,
     is_flag=True,
     callback=_print_citation,
-    expose_value=False,
-    is_eager=True,
-)
-@click.option(
-    "--debug",
-    help="Produce OS / environment information useful for filing a bug report",
-    default=False,
-    is_flag=True,
-    callback=_debug,
     expose_value=False,
     is_eager=True,
 )
@@ -69,8 +54,8 @@ pyhf.add_command(infer.cls)
 
 pyhf.add_command(patchset.cli)
 
+pyhf.add_command(utils.cli)
+
 pyhf.add_command(complete.cli)
 
 pyhf.add_command(contrib.cli)
-
-# pyhf.add_command(utils.cli)

--- a/src/pyhf/cli/cli.py
+++ b/src/pyhf/cli/cli.py
@@ -4,10 +4,10 @@ import logging
 
 import click
 
-from pyhf import __version__
-from pyhf.cli import complete, infer, patchset, rootio, spec, utils
+from pyhf import __version__, utils
+from pyhf.cli import complete, infer, patchset, rootio, spec
+from pyhf.cli import utils as utils_cli
 from pyhf.contrib import cli as contrib
-from pyhf.utils import citation
 
 logging.basicConfig()
 log = logging.getLogger(__name__)
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 def _print_citation(ctx, param, value):  # noqa: ARG001
     if not value or ctx.resilient_parsing:
         return
-    click.echo(citation())
+    click.echo(utils.citation())
     ctx.exit()
 
 
@@ -54,7 +54,7 @@ pyhf.add_command(infer.cls)
 
 pyhf.add_command(patchset.cli)
 
-pyhf.add_command(utils.cli)
+pyhf.add_command(utils_cli.cli)
 
 pyhf.add_command(complete.cli)
 

--- a/src/pyhf/cli/utils.py
+++ b/src/pyhf/cli/utils.py
@@ -1,0 +1,17 @@
+"""The pyhf utils CLI subcommand."""
+import logging
+
+import click
+from pyhf import utils
+
+log = logging.getLogger(__name__)
+
+
+@click.group(name="utils")
+def cli():
+    """Utils CLI group."""
+
+
+@cli.command()
+def debug():
+    click.echo(utils.debug_info())

--- a/src/pyhf/cli/utils.py
+++ b/src/pyhf/cli/utils.py
@@ -1,5 +1,6 @@
 """The pyhf utils CLI subcommand."""
 import logging
+from pathlib import Path
 
 import click
 from pyhf import utils
@@ -13,5 +14,21 @@ def cli():
 
 
 @cli.command()
-def debug():
-    click.echo(utils.debug_info())
+@click.option(
+    "-o",
+    "--output-file",
+    help="The location of the output file. If not specified, prints to screen.",
+    default=None,
+)
+def debug(output_file):
+    debug_info = utils.debug_info()
+
+    if output_file:
+        output_file = Path(output_file)
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(output_file, "w+", encoding="utf-8") as out_file:
+            out_file.write(debug_info)
+        log.debug(f"Written to {output_file}")
+    else:
+        click.echo(debug_info)

--- a/src/pyhf/cli/utils.py
+++ b/src/pyhf/cli/utils.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 
 import click
+
 from pyhf import utils
 
 log = logging.getLogger(__name__)

--- a/src/pyhf/cli/utils.py
+++ b/src/pyhf/cli/utils.py
@@ -21,15 +21,15 @@ def cli():
     help="The location of the output file. If not specified, prints to screen.",
     default=None,
 )
-def debug(output_file):
-    debug_info = utils.debug_info()
+def environment(output_file):
+    environment_info = utils.environment_info()
 
     if output_file:
         output_file = Path(output_file)
         output_file.parent.mkdir(parents=True, exist_ok=True)
 
         with open(output_file, "w+", encoding="utf-8") as out_file:
-            out_file.write(debug_info)
-        log.debug(f"Written to {output_file}")
+            out_file.write(environment_info)
+        log.environment(f"Written to {output_file}")
     else:
-        click.echo(debug_info)
+        click.echo(environment_info)

--- a/src/pyhf/cli/utils.py
+++ b/src/pyhf/cli/utils.py
@@ -1,4 +1,5 @@
 """The pyhf utils CLI subcommand."""
+
 import logging
 from pathlib import Path
 
@@ -28,7 +29,7 @@ def environment(output_file):
         output_file = Path(output_file)
         output_file.parent.mkdir(parents=True, exist_ok=True)
 
-        with open(output_file, "w+", encoding="utf-8") as out_file:
+        with output_file.open("w+", encoding="utf-8") as out_file:
             out_file.write(environment_info)
         log.environment(f"Written to {output_file}")
     else:

--- a/src/pyhf/cli/utils.py
+++ b/src/pyhf/cli/utils.py
@@ -23,14 +23,15 @@ def cli():
     default=None,
 )
 def environment(output_file):
-    environment_info = utils.environment_info()
+    """Print information about the pyhf environment useful for bug reports."""
+    info = utils.environment_info()
 
     if output_file:
         output_file = Path(output_file)
         output_file.parent.mkdir(parents=True, exist_ok=True)
 
         with output_file.open("w+", encoding="utf-8") as out_file:
-            out_file.write(environment_info)
-        log.environment(f"Written to {output_file}")
+            out_file.write(info)
+        log.debug("Written to %s", output_file)
     else:
-        click.echo(environment_info)
+        click.echo(info)

--- a/src/pyhf/cli/utils.py
+++ b/src/pyhf/cli/utils.py
@@ -26,12 +26,9 @@ def environment(output_file):
     """Print information about the pyhf environment useful for bug reports."""
     info = utils.environment_info()
 
-    if output_file:
-        output_file = Path(output_file)
-        output_file.parent.mkdir(parents=True, exist_ok=True)
-
-        with output_file.open("w+", encoding="utf-8") as out_file:
+    if output_file is None:
+        click.echo(info, nl=False)
+    else:
+        with Path(output_file).open("w+", encoding="utf-8") as out_file:
             out_file.write(info)
         log.debug("Written to %s", output_file)
-    else:
-        click.echo(info)

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -20,6 +20,7 @@ else:
 __all__ = [
     "EqDelimStringParamType",
     "citation",
+    "debug_info",
     "digest",
     "options_from_eqdelimstring",
 ]

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import importlib.metadata
 import json
 import platform
 import sys
@@ -126,15 +127,27 @@ def citation(oneline=False):
 
 def environment_info():
     """
-    Produce OS / environment information useful for filing a bug report
+    Produce OS / environment information useful for filing a bug report.
+
+    The output is formatted as a Markdown bullet list for easy copy-paste
+    into GitHub issues.
 
     Example:
 
         >>> import pyhf
-        >>> pyhf.utils.environment_info()
+        >>> print(pyhf.utils.environment_info())  # doctest: +ELLIPSIS
+        * os version: ...
+        * kernel version: ...
+        * python version: ...
+        * pyhf version: ...
+        * numpy version: ...
+        * scipy version: ...
+        * iminuit version: ...
+        * jax version: ...
+        * jaxlib version: ...
 
     Returns:
-        os_info (:obj:`str`): The operating system and environment information
+        :obj:`str`: The operating system and environment information
         for the host machine.
     """
 
@@ -170,8 +183,29 @@ def environment_info():
     elif sys.platform == "darwin":
         os_version = f"macOS {platform.mac_ver()[0]}"
 
-    os_info = f"* os version: {os_version}\n"
-    kernel_info = f"* kernel version: {platform.system()} {platform.release()} {platform.machine()}\n"
-    python_info = f"* python version: {platform.python_implementation()} {platform.python_version()} [{platform.python_compiler()}]\n"
-    pyhf_version = f"* pyhf version: {__version__}\n"
-    return os_info + kernel_info + python_info + pyhf_version
+    lines = [
+        f"* os version: {os_version}",
+        f"* kernel version: {platform.system()} {platform.release()} {platform.machine()}",
+        f"* python version: {platform.python_implementation()} {platform.python_version()} [{platform.python_compiler()}]",
+        f"* pyhf version: {__version__}",
+        f"* numpy version: {importlib.metadata.version('numpy')}",
+        f"* scipy version: {importlib.metadata.version('scipy')}",
+    ]
+
+    # Optional backends — show "not installed" if absent
+    try:
+        lines.append(f"* iminuit version: {importlib.metadata.version('iminuit')}")
+    except importlib.metadata.PackageNotFoundError:
+        lines.append("* iminuit version: not installed")
+
+    try:
+        lines.append(f"* jax version: {importlib.metadata.version('jax')}")
+    except importlib.metadata.PackageNotFoundError:
+        lines.append("* jax version: not installed")
+
+    try:
+        lines.append(f"* jaxlib version: {importlib.metadata.version('jaxlib')}")
+    except importlib.metadata.PackageNotFoundError:
+        lines.append("* jaxlib version: not installed")
+
+    return "\n".join(lines) + "\n"

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -117,3 +117,40 @@ def citation(oneline=False):
     if oneline:
         data = "".join(data.splitlines())
     return data
+
+
+# # Linux
+# $ cat /etc/os-release
+# NAME="Ubuntu"
+# VERSION="20.04.2 LTS (Focal Fossa)"
+# ID=ubuntu
+# ID_LIKE=debian
+# PRETTY_NAME="Ubuntu 20.04.2 LTS"
+# VERSION_ID="20.04"
+# HOME_URL="https://www.ubuntu.com/"
+# SUPPORT_URL="https://help.ubuntu.com/"
+# BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+# PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+# VERSION_CODENAME=focal
+# UBUNTU_CODENAME=focal
+
+
+def debug_os_info():
+    """
+    Produce OS / environment information useful for filing a bug report
+
+    Example:
+
+        >>> import pyhf
+        >>> pyhf.utils.debug_os_info()
+
+    Returns:
+        os_info (:obj:`str`): The operating system and environment information
+        for the host machine.
+    """
+    import os
+    from pyhf import __version__
+
+    pyhf_version = f"pyhf version: {__version__}\n"
+    summary = pyhf_version + "hi"
+    return summary

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -10,13 +10,6 @@ import yaml
 
 from pyhf import __version__
 
-# importlib.resources.as_file wasn't added until Python 3.9
-# c.f. https://docs.python.org/3.9/library/importlib.html#importlib.resources.as_file
-if sys.version_info >= (3, 9):
-    from importlib import resources
-else:
-    import importlib_resources as resources
-
 __all__ = [
     "EqDelimStringParamType",
     "citation",
@@ -158,17 +151,16 @@ def environment_info():
             def freedesktop_os_release():
                 os_release_path = Path("/etc") / "os-release"
                 if os_release_path.exists():
-                    with open(os_release_path, encoding="utf8") as read_file:
+                    with os_release_path.open(encoding="utf8") as read_file:
                         os_release_file = read_file.read()
                     os_release_list = os_release_file.split("\n")
                     # Remove all trailing lines
                     os_release_list = list(filter(("").__ne__, os_release_list))
                     return {
-                        token.split("=")[0]: token.split("=")[1].replace('"', '')
+                        token.split("=")[0]: token.split("=")[1].replace('"', "")
                         for token in os_release_list
                     }
-                else:
-                    raise OSError
+                raise OSError
 
         try:
             os_release = freedesktop_os_release()

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -161,7 +161,8 @@ def debug_info():
                     with open(os_release_path, encoding="utf8") as read_file:
                         os_release_file = read_file.read()
                     os_release_list = os_release_file.split("\n")
-                    os_release_list.remove("")  # Remove trailing line
+                    # Remove all trailing lines
+                    os_release_list = list(filter(("").__ne__, os_release_list))
                     return {
                         token.split("=")[0]: token.split("=")[1].replace('"', '')
                         for token in os_release_list

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -1,10 +1,21 @@
 import hashlib
 import json
+import platform
+import sys
 from gettext import gettext
 from importlib import resources
 
 import click
 import yaml
+
+from pyhf import __version__
+
+# importlib.resources.as_file wasn't added until Python 3.9
+# c.f. https://docs.python.org/3.9/library/importlib.html#importlib.resources.as_file
+if sys.version_info >= (3, 9):
+    from importlib import resources
+else:
+    import importlib_resources as resources
 
 __all__ = [
     "EqDelimStringParamType",
@@ -119,38 +130,54 @@ def citation(oneline=False):
     return data
 
 
-# # Linux
-# $ cat /etc/os-release
-# NAME="Ubuntu"
-# VERSION="20.04.2 LTS (Focal Fossa)"
-# ID=ubuntu
-# ID_LIKE=debian
-# PRETTY_NAME="Ubuntu 20.04.2 LTS"
-# VERSION_ID="20.04"
-# HOME_URL="https://www.ubuntu.com/"
-# SUPPORT_URL="https://help.ubuntu.com/"
-# BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
-# PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
-# VERSION_CODENAME=focal
-# UBUNTU_CODENAME=focal
-
-
-def debug_os_info():
+def debug_info():
     """
     Produce OS / environment information useful for filing a bug report
 
     Example:
 
         >>> import pyhf
-        >>> pyhf.utils.debug_os_info()
+        >>> pyhf.utils.debug_info()
 
     Returns:
         os_info (:obj:`str`): The operating system and environment information
         for the host machine.
     """
-    import os
-    from pyhf import __version__
 
-    pyhf_version = f"pyhf version: {__version__}\n"
-    summary = pyhf_version + "hi"
-    return summary
+    os_version = "Cannot be determined"
+    if sys.platform == "linux":
+        try:
+            # platform.freedesktop_os_release added in Python 3.10
+            # Remove when Python 3.9 support dropped
+            from platform import freedesktop_os_release
+        except ImportError:
+            # c.f. https://docs.python.org/3/library/platform.html#platform.freedesktop_os_release
+            from pathlib import Path
+
+            def freedesktop_os_release():
+                os_release_path = Path("/etc") / "os-release"
+                if os_release_path.exists():
+                    with open(os_release_path, encoding="utf8") as read_file:
+                        os_release_file = read_file.read()
+                    os_release_list = os_release_file.split("\n")
+                    os_release_list.remove("")  # Remove trailing line
+                    return {
+                        token.split("=")[0]: token.split("=")[1].replace('"', '')
+                        for token in os_release_list
+                    }
+                else:
+                    raise OSError
+
+        try:
+            os_release = freedesktop_os_release()
+            os_version = f"{os_release['NAME']} {os_release['VERSION']}"
+        except OSError:
+            os_version = "Cannot be determined"
+    elif sys.platform == "darwin":
+        os_version = f"macOS {platform.mac_ver()[0]}"
+
+    os_info = f"* os version: {os_version}\n"
+    kernel_info = f"* kernel version: {platform.system()} {platform.release()} {platform.machine()}\n"
+    python_info = f"* python version: {platform.python_implementation()} {platform.python_version()} [{platform.python_compiler()}]\n"
+    pyhf_version = f"* pyhf version: {__version__}\n"
+    return os_info + kernel_info + python_info + pyhf_version

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -20,7 +20,7 @@ else:
 __all__ = [
     "EqDelimStringParamType",
     "citation",
-    "debug_info",
+    "environment_info",
     "digest",
     "options_from_eqdelimstring",
 ]
@@ -131,14 +131,14 @@ def citation(oneline=False):
     return data
 
 
-def debug_info():
+def environment_info():
     """
     Produce OS / environment information useful for filing a bug report
 
     Example:
 
         >>> import pyhf
-        >>> pyhf.utils.debug_info()
+        >>> pyhf.utils.environment_info()
 
     Returns:
         os_info (:obj:`str`): The operating system and environment information

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -20,8 +20,8 @@ else:
 __all__ = [
     "EqDelimStringParamType",
     "citation",
-    "environment_info",
     "digest",
+    "environment_info",
     "options_from_eqdelimstring",
 ]
 

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -193,19 +193,11 @@ def environment_info():
     ]
 
     # Optional backends — show "not installed" if absent
-    try:
-        lines.append(f"* iminuit version: {importlib.metadata.version('iminuit')}")
-    except importlib.metadata.PackageNotFoundError:
-        lines.append("* iminuit version: not installed")
-
-    try:
-        lines.append(f"* jax version: {importlib.metadata.version('jax')}")
-    except importlib.metadata.PackageNotFoundError:
-        lines.append("* jax version: not installed")
-
-    try:
-        lines.append(f"* jaxlib version: {importlib.metadata.version('jaxlib')}")
-    except importlib.metadata.PackageNotFoundError:
-        lines.append("* jaxlib version: not installed")
+    for package in ("iminuit", "jax", "jaxlib"):
+        try:
+            version = importlib.metadata.version(package)
+        except importlib.metadata.PackageNotFoundError:
+            version = "not installed"
+        lines.append(f"* {package} version: {version}")
 
     return "\n".join(lines) + "\n"

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -186,21 +186,26 @@ def environment_info():
 
         try:
             os_release = freedesktop_os_release()
-        except OSError:
+        # ValueError covers UnicodeDecodeError from a non-UTF-8 os-release file
+        except (OSError, ValueError):
             pass
         else:
-            if "NAME" in os_release and "VERSION" in os_release:
-                os_version = f"{os_release['NAME']} {os_release['VERSION']}"
-            else:
-                # VERSION is optional in the os-release spec (e.g. rolling releases)
-                os_version = os_release.get("PRETTY_NAME", "Cannot be determined")
+            # VERSION is optional in the os-release spec (e.g. rolling releases)
+            os_version = " ".join(
+                part
+                for part in (
+                    os_release.get("NAME"),
+                    os_release.get("VERSION", os_release.get("VERSION_ID")),
+                )
+                if part
+            ) or os_release.get("PRETTY_NAME", "Cannot be determined")
     elif sys.platform == "darwin":
         os_version = f"macOS {platform.mac_ver()[0]}"
 
     lines = [
         f"* os version: {os_version}",
         f"* kernel version: {platform.system()} {platform.release()} {platform.machine()}",
-        f"* python version: {platform.python_implementation()} {platform.python_version()} [{platform.python_compiler()}]",
+        f"* python version: {platform.python_implementation()} {platform.python_version()} [{platform.python_compiler().strip()}]",
         f"* pyhf version: {__version__}",
     ]
 

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -9,7 +9,9 @@ from importlib import resources
 import click
 import yaml
 
-from pyhf import __version__
+# Import from pyhf._version instead of pyhf to avoid a circular import, as
+# pyhf.utils is imported while pyhf.__init__ is still executing
+from pyhf._version import version as __version__
 
 __all__ = [
     "EqDelimStringParamType",
@@ -162,24 +164,36 @@ def environment_info():
             from pathlib import Path
 
             def freedesktop_os_release():
-                os_release_path = Path("/etc") / "os-release"
-                if os_release_path.exists():
-                    with os_release_path.open(encoding="utf8") as read_file:
-                        os_release_file = read_file.read()
-                    os_release_list = os_release_file.split("\n")
-                    # Remove all trailing lines
-                    os_release_list = list(filter(("").__ne__, os_release_list))
-                    return {
-                        token.split("=")[0]: token.split("=")[1].replace('"', "")
-                        for token in os_release_list
-                    }
+                # Values may contain "=" and files may contain comment lines
+                # c.f. https://www.freedesktop.org/software/systemd/man/os-release.html
+                for os_release_path in (
+                    Path("/etc/os-release"),
+                    Path("/usr/lib/os-release"),
+                ):
+                    try:
+                        with os_release_path.open(encoding="utf8") as read_file:
+                            return {
+                                key: value.strip("\"'")
+                                for key, _, value in (
+                                    line.strip().partition("=")
+                                    for line in read_file
+                                    if "=" in line and not line.lstrip().startswith("#")
+                                )
+                            }
+                    except OSError:  # noqa: PERF203
+                        continue
                 raise OSError
 
         try:
             os_release = freedesktop_os_release()
-            os_version = f"{os_release['NAME']} {os_release['VERSION']}"
         except OSError:
-            os_version = "Cannot be determined"
+            pass
+        else:
+            if "NAME" in os_release and "VERSION" in os_release:
+                os_version = f"{os_release['NAME']} {os_release['VERSION']}"
+            else:
+                # VERSION is optional in the os-release spec (e.g. rolling releases)
+                os_version = os_release.get("PRETTY_NAME", "Cannot be determined")
     elif sys.platform == "darwin":
         os_version = f"macOS {platform.mac_ver()[0]}"
 
@@ -188,12 +202,12 @@ def environment_info():
         f"* kernel version: {platform.system()} {platform.release()} {platform.machine()}",
         f"* python version: {platform.python_implementation()} {platform.python_version()} [{platform.python_compiler()}]",
         f"* pyhf version: {__version__}",
-        f"* numpy version: {importlib.metadata.version('numpy')}",
-        f"* scipy version: {importlib.metadata.version('scipy')}",
     ]
 
-    # Optional backends — show "not installed" if absent
-    for package in ("iminuit", "jax", "jaxlib"):
+    # Guard all lookups as optional backends may be absent and even core
+    # dependencies could be installed in a strange way that they are importable
+    # without dist-info metadata. Show "not installed" instead of raising.
+    for package in ("numpy", "scipy", "iminuit", "jax", "jaxlib"):
         try:
             version = importlib.metadata.version(package)
         except importlib.metadata.PackageNotFoundError:

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -157,7 +157,7 @@ def environment_info():
     if sys.platform == "linux":
         try:
             # platform.freedesktop_os_release added in Python 3.10
-            # Remove when Python 3.9 support dropped
+            # FIXME: Remove when Python 3.9 support dropped
             from platform import freedesktop_os_release
         except ImportError:
             # c.f. https://docs.python.org/3/library/platform.html#platform.freedesktop_os_release

--- a/tests/test_public_api_repr.py
+++ b/tests/test_public_api_repr.py
@@ -252,6 +252,7 @@ def test_utils_public_api():
         "EqDelimStringParamType",
         "citation",
         "digest",
+        "environment_info",
         "options_from_eqdelimstring",
     ]
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -53,6 +53,31 @@ def test_citation(script_runner, flag):
     assert elapsed < 1.0
 
 
+def test_utils_environment(script_runner):
+    ret = script_runner.run(shlex.split("pyhf utils environment"))
+    assert ret.success
+    assert ret.stderr == ""
+    assert "* os version:" in ret.stdout
+    assert "* kernel version:" in ret.stdout
+    assert "* python version:" in ret.stdout
+    assert f"* pyhf version: {pyhf.__version__}" in ret.stdout
+    assert "* numpy version:" in ret.stdout
+    assert "* scipy version:" in ret.stdout
+
+
+def test_utils_environment_output_file(tmp_path, script_runner):
+    outfile = tmp_path / "environment.md"
+    ret = script_runner.run(
+        shlex.split(f"pyhf utils environment --output-file {outfile}")
+    )
+    assert ret.success
+    assert ret.stderr == ""
+    assert ret.stdout == ""
+    contents = outfile.read_text(encoding="utf-8")
+    assert "* pyhf version:" in contents
+    assert "* numpy version:" in contents
+
+
 # see test_import.py for the same (detailed) test
 def test_import_prepHistFactory(tmp_path, script_runner):
     temp = tmp_path.joinpath("parsed_output.json")

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -57,12 +57,9 @@ def test_utils_environment(script_runner):
     ret = script_runner.run(shlex.split("pyhf utils environment"))
     assert ret.success
     assert ret.stderr == ""
-    assert "* os version:" in ret.stdout
-    assert "* kernel version:" in ret.stdout
-    assert "* python version:" in ret.stdout
     assert f"* pyhf version: {pyhf.__version__}" in ret.stdout
-    assert "* numpy version:" in ret.stdout
-    assert "* scipy version:" in ret.stdout
+    # Exact match ensures no extra trailing newline from click.echo
+    assert ret.stdout == pyhf.utils.environment_info()
 
 
 def test_utils_environment_output_file(tmp_path, script_runner):
@@ -73,9 +70,8 @@ def test_utils_environment_output_file(tmp_path, script_runner):
     assert ret.success
     assert ret.stderr == ""
     assert ret.stdout == ""
-    contents = outfile.read_text(encoding="utf-8")
-    assert "* pyhf version:" in contents
-    assert "* numpy version:" in contents
+    # File output identical to terminal output
+    assert outfile.read_text(encoding="utf-8") == pyhf.utils.environment_info()
 
 
 # see test_import.py for the same (detailed) test

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -82,6 +82,7 @@ def test_environment_info_linux(monkeypatch):
         platform,
         "freedesktop_os_release",
         lambda: {"NAME": "Ubuntu", "VERSION": "22.04.2 LTS (Jammy Jellyfish)"},
+        raising=False,
     )
     info = pyhf.utils.environment_info()
     assert "* os version: Ubuntu 22.04.2 LTS (Jammy Jellyfish)" in info
@@ -93,7 +94,9 @@ def test_environment_info_linux_oserror(monkeypatch):
     def raise_oserror():
         raise OSError
 
-    monkeypatch.setattr(platform, "freedesktop_os_release", raise_oserror)
+    monkeypatch.setattr(
+        platform, "freedesktop_os_release", raise_oserror, raising=False
+    )
     info = pyhf.utils.environment_info()
     assert "* os version: Cannot be determined" in info
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,6 @@
 import importlib.metadata
+import platform
+import sys
 
 import pytest
 
@@ -72,6 +74,41 @@ def test_environment_info():
     # Output should be markdown bullet list lines
     for line in info.strip().splitlines():
         assert line.startswith("* ")
+
+
+def test_environment_info_linux(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(
+        platform,
+        "freedesktop_os_release",
+        lambda: {"NAME": "Ubuntu", "VERSION": "22.04.2 LTS (Jammy Jellyfish)"},
+    )
+    info = pyhf.utils.environment_info()
+    assert "* os version: Ubuntu 22.04.2 LTS (Jammy Jellyfish)" in info
+
+
+def test_environment_info_linux_oserror(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    def raise_oserror():
+        raise OSError
+
+    monkeypatch.setattr(platform, "freedesktop_os_release", raise_oserror)
+    info = pyhf.utils.environment_info()
+    assert "* os version: Cannot be determined" in info
+
+
+def test_environment_info_darwin(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(platform, "mac_ver", lambda: ("14.1.0", ("", "", ""), ""))
+    info = pyhf.utils.environment_info()
+    assert "* os version: macOS 14.1.0" in info
+
+
+def test_environment_info_unknown_platform(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    info = pyhf.utils.environment_info()
+    assert "* os version: Cannot be determined" in info
 
 
 def test_environment_info_missing_optional(monkeypatch):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import importlib.metadata
+import pathlib
 import platform
 import sys
 
@@ -96,6 +97,21 @@ def test_environment_info_linux_oserror(monkeypatch):
 
     monkeypatch.setattr(
         platform, "freedesktop_os_release", raise_oserror, raising=False
+    )
+    info = pyhf.utils.environment_info()
+    assert "* os version: Cannot be determined" in info
+
+
+def test_environment_info_linux_fallback_no_os_release_file(monkeypatch):
+    # Simulate Python 3.9 (no platform.freedesktop_os_release) with no /etc/os-release
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delattr(platform, "freedesktop_os_release", raising=False)
+
+    original_exists = pathlib.Path.exists
+    monkeypatch.setattr(
+        pathlib.Path,
+        "exists",
+        lambda self: False if "os-release" in str(self) else original_exists(self),
     )
     info = pyhf.utils.environment_info()
     assert "* os version: Cannot be determined" in info

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+import importlib.metadata
+
 import pytest
 
 import pyhf
@@ -53,3 +55,38 @@ def test_citation(oneline):
     assert citation
     if oneline:
         assert "\n" not in citation
+
+
+def test_environment_info():
+    info = pyhf.utils.environment_info()
+    assert isinstance(info, str)
+    assert "* os version:" in info
+    assert "* kernel version:" in info
+    assert "* python version:" in info
+    assert f"* pyhf version: {pyhf.__version__}" in info
+    assert "* numpy version:" in info
+    assert "* scipy version:" in info
+    assert "* iminuit version:" in info
+    assert "* jax version:" in info
+    assert "* jaxlib version:" in info
+    # Output should be markdown bullet list lines
+    for line in info.strip().splitlines():
+        assert line.startswith("* ")
+
+
+def test_environment_info_missing_optional(monkeypatch):
+    original_version = importlib.metadata.version
+
+    def mock_version(name):
+        if name in ("iminuit", "jax", "jaxlib"):
+            raise importlib.metadata.PackageNotFoundError(name)
+        return original_version(name)
+
+    monkeypatch.setattr(importlib.metadata, "version", mock_version)
+    info = pyhf.utils.environment_info()
+    assert "* iminuit version: not installed" in info
+    assert "* jax version: not installed" in info
+    assert "* jaxlib version: not installed" in info
+    # Core packages still present
+    assert "* numpy version:" in info
+    assert "* scipy version:" in info

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import importlib.metadata
+import io
 import pathlib
 import platform
 import sys
@@ -89,6 +90,19 @@ def test_environment_info_linux(monkeypatch):
     assert "* os version: Ubuntu 22.04.2 LTS (Jammy Jellyfish)" in info
 
 
+def test_environment_info_linux_no_version(monkeypatch):
+    # VERSION is optional in the os-release spec (e.g. rolling releases)
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(
+        platform,
+        "freedesktop_os_release",
+        lambda: {"NAME": "Arch Linux", "ID": "arch", "PRETTY_NAME": "Arch Linux"},
+        raising=False,
+    )
+    info = pyhf.utils.environment_info()
+    assert "* os version: Arch Linux" in info
+
+
 def test_environment_info_linux_oserror(monkeypatch):
     monkeypatch.setattr(sys, "platform", "linux")
 
@@ -103,18 +117,47 @@ def test_environment_info_linux_oserror(monkeypatch):
 
 
 def test_environment_info_linux_fallback_no_os_release_file(monkeypatch):
-    # Simulate Python 3.9 (no platform.freedesktop_os_release) with no /etc/os-release
+    # Simulate Python 3.9 (no platform.freedesktop_os_release) with no os-release file
     monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.delattr(platform, "freedesktop_os_release", raising=False)
 
-    original_exists = pathlib.Path.exists
-    monkeypatch.setattr(
-        pathlib.Path,
-        "exists",
-        lambda self: False if "os-release" in str(self) else original_exists(self),
-    )
+    original_open = pathlib.Path.open
+
+    def mock_open(self, *args, **kwargs):
+        if "os-release" in str(self):
+            raise FileNotFoundError(str(self))
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "open", mock_open)
     info = pyhf.utils.environment_info()
     assert "* os version: Cannot be determined" in info
+
+
+def test_environment_info_linux_fallback_parses_os_release(monkeypatch):
+    # Simulate Python 3.9 with an os-release file exercising what the spec
+    # permits: comment lines, quoted values, values containing "=", no VERSION
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delattr(platform, "freedesktop_os_release", raising=False)
+
+    os_release_content = (
+        "# This file is part of systemd\n"
+        'NAME="Arch Linux"\n'
+        'PRETTY_NAME="Arch Linux"\n'
+        "ID=arch\n"
+        'BUG_REPORT_URL="https://bugs.example.org/?product=arch"\n'
+        "\n"
+    )
+
+    original_open = pathlib.Path.open
+
+    def mock_open(self, *args, **kwargs):
+        if "os-release" in str(self):
+            return io.StringIO(os_release_content)
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "open", mock_open)
+    info = pyhf.utils.environment_info()
+    assert "* os version: Arch Linux" in info
 
 
 def test_environment_info_darwin(monkeypatch):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -135,14 +135,15 @@ def test_environment_info_linux_fallback_no_os_release_file(monkeypatch):
 
 def test_environment_info_linux_fallback_parses_os_release(monkeypatch):
     # Simulate Python 3.9 with an os-release file exercising what the spec
-    # permits: comment lines, quoted values, values containing "=", no VERSION
+    # permits: comment lines, quoted values, values containing "=", and no
+    # NAME/VERSION so the reported value is PRETTY_NAME, whose embedded "="
+    # pins that values are only split on the first "="
     monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.delattr(platform, "freedesktop_os_release", raising=False)
 
     os_release_content = (
         "# This file is part of systemd\n"
-        'NAME="Arch Linux"\n'
-        'PRETTY_NAME="Arch Linux"\n'
+        'PRETTY_NAME="Arch Linux (build=rolling)"\n'
         "ID=arch\n"
         'BUG_REPORT_URL="https://bugs.example.org/?product=arch"\n'
         "\n"
@@ -157,7 +158,25 @@ def test_environment_info_linux_fallback_parses_os_release(monkeypatch):
 
     monkeypatch.setattr(pathlib.Path, "open", mock_open)
     info = pyhf.utils.environment_info()
-    assert "* os version: Arch Linux" in info
+    assert "* os version: Arch Linux (build=rolling)" in info
+
+
+def test_environment_info_linux_version_id_fallback(monkeypatch):
+    # Distributions like Alpine provide VERSION_ID but no VERSION
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(
+        platform,
+        "freedesktop_os_release",
+        lambda: {
+            "NAME": "Alpine Linux",
+            "ID": "alpine",
+            "VERSION_ID": "3.20.1",
+            "PRETTY_NAME": "Alpine Linux v3.20",
+        },
+        raising=False,
+    )
+    info = pyhf.utils.environment_info()
+    assert "* os version: Alpine Linux 3.20.1" in info
 
 
 def test_environment_info_darwin(monkeypatch):
@@ -186,6 +205,6 @@ def test_environment_info_missing_optional(monkeypatch):
     assert "* iminuit version: not installed" in info
     assert "* jax version: not installed" in info
     assert "* jaxlib version: not installed" in info
-    # Core packages still present
-    assert "* numpy version:" in info
-    assert "* scipy version:" in info
+    # Core packages still report their real versions, not "not installed"
+    assert f"* numpy version: {original_version('numpy')}" in info
+    assert f"* scipy version: {original_version('scipy')}" in info


### PR DESCRIPTION
# Description

Resolves #1580

Add `pyhf.utils.environment_info` which produces a Markdown-friendly bullet list summary of the environment useful for bug reports. Also adds a CLI command `pyhf utils environment`. Optional backends (iminuit, jax, jaxlib) show "not installed" when absent.

Example output:

```console
$ pyhf utils environment
* os version: macOS 14.6.1
* kernel version: Darwin 23.6.0 arm64
* python version: CPython 3.12.7 [Clang 16.0.0 (clang-1600.0.26.4)]
* pyhf version: 0.8.0.dev0
* numpy version: 2.1.3
* scipy version: 1.14.1
* iminuit version: 2.30.1
* jax version: not installed
* jaxlib version: not installed
```

Relevant doc build: https://pyhf--2129.org.readthedocs.build/en/2129/cli.html#pyhf-utils-environment

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

---

```
* Add pyhf.utils.environment_info() to produce OS, Python, pyhf, numpy,
  scipy, and optional backend (iminuit, jax, jaxlib) version information
  as a Markdown-friendly bullet list for bug reports. Optional packages
  show "not installed" when absent.
* Add pyhf utils environment CLI command with --output-file option.
* Add tests for environment_info() including missing optional packages
  via monkeypatch, and CLI tests via script_runner.
* Add 'pyhf utils environment' to bug Issue report template and
  troubleshooting section of FAQ.

Assisted-by: ClaudeCode:claude-fable-5

Co-authored-by: Giordon Stark <kratsg@gmail.com>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an environment report covering operating system, kernel, Python, pyhf, NumPy, SciPy, and optional backend versions.
  * Added the `pyhf utils environment` command to display the report or save it to a Markdown file.
  * Added graceful handling for unavailable system and package information.

* **Documentation**
  * Documented the environment-reporting utility and updated bug-report guidance.

* **Tests**
  * Added coverage for command output, file export, platform detection, and missing metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->