### PR TITLE
ci(backport): Use gh-action-pypi-publish v1.7.0+ APIs

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -97,12 +97,12 @@ jobs:
       uses: pypa/gh-action-pypi-publish@v1.8.5
       with:
         password: ${{ secrets.test_pypi_password }}
-        repository_url: https://test.pypi.org/legacy/
-        print_hash: true
+        repository-url: https://test.pypi.org/legacy/
+        print-hash: true
 
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf'
       uses: pypa/gh-action-pypi-publish@v1.8.5
       with:
         password: ${{ secrets.pypi_password }}
-        print_hash: true
+        print-hash: true


### PR DESCRIPTION
# Description

* Backport PR https://github.com/scikit-hep/pyhf/pull/2177
* In pypa/gh-action-pypi-publish v1.7.0 inputs were changed to use kebab-case. Update to all inputs that were previously snake_case to use the new input format.
   - c.f. https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.7.0

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Backport PR https://github.com/scikit-hep/pyhf/pull/2177
* In pypa/gh-action-pypi-publish v1.7.0 inputs were changed to use
  kebab-case. Update to all inputs that were previously snake_case to
  use the new input format.
   - c.f. https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.7.0
```