### PR TITLE
fix: Disallow TensorFlow Probability v0.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ shellcomplete = ["click_completion"]
 tensorflow = [
     "tensorflow>=2.7.0; platform_machine != 'arm64'",  # c.f. PR #1962
     "tensorflow-macos>=2.7.0; platform_machine == 'arm64' and platform_system == 'Darwin'",  # c.f. PR #2119
-    "tensorflow-probability>=0.11.0",  # c.f. PR #1657
+    "tensorflow-probability>=0.11.0,!=0.20.0",  # c.f. PR #1657, PR #2203
 ]
 torch = ["torch>=1.10.0"]  # c.f. PR #1657
 jax = [


### PR DESCRIPTION
# Description

* `tensorflow-probability` `v0.20.0` breaks all Python 3.7 and older as it lacks `requires-python` metadata, and so is explicitly disallowed.
   - c.f. https://github.com/tensorflow/probability/issues/1723

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* tensorflow-probability v0.20.0 breaks all Python 3.7 and older as it lacks
  requires-python metadata, and so is explicitly disallowed.
```