### PR TITLE
fix: Add ipympl to 'test' extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ test = [
     "pytest-benchmark[histogram]",
     "pytest-console-scripts>=1.4.0",
     "pytest-mpl",
+    "ipympl>=0.3.0",
     "pydocstyle",
     "papermill~=2.3.4",
     "scrapbook~=0.5.0",


### PR DESCRIPTION
# Description

* Add `ipympl>=0.3.0` to the 'test' extra environment as it is used in the notebooks as of PR #2252. The lower bound of `v0.3.0` is chosen as this corresponds in time with the 'contrib' lower bound on matplotlib of `matplotlib>=3.0.0`.
* Amends PR #2252.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add ipympl>=0.3.0 to the 'test' extra environment as it is used in the
  notebooks as of PR #2252. The lower bound of v0.3.0 is chosen as this
  corresponds in time with the 'contrib' lower bound on matplotlib of
  matplotlib>=3.0.0.
* Amends PR #2252.
```