### PR TITLE
docs: Require sphinx-rtd-theme compatible with Sphinx 7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ docs = [
     "sphinx>=5.1.1",  # c.f. https://github.com/scikit-hep/pyhf/pull/1926
     "sphinxcontrib-bibtex~=2.1",
     "sphinx-click",
-    "sphinx_rtd_theme",
+    "sphinx-rtd-theme>=1.3.0rc1",  # c.f. https://github.com/scikit-hep/pyhf/pull/2271
     "nbsphinx!=0.8.8",  # c.f. https://github.com/spatialaudio/nbsphinx/issues/620
     "ipywidgets",
     "sphinx-issues",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ test = [
 ]
 docs = [
     "pyhf[xmlio,contrib]",
-    "sphinx>=5.1.1",  # c.f. https://github.com/scikit-hep/pyhf/pull/1926
+    "sphinx>=7.0.0",  # c.f. https://github.com/scikit-hep/pyhf/pull/2271
     "sphinxcontrib-bibtex~=2.1",
     "sphinx-click",
     "sphinx-rtd-theme>=1.3.0rc1",  # c.f. https://github.com/scikit-hep/pyhf/pull/2271


### PR DESCRIPTION
# Description

* Update lower bound on sphinx-rtd-theme to v1.3.0rc1 to ensure compatibility with Sphinx v7+.
   - c.f. https://github.com/readthedocs/sphinx_rtd_theme/issues/1463
   - As soon as sphinx-rtd-theme v1.3.0 is released on PyPI the lower bound should be updated to reflect this stable release. The release candidate is being used to unbreak CI.
* Update lower bound of Sphinx to v7.0.0 for consistency.


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update lower bound on sphinx-rtd-theme to v1.3.0rc1 to ensure
  compatibility with Sphinx v7+.
   - c.f. https://github.com/readthedocs/sphinx_rtd_theme/issues/1463
   - As soon as sphinx-rtd-theme v1.3.0 is released on PyPI the lower
     bound should be updated to reflect this stable release. The release
     candidate is being used to unbreak CI.
* Update lower bound of Sphinx to v7.0.0 for consistency.
```