### PR TITLE
docs: Update use citations references to include journal publications

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -173,9 +173,12 @@
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
     reportNumber = "IPPP/22/41",
-    month = "6",
-    year = "2022",
-    journal = ""
+    doi = "10.21468/SciPostPhys.14.1.009",
+    journal = "SciPost Phys.",
+    volume = "14",
+    number = "1",
+    pages = "009",
+    year = "2023"
 }
 
 % 2022-04-19


### PR DESCRIPTION
# Description

* Update use citations references to include their journal publication information.
   - 'Signal region combination with full and simplified likelihoods in MadAnalysis 5' is published as SciPost Phys. 14 (2023) 1, 009. https://doi.org/10.21468/SciPostPhys.14.1.009

:clap: @jackaraz

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update use citations references to include their journal
  publication information.
   - 'Signal region combination with full and simplified likelihoods in
     MadAnalysis 5' is published as SciPost Phys. 14 (2023) 1, 009.
     https://doi.org/10.21468/SciPostPhys.14.1.009
```