### PR TITLE
ci(backport): Update CI workflows and use Trusted Publishers

### DIFF
--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -15,5 +15,4 @@ jobs:
     - name: Trigger Binder build
       run: |
         # Use Binder build API to trigger repo2docker to build image on Google Cloud and Turing Institute Binder Federation clusters
-        bash binder/trigger_binder.sh https://gke.mybinder.org/build/gh/scikit-hep/pyhf/main
         bash binder/trigger_binder.sh https://turing.mybinder.org/build/gh/scikit-hep/pyhf/main

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -25,8 +25,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-publish:
-    name: Build and publish Python distro to (Test)PyPI
+  build:
+    name: Build Python distribution
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -88,21 +88,48 @@ jobs:
     - name: List contents of wheel
       run: python -m zipfile --list dist/pyhf-*.whl
 
+    - name: Upload distribution artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: dist-artifact
+        path: dist
+
+  publish:
+    name: Publish Python distribution to (Test)PyPI
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    # Mandatory for publishing with a trusted publisher
+    # c.f. https://docs.pypi.org/trusted-publishers/using-a-publisher/
+    permissions:
+      id-token: write
+    # Restrict to the environment set for the trusted publisher
+    environment:
+      name: publish-package
+
+    steps:
+    - name: Download distribution artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: dist-artifact
+        path: dist
+
+    - name: List all files
+      run: ls -lh dist
+
     - name: Publish distribution 📦 to Test PyPI
       # Publish to TestPyPI on tag events of if manually triggered
       # Compare to 'true' string as booleans get turned into strings in the console
       if: >-
         (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
         || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
-      uses: pypa/gh-action-pypi-publish@v1.8.5
+      uses: pypa/gh-action-pypi-publish@v1.8.6
       with:
-        password: ${{ secrets.test_pypi_password }}
         repository-url: https://test.pypi.org/legacy/
         print-hash: true
 
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf'
-      uses: pypa/gh-action-pypi-publish@v1.8.5
+      uses: pypa/gh-action-pypi-publish@v1.8.6
       with:
-        password: ${{ secrets.pypi_password }}
         print-hash: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
       additional_dependencies: [flake8-encodings==0.5.0.post1]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1
+    rev: v1.2.0
     # check the oldest and newest supported Pythons
     # Though use Python 3.8 as the oldest Python to run mypy
     # to avoid positional-only errors from NumPy in Python 3.11


### PR DESCRIPTION
# Description

* Backport components of:
   - PR https://github.com/scikit-hep/pyhf/pull/2183
   - PR https://github.com/scikit-hep/pyhf/pull/2189
   - PR https://github.com/scikit-hep/pyhf/pull/2193
   - PR https://github.com/scikit-hep/pyhf/pull/2195

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Backport components of:
   - PR https://github.com/scikit-hep/pyhf/pull/2183
   - PR https://github.com/scikit-hep/pyhf/pull/2189
   - PR https://github.com/scikit-hep/pyhf/pull/2193
   - PR https://github.com/scikit-hep/pyhf/pull/2195
```