### PR TITLE
fix: Use unittest.mock.patch.object to mock attributes

### DIFF
--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -602,7 +602,7 @@ def test_trigger_tensorlib_changed_precision(mocker):
 def test_tensorlib_setup(tensorlib, precision, mocker):
     tb = getattr(pyhf.tensor, tensorlib)(precision=precision)
 
-    func = mocker.patch(f'pyhf.tensor.{tensorlib}._setup')
-    assert func.call_count == 0
+    _setup_mock = mocker.patch.object(getattr(pyhf.tensor, tensorlib), "_setup")
+    assert _setup_mock.call_count == 0
     pyhf.set_backend(tb)
-    assert func.call_count == 1
+    assert _setup_mock.call_count == 1


### PR DESCRIPTION
# Description

Resolves #2143 

In Python 3.11 mocking of attributes through [`unittest.mock.patch`](https://docs.python.org/3.11/library/unittest.mock.html#patch) will fail with an `AttributeError`. To avoid this, use [`unittest.mock.patch.object`](https://docs.python.org/3.11/library/unittest.mock.html#patch-object) to mock the `_setup` attribute of a `pyhf.tensorlib` object.

c.f. https://docs.python.org/3.11/library/unittest.mock.html#the-mock-class footnote:

> The only exceptions are magic methods and attributes (those that have leading and trailing double underscores). Mock doesn’t create these but instead raises an [AttributeError](https://docs.python.org/3.11/library/exceptions.html#AttributeError). This is because the interpreter will often implicitly request these methods, and gets very confused to get a new Mock object when it expects a magic method

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* In Python 3.11 mocking of attributes through unittest.mock.patch will
  fail with an AttributeError. To avoid this, use unittest.mock.patch.object
  to mock the "_setup" attribute of a pyhf.tensorlib object.
   - c.f. https://docs.python.org/3.11/library/unittest.mock.html#the-mock-class
     footnote:

     > The only exceptions are magic methods and attributes (those that have
     > leading and trailing double underscores). Mock doesn’t create these but
     > instead raises an AttributeError. This is because the interpreter will
     > often implicitly request these methods, and gets very confused to get a
     > new Mock object when it expects a magic method.
```