### PR TITLE
fix: Add filterwarnings ignore for ml-dtypes DeprecationWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,7 @@ filterwarnings = [
     'ignore:Call to deprecated create function:DeprecationWarning',  # protobuf via tensorflow
     'ignore:`np.bool8` is a deprecated alias for `np.bool_`:DeprecationWarning',  # numpy via tensorflow
     "ignore:module 'sre_constants' is deprecated:DeprecationWarning",  # tensorflow v2.12.0+ for Python 3.11+
+    "ignore:ml_dtypes.float8_e4m3b11 is deprecated.",  #FIXME: Can remove when jaxlib>=0.4.12
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
# Description

Add an ignore to filterwarnings to avoid `ml_dtypes` `DeprecationWarning` from use of jaxlib

> DeprecationWarning: ml_dtypes.float8_e4m3b11 is deprecated. Use ml_dtypes.float8_e4m3b11fnuz

`ml_dtypes` deprecated this behavior in [`v0.2.0`](https://github.com/jax-ml/ml_dtypes/releases/tag/v0.2.0) and `jaxlib` will [avoid the deprecation in `jaxlib` `v0.4.12`](https://github.com/google/jax/blob/01ed663163faa7bff9890a7b9ac8096c7014022e/pyproject.toml#L69-L71). (c.f. https://github.com/google/jax/pull/16277)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add an ignore to filterwarnings to avoid ml_dtypes DeprecationWarning
from use of jaxlib

> DeprecationWarning: ml_dtypes.float8_e4m3b11 is deprecated. Use ml_dtypes.float8_e4m3b11fnuz

ml_dtypes deprecated this behavior in v0.2.0
(https://github.com/jax-ml/ml_dtypes/releases/tag/v0.2.0) and jaxlib
will avoid the deprecation in jaxlib v0.4.12.
   - c.f. https://github.com/google/jax/pull/16277
```