### PR TITLE
docs: Update JAX backend array_type to jaxlib.xla_extension.ArrayImpl

### DIFF
--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -216,13 +216,13 @@ class jax_backend:
             Array([[1., 2., 3.],
                    [4., 5., 6.]], dtype=float64)
             >>> type(tensor) # doctest:+ELLIPSIS
-            <class '...Array'>
+            <class '...ArrayImpl'>
 
         Args:
             tensor_in (Number or Tensor): Tensor object
 
         Returns:
-            `jaxlib.xla_extension.Array`: A multi-dimensional, fixed-size homogeneous array.
+            `jaxlib.xla_extension.ArrayImpl`: A multi-dimensional, fixed-size homogeneous array.
         """
         # TODO: Remove doctest:+ELLIPSIS when JAX API stabilized
         try:


### PR DESCRIPTION
# Description

Update JAX backend array_type to `jaxlib.xla_extension.ArrayImpl`, which is a unified array type introduced in `jaxlib` `v0.4.6`.
   - c.f. https://github.com/google/jax/releases/tag/jaxlib-v0.4.6
   - c.f. https://github.com/google/jax/issues/14768


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update JAX backend array_type to jaxlib.xla_extension.ArrayImpl, which is a unified
  array type introduced in jaxlib v0.4.6.
   - c.f. https://github.com/google/jax/releases/tag/jaxlib-v0.4.6
   - c.f. https://github.com/google/jax/issues/14768
```