### PR TITLE
docs: Add use citation from Belle II lepton-flavor-violating decays paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,16 @@
+% 2023-05-08
+@article{Belle-II:2023bnh,
+    author = "Belle II Collaboration",
+    title = "{Search for lepton-flavor-violating $\tau^- \to \ell^-\phi$ decays in 2019-2021 Belle II data}",
+    eprint = "2305.04759",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    reportNumber = "BELLE2-CONF-2023-004",
+    month = "5",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-04-11
 @article{Shadura:2023zks,
     author = "Shadura, Oksana and Held, Alexander",


### PR DESCRIPTION
# Description

Add use citation from [Search for lepton-flavor-violating τ−→ℓ−ϕ decays in 2019-2021 Belle II data](https://inspirehep.net/literature/2657628) by the Belle II collaboration.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Search for lepton-flavor-violating τ−→ℓ−ϕ
  decays in 2019-2021 Belle II data'.
   - c.f. https://inspirehep.net/literature/2657628
```