### PR TITLE
fix: Correct handling of strategy 0 for Minuit optimizer

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -31,3 +31,4 @@ Contributors include:
 - Jerry Ling
 - Nathan Simpson
 - Beojan Stanislaus
+- Daniel Werner

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -102,7 +102,7 @@ class minuit_optimizer(OptimizerMixin):
         # 0: Fast, user-provided gradient
         # 1: Default, no user-provided gradient
         strategy = options.pop(
-            'strategy', self.strategy if self.strategy else not do_grad
+            'strategy', self.strategy if self.strategy is not None else not do_grad
         )
         tolerance = options.pop('tolerance', self.tolerance)
         if options:

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -182,7 +182,6 @@ def test_minuit_strategy_global(mocker, backend, strategy):
     m = pyhf.simplemodels.uncorrelated_background([50.0], [100.0], [10.0])
     data = pyhf.tensorlib.astensor([125.0] + m.config.auxdata)
 
-    do_grad = pyhf.tensorlib.default_do_grad
     pyhf.infer.mle.fit(data, m)
     assert spy.call_count == 1
     assert spy.spy_return.minuit.strategy == strategy

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -185,7 +185,7 @@ def test_minuit_strategy_global(mocker, backend, strategy):
     do_grad = pyhf.tensorlib.default_do_grad
     pyhf.infer.mle.fit(data, m)
     assert spy.call_count == 1
-    assert spy.spy_return.minuit.strategy == strategy if do_grad else 1
+    assert spy.spy_return.minuit.strategy == strategy
 
     pyhf.infer.mle.fit(data, m, strategy=0)
     assert spy.call_count == 2


### PR DESCRIPTION
# Description
The relevant line is supposed to set the strategy of minuit to one of the supported values `0`, `1`, ~~or `2`~~ (Note from @matthewfeickert: `pyhf` doesn't support option `2` at this time). Since the strategy `0` evaluates to `False`, this strategy couldn't be set when creating the optimizer if `do_grad` was `False`

https://github.com/scikit-hep/pyhf/blob/f8f3c96e8be560c3e5712fe080f97e95702d4942/src/pyhf/optimize/opt_minuit.py#L104-L106

. The default value in the case of no specified strategy is `None`

https://github.com/scikit-hep/pyhf/blob/f8f3c96e8be560c3e5712fe080f97e95702d4942/src/pyhf/optimize/opt_minuit.py#L39

meaning that the statement `is not None` solves the issue with

```python
self.strategy if self.strategy is not None else not do_grad
```
.

Amends PR https://github.com/scikit-hep/pyhf/pull/1183.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Properly guard the `strategy` option for the Minuit optimizer in the case that
  `strategy` option of 0 is used.
  Without checking `self.strategy is not None` the `if self.strategy` for
  self.strategy==0 evaluates to truthiness of False, giving the wrong value of
  `not do_grad` for do_grad of False.
   - Amends PR https://github.com/scikit-hep/pyhf/pull/1183
* Use the corrected behavior to improve testing of default in test_minuit_strategy_global.
* Add Daniel Werner to contributors list.
```