### PR TITLE
feat: Use non-root default user for Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.nox
+.*cache
+*.git

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
 .nox
 .*cache
-*.git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,16 +16,46 @@ RUN apt-get -qq -y update && \
     python -m venv /usr/local/venv && \
     cd /code && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
-    python -m pip --no-cache-dir install .[xmlio,contrib] && \
+    python -m pip --no-cache-dir install '.[xmlio,contrib]' && \
     python -m pip list
 
 FROM base
+
+USER root
+
 ENV PATH=/usr/local/venv/bin:"${PATH}"
+
 RUN apt-get -qq -y update && \
     apt-get -qq -y install --no-install-recommends \
         curl && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/*
+
+# Create non-root user "moby" with uid 1000
+RUN adduser \
+      --shell /bin/bash \
+      --gecos "default user" \
+      --uid 1000 \
+      --disabled-password \
+      moby && \
+    chown -R moby /home/moby && \
+    mkdir /work && \
+    chown -R moby /work && \
+    printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> /home/moby/.bashrc
+
 COPY --from=builder /usr/local/venv /usr/local/venv
+
+USER moby
+
+ENV USER ${USER}
+ENV HOME /home/moby
+WORKDIR ${HOME}/work
+
+# Use C.UTF-8 locale to avoid issues with ASCII encoding
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+ENV PATH=${HOME}/.local/bin:${PATH}
+
 ENTRYPOINT ["/usr/local/venv/bin/pyhf"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,7 @@ RUN adduser \
     chown -R moby /home/moby && \
     mkdir /work && \
     chown -R moby /work && \
-    printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> /home/moby/.bashrc
+    printf "\nexport PATH=/usr/local/venv/bin:${PATH}\n" >> /home/moby/.bashrc
 
 COPY --from=builder --chown=moby /usr/local/venv /usr/local/venv/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,7 @@ RUN adduser \
     chown -R moby /home/moby && \
     mkdir /work && \
     chown -R moby /work && \
-    printf "\nexport PATH=/usr/local/venv/bin:${PATH}\n" >> /home/moby/.bashrc
+    echo -e "\nexport PATH=/usr/local/venv/bin:${PATH}\n" >> /home/moby/.bashrc
 
 COPY --from=builder --chown=moby /usr/local/venv /usr/local/venv/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,7 @@ FROM base
 
 USER root
 
+SHELL [ "/bin/bash", "-c" ]
 ENV PATH=/usr/local/venv/bin:"${PATH}"
 
 RUN apt-get -qq -y update && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN adduser \
     chown -R moby /work && \
     printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> /home/moby/.bashrc
 
-COPY --from=builder /usr/local/venv /usr/local/venv
+COPY --from=builder --chown=moby /usr/local/venv /usr/local/venv/
 
 USER moby
 


### PR DESCRIPTION
# Description

For security reasons and to avoid the case where a user will bind mount the image and then find that they have `root` owned files on their machine, use a non-root default user "moby" for the Docker images that owns the Python virtual environment. "moby" has uid of `1000` as this should ensure that any files created in the container while bind mounted are owned by the user regardless of OS.

```console
$ docker run --rm -ti --entrypoint /bin/bash -v $PWD:/home/moby/work pyhf/pyhf:debug-local
moby@a470af96916a:~/work$ echo "hi" > here.txt
moby@a470af96916a:~/work$ exit
exit
$ ls -l here.txt 
-rw-r--r-- 1 feickert feickert 3 Jul  5 11:50 here.txt
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add non-root default user 'moby' with uid 1000 that owns the Python virtual environment.
   - Set default working directory to /home/moby/work/.
* Add .dockerignore for local builds.
```