### PR TITLE
docs: Correct 'tensorflow' typo in v0.7.1 release notes

### DIFF
--- a/docs/release-notes/v0.7.1.rst
+++ b/docs/release-notes/v0.7.1.rst
@@ -9,7 +9,7 @@ Important Notes
 * All backends are now fully compatible and tested with
   `Python 3.11 <https://peps.python.org/pep-0664/>`_.
   (PR :pr:`2145`)
-* The ``tensorflow`` extra (``'pyhf[tensorlfow]'``) now automatically installs
+* The ``tensorflow`` extra (``'pyhf[tensorflow]'``) now automatically installs
   ``tensorflow-macos`` for Apple silicon machines.
   (PR :pr:`2119`)
 


### PR DESCRIPTION
# Description

Fix 'tensorlfow' -> 'tensorflow' typ in the v0.7.1 release notes. :grimacing: 

https://github.com/scikit-hep/pyhf/blob/5161749fe8509dde6f5f9c1d6fcb7d7b8a796a9f/docs/release-notes/v0.7.1.rst?plain=1#L12

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Fix 'tensorlfow' -> 'tensorflow'
```