### PR TITLE
ci: Run CI and packaging workflows on release branch PRs  

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         include:
           - os: macos-latest
-            python-version: '3.10'
+            python-version: '3.11'
 
     steps:
     - uses: actions/checkout@v3
@@ -71,24 +71,24 @@ jobs:
         pytest tests/contrib --mpl --mpl-baseline-path tests/contrib/baseline
 
     - name: Report contrib coverage with Codecov
-      if: github.event_name != 'schedule' && matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
+      if: github.event_name != 'schedule' && matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
         flags: contrib
 
     - name: Test docstring examples with doctest
-      if: matrix.python-version == '3.10'
+      if: matrix.python-version == '3.11'
       run: pytest src/ README.rst
 
     - name: Report doctest coverage with Codecov
-      if: github.event_name != 'schedule' && matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
+      if: github.event_name != 'schedule' && matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
         flags: doctest
 
     - name: Run benchmarks
-      if: github.event_name == 'schedule' && matrix.python-version == '3.10'
+      if: github.event_name == 'schedule' && matrix.python-version == '3.11'
       run: |
         pytest --benchmark-sort=mean tests/benchmarks/test_benchmark.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
     - main
+    - release/v*
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
     - main
+    - release/v*
   schedule:
     - cron:  '1 0 * * *'
   release:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Test build
         id: docker_build_test
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: docker/Dockerfile
@@ -111,7 +111,7 @@ jobs:
         # every PR will trigger a push event on main, so check the push event is actually coming from main
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'scikit-hep/pyhf'
         id: docker_build_latest
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: docker/Dockerfile
@@ -121,11 +121,12 @@ jobs:
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
           push: true
+          platforms: linux/amd64,linux/arm64
 
       - name: Build and publish to registry with release tag
         if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf'
         id: docker_build_release
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: docker/Dockerfile
@@ -135,3 +136,4 @@ jobs:
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
           push: true
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@ on:
     branches:
     - main
   pull_request:
+    branches:
+    - main
+    - release/v*
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install Python dependencies
       run: |
@@ -105,8 +105,8 @@ jobs:
 
     steps:
     - name: Setup Pages
-      uses: actions/configure-pages@v2
+      uses: actions/configure-pages@v3
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v1
+      uses: actions/deploy-pages@v2

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
     - main
+    - release/v*
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -33,10 +33,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install python-build and twine
       run: |
@@ -94,7 +94,7 @@ jobs:
       if: >-
         (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
         || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
-      uses: pypa/gh-action-pypi-publish@v1.5.1
+      uses: pypa/gh-action-pypi-publish@v1.8.3
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
@@ -102,7 +102,7 @@ jobs:
 
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf'
-      uses: pypa/gh-action-pypi-publish@v1.5.1
+      uses: pypa/gh-action-pypi-publish@v1.8.3
       with:
         password: ${{ secrets.pypi_password }}
         print_hash: true

--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -19,6 +19,6 @@ jobs:
 
     steps:
       - name: Check PR title matches Conventional Commits spec
-        uses: amannn/action-semantic-pull-request@v4
+        uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
   apt_packages:
     - curl
     - jq

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=python:3.10-slim-bullseye
+ARG BASE_IMAGE=python:3.11-slim-bullseye
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE} as base
 
@@ -16,7 +16,7 @@ RUN apt-get -qq -y update && \
     python -m venv /usr/local/venv && \
     cd /code && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
-    python -m pip --no-cache-dir install .[xmlio,contrib] && \
+    python -m pip --no-cache-dir install '.[xmlio,contrib]' && \
     python -m pip list
 
 FROM base


### PR DESCRIPTION
# Description

* Backport PR #2149 and add Docker build and docs workflows
  to run on PRs on patch release branches.
* Backport components of:
   - PR https://github.com/scikit-hep/pyhf/pull/2047
   - PR https://github.com/scikit-hep/pyhf/pull/2058
   - PR https://github.com/scikit-hep/pyhf/pull/2102
   - PR https://github.com/scikit-hep/pyhf/pull/2106
   - PR https://github.com/scikit-hep/pyhf/pull/2140
   - PR https://github.com/scikit-hep/pyhf/pull/2145
   - PR https://github.com/scikit-hep/pyhf/pull/2146

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Backport PR #2149 and add Docker build and docs workflows
  to run on PRs on patch release branches.
* Backport components of:
   - PR https://github.com/scikit-hep/pyhf/pull/2047
   - PR https://github.com/scikit-hep/pyhf/pull/2058
   - PR https://github.com/scikit-hep/pyhf/pull/2102
   - PR https://github.com/scikit-hep/pyhf/pull/2106
   - PR https://github.com/scikit-hep/pyhf/pull/2140
   - PR https://github.com/scikit-hep/pyhf/pull/2145
   - PR https://github.com/scikit-hep/pyhf/pull/2146
```