### PR TITLE
docs: Update Binder to launch into JupyterLab environment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -372,7 +372,7 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
 .. |Jupyter Book tutorial| image:: https://jupyterbook.org/_images/badge.svg
    :target: https://pyhf.github.io/pyhf-tutorial/
 .. |Binder| image:: https://mybinder.org/badge_logo.svg
-   :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/main?filepath=docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
+   :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/main?labpath=docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
 
 .. |PyPI version| image:: https://badge.fury.io/py/pyhf.svg
    :target: https://badge.fury.io/py/pyhf

--- a/README.rst
+++ b/README.rst
@@ -372,7 +372,7 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
 .. |Jupyter Book tutorial| image:: https://jupyterbook.org/_images/badge.svg
    :target: https://pyhf.github.io/pyhf-tutorial/
 .. |Binder| image:: https://mybinder.org/badge_logo.svg
-   :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/main?urlpath=lab/tree/docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
+   :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/main?filepath=docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
 
 .. |PyPI version| image:: https://badge.fury.io/py/pyhf.svg
    :target: https://badge.fury.io/py/pyhf

--- a/README.rst
+++ b/README.rst
@@ -372,7 +372,7 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
 .. |Jupyter Book tutorial| image:: https://jupyterbook.org/_images/badge.svg
    :target: https://pyhf.github.io/pyhf-tutorial/
 .. |Binder| image:: https://mybinder.org/badge_logo.svg
-   :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/main?filepath=docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
+   :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/main?urlpath=lab/tree/docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
 
 .. |PyPI version| image:: https://badge.fury.io/py/pyhf.svg
    :target: https://badge.fury.io/py/pyhf

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,2 +1,5 @@
 python -m pip install --upgrade '.[all]'
-python -m pip install altair
+python -m pip install --upgrade \
+    ipywidgets \
+    ipympl \
+    altair

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -4,7 +4,7 @@ Examples
 Try out in Binder! |Binder|
 
 .. |Binder| image:: https://mybinder.org/badge_logo.svg
-    :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/main?urlpath=lab/tree/docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
+    :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/main?filepath=docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
 
 Notebooks:
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -4,7 +4,7 @@ Examples
 Try out in Binder! |Binder|
 
 .. |Binder| image:: https://mybinder.org/badge_logo.svg
-    :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/main?filepath=docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
+    :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/main?labpath=docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
 
 Notebooks:
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -4,7 +4,7 @@ Examples
 Try out in Binder! |Binder|
 
 .. |Binder| image:: https://mybinder.org/badge_logo.svg
-    :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/main?filepath=docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
+    :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/main?urlpath=lab/tree/docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
 
 Notebooks:
 

--- a/docs/examples/notebooks/binderexample/StatisticalAnalysis.ipynb
+++ b/docs/examples/notebooks/binderexample/StatisticalAnalysis.ipynb
@@ -16,7 +16,7 @@
     "from pyhf.contrib.viz import brazil\n",
     "\n",
     "import base64\n",
-    "from IPython.core.display import display, HTML\n",
+    "from IPython.display import display, HTML\n",
     "from ipywidgets import interact, fixed"
    ]
   },
@@ -1248,7 +1248,7 @@
     }
    ],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "fig, ax = plt.subplots(1, 1)\n",
     "fig.set_size_inches(10, 5)\n",
     "ax.set_ylim(0, 1.5 * np.max(workspace.data(pdf, include_auxdata=False)))\n",


### PR DESCRIPTION
# Description

* Install ipywidgets and ipympl to have interactive IPython widgets in modern JupyterLab.
* Use from IPython.display import display to avoid using deprecated APIs.
* Use %matplotlib widget to get interactive matplotlib in JupyterLab.
* Use 'labpath' to open up files in JupyterLab.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Install ipywidgets and ipympl to have interactive IPython widgets in
  modern JupyterLab.
* Use from IPython.display import display to avoid using deprecated APIs.
* Use %matplotlib widget to get interactive matplotlib in JupyterLab.
* Use 'labpath' to open up files in JupyterLab.
```