### PR TITLE
test: Ignore CERN Twiki URLs during Sphinx linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -519,6 +519,8 @@ linkcheck_ignore = [
     r'https://indico.desy.de/event/22731/.*',
     # https://indico.belle2.org/event/8470/contributions/55871/ is frequently generating 403 Client Error
     r'https://indico.belle2.org/event/8470/.*',
+    # CERN doesn't maintain its SSL certs well enough to not have SSLErrors
+    r'https://twiki.cern.ch/.*',
     # tags for a release won't exist until it is made, but the release notes
     # and ReadTheDocs need to reference them
     r'https://github.com/scikit-hep/pyhf/releases/tag/.*',


### PR DESCRIPTION
# Description

Ignore URLs for CERN's Twiki instance https://twiki.cern.ch/ from Sphinx linkcheck tests as CERN seems to have problems regularly maintaining their SSL certs which can lead to SSL errors.

Example:
```
Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1002)'))
```

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Ignore URLs for CERN's Twiki instance https://twiki.cern.ch/ from
  Sphinx linkcheck tests as CERN seems to have problems regularly
  maintaining their SSL certs which can lead to SSL errors.

  Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED]
  certificate verify failed: unable to get local issuer certificate (_ssl.c:1002)'))
```