### PR TITLE
ci: Use PyPI Trusted Publisher for publishing package

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -25,16 +25,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-publish:
-    name: Build and publish Python distro to (Test)PyPI
+  build:
+    name: Build Python distribution
     runs-on: ubuntu-latest
-    # Mandatory for publishing with a trusted publisher
-    # c.f. https://docs.pypi.org/trusted-publishers/using-a-publisher/
-    permissions:
-      id-token: write
-    # Restrict to the environment set for the trusted publisher
-    environment:
-      name: publish-package
     steps:
     - uses: actions/checkout@v3
       with:
@@ -94,6 +87,36 @@ jobs:
 
     - name: List contents of wheel
       run: python -m zipfile --list dist/pyhf-*.whl
+
+    - name: Upload distribution artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: dist-artifact
+        path: dist
+
+  publish:
+    name: Publish Python distribution to (Test)PyPI
+    if: github.event_name != 'pull_request'
+    needs: build
+
+    runs-on: ubuntu-latest
+    # Mandatory for publishing with a trusted publisher
+    # c.f. https://docs.pypi.org/trusted-publishers/using-a-publisher/
+    permissions:
+      id-token: write
+    # Restrict to the environment set for the trusted publisher
+    environment:
+      name: publish-package
+
+    steps:
+    - name: Download distribution artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: dist-artifact
+        path: dist
+
+    - name: List all files
+      run: ls -lh dist
 
     - name: Publish distribution 📦 to Test PyPI
       # Publish to TestPyPI on tag events of if manually triggered

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -98,7 +98,6 @@ jobs:
     name: Publish Python distribution to (Test)PyPI
     if: github.event_name != 'pull_request'
     needs: build
-
     runs-on: ubuntu-latest
     # Mandatory for publishing with a trusted publisher
     # c.f. https://docs.pypi.org/trusted-publishers/using-a-publisher/

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -28,6 +28,13 @@ jobs:
   build-and-publish:
     name: Build and publish Python distro to (Test)PyPI
     runs-on: ubuntu-latest
+    # Mandatory for publishing with a trusted publisher
+    # c.f. https://docs.pypi.org/trusted-publishers/using-a-publisher/
+    permissions:
+      id-token: write
+    # Restrict to the environment set for the trusted publisher
+    environment:
+      name: publish-package
     steps:
     - uses: actions/checkout@v3
       with:
@@ -96,7 +103,6 @@ jobs:
         || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
       uses: pypa/gh-action-pypi-publish@v1.8.5
       with:
-        password: ${{ secrets.test_pypi_password }}
         repository-url: https://test.pypi.org/legacy/
         print-hash: true
 
@@ -104,5 +110,4 @@ jobs:
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf'
       uses: pypa/gh-action-pypi-publish@v1.8.5
       with:
-        password: ${{ secrets.pypi_password }}
         print-hash: true


### PR DESCRIPTION
# Description

Use the OpenID Connect (OIDC) standard to publish to PyPI and TestPyPI using PyPI's "Trusted Publisher" implementation to publish without using API tokens stored as GitHub Actions secrets. Use an optional GitHub Actions environment to further restrict publishing to selected branches (`main` and `release/*`) for additional security.
   - c.f. https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
   - c.f. https://docs.pypi.org/trusted-publishers/

![publish-package-environment](https://user-images.githubusercontent.com/5142394/233553008-d0edfa14-52ec-4366-845a-c162fb13c0a0.png)


Thanks to @di and the PyPI team for making this happen and for the helpful [discussion on Twitter](https://twitter.com/HEPfeickert/status/1649181900521472001?s=20) and https://github.com/pypi/warehouse/issues/13463!

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Split the build and publish steps into two separate jobs. The 'build' job
  builds and checks the distributions and then uploads them as a job artifact.
  The 'publish' job downloads the required artifact from the 'build' job and
  the publishes them to TestPyPI or PyPI if the typical publishing requirements
  are met.
* Use the OpenID Connect (OIDC) standard to publish to PyPI and TestPyPI
  using PyPI's "Trusted Publisher" implementation to publish without
  using API tokens stored as GitHub Actions secrets. Use an optional
  GitHub Actions environment to further restrict publishing to selected
  branches ('main' and 'release/*') for additional security.
   - c.f. https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
   - c.f. https://docs.pypi.org/trusted-publishers/
```