### PR TITLE
docs: Add general use citation from Julia in HEP paper

### DIFF
--- a/docs/bib/general_citations.bib
+++ b/docs/bib/general_citations.bib
@@ -1,3 +1,15 @@
+% 2023-06-06
+@article{Eschle:2023ikn,
+    author = "Eschle, J. and others",
+    title = "{Potential of the Julia programming language for high energy physics computing}",
+    eprint = "2306.03675",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    month = "6",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-02-02
 @article{Bockelman:2023gbj,
     author = "Bockelman, Brian and Elmer, Peter and Watts, Gordon",


### PR DESCRIPTION
# Description

Add general citation from [Potential of the Julia programming language for high energy physics computing](https://inspirehep.net/literature/2666479).

(Also congrats to the authors for getting this up on arXiv! I know it was a long process.)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add general citation from 'Potential of the Julia programming
  language for high energy physics computing'.
   - c.f. https://inspirehep.net/literature/2666479
```