### PR TITLE
fix(backport): Catch use of multi-component parameters as POI

### DIFF
--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -464,10 +464,13 @@ class _ModelConfig(_ChannelSummaryMixin):
             raise exceptions.InvalidModel(
                 f"The parameter of interest '{name:s}' cannot be fit as it is not declared in the model specification."
             )
-        s = self.par_slice(name)
-        assert s.stop - s.start == 1
+        if self.param_set(name).n_parameters > 1:
+            # multi-parameter modifiers are not supported as POIs
+            raise exceptions.InvalidModel(
+                f"The parameter '{name:s}' contains multiple components and is not currently supported as parameter of interest."
+            )
         self._poi_name = name
-        self._poi_index = s.start
+        self._poi_index = self.par_slice(name).start
 
     def _create_and_register_paramsets(self, required_paramsets):
         next_index = 0

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1329,3 +1329,33 @@ def test_is_shared_paramset_shapesys_same_sample_same_channel():
 
     with pytest.raises(pyhf.exceptions.InvalidModel):
         pyhf.Workspace(spec).model()
+
+
+def test_multi_component_poi():
+    spec = {
+        "channels": [
+            {
+                "name": "SR",
+                "samples": [
+                    {
+                        "data": [5.0, 10.0],
+                        "modifiers": [
+                            {"data": None, "name": "mu", "type": "shapefactor"}
+                        ],
+                        "name": "Signal",
+                    }
+                ],
+            }
+        ],
+        "measurements": [
+            {"config": {"parameters": [], "poi": "mu"}, "name": "example"}
+        ],
+        "observations": [{"data": [5.0, 10.0], "name": "SR"}],
+        "version": "1.0.0",
+    }
+
+    with pytest.raises(
+        pyhf.exceptions.InvalidModel,
+        match="The parameter 'mu' contains multiple components and is not currently supported as parameter of interest.",
+    ):
+        pyhf.Workspace(spec).model()


### PR DESCRIPTION
# Description

Backport PR https://github.com/scikit-hep/pyhf/pull/2197

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Backport PR https://github.com/scikit-hep/pyhf/pull/2197
```