### PR TITLE
docs: Add use citation from Gauge SU(2)f flavour paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,16 @@
+% 2023-07-18
+@article{Darme:2023nsy,
+    author = "Darm\'e, Luc and Deandrea, Aldo and Mahmoudi, Farvah",
+    title = "{Gauge $SU(2)_f$ flavour transfers}",
+    eprint = "2307.09595",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "CERN-TH-2023-139",
+    month = "7",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-07-13
 @article{Araz:2023bwx,
     author = "Araz, Jack Y.",


### PR DESCRIPTION
# Description

Add use citation from '[Gauge SU(2)f flavour transfers](https://inspirehep.net/literature/2678488)' by Luc Darmé, Aldo Deandrea, Farvah Mahmoudi.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Gauge SU(2)f flavour transfers'.
   - c.f. https://inspirehep.net/literature/2678488
```