### PR TITLE
fix: Disallow sphinx-copybutton v0.5.1 to avoid output in copy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ docs = [
     "nbsphinx!=0.8.8",  # c.f. https://github.com/spatialaudio/nbsphinx/issues/620
     "ipywidgets",
     "sphinx-issues",
-    "sphinx-copybutton>=0.3.2",
+    "sphinx-copybutton>=0.3.2,!=0.5.1",
     "jupyterlite-sphinx>=0.8.0",
     "jupyterlite-pyodide-kernel>=0.0.7",
     "jupytext>=1.14.0",


### PR DESCRIPTION
# Description

`sphinx-copybutton` `v0.5.1` has a bug that will place lines of output in the copy contents, so explicitly disallow `v0.5.1`. This bug is fixed in `sphinx-copybutton` `v0.5.2`.

---

In `sphinx-copybutton` `v0.5.1` the following reStructuredText block

https://github.com/scikit-hep/pyhf/blob/0cac4583ba33de33450daba6ab901ee712c74e73/README.rst?plain=1#L68-L82

when copied will contain the line

```
Observed: 0.05251497, Expected: 0.06445321
```

in the output which is not the desired effect.

`v0.5.0` copy contents:

```
import pyhf
pyhf.set_backend("numpy")
model = pyhf.simplemodels.uncorrelated_background(
    signal=[12.0, 11.0], bkg=[50.0, 52.0], bkg_uncertainty=[3.0, 7.0]
)
data = [51, 48] + model.config.auxdata
test_mu = 1.0
CLs_obs, CLs_exp = pyhf.infer.hypotest(
    test_mu, data, model, test_stat="qtilde", return_expected=True
)
print(f"Observed: {CLs_obs:.8f}, Expected: {CLs_exp:.8f}")
```

`v0.5.1` copy contents:

```
import pyhf
pyhf.set_backend("numpy")
model = pyhf.simplemodels.uncorrelated_background(
    signal=[12.0, 11.0], bkg=[50.0, 52.0], bkg_uncertainty=[3.0, 7.0]
)
data = [51, 48] + model.config.auxdata
test_mu = 1.0
CLs_obs, CLs_exp = pyhf.infer.hypotest(
    test_mu, data, model, test_stat="qtilde", return_expected=True
)
print(f"Observed: {CLs_obs:.8f}, Expected: {CLs_exp:.8f}")
Observed: 0.05251497, Expected: 0.06445321
```

`v0.5.2` copy contents:

```
import pyhf
pyhf.set_backend("numpy")
model = pyhf.simplemodels.uncorrelated_background(
    signal=[12.0, 11.0], bkg=[50.0, 52.0], bkg_uncertainty=[3.0, 7.0]
)
data = [51, 48] + model.config.auxdata
test_mu = 1.0
CLs_obs, CLs_exp = pyhf.infer.hypotest(
    test_mu, data, model, test_stat="qtilde", return_expected=True
)
print(f"Observed: {CLs_obs:.8f}, Expected: {CLs_exp:.8f}")
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* sphinx-copybutton v0.5.1 has a bug that will place lines of output in
  the copy contents, so explicitly disallow v0.5.1. This bug is fixed
  in sphinx-copybutton v0.5.2.
```