### PR TITLE
chore: Remove GKE mybinder build

### DIFF
--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -15,5 +15,4 @@ jobs:
     - name: Trigger Binder build
       run: |
         # Use Binder build API to trigger repo2docker to build image on Google Cloud and Turing Institute Binder Federation clusters
-        bash binder/trigger_binder.sh https://gke.mybinder.org/build/gh/scikit-hep/pyhf/main
         bash binder/trigger_binder.sh https://turing.mybinder.org/build/gh/scikit-hep/pyhf/main


### PR DESCRIPTION
# Description

The GKE Binder Federation instance is being taken offline on 2023-04-28 and so requests made to gke.mybinder.org will fail. :disappointed: To keep the GHA workflow from failing remove the GKE build triggers.
   - c.f. 2023-04-25 blog [Mybinder.org reducing capacity](https://blog.jupyter.org/mybinder-org-reducing-capacity-c93ccfc6413f)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* The GKE Binder Federation instance is being taken offline on
  2023-04-28 and so requests made to gke.mybinder.org will fail.
  To keep the GHA workflow from failing remove the GKE build triggers.
   - c.f. https://blog.jupyter.org/mybinder-org-reducing-capacity-c93ccfc6413f
```