### PR TITLE
docs(backport): Add sphinx_rtd_theme to extensions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
     'sphinx.ext.intersphinx',
+    'sphinx_rtd_theme',
     'sphinxcontrib.bibtex',
     'sphinx.ext.napoleon',
     'sphinx_click.ext',


### PR DESCRIPTION
# Description

* Backport PR https://github.com/scikit-hep/pyhf/pull/2220
* sphinx_rtd_theme must be added to the sphinx extensions in sphinx v6.0+ to properly load jQuery.
   - c.f. https://sphinx-rtd-theme.readthedocs.io/en/1.2.0/changelog.html#known-issues

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Backport PR https://github.com/scikit-hep/pyhf/pull/2220
* sphinx_rtd_theme must be added to the sphinx extensions in sphinx v6.0+
  to properly load jQuery.
   - c.f. https://sphinx-rtd-theme.readthedocs.io/en/1.2.0/changelog.html#known-issues
```