### PR TITLE
fix: Add filterwarnings ignore for jsonschema.RefResolver DeprecationWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,7 @@ filterwarnings = [
     'ignore:`np.bool8` is a deprecated alias for `np.bool_`:DeprecationWarning',  # numpy via tensorflow
     "ignore:module 'sre_constants' is deprecated:DeprecationWarning",  # tensorflow v2.12.0+ for Python 3.11+
     "ignore:ml_dtypes.float8_e4m3b11 is deprecated.",  #FIXME: Can remove when jaxlib>=0.4.12
+    "ignore:jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the:DeprecationWarning",  # Issue #2139
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
# Description

Add an ignore to filterwarnings to avoid `jsonschema.RefResolver` `DeprecationWarning`

> DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the https://github.com/python-jsonschema/referencing library, which provides more compliant referencing behavior as well as more flexible APIs for customization. A future release will remove RefResolver. Please file a feature request (on referencing) if you are missing an API for the kind of customization you need.

  This filterwarning should be removed once pyhf updates to referencing.
  - c.f. https://github.com/scikit-hep/pyhf/issues/2139

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add an ignore to filterwarnings to avoid jsonschema.RefResolver DeprecationWarning

> DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0, in favor
> of the https://github.com/python-jsonschema/referencing library, which provides
> more compliant referencing behavior as well as more flexible APIs for customization.
> A future release will remove RefResolver. Please file a feature request
> (on referencing) if you are missing an API for the kind of customization you need.

  This filterwarning should be removed once pyhf updates to referencing.
  - c.f. https://github.com/scikit-hep/pyhf/issues/2139
```