### PR TITLE
docs(backport): Use Plausible for page visit statistics

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -274,6 +274,10 @@ html_css_files = [
 
 html_js_files = [
     'js/custom.js',
+    (
+        'https://views.scientific-python.org/js/plausible.js',
+        {"data-domain": "pyhf.readthedocs.io", "defer": "defer"},
+    ),
 ]
 
 # Add any extra paths that contain custom files (such as robots.txt or


### PR DESCRIPTION
# Description

Backport PR https://github.com/scikit-hep/pyhf/pull/2186

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Backport PR https://github.com/scikit-hep/pyhf/pull/2186
* Use the Scientific Python org's Plausible instance to collect page visit
  statistics for the pyhf docs by adding it to the html_js_files in the
  Sphinx config.
   - c.f. https://views.scientific-python.org/pyhf.readthedocs.io/
```