### PR TITLE
fix: Set workflow output parameter with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -175,7 +175,8 @@ jobs:
             echo "* Bumping version ${current_tag} to ${{ github.event.inputs.part }} version ${{ github.event.inputs.new_version }}"
         fi
 
-        echo ::set-output name=old_tag::v${current_tag}
+        echo "steps.script.outputs.old_tag=v${current_tag}"
+        echo "old_tag=v${current_tag}" >> $GITHUB_OUTPUT
 
     - name: Set up Python 3.11
       if: success()

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,9 +45,12 @@ jobs:
           if [ "${{ github.event_name }}" = "release" ]; then
             TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable,ghcr.io/${{github.repository}}:latest-stable,ghcr.io/${{github.repository}}:${VERSION}"
           fi
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "steps.prep.outputs.version=${VERSION}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "steps.prep.outputs.tags=${TAGS}"
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "steps.prep.outputs.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
# Description

* Update to use the new GitHub workflow GITHUB_OUTPUT environmental file to avoid problems when the setting 'set-output' via stdout is deprecated in 2023. c.f.:
   - https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
   - https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
   - https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-setting-an-output-parameter

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update to use the new GitHub workflow GITHUB_OUTPUT environmental file
  to avoid problems when the setting 'set-output' via stdout is deprecated
  in 2023. c.f.:
   - https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
   - https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
   - https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-setting-an-output-parameter
```