### PR TITLE
docs: Add use citation from IRIS-HEP AGC ACAT 2022 paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,5 +1,5 @@
 % 2023-04-11
-@inproceedings{Shadura:2023zks,
+@article{Shadura:2023zks,
     author = "Shadura, Oksana and Held, Alexander",
     title = "{First performance measurements with the Analysis Grand Challenge}",
     eprint = "2304.05214",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,15 @@
+% 2023-04-11
+@inproceedings{Shadura:2023zks,
+    author = "Shadura, Oksana and Held, Alexander",
+    title = "{First performance measurements with the Analysis Grand Challenge}",
+    eprint = "2304.05214",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    month = "4",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-04-04
 @article{Guo:2023jkz,
     author = "Guo, Qilong and Gao, Leyun and Mao, Yajun and Li, Qiang",


### PR DESCRIPTION
# Description

Add use citation from [First performance measurements with the Analysis Grand Challenge](https://inspirehep.net/literature/2650460) by @oshadura and @alexander-held. Submitted as proceedings for 21st International Workshop on Advanced Computing and Analysis Techniques in Physics Research (ACAT 2022) to Journal Of Physics: Conference Series.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'First performance measurements with the Analysis
  Grand Challenge'.
   - c.f. https://inspirehep.net/literature/2650460
   - Submitted as proceedings for 21st International Workshop on Advanced
     Computing and Analysis Techniques in Physics Research (ACAT 2022) to
     Journal Of Physics: Conference Series
```