### PR TITLE
docs: Remove python.sytem_packages from ReadTheDocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -28,4 +28,3 @@ python:
       path: .
       extra_requirements:
         - docs
-  system_packages: true


### PR DESCRIPTION
# Description

* ReadTheDocs is removing the "use system packages" feature on 2023-08-29. The user should fully specify the docs environment, which for pyhf is already done, but pyhf was following the default template which included the uses of system_packages.

The following email was received:

> Hello,
>
> You are receving this email because your Read the Docs project is impacted by an upcoming deprecation.
>
> Read the Docs used to pre-install common scientific Python packages like scipy, numpy, pandas, matplotlib and others at system level to speed up the build process. However, with all the work done in the Python ecosystem and the introduction of "wheels", these packages are a lot easier to install via pip install and these pre-installed packages are not required anymore. If you have Apt package dependencies, they can be installed with [`build.apt_packages`](https://docs.readthedocs.io/en/stable/config-file/v2.html#build-apt-packages).
>
> With the introduction of our new "Ubuntu 20.04" and "Ubuntu 22.04" Docker images, we stopped pre-installing these extra Python packages and we encouraged users to install and pin all their dependencies using a `requirements.txt` file. We have already stopped supporting "use system packages" on these newer images.
>
> **We are removing the "use system packages" feature on August 29th**. Make sure you are installing all the required dependecies to build your project's documentation using a `requirements.txt` file and specifying it in your `.readthedocs.yaml`.
>
> Here you have an example of the section required on the `.readthedocs.yaml` configuration file:
>
> ```yaml
> python:
>   install:
>     - requirements: docs/requirements.txt
> ```
> 
> The content of docs/requirements.txt would be similar to:
>
> ```txt
> scipy==1.11.1
> numpy==1.25.2
> pandas==2.0.3
> matplotlib==3.7.2
> ```
> 
> We are sending you this email because you are a maintainer of the following projects that are affected by this removal. Either using "Use system package" checkbox in the Admin UI, or the config key `python.sytem_packages` or `python.use_system_site_packages` in your `.readthedocs.yaml` file:
>
> pyhf
>
> Read more about this in our [Reproducible builds](https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html) guide for more details.
>
> Keep documenting,
> Read the Docs

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* ReadTheDocs is removing the "use system packages" feature on
  2023-08-29. The user should fully specify the docs environment, which
  for pyhf is already done, but pyhf was following the default template
  which included the uses of system_packages.
```