### PR TITLE
docs: Add NumFOCUS Affiliated Project to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -363,7 +363,7 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
    :target: https://scikit-hep.org/
 .. |NSF Award Number| image:: https://img.shields.io/badge/NSF-1836650-blue.svg
    :target: https://nsf.gov/awardsearch/showAward?AWD_ID=1836650
-.. |NumFOCUS Affiliated Project| image:: https://img.shields.io/badge/NumFOCUS-affiliated%20project-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
+.. |NumFOCUS Affiliated Project| image:: https://img.shields.io/badge/NumFOCUS-Affiliated%20Project-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
    :target: https://numfocus.org/sponsored-projects/affiliated-projects
 .. |Docs from latest| image:: https://img.shields.io/badge/docs-v0.7.1-blue.svg
    :target: https://pyhf.readthedocs.io/

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@
 pure-python fitting/limit-setting/interval estimation HistFactory-style
 =======================================================================
 
-|GitHub Project| |DOI| |JOSS DOI| |Scikit-HEP| |NSF Award Number|
+|GitHub Project| |DOI| |JOSS DOI| |Scikit-HEP| |NSF Award Number| |NumFOCUS Affiliated Project|
 
 |Docs from latest| |Docs from main| |Jupyter Book tutorial| |Binder|
 
@@ -361,6 +361,8 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
    :target: https://scikit-hep.org/
 .. |NSF Award Number| image:: https://img.shields.io/badge/NSF-1836650-blue.svg
    :target: https://nsf.gov/awardsearch/showAward?AWD_ID=1836650
+.. |NumFOCUS Affiliated Project| image:: https://img.shields.io/badge/NumFOCUS-affiliated%20project-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
+   :target: https://numfocus.org/sponsored-projects/affiliated-projects
 .. |Docs from latest| image:: https://img.shields.io/badge/docs-v0.7.1-blue.svg
    :target: https://pyhf.readthedocs.io/
 .. |Docs from main| image:: https://img.shields.io/badge/docs-main-blue.svg

--- a/README.rst
+++ b/README.rst
@@ -351,6 +351,8 @@ Matthew Feickert has received support to work on ``pyhf`` provided by NSF
 cooperative agreement `OAC-1836650 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1836650>`__ (IRIS-HEP)
 and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377>`__ (DIANA/HEP).
 
+``pyhf`` is a `NumFOCUS Affiliated Project <https://numfocus.org/sponsored-projects/affiliated-projects>`__.
+
 .. |GitHub Project| image:: https://img.shields.io/badge/GitHub--blue?style=social&logo=GitHub
    :target: https://github.com/scikit-hep/pyhf
 .. |DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1169739.svg


### PR DESCRIPTION
# Description

Add the NumFOCUS Affilated Project badge to the README and mention in the Acknowledgements section.

[![NumFOCUS Affiliated Project](https://img.shields.io/badge/NumFOCUS-Affiliated%20Project-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org/sponsored-projects/affiliated-projects)

I don't think(?) there is an official badge given this discussion https://github.com/glotzerlab/signac/pull/202#discussion_r299648150 between @bdice and @csadorf (:wave:), but I like what they made so I'm going to [copy `signac`](https://github.com/glotzerlab/signac/blob/1472dfa3037c0622b1869c9d3b0479ed8e0fa4f6/README.md?plain=1#L3). :+1: 

A note for posterity, `pyhf` became a NumFOCUS Affiliated Project on December 19th, 2022, but @matthewfeickert delayed a bit in getting a SVG version of the logo so it only got added to the [project pages](https://numfocus.org/sponsored-projects/affiliated-projects) in April, 2022. But it is up now, and soon to be joined by https://github.com/scikit-hep/awkward who were accepted in the first round of 2023 applications! 

(cc @cranmer)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* pyhf became a NumFOCUS Affiliated Project on 2022-12-19.
   - c.f. https://numfocus.org/sponsored-projects/affiliated-projects
* Add mention of being a NumFOCUS Affiliated Project to the Acknowledgements
  section.
```