### PR TITLE
fix: Catch use of multi-component parameters as POI with error message

### DIFF
--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -464,11 +464,10 @@ class _ModelConfig(_ChannelSummaryMixin):
             raise exceptions.InvalidModel(
                 f"The parameter of interest '{name:s}' cannot be fit as it is not declared in the model specification."
             )
-        if dict(self.modifiers).get(name, "") == "shapefactor":
-            # in the case of custom modifiers, the desired POI is in self.parameters but
-            # not in self.modifiers
+        if self.param_set(name).n_parameters > 1:
+            # multi-parameter modifiers are not supported as POIs
             raise exceptions.InvalidModel(
-                f"The parameter '{name:s}' is of type 'shapefactor' and thus cannot be used as parameter of interest."
+                f"The parameter '{name:s}' contains multiple components and is not currently supported as parameter of interest."
             )
         s = self.par_slice(name)
         assert s.stop - s.start == 1

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -469,10 +469,8 @@ class _ModelConfig(_ChannelSummaryMixin):
             raise exceptions.InvalidModel(
                 f"The parameter '{name:s}' contains multiple components and is not currently supported as parameter of interest."
             )
-        s = self.par_slice(name)
-        assert s.stop - s.start == 1
         self._poi_name = name
-        self._poi_index = s.start
+        self._poi_index = self.par_slice(name).start
 
     def _create_and_register_paramsets(self, required_paramsets):
         next_index = 0

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -464,7 +464,9 @@ class _ModelConfig(_ChannelSummaryMixin):
             raise exceptions.InvalidModel(
                 f"The parameter of interest '{name:s}' cannot be fit as it is not declared in the model specification."
             )
-        if dict(self.modifiers)[name] == "shapefactor":
+        if dict(self.modifiers).get(name, "") == "shapefactor":
+            # in the case of custom modifiers, the desired POI is in self.parameters but
+            # not in self.modifiers
             raise exceptions.InvalidModel(
                 f"The parameter '{name:s}' is of type 'shapefactor' and thus cannot be used as parameter of interest."
             )

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -464,6 +464,10 @@ class _ModelConfig(_ChannelSummaryMixin):
             raise exceptions.InvalidModel(
                 f"The parameter of interest '{name:s}' cannot be fit as it is not declared in the model specification."
             )
+        if dict(self.modifiers)[name] == "shapefactor":
+            raise exceptions.InvalidModel(
+                f"The parameter '{name:s}' is of type 'shapefactor' and thus cannot be used as parameter of interest."
+            )
         s = self.par_slice(name)
         assert s.stop - s.start == 1
         self._poi_name = name

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1331,7 +1331,7 @@ def test_is_shared_paramset_shapesys_same_sample_same_channel():
         pyhf.Workspace(spec).model()
 
 
-def test_shapefactor_as_poi():
+def test_multi_component_poi():
     spec = {
         "channels": [
             {

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1356,7 +1356,7 @@ def test_shapefactor_as_poi():
 
     with pytest.raises(
         pyhf.exceptions.InvalidModel,
-        match="The parameter 'mu' is of type 'shapefactor' and thus cannot be used as "
-        "parameter of interest.",
+        match="The parameter 'mu' contains multiple components and is not currently "
+        "supported as parameter of interest.",
     ):
         pyhf.Workspace(spec).model()

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1329,3 +1329,34 @@ def test_is_shared_paramset_shapesys_same_sample_same_channel():
 
     with pytest.raises(pyhf.exceptions.InvalidModel):
         pyhf.Workspace(spec).model()
+
+
+def test_shapefactor_as_poi():
+    spec = {
+        "channels": [
+            {
+                "name": "SR",
+                "samples": [
+                    {
+                        "data": [5.0, 10.0],
+                        "modifiers": [
+                            {"data": None, "name": "mu", "type": "shapefactor"}
+                        ],
+                        "name": "Signal",
+                    }
+                ],
+            }
+        ],
+        "measurements": [
+            {"config": {"parameters": [], "poi": "mu"}, "name": "example"}
+        ],
+        "observations": [{"data": [5.0, 10.0], "name": "SR"}],
+        "version": "1.0.0",
+    }
+
+    with pytest.raises(
+        pyhf.exceptions.InvalidModel,
+        match="The parameter 'mu' is of type 'shapefactor' and thus cannot be used as "
+        "parameter of interest.",
+    ):
+        pyhf.Workspace(spec).model()

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1356,7 +1356,6 @@ def test_multi_component_poi():
 
     with pytest.raises(
         pyhf.exceptions.InvalidModel,
-        match="The parameter 'mu' contains multiple components and is not currently "
-        "supported as parameter of interest.",
+        match="The parameter 'mu' contains multiple components and is not currently supported as parameter of interest.",
     ):
         pyhf.Workspace(spec).model()


### PR DESCRIPTION
# Description

Resolves #2200.

This addresses #2194. When a parameter with multiple components (`shapefactor` / `shapesys` / `staterror`) is used as POI, the model construction currently fails at an `assert` (assuming Python is not run with `-O`). This PR turns the failure into an exception with an error message to provide more context.

For simple MLEs, bypassing the `assert` actually  makes things work (so one could argue to not catch this early and force the exception). However, this would cause even more confusing issues down the line once the POI starts mattering. As an example, a `hypotest` could result in `RuntimeWarning: invalid value encountered in subtract` within `scipy`. I do not see any benefit in allowing to bypass the exception to allow running things that do not depend on the POI definition though.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

(summary provided by @matthewfeickert)

```
* Raise exceptions.InvalidModel for multiple component parameter of interest.
  This guards against modifiers like 'shapefactor', 'shapesys', and 'staterror'
  from being used as POIs.
   - Remove use of 'assert' to check the same information.
* Add test to test_pdf.py to validate.
```