### PR TITLE
ci: Use GITHUB_REF_NAME environmental variable to set tag version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
           DOCKER_IMAGE=pyhf/pyhf
           VERSION=latest
           if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
+            VERSION=${GITHUB_REF_NAME}
           elif [[ $GITHUB_REF == refs/pull/* ]]; then
             VERSION=pr-${{ github.event.number }}
           fi
@@ -117,7 +117,9 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          tags: pyhf/pyhf:latest,ghcr.io/${{github.repository}}:latest
+          tags: |
+            pyhf/pyhf:latest
+            ghcr.io/${{ github.repository }}:latest
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}


### PR DESCRIPTION
# Description

* Instead of trying to parse the `GITHUB_REF` environmental variable to get the tag or branch name use `GITHUB_REF_NAME` which provides this already.
* Split tag names over multiple lines in the YAML file for visual clarity.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Instead of trying to parse the GITHUB_REF environmental variable to
  get the tag or branch name use GITHUB_REF_NAME which provides this
  already.
* Split tag names over multiple lines in the YAML file for visual clarity.
```