### PR TITLE
ci: Add workflow input for bump version branch

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -20,6 +20,12 @@ on:
       new_version:
         description: 'New version to bump to'
         required: true
+        type: string
+      target_branch:
+        description: 'Branch to push tag to'
+        required: true
+        type: string
+        default: 'main'
       force:
         type: choice
         description: 'Force override check?'
@@ -241,5 +247,5 @@ jobs:
         if [ ${{ github.event.inputs.dry_run }} == 'true' ]; then
             echo "# DRY RUN"
         else
-            git push origin main --tags
+            git push origin ${{ github.event.inputs.target_branch }} --tags
         fi

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -49,6 +49,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
+        ref: ${{ github.event.inputs.target_branch }}
         fetch-depth: 0
         token: ${{ secrets.ACCESS_TOKEN }}
 

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -53,6 +53,17 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.ACCESS_TOKEN }}
 
+    - name: Check target branch is intended for release
+      if: github.event.inputs.force == 'false'
+      shell: bash
+      run: |
+        git rev-parse --abbrev-ref HEAD | grep 'main\|release/'
+        if [ $? -eq 1 ]; then
+            echo "ERROR: Branch $(git rev-parse --abbrev-ref HEAD) is not intended for release."
+            echo "       Releases are made only from main or release branches."
+            exit 1
+        fi
+
     - name: Verify new version bump step is valid
       if: github.event.inputs.force == 'false'
       id: script

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -23,9 +23,9 @@ on:
         type: string
       target_branch:
         description: 'Branch to push tag to'
+        default: 'main'
         required: true
         type: string
-        default: 'main'
       force:
         type: choice
         description: 'Force override check?'

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -225,6 +225,12 @@ jobs:
         git tag -n99 --list "${NEW_TAG}"
 
         CHANGES=$(git log --pretty=format:'%s' "${OLD_TAG}"..HEAD --regexp-ignore-case --extended-regexp --grep='^([a-z]*?):')
+        # Also include any backported changes
+        BACKPORTED_CHANGES=$(git log --pretty=format:'%s' "${OLD_TAG}"..HEAD --grep='(backport):')
+        if [ ! -z "${BACKPORTED_CHANGES}" ]; then
+            CHANGES=$(printf "${CHANGES}\n${BACKPORTED_CHANGES}")
+        fi
+
         CHANGES_NEWLINE="$(echo "${CHANGES}" | sed -e 's/^/  - /')"
         SANITIZED_CHANGES=$(echo "${CHANGES}" | sed -e 's/^/<li>/' -e 's|$|</li>|' -e 's/(#[0-9]\+)//' -e 's/"/'"'"'/g')
         NUM_CHANGES=$(echo -n "${CHANGES}" | grep -c '^')


### PR DESCRIPTION
# Description

Add option in bump version workflow for the target branch to checkout and push the resulting tag back to. Also include changes that have the string `(backport):` in the commit message, but include them last in the list of changes.


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add option in bump version workflow for the target branch to checkout
  and push the resulting tag back to.
* Add check that the target branch is either 'main' or a 'release/' branch.
  Though don't run this check if the 'force override check' option is
  enabled.
* Include changes that have the string '(backport):' in the commit
  message, but include them last in the list of changes.
```