### PR TITLE
build: Remove sphinx-togglebutton from 'docs' extra

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,6 @@ extensions = [
     'nbsphinx',
     'sphinx_issues',
     'sphinx_copybutton',
-    'sphinx_togglebutton',
     'xref',
     'jupyterlite_sphinx',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,6 @@ docs = [
     "ipywidgets",
     "sphinx-issues",
     "sphinx-copybutton>=0.3.2",
-    "sphinx-togglebutton>=0.3.0",
     "jupyterlite-sphinx>=0.8.0",
     "jupyterlite-pyodide-kernel>=0.0.7",
     "jupytext>=1.14.0",


### PR DESCRIPTION
# Description

Remove `sphinx-togglebutton` dependency from the 'docs' extra as `sphinx-togglebutton` was used only to make a instructional admonition into a toggleable dropdown. The admonition was removed in PR #2187 and so `sphinx-togglebutton` is no longer needed.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove sphinx-togglebutton dependency from the 'docs' extra as
  sphinx-togglebutton was used only to make a instructional admonition
  into a toggleable dropdown. The admonition was removed in PR #2187 and so
  sphinx-togglebutton is no longer needed.
* Remove use of sphinx_togglebutton extension from docs/conf.py.
* Amends PR https://github.com/scikit-hep/pyhf/pull/2187.
```