### PR TITLE
docs: Add ATLAS search for gluinos in multi-b final states statistical model record

### DIFF
--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -1,3 +1,13 @@
+% 2022-11-15
+@misc{ins2182381,
+    title = "{Search for supersymmetry in final states with missing transverse momentum and three or more b-jets in $139~\text{fb}^{-1}$ of proton-proton collisions at $\sqrt{s} = 13$ TeV with the ATLAS detector}",
+    doi = "10.17182/hepdata.95928",
+    url = "https://doi.org/10.17182/hepdata.95928",
+    year = "2022",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
 % 2022-05-05
 @misc{ins2077557,
     title = "{Search for flavour-changing neutral-current couplings between the top quark and the photon with the ATLAS detector at $\sqrt{s} = 13$ TeV}",


### PR DESCRIPTION
# Description

* Add ATLAS search for gluinos in multi-b final states statistical model HEPDdata record
   - c.f. https://www.hepdata.net/record/ins2182381
   - Corresponding INSPIRE record: https://inspirehep.net/literature/2182381

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add ATLAS search for gluinos in multi-b final states statistical model HEPDdata record
   - c.f. https://www.hepdata.net/record/ins2182381
   - Corresponding INSPIRE record: https://inspirehep.net/literature/2182381
```