### PR TITLE
ci: Use scientific-python-nightly-wheels package index for dependency nightlies

### DIFF
--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -64,7 +64,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade .[test]
         python -m pip uninstall --yes scipy
-        python -m pip install --upgrade --index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy
+        python -m pip install --upgrade --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
         python -m pip list
 
     - name: Test with pytest
@@ -143,12 +143,13 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade .[test]
         python -m pip uninstall --yes matplotlib
-        # Need to use --extra-index-url as dependencies aren't on scipy-wheels-nightly package index.
+        # Need to use --extra-index-url as dependencies aren't on scientific-python-nightly-wheels package index.
         # Need to use --pre as dev releases will need priority over stable releases.
         python -m pip install \
           --upgrade \
           --pre \
-          --extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple \
+          --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
+          --extra-index-url https://pypi.org/simple/ \
           matplotlib
 
     - name: List installed Python packages


### PR DESCRIPTION
# Description

Nightly wheels for the Scientific Python community have migrated from the Anaconda Cloud https://anaconda.org/scipy-wheels-nightly/ package index to https://anaconda.org/scientific-python-nightly-wheels/.

   - c.f. https://scientific-python.org/specs/spec-0004/
   - c.f. https://github.com/scientific-python/specs/pull/182
   - c.f. https://github.com/matplotlib/matplotlib/pull/25950

For matplotlib use `--index-url` of `scientific-python-nightly-wheels` and use `--extra-index-url` of public PyPI (https://pypi.org) as some of `matplotlib`'s dependencies aren't on `scientific-python-nightly-wheels`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Nightly wheels for the Scientific Python community have migrated from
  the Anaconda Cloud https://anaconda.org/scipy-wheels-nightly/ package
  index to https://anaconda.org/scientific-python-nightly-wheels.
   - c.f. https://scientific-python.org/specs/spec-0004/
   - c.f. https://github.com/scientific-python/specs/pull/182
   - c.f. https://github.com/matplotlib/matplotlib/pull/25950
* For matplotlib use --index-url of scientific-python-nightly-wheels and
  use --extra-index-url of public PyPI (https://pypi.org/) as some of
  matplotlib's dependencies aren't on scientific-python-nightly-wheels.
```