### PR TITLE
docs: Use Plausible for page visit statistics

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -274,6 +274,10 @@ html_css_files = [
 
 html_js_files = [
     'js/custom.js',
+    (
+        'https://views.scientific-python.org/js/plausible.js',
+        {"data-domain": "pyhf.readthedocs.io", "defer": "defer"},
+    ),
 ]
 
 # Add any extra paths that contain custom files (such as robots.txt or

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,7 @@ extensions = [
     'sphinx_copybutton',
     'sphinx_togglebutton',
     'xref',
+    'sphinx_plausible',
 ]
 bibtex_bibfiles = [
     "bib/docs.bib",
@@ -83,6 +84,10 @@ intersphinx_mapping = {
 
 # GitHub repo
 issues_github_path = 'scikit-hep/pyhf'
+
+# c.f. https://github.com/scikit-hep/scikit-hep.github.io/issues/278
+plausible_domain = "pyhf.readthedocs.io"
+plausible_script = "https://views.scientific-python.org/js/plausible.js"
 
 # Generate the API documentation when building
 autosummary_generate = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,6 @@ extensions = [
     'sphinx_copybutton',
     'sphinx_togglebutton',
     'xref',
-    'sphinx_plausible',
 ]
 bibtex_bibfiles = [
     "bib/docs.bib",
@@ -84,10 +83,6 @@ intersphinx_mapping = {
 
 # GitHub repo
 issues_github_path = 'scikit-hep/pyhf'
-
-# c.f. https://github.com/scikit-hep/scikit-hep.github.io/issues/278
-plausible_domain = "pyhf.readthedocs.io"
-plausible_script = "https://views.scientific-python.org/js/plausible.js"
 
 # Generate the API documentation when building
 autosummary_generate = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ docs = [
     "sphinx-issues",
     "sphinx-copybutton>=0.3.2",
     "sphinx-togglebutton>=0.3.0",
+    "sphinx-plausible>=0.1.2",
     "ipython!=8.7.0",  # c.f. https://github.com/scikit-hep/pyhf/pull/2068
 ]
 develop = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,6 @@ docs = [
     "sphinx-issues",
     "sphinx-copybutton>=0.3.2",
     "sphinx-togglebutton>=0.3.0",
-    "sphinx-plausible>=0.1.2",
     "ipython!=8.7.0",  # c.f. https://github.com/scikit-hep/pyhf/pull/2068
 ]
 develop = [


### PR DESCRIPTION
# Description

Related to https://github.com/scikit-hep/scikit-hep.github.io/issues/278

* Use the Scientific Python org's Plausible instance to collect page visit statistics for the pyhf docs by adding it to the `html_js_files` in the Sphinx config.

After building the docs

```console
$ grep "plausible" docs/_build/html/index.html
        <script data-domain="pyhf.readthedocs.io" defer="defer" src="https://views.scientific-python.org/js/plausible.js"></script>
```

c.f. https://views.scientific-python.org/pyhf.readthedocs.io/

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use the Scientific Python org's Plausible instance to collect page visit
  statistics for the pyhf docs by adding it to the html_js_files in the
  Sphinx config.
   - c.f. https://views.scientific-python.org/pyhf.readthedocs.io/
```