### PR TITLE
test: Add test for iterator exhaustion with `next`

### DIFF
--- a/tests/contrib/test_viz.py
+++ b/tests/contrib/test_viz.py
@@ -181,3 +181,25 @@ def test_plot_results_components_data_structure(datadir):
         brazil.plot_results(
             data["testmus"], data["results"], test_size=0.05, ax=ax, components=True
         )
+
+
+def test_plot_results_wrong_axis_labels(datadir, mocker):
+    """
+    If the returned labels are different from the expected, then the hardcoded
+    values in label_part will be wrong, causing `next` to fail on the iterator
+    for label_idx.
+    """
+    data = json.load(datadir.joinpath("hypotest_results.json").open(encoding="utf-8"))
+
+    fig = Figure()
+    ax = fig.subplots()
+
+    get_legend_handles_labels = mocker.patch(
+        "matplotlib.axes._axes.Axes.get_legend_handles_labels",
+        return_value=(None, ["fail"]),
+    )
+
+    with pytest.raises(StopIteration):
+        brazil.plot_results(data["testmus"], data["results"], test_size=0.05, ax=ax)
+
+    assert get_legend_handles_labels.called


### PR DESCRIPTION
# Description

* Add test to `tests/contrib/test_viz.py` to cover the case where the wrong labels are somehow returned in `brazil.plot_results`, causing the legend label ordering logic to fail.
* Amends PR #2264 (this provides the coverage that was missing in https://github.com/scikit-hep/pyhf/pull/2264#pullrequestreview-1571224664).


# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add test to tests/contrib/test_viz.py to cover the case where the
  wrong labels are somehow returned in brazil.plot_results, causing the
  legend label ordering logic to fail.
* Amends PR #2264
```