### PR TITLE
docs: Add use citation from vector-like leptons at a muon collider paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,15 @@
+% 2023-04-04
+@article{Guo:2023jkz,
+    author = "Guo, Qilong and Gao, Leyun and Mao, Yajun and Li, Qiang",
+    title = "{Search for vector-like leptons at a Muon Collider}",
+    eprint = "2304.01885",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    month = "4",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-02-24
 @article{Behera:2023eeo,
     author = "Behera, Subhasish and Hageluken, Manuel and Schott, Matthias",


### PR DESCRIPTION
# Description

Add use citation from [Search for vector-like leptons at a Muon Collider](https://inspirehep.net/literature/2648832) by Qilong Guo, Leyun Gao, Yajun Mao, Qiang Li.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Search for vector-like leptons at a Muon Collider'.
   - c.f. https://inspirehep.net/literature/2648832
```