### PR TITLE
docs: Update talk list through May 2023

### DIFF
--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -1,6 +1,16 @@
 % NB: entries with same author-title-year are not picked up:
 %     https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/117
 
+@unpublished{Feickert_20210520,
+  title  = {{Distributed statistical inference with pyhf enabled through funcX}},
+  author = {Matthew Feickert},
+  year   = {2021},
+  month  = {May},
+  day    = {20},
+  note   = {vCHEP 2021 Conference},
+  url    = {https://indico.cern.ch/event/948465/contributions/4324013/},
+}
+
 @unpublished{Feickert_20210407,
   title  = {{Tutorial on pyhf}},
   author = {Matthew Feickert},

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -32,7 +32,7 @@
 }
 
 @unpublished{Feickert_20220708,
-  title  = {{pyhf: a pure-Python statistical fitting library with tensors and automatic differentiation}},
+  title  = {{pyhf: pure-Python statistical fitting library with tensors and automatic differentiation}},
   author = {Matthew Feickert},
   year   = {2022},
   month  = {Jul},

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -93,17 +93,6 @@
   url    = {https://indico.cern.ch/event/948465/contributions/4324013/},
 }
 
-@unpublished{Feickert_20210407,
-  title  = {{Tutorial on pyhf}},
-  author = {Matthew Feickert},
-  year   = {2021},
-  month  = {Apr},
-  day    = {7},
-  note   = {PyHEP Python Module of the Month (April 2021)},
-  doi    = {10.5281/zenodo.4670322},
-  url    = {https://indico.cern.ch/event/985425/},
-}
-
 @unpublished{Feickert_20201103,
   title  = {{pyhf: pure-Python implementation of HistFactory with tensors and automatic differentiation}},
   author = {Matthew Feickert},

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -4,8 +4,16 @@
 12 Apr 2023 - "pyhf: pure-Python implementation of HistFactory with tensors and automatic differentiation", Matthew Feickert, CMS Common Analysis Tools General Meeting
 3 Mar 2023 - "How to contribute to pyhf development", Matthew Feickert, Belle II pyhf workshop 2023
 6 Sep 2022 - "pyhf and analysis optimization with automatic differentiation", Matthew Feickert, ATLAS HDBS Workshop 2022
-8 Jul 2022 - "pyhf: a pure-Python statistical fitting library with tensors and automatic differentiation", Matthew Feickert, International Conference on High Energy Physics (ICHEP) 2022
 
+@unpublished{Feickert_20220708,
+  title  = {{pyhf: a pure-Python statistical fitting library with tensors and automatic differentiation}},
+  author = {Matthew Feickert},
+  year   = {2022},
+  month  = {Jul},
+  day    = {8},
+  note   = {International Conference on High Energy Physics (ICHEP) 2022},
+  url    = {https://agenda.infn.it/event/28874/contributions/169217/},
+}
 
 @unpublished{Feickert_20220425,
   title  = {{Statistical inference: pyhf and cabinetry}},

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -1,6 +1,28 @@
 % NB: entries with same author-title-year are not picked up:
 %     https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/117
 
+@unpublished{Feickert_20210715,
+  title  = {{Distributed statistical inference with pyhf powered by funcX}},
+  author = {Matthew Feickert},
+  year   = {2021},
+  month  = {Jul},
+  day    = {15},
+  note   = {20th Python in Science Conference (SciPy 2021)},
+  doi    = {10.25080/majora-1b6fd038-023},
+  url    = {https://conference.scipy.org/proceedings/scipy2021/slides.html},
+}
+
+@unpublished{Feickert_20210706,
+  title  = {{Distributed statistical inference with pyhf}},
+  author = {Matthew Feickert},
+  year   = {2021},
+  month  = {Jul},
+  day    = {6},
+  note   = {PyHEP 2021 (virtual) Workshop},
+  doi    = {10.5281/zenodo.5136819},
+  url    = {https://indico.cern.ch/event/1019958/contributions/4418598/},
+}
+
 @unpublished{Feickert_20210520,
   title  = {{Distributed statistical inference with pyhf enabled through funcX}},
   author = {Matthew Feickert},

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -2,7 +2,16 @@
 %     https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/117
 
 12 Apr 2023 - "pyhf: pure-Python implementation of HistFactory with tensors and automatic differentiation", Matthew Feickert, CMS Common Analysis Tools General Meeting
-3 Mar 2023 - "How to contribute to pyhf development", Matthew Feickert, Belle II pyhf workshop 2023
+
+@unpublished{Feickert_20230303,
+  title  = {{How to contribute to pyhf development}},
+  author = {Matthew Feickert},
+  year   = {2023},
+  month  = {Mar},
+  day    = {3},
+  note   = {Belle II pyhf workshop 2023},
+  url    = {https://indico.belle2.org/event/8470/contributions/55871/},
+}
 
 @unpublished{Feickert_20220906,
   title  = {{pyhf and analysis optimization with automatic differentiation}},

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -3,7 +3,16 @@
 
 12 Apr 2023 - "pyhf: pure-Python implementation of HistFactory with tensors and automatic differentiation", Matthew Feickert, CMS Common Analysis Tools General Meeting
 3 Mar 2023 - "How to contribute to pyhf development", Matthew Feickert, Belle II pyhf workshop 2023
-6 Sep 2022 - "pyhf and analysis optimization with automatic differentiation", Matthew Feickert, ATLAS HDBS Workshop 2022
+
+@unpublished{Feickert_20220906,
+  title  = {{pyhf and analysis optimization with automatic differentiation}},
+  author = {Matthew Feickert},
+  year   = {2022},
+  month  = {Sep},
+  day    = {6},
+  note   = {(Internal) ATLAS HDBS Workshop 2022},
+  url    = {https://indico.cern.ch/event/1132691/contributions/4994710/},
+}
 
 @unpublished{Feickert_20220708,
   title  = {{pyhf: a pure-Python statistical fitting library with tensors and automatic differentiation}},

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -1,6 +1,23 @@
 % NB: entries with same author-title-year are not picked up:
 %     https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/117
 
+12 Apr 2023 - "pyhf: pure-Python implementation of HistFactory with tensors and automatic differentiation", Matthew Feickert, CMS Common Analysis Tools General Meeting
+3 Mar 2023 - "How to contribute to pyhf development", Matthew Feickert, Belle II pyhf workshop 2023
+6 Sep 2022 - "pyhf and analysis optimization with automatic differentiation", Matthew Feickert, ATLAS HDBS Workshop 2022
+8 Jul 2022 - "pyhf: a pure-Python statistical fitting library with tensors and automatic differentiation", Matthew Feickert, International Conference on High Energy Physics (ICHEP) 2022
+25 Apr 2022 - "Statistical inference: pyhf and cabinetry", Matthew Feickert, IRIS-HEP AGC Tools 2022 Workshop
+
+
+@unpublished{Feickert_20211201,
+  title  = {{pyhf: pure-Python implementation of HistFactory with tensors and automatic differentiation}},
+  author = {Matthew Feickert},
+  year   = {2021},
+  month  = {Dec},
+  day    = {1},
+  note   = {CMS Analysis Tools Task Force},
+  url    = {https://indico.cern.ch/event/1100873/contributions/4631656/},
+}
+
 @unpublished{Feickert_20210715,
   title  = {{Distributed statistical inference with pyhf powered by funcX}},
   author = {Matthew Feickert},

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -1,6 +1,17 @@
 % NB: entries with same author-title-year are not picked up:
 %     https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/117
 
+@unpublished{Feickert_20210407,
+  title  = {{Tutorial on pyhf}},
+  author = {Matthew Feickert},
+  year   = {2021},
+  month  = {Apr},
+  day    = {7},
+  note   = {PyHEP Python Module of the Month (April 2021)},
+  doi    = {10.5281/zenodo.4670322},
+  url    = {https://indico.cern.ch/event/985425/},
+}
+
 @unpublished{Feickert_20201103,
   title  = {{pyhf: pure-Python implementation of HistFactory with tensors and automatic differentiation}},
   author = {Matthew Feickert},

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -5,8 +5,17 @@
 3 Mar 2023 - "How to contribute to pyhf development", Matthew Feickert, Belle II pyhf workshop 2023
 6 Sep 2022 - "pyhf and analysis optimization with automatic differentiation", Matthew Feickert, ATLAS HDBS Workshop 2022
 8 Jul 2022 - "pyhf: a pure-Python statistical fitting library with tensors and automatic differentiation", Matthew Feickert, International Conference on High Energy Physics (ICHEP) 2022
-25 Apr 2022 - "Statistical inference: pyhf and cabinetry", Matthew Feickert, IRIS-HEP AGC Tools 2022 Workshop
 
+
+@unpublished{Feickert_20220425,
+  title  = {{Statistical inference: pyhf and cabinetry}},
+  author = {Matthew Feickert},
+  year   = {2022},
+  month  = {Apr},
+  day    = {25},
+  note   = {IRIS-HEP Analysis Grand Challenge Tools 2022 Workshop},
+  url    = {https://indico.cern.ch/event/1126109/contributions/4780155/},
+}
 
 @unpublished{Feickert_20211201,
   title  = {{pyhf: pure-Python implementation of HistFactory with tensors and automatic differentiation}},

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -53,7 +53,7 @@
   day    = {30},
   note   = {1st Pan-European Advanced School on Statistics in High Energy Physics},
   organization = {DESY},
-  url    = {https://indico.desy.de/indico/event/22731/session/4/contribution/19},
+  url    = {https://indico.desy.de/event/22731/contributions/47953/},
 }
 
 @unpublished{Stark20191023,

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -1,7 +1,15 @@
 % NB: entries with same author-title-year are not picked up:
 %     https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/117
 
-12 Apr 2023 - "pyhf: pure-Python implementation of HistFactory with tensors and automatic differentiation", Matthew Feickert, CMS Common Analysis Tools General Meeting
+@unpublished{Feickert_20230412,
+  title  = {{pyhf: pure-Python implementation of HistFactory with tensors and automatic differentiation}},
+  author = {Matthew Feickert},
+  year   = {2023},
+  month  = {Apr},
+  day    = {12},
+  note   = {(Internal) CMS Common Analysis Tools General Meeting (April 2023)},
+  url    = {https://indico.cern.ch/event/1264029/contributions/5308065/},
+}
 
 @unpublished{Feickert_20230303,
   title  = {{How to contribute to pyhf development}},

--- a/docs/bib/tutorials.bib
+++ b/docs/bib/tutorials.bib
@@ -1,6 +1,17 @@
 % NB: entries with same author-title-year are not picked up:
 %     https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/117
 
+@unpublished{Feickert_20210407,
+  title  = {{Tutorial on pyhf}},
+  author = {Matthew Feickert},
+  year   = {2021},
+  month  = {Apr},
+  day    = {7},
+  note   = {PyHEP Python Module of the Month (April 2021)},
+  doi    = {10.5281/zenodo.4670322},
+  url    = {https://indico.cern.ch/event/985425/},
+}
+
 @unpublished{GStark20200925,
   title  = {{ATLAS Exotics + SUSY Workshop 2020 pyhf Tutorial}},
   author = {Giordon Stark},


### PR DESCRIPTION
# Description

Update pyhf talk and tutorial list through May 2023.

Fix DESY Indico URL for 'Traditional inference with machine learning tools' to avoid timeout error during linkcheck.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update pyhf talk and tutorial list through May 2023.
* Fix DESY Indico URL for 'Traditional inference with machine learning tools'
  to avoid timeout error during linkcheck.
```