### PR TITLE
test: Remove xfail test for floating point agreement on macOS

### DIFF
--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1,7 +1,9 @@
-import pytest
 import logging
+
 import numpy as np
+import pytest
 import tensorflow as tf
+
 import pyhf
 from pyhf.simplemodels import uncorrelated_background
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1,4 +1,3 @@
-from sys import platform
 import pytest
 import logging
 import numpy as np
@@ -88,17 +87,6 @@ def test_simple_tensor_ops(backend):
         [2.0, 5.0],
         [3.0, 6.0],
     ]
-
-
-@pytest.mark.xfail(platform == "darwin", reason="c.f. Issue #1759")
-@pytest.mark.only_tensorflow
-def test_simple_tensor_ops_floating_point(backend):
-    """
-    xfail test to know if test_simple_tensor_ops stops failing for tensorflow
-    on macos
-    """
-    tb = pyhf.tensorlib
-    assert tb.tolist(tb.log(tb.exp(tb.astensor([2, 3, 4])))) == [2, 3, 4]
 
 
 def test_tensor_where_scalar(backend):


### PR DESCRIPTION
# Description

Remove the xfail test as for TensorFlow v2.12.0+ the floating point agreement is restored and so the test is no longer needed. c.f. Issue #1759 for details.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove the xfail test as for TensorFlow v2.12.0+ the floating point
  agreement is restored and so the test is no longer needed.
   - c.f. https://github.com/scikit-hep/pyhf/issues/1759 for summary details.
```