### PR TITLE
docs: Update citations references to include journal pubs through 2023-04

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -169,14 +169,16 @@
 % 2022-07-21
 @article{Allwicher:2022mcg,
     author = "Allwicher, Lukas and Faroughy, Darius. A. and Jaffredo, Florentin and Sumensari, Olcyr and Wilsch, Felix",
-    title = "{HighPT: A Tool for high-$p_T$ Drell-Yan Tails Beyond the Standard Model}",
+    title = "{HighPT: A tool for high-pT Drell-Yan tails beyond the standard model}",
     eprint = "2207.10756",
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
     reportNumber = "ZU-TH-29/22",
-    month = "7",
-    year = "2022",
-    journal = ""
+    doi = "10.1016/j.cpc.2023.108749",
+    journal = "Comput. Phys. Commun.",
+    volume = "289",
+    pages = "108749",
+    year = "2023"
 }
 
 % 2022-07-15

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -79,9 +79,11 @@
     eprint = "2301.05676",
     archivePrefix = "arXiv",
     primaryClass = "hep-ex",
-    month = "1",
-    year = "2023",
-    journal = ""
+    doi = "10.1007/JHEP04(2023)084",
+    journal = "JHEP",
+    volume = "04",
+    pages = "084",
+    year = "2023"
 }
 
 % 2022-12-06


### PR DESCRIPTION
# Description

* '[Simplified likelihoods using linearized systematic uncertainties](https://inspirehep.net/literature/2623097)' is published as JHEP 04 (2023) 084. https://doi.org/10.1007/JHEP04(2023)084
* '[HighPT: A tool for high-pT Drell-Yan tails beyond the standard model](https://inspirehep.net/literature/2121076)' is published as Comput.Phys.Commun. 289 (2023) 108749. https://doi.org/10.1016/j.cpc.2023.108749

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update use citations references to include their journal
  publication information.
   - 'Simplified likelihoods using linearized systematic uncertainties'
     is published as JHEP 04 (2023) 084.
     https://doi.org/10.1007/JHEP04(2023)084
   - 'HighPT: A tool for high-pT Drell-Yan tails beyond the standard
     model' is published as Comput.Phys.Commun. 289 (2023) 108749.
     https://doi.org/10.1016/j.cpc.2023.108749
```