### PR TITLE
test: Use pytest.raises match argument to check Error messages

### DIFF
--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -497,11 +497,10 @@ def test_import_missingPOI(mocker, datadir):
     mocker.patch('pyhf.readxml.import_root_histogram', return_value=(_data, _err))
 
     basedir = datadir.joinpath("xmlimport_missingPOI")
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(
+        RuntimeError, match="Measurement GaussExample is missing POI specification"
+    ):
         pyhf.readxml.parse(basedir.joinpath("config/example.xml"), basedir)
-        assert 'Measurement GaussExample is missing POI specification' in str(
-            excinfo.value
-        )
 
 
 def test_import_resolver():

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -26,9 +26,8 @@ def test_dedupe_parameters():
     ]
     assert len(pyhf.readxml.dedupe_parameters(parameters)) == 1
     parameters[1]['bounds'] = [[0.0, 2.0]]
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(RuntimeError, match="SigXsecOverSM"):
         pyhf.readxml.dedupe_parameters(parameters)
-        assert 'SigXsecOverSM' in str(excinfo.value)
 
 
 def test_process_normfactor_configs():
@@ -486,9 +485,10 @@ def test_import_noChannelData(mocker, datadir):
     mocker.patch('pyhf.readxml.import_root_histogram', return_value=(_data, _err))
 
     basedir = datadir.joinpath("xmlimport_noChannelData")
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(
+        RuntimeError, match="Channel channel1 is missing data. See issue #1911"
+    ):
         pyhf.readxml.parse(basedir.joinpath("config/example.xml"), basedir)
-        assert 'Channel channel1 is missing data. See issue #1911' in str(excinfo.value)
 
 
 def test_import_missingPOI(mocker, datadir):

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -218,9 +218,10 @@ def test_optimizer_unsupported_minimizer_options(optimizer):
     pyhf.set_backend(pyhf.default_backend, optimizer())
     m = pyhf.simplemodels.uncorrelated_background([5.0], [10.0], [3.5])
     data = pyhf.tensorlib.astensor([10.0] + m.config.auxdata)
-    with pytest.raises(pyhf.exceptions.Unsupported) as excinfo:
+    with pytest.raises(
+        pyhf.exceptions.Unsupported, match="unsupported_minimizer_options"
+    ):
         pyhf.infer.mle.fit(data, m, unsupported_minimizer_options=False)
-    assert 'unsupported_minimizer_options' in str(excinfo.value)
 
 
 @pytest.mark.parametrize('return_result_obj', [False, True], ids=['no_obj', 'obj'])

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -438,18 +438,19 @@ def test_minuit_failed_optimization(
     pdf = pyhf.simplemodels.uncorrelated_background([5], [10], [3.5])
     data = [10] + pdf.config.auxdata
     spy = mocker.spy(pyhf.optimize.minuit_optimizer, '_minimize')
-    with pytest.raises(pyhf.exceptions.FailedMinimization) as excinfo:
+    with pytest.raises(
+        pyhf.exceptions.FailedMinimization, match="Optimization failed"
+    ) as exc_info:
         pyhf.infer.mle.fit(data, pdf)
 
-    assert isinstance(excinfo.value.result, OptimizeResult)
+    assert isinstance(exc_info.value.result, OptimizeResult)
 
-    assert excinfo.match('Optimization failed')
     assert 'Optimization failed' in spy.spy_return.message
     if has_reached_call_limit:
-        assert excinfo.match('Call limit was reached')
+        assert exc_info.match('Call limit was reached')
         assert 'Call limit was reached' in spy.spy_return.message
     if is_above_max_edm:
-        assert excinfo.match('Estimated distance to minimum too large')
+        assert exc_info.match('Estimated distance to minimum too large')
         assert 'Estimated distance to minimum too large' in spy.spy_return.message
 
 
@@ -467,10 +468,8 @@ def test_minuit_set_options(mocker):
 
 def test_get_tensor_shim(monkeypatch):
     monkeypatch.setattr(pyhf.tensorlib, 'name', 'fake_backend')
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="No optimizer shim for fake_backend."):
         _get_tensor_shim()
-
-    assert 'No optimizer shim for fake_backend.' == str(excinfo.value)
 
 
 def test_stitch_pars(backend):

--- a/tests/test_patchset.py
+++ b/tests/test_patchset.py
@@ -74,10 +74,12 @@ def test_patchset_get_patch_by_values(patchset):
 
 
 def test_patchset_get_nonexisting_patch(patchset):
-    with pytest.raises(pyhf.exceptions.InvalidPatchLookup) as excinfo:
+    # Using asserts with str(exc_info.value) over pytest.raises(..., match="...")
+    # to make it easier to check multiple strings.
+    with pytest.raises(pyhf.exceptions.InvalidPatchLookup) as exc_info:
         patchset.__getitem__('nonexisting_patch')
-    assert 'No patch associated with' in str(excinfo.value)
-    assert 'nonexisting_patch' in str(excinfo.value)
+    assert 'No patch associated with' in str(exc_info.value)
+    assert 'nonexisting_patch' in str(exc_info.value)
 
 
 def test_patchset_iterable(patchset):

--- a/tests/test_teststats.py
+++ b/tests/test_teststats.py
@@ -118,50 +118,45 @@ def test_no_poi_test_stats():
     par_bounds = model.config.suggested_bounds()
     fixed_params = model.config.suggested_fixed()
 
-    with pytest.raises(pyhf.exceptions.UnspecifiedPOI) as excinfo:
+    with pytest.raises(
+        pyhf.exceptions.UnspecifiedPOI,
+        match="No POI is defined. A POI is required for profile likelihood based test statistics.",
+    ):
         pyhf.infer.test_statistics.q0(
             test_poi, data, model, init_pars, par_bounds, fixed_params
         )
-    assert (
-        "No POI is defined. A POI is required for profile likelihood based test statistics."
-        in str(excinfo.value)
-    )
 
-    with pytest.raises(pyhf.exceptions.UnspecifiedPOI) as excinfo:
+    with pytest.raises(
+        pyhf.exceptions.UnspecifiedPOI,
+        match="No POI is defined. A POI is required for profile likelihood based test statistics.",
+    ):
         pyhf.infer.test_statistics.qmu(
             test_poi, data, model, init_pars, par_bounds, fixed_params
         )
-    assert (
-        "No POI is defined. A POI is required for profile likelihood based test statistics."
-        in str(excinfo.value)
-    )
 
-    with pytest.raises(pyhf.exceptions.UnspecifiedPOI) as excinfo:
+    with pytest.raises(
+        pyhf.exceptions.UnspecifiedPOI,
+        match="No POI is defined. A POI is required for profile likelihood based test statistics.",
+    ):
         pyhf.infer.test_statistics.qmu_tilde(
             test_poi, data, model, init_pars, par_bounds, fixed_params
         )
-    assert (
-        "No POI is defined. A POI is required for profile likelihood based test statistics."
-        in str(excinfo.value)
-    )
 
-    with pytest.raises(pyhf.exceptions.UnspecifiedPOI) as excinfo:
+    with pytest.raises(
+        pyhf.exceptions.UnspecifiedPOI,
+        match="No POI is defined. A POI is required for profile likelihood based test statistics.",
+    ):
         pyhf.infer.test_statistics.tmu(
             test_poi, data, model, init_pars, par_bounds, fixed_params
         )
-    assert (
-        "No POI is defined. A POI is required for profile likelihood based test statistics."
-        in str(excinfo.value)
-    )
 
-    with pytest.raises(pyhf.exceptions.UnspecifiedPOI) as excinfo:
+    with pytest.raises(
+        pyhf.exceptions.UnspecifiedPOI,
+        match="No POI is defined. A POI is required for profile likelihood based test statistics.",
+    ):
         pyhf.infer.test_statistics.tmu_tilde(
             test_poi, data, model, init_pars, par_bounds, fixed_params
         )
-    assert (
-        "No POI is defined. A POI is required for profile likelihood based test statistics."
-        in str(excinfo.value)
-    )
 
 
 @pytest.mark.parametrize("test_stat", ["qtilde", "q"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,15 +37,13 @@ def test_digest(obj, algorithm):
 
 
 def test_digest_bad_obj():
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="not JSON-serializable"):
         pyhf.utils.digest(object())
-    assert 'not JSON-serializable' in str(excinfo.value)
 
 
 def test_digest_bad_alg():
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="nonexistent_algorithm"):
         pyhf.utils.digest({}, algorithm='nonexistent_algorithm')
-    assert 'nonexistent_algorithm' in str(excinfo.value)
 
 
 @pytest.mark.parametrize('oneline', [False, True])


### PR DESCRIPTION
# Description

Resolves #2161 

* This is a much simpler way and more maintainable way to check Error message content rather than manually checking captured output. In the cases where multiple strings need to be checked for still keep checking the values are in `str(exc_info.value)`.
* Fix checks in `tests/test_import.py` that were not properly checking the output.

Should go in before PR #2109 to allow that PR to use this as @alexander-held has already started to implement these changes there.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* This is a much simpler way and more maintainable way to check Error
  message content rather than manually checking captured output. In the
  cases where multiple strings need to be checked for still keep
  checking the values are in str(exc_info.value).
* Fix checks in tests/test_import.py that were not properly checking the
  output.

Co-authored-by: Alexander Held <45009355+alexander-held@users.noreply.github.com>
```