### PR TITLE
chore: ruff moved to astral-sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       # exclude generated files
       exclude: ^validation/|\.dtd$|\.xml$
 
-- repo: https://github.com/charliermarsh/ruff-pre-commit
+- repo: https://github.com/astral-sh/ruff-pre-commit
   rev: "v0.0.270"
   hooks:
     - id: ruff


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/pull/200.

Committed via https://github.com/asottile/all-repos

```
* Update Ruff pre-commit hook url to https://github.com/astral-sh/ruff-pre-commit
   - c.f. https://github.com/scientific-python/cookie/pull/200
```