### PR TITLE
docs: Add matplotlib to piplite installs for JupyterLite example

### DIFF
--- a/docs/generate_jupyterlite_iframe.py
+++ b/docs/generate_jupyterlite_iframe.py
@@ -4,7 +4,7 @@ import urllib.parse
 def main():
     code = """\
 import piplite
-await piplite.install(["pyhf==0.7.0"])
+await piplite.install(["pyhf==0.7.0", "matplotlib>=3.0.0"])
 %matplotlib inline
 import pyhf\
 """

--- a/docs/jupyterlite.rst
+++ b/docs/jupyterlite.rst
@@ -21,7 +21,7 @@ Try out now with JupyterLite_
 .. raw:: html
 
    <iframe
-      src="https://jupyterlite.github.io/demo/repl/index.html?kernel=python&toolbar=1&code=import%20piplite%0Aawait%20piplite.install%28%5B%22pyhf%3D%3D0.7.0%22%5D%29%0A%25matplotlib%20inline%0Aimport%20pyhf"
+      src="https://jupyterlite.github.io/demo/repl/index.html?kernel=python&toolbar=1&code=import%20piplite%0Aawait%20piplite.install%28%5B%22pyhf%3D%3D0.7.0%22%2C%20%22matplotlib%3E%3D3.0.0%22%5D%29%0A%25matplotlib%20inline%0Aimport%20pyhf"
       width="100%"
       height="500px"
    ></iframe>


### PR DESCRIPTION
# Description

Resolves #2132

To ensure that all the dependencies for examples in the JupyterLite are available add matplotlib to the list of libraries to install with piplite.


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* To ensure that all the dependencies for examples in the JupyterLite
  are available add matplotlib to the list of libraries to install with
  piplite.
```