### PR TITLE
docs: Add use citation from constraints on electroweakino dark matter paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -115,6 +115,18 @@
     url = "https://inspirehep.net/literature/2157017"
 }
 
+% 2022-08-08
+@article{Buanes:2022wgm,
+    author = "Buanes, Trygve and Lara, I\~naki and Rolbiecki, Krzysztof and Sakurai, Kazuki",
+    title = "{LHC constraints on electroweakino dark matter revisited}",
+    eprint = "2208.04342",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    month = "8",
+    year = "2022",
+    journal = ""
+}
+
 % 2022-07-21
 @article{Allwicher:2022mcg,
     author = "Allwicher, Lukas and Faroughy, Darius. A. and Jaffredo, Florentin and Sumensari, Olcyr and Wilsch, Felix",


### PR DESCRIPTION
# Description

* Add use citation from [LHC constraints on electroweakino dark matter revisited](https://inspirehep.net/literature/2133874) by Trygve Buanes, Iñaki Lara, Krzysztof Rolbiecki, and Kazuki Sakurai. (This wasn't missed earlier, the citation first appeared in [v4](https://arxiv.org/abs/2208.04342v4) of the arXiv preprint which came out in March 2023 :+1:).


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'LHC constraints on electroweakino dark matter revisited'.
   - c.f. https://inspirehep.net/literature/2133874
```