### PR TITLE
fix: Add TYPE_CHECKING guard for numpy.typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,8 +225,7 @@ omit = ["*/pyhf/typing.py"]
 precision = 1
 sort = "cover"
 show_missing = true
-exclude_lines = [
-    "pragma: no cover",
+exclude_also = [
     "if TYPE_CHECKING:"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,6 +225,10 @@ omit = ["*/pyhf/typing.py"]
 precision = 1
 sort = "cover"
 show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:"
+]
 
 [tool.mypy]
 files = "src"

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Callable, Generic, Mapping, Sequence, TypeVar,
 
 import numpy as np
 
+# Needed while numpy lower bound is older than v1.21.0
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike, DTypeLike, NBitBase, NDArray
 

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -2,17 +2,20 @@
 from __future__ import annotations
 
 import logging
-from typing import Callable, Generic, Mapping, Sequence, TypeVar, Union
+from typing import TYPE_CHECKING, Callable, Generic, Mapping, Sequence, TypeVar, Union
 
 import numpy as np
-from numpy.typing import ArrayLike, DTypeLike, NBitBase, NDArray
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike, DTypeLike, NBitBase, NDArray
+
 from scipy import special
 from scipy.special import gammaln, xlogy
 from scipy.stats import norm, poisson
 
 from pyhf.typing import Literal, Shape
 
-T = TypeVar("T", bound=NBitBase)
+T = TypeVar("T", bound="NBitBase")
 
 Tensor = Union["NDArray[np.number[T]]", "NDArray[np.bool_]"]
 FloatIntOrBool = Literal["float", "int", "bool"]

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -9,6 +9,8 @@ import numpy as np
 # Needed while numpy lower bound is older than v1.21.0
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike, DTypeLike, NBitBase, NDArray
+else:
+    NBitBase = "NBitBase"
 
 from scipy import special
 from scipy.special import gammaln, xlogy
@@ -16,7 +18,7 @@ from scipy.stats import norm, poisson
 
 from pyhf.typing import Literal, Shape
 
-T = TypeVar("T", bound="NBitBase")
+T = TypeVar("T", bound=NBitBase)
 
 Tensor = Union["NDArray[np.number[T]]", "NDArray[np.bool_]"]
 FloatIntOrBool = Literal["float", "int", "bool"]


### PR DESCRIPTION
# Description

Resolves #2207 

The addition of `typing.TYPE_CHECKING` avoids situations in which the version of NumPy (whose lower bounds is enforced by SciPy) doesn't have `numpy.typing`, which was added in NumPy `v1.21.0`.

To avoid drops in code coverage at the patch level, exclude `if TYPE_CHECKING:` from the `coverage` report by using the `exclude_also` option.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* The addition of typing.TYPE_CHECKING avoids situations in which
  the version of NumPy (whose lower bounds is enforced by SciPy)
  doesn't have numpy.typing, which was added in NumPy v1.21.0.
* Exclude lines that match 'if TYPE_CHECKING:' from the coverage
  report to avoid artificial drops in code coverage.
   - c.f. https://coverage.readthedocs.io/en/stable/excluding.html#advanced-exclusion

Co-authored-by: Giordon Stark <kratsg@gmail.com>
```