### PR TITLE
test: Ignore DESY Indico presentation URL during Sphinx linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -515,6 +515,8 @@ linkcheck_ignore = [
     r'https://doi\.org/10\.31526/.*',
     # https://doi.org/10.1051/epjconf/x DOI URLs will periodically generate 500 Server Error
     r'https://doi\.org/10\.1051/epjconf/.*',
+    # https://indico.desy.de/event/22731/contributions/47953/ is frequently generating 403 Client Error
+    r'https://indico.desy.de/event/22731/.*',
     # tags for a release won't exist until it is made, but the release notes
     # and ReadTheDocs need to reference them
     r'https://github.com/scikit-hep/pyhf/releases/tag/.*',


### PR DESCRIPTION
# Description

Ignore URLs for https://indico.desy.de/event/22731 from Sphinx linkcheck tests as the URL
https://indico.desy.de/event/22731/contributions/47953/ is frequently generating 403 Client Error.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Ignore URLs for https://indico.desy.de/event/22731 from Sphinx
  linkcheck tests as the URL
  https://indico.desy.de/event/22731/contributions/47953/ is frequently
  generating 403 Client Error.
```