### PR TITLE
docs: Add v0.7.1 release notes

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -2,6 +2,7 @@
 Release Notes
 =============
 
+.. include:: release-notes/v0.7.1.rst
 .. include:: release-notes/v0.7.0.rst
 .. include:: release-notes/v0.6.3.rst
 .. include:: release-notes/v0.6.2.rst

--- a/docs/release-notes/v0.7.0.rst
+++ b/docs/release-notes/v0.7.0.rst
@@ -9,7 +9,7 @@ Important Notes
 * Please note this release has **API breaking changes** and carefully read these
   notes while updating your code to the ``v0.7.0`` API.
 * All backends are now fully compatible and tested with
-  `Python 3.10 <https://peps.python.org/pep-0310/>`_.
+  `Python 3.10 <https://peps.python.org/pep-0619/>`_.
   (PR :pr:`1809`)
 * The ``pyhf.tensorlib.poisson`` API now allows for the expected rate parameter
   ``lam`` to be ``0`` in the case that the observed events ``n`` is ``0`` given

--- a/docs/release-notes/v0.7.1.rst
+++ b/docs/release-notes/v0.7.1.rst
@@ -1,0 +1,31 @@
+|release v0.7.1|_
+=================
+
+This is a patch release from ``v0.7.0`` → ``v0.7.1``.
+
+Important Notes
+---------------
+
+* All backends are now fully compatible and tested with
+  `Python 3.11 <https://peps.python.org/pep-0664/>`_.
+  (PR :pr:`2145`)
+* The ``tensorflow`` extra (``'pyhf[tensorlfow]'``) now automatically installs
+  ``tensorflow-macos`` for Apple silicon machines.
+  (PR :pr:`2119`)
+
+Fixes
+-----
+
+* Raise :class:`NotImplementedError` when attempting to convert a XML
+  workspace that contains no data.
+  (PR :pr:`2109`)
+
+Contributors
+------------
+
+``v0.7.1`` benefited from contributions from:
+
+* Alexander Held
+
+.. |release v0.7.1| replace:: ``v0.7.1``
+.. _`release v0.7.1`: https://github.com/scikit-hep/pyhf/releases/tag/v0.7.1


### PR DESCRIPTION
# Description

* Forward port PR #2168 from `release/v0.7.x` to `main`.
* Add release notes for pyhf v0.7.1.
* Fix the PEP number of Python 3.10 in v0.7.0 release notes.
   - c.f. https://peps.python.org/pep-0619/

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Forward port PR #2168 from release/v0.7.x to main.
* Add release notes for pyhf v0.7.1.
* Fix the PEP number of Python 3.10 in v0.7.0 release notes.
   - c.f. https://peps.python.org/pep-0619/
```