### PR TITLE
feat: Add Python 3.11 to testing and default to using it

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -177,11 +177,11 @@ jobs:
 
         echo ::set-output name=old_tag::v${current_tag}
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       if: success()
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         include:
           - os: macos-latest
-            python-version: '3.10'
+            python-version: '3.11'
 
     steps:
     - uses: actions/checkout@v3
@@ -80,30 +80,30 @@ jobs:
         coverage xml
 
     - name: Report contrib coverage with Codecov
-      if: github.event_name != 'schedule' && matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
+      if: github.event_name != 'schedule' && matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
         flags: contrib
 
     - name: Test docstring examples with doctest
-      if: matrix.python-version == '3.10'
+      if: matrix.python-version == '3.11'
       run: coverage run --data-file=.coverage-doctest --module pytest src/ README.rst
 
     - name: Coverage report for doctest only
-      if: matrix.python-version == '3.10'
+      if: matrix.python-version == '3.11'
       run: |
         coverage report --data-file=.coverage-doctest
         coverage xml --data-file=.coverage-doctest -o doctest-coverage.xml
 
     - name: Report doctest coverage with Codecov
-      if: github.event_name != 'schedule' && matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
+      if: github.event_name != 'schedule' && matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v3
       with:
         files: doctest-coverage.xml
         flags: doctest
 
     - name: Run benchmarks
-      if: github.event_name == 'schedule' && matrix.python-version == '3.10'
+      if: github.event_name == 'schedule' && matrix.python-version == '3.11'
       run: |
         pytest --benchmark-sort=mean tests/benchmarks/test_benchmark.py

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     steps:
     - uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     steps:
     - uses: actions/checkout@v3
@@ -77,7 +77,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     steps:
     - uses: actions/checkout@v3
@@ -103,7 +103,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     steps:
     - uses: actions/checkout@v3
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     steps:
     - uses: actions/checkout@v3
@@ -164,7 +164,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -32,10 +32,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install python-build and twine
       run: |

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -18,10 +18,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         include:
           - os: macos-latest
-            python-version: '3.10'
+            python-version: '3.11'
 
     steps:
     - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,8 +55,8 @@ repos:
           ['numpy', 'types-tqdm', 'click', 'types-jsonpatch', 'types-pyyaml', 'types-jsonschema', 'importlib_metadata', 'packaging']
         args: ["--python-version=3.8"]
       - <<: *mypy
-        name: mypy with Python 3.10
-        args: ["--python-version=3.10"]
+        name: mypy with Python 3.11
+        args: ["--python-version=3.11"]
 
 -   repo: https://github.com/nbQA-dev/nbQA
     rev: 1.6.3

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
   apt_packages:
     - curl
     - jq

--- a/binder/runtime.txt
+++ b/binder/runtime.txt
@@ -1,1 +1,1 @@
-python-3.10
+python-3.11

--- a/codemeta.json
+++ b/codemeta.json
@@ -50,6 +50,7 @@
     "runtimePlatform": [
         "Python 3",
         "Python 3 Only",
+        "Python 3.11",
         "Python 3.10",
         "Python 3.8",
         "Python 3.9",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=python:3.10-slim-bullseye
+ARG BASE_IMAGE=python:3.11-slim-bullseye
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE} as base
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -97,7 +97,7 @@ contrib module, or notebooks, and so instead to test the core codebase a develop
 
 .. code-block:: console
 
-    nox --session tests --python 3.10
+    nox --session tests --python 3.11
 
 Contrib module matplotlib image tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -107,7 +107,7 @@ To run the visualization tests for the ``contrib`` module with the ``pytest-mpl`
 
 .. code-block:: console
 
-    nox --session tests --python 3.10 -- contrib
+    nox --session tests --python 3.11 -- contrib
 
 If the image files need to be regenerated, run the tests with the
 ``--mpl-generate-path=tests/contrib/baseline`` option or just run
@@ -141,7 +141,7 @@ or pass ``coverage`` as a positional argument to the ``nox`` ``tests`` session
 
 .. code-block:: console
 
-    nox --session tests --python 3.10 -- coverage
+    nox --session tests --python 3.11 -- coverage
 
 Coverage Report
 ^^^^^^^^^^^^^^^

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 import nox
 
-ALL_PYTHONS = ["3.8", "3.9", "3.10"]
+ALL_PYTHONS = ["3.8", "3.9", "3.10", "3.11"]
 
 # Default sessions to run if no session handles are passed
-nox.options.sessions = ["lint", "tests-3.10"]
+nox.options.sessions = ["lint", "tests-3.11"]
 
 
 DIR = Path(__file__).parent.resolve()
@@ -30,10 +30,10 @@ def tests(session):
 
     Examples:
 
-        $ nox --session tests --python 3.10
-        $ nox --session tests --python 3.10 -- contrib  # run the contrib module tests
-        $ nox --session tests --python 3.10 -- tests/test_tensor.py  # run specific tests
-        $ nox --session tests --python 3.10 -- coverage  # run with coverage but slower
+        $ nox --session tests --python 3.11
+        $ nox --session tests --python 3.11 -- contrib  # run the contrib module tests
+        $ nox --session tests --python 3.11 -- tests/test_tensor.py  # run specific tests
+        $ nox --session tests --python 3.11 -- coverage  # run with coverage but slower
     """
     session.install("--upgrade", "--editable", ".[test]")
     session.install("--upgrade", "pytest")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ packages = ["src/pyhf"]
 
 [tool.black]
 line-length = 88
-target-version = ['py38', 'py39', 'py310']
+target-version = ['py38', 'py39', 'py310', 'py311']
 skip-string-normalization = true
 include = '\.pyi?$'
 exclude = '''
@@ -225,7 +225,7 @@ show_missing = true
 
 [tool.mypy]
 files = "src"
-python_version = "3.10"
+python_version = "3.11"
 warn_unused_configs = true
 strict = true
 show_error_codes = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Physics",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,7 +211,7 @@ filterwarnings = [
     'ignore:[A-Z]+ is deprecated and will be removed in Pillow 10:DeprecationWarning',  # keras
     'ignore:Call to deprecated create function:DeprecationWarning',  # protobuf via tensorflow
     'ignore:`np.bool8` is a deprecated alias for `np.bool_`:DeprecationWarning',  # numpy via tensorflow
-    "ignore:module 'sre_constants' is deprecated:DeprecationWarning",  # tensorflow v2.12.0+
+    "ignore:module 'sre_constants' is deprecated:DeprecationWarning",  # tensorflow v2.12.0+ for Python 3.11+
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,7 @@ filterwarnings = [
     'ignore:[A-Z]+ is deprecated and will be removed in Pillow 10:DeprecationWarning',  # keras
     'ignore:Call to deprecated create function:DeprecationWarning',  # protobuf via tensorflow
     'ignore:`np.bool8` is a deprecated alias for `np.bool_`:DeprecationWarning',  # numpy via tensorflow
+    "ignore:module 'sre_constants' is deprecated:DeprecationWarning",  # tensorflow v2.12.0+
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
# Description

Now that [TensorFlow `v2.12.0`](https://pypi.org/project/tensorflow/2.12.0/) is out with Python 3.11 support, add Python 3.11 to the testing in CI and then default all the uses of Python 3.10 in the project to Python 3.11.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add Python 3.11 to testing in CI.
* Default to using Python 3.11 in GitHub Actions where possible.
* Update to using Python 3.11 in linting and validation tools.
* Update Binder runtime Python to Python 3.11.
* Update Dockerfile base image to python:3.11-slim-bullseye.
* Update the docs to advocate using Python 3.11 for development.
* Add ignore of DeprecationWarning of Python's sre_constants from TensorFlow
   - c.f. https://docs.python.org/3.11/whatsnew/3.11.html#modules
     > Undocumented modules sre_compile, sre_constants and sre_parse
     > are now deprecated. (Contributed by Serhiy Storchaka in bpo-47152.)
* Add Python 3.11 trove classifier to PyPI metadata.
```