### PR TITLE
docs: Add use citation from Spey paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,16 @@
+% 2023-07-13
+@article{Araz:2023bwx,
+    author = "Araz, Jack Y.",
+    title = "{Spey: smooth inference for reinterpretation studies}",
+    eprint = "2307.06996",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "IPPP/23/34",
+    month = "7",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-06-30
 @article{MahdiAltakach:2023bdn,
     author = "Mahdi Altakach, Mohammad and Kraml, Sabine and Lessa, Andre and Narasimha, Sahana and Pascal, Timoth\'ee and Waltenberger, Wolfgang",


### PR DESCRIPTION
# Description

Add use citation from '[Spey: smooth inference for reinterpretation studies](https://inspirehep.net/literature/2677291)' by @jackaraz.
   - Use comes from spey-pyhf optional backend https://github.com/SpeysideHEP/spey-pyhf

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Spey: smooth inference for reinterpretation
  studies'.
   - c.f. https://inspirehep.net/literature/2677291
   - Use comes from spey-pyhf optional backend
     https://github.com/SpeysideHEP/spey-pyhf
```