### PR TITLE
fix: Guard Minuit optimizer against provided strategy of None

### DIFF
--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -104,6 +104,9 @@ class minuit_optimizer(OptimizerMixin):
         strategy = options.pop(
             'strategy', self.strategy if self.strategy is not None else int(not do_grad)
         )
+        # Passing strategy=None to options requires another check to guard against None
+        if strategy is None:
+            strategy = int(not do_grad)
         tolerance = options.pop('tolerance', self.tolerance)
         if options:
             raise exceptions.Unsupported(

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -108,7 +108,7 @@ class minuit_optimizer(OptimizerMixin):
         strategy = options.pop(
             'strategy', self.strategy if self.strategy is not None else int(not do_grad)
         )
-        # Passing strategy=None to options requires another check to guard against None
+        # Passing strategy=None as options kwarg requires another check to guard against None
         if strategy is None:
             strategy = int(not do_grad)
         tolerance = options.pop('tolerance', self.tolerance)

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -106,7 +106,8 @@ class minuit_optimizer(OptimizerMixin):
         #   0: Fast. Does not check a user-provided gradient.
         #   1: Default. Checks user-provided gradient against numerical gradient.
         strategy = options.pop("strategy", self.strategy)
-        # Passing strategy=None as options kwarg requires check to guard against None
+        # Guard against None from either self.strategy defaulting to None or
+        # passing strategy=None as options kwarg
         if strategy is None:
             strategy = int(not do_grad)
         tolerance = options.pop('tolerance', self.tolerance)

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -102,7 +102,7 @@ class minuit_optimizer(OptimizerMixin):
         # 0: Fast, user-provided gradient
         # 1: Default, no user-provided gradient
         strategy = options.pop(
-            'strategy', self.strategy if self.strategy is not None else not do_grad
+            'strategy', self.strategy if self.strategy is not None else int(not do_grad)
         )
         tolerance = options.pop('tolerance', self.tolerance)
         if options:

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -28,7 +28,10 @@ class minuit_optimizer(OptimizerMixin):
         Args:
             errordef (:obj:`float`): See minuit docs. Default is ``1.0``.
             steps (:obj:`int`): Number of steps for the bounds. Default is ``1000``.
-            strategy (:obj:`int`): See :attr:`iminuit.Minuit.strategy`. Default is ``None``.
+            strategy (:obj:`int`): See :attr:`iminuit.Minuit.strategy`.
+              Default is ``None``, which results in either
+              :attr:`iminuit.Minuit.strategy` ``0`` or ``1`` from the evaluation of
+              ``int(not pyhf.tensorlib.default_do_grad)``.
             tolerance (:obj:`float`): Tolerance for termination.
               See specific optimizer for detailed meaning.
               Default is ``0.1``.

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -102,8 +102,9 @@ class minuit_optimizer(OptimizerMixin):
             fitresult (scipy.optimize.OptimizeResult): the fit result
         """
         maxiter = options.pop('maxiter', self.maxiter)
-        # 0: Fast, user-provided gradient
-        # 1: Default, no user-provided gradient
+        # int(not do_grad) results in iminuit.Minuit.strategy of either:
+        #   0: Fast. Does not check a user-provided gradient.
+        #   1: Default. Checks user-provided gradient against numerical gradient.
         strategy = options.pop(
             'strategy', self.strategy if self.strategy is not None else int(not do_grad)
         )

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -102,14 +102,14 @@ class minuit_optimizer(OptimizerMixin):
             fitresult (scipy.optimize.OptimizeResult): the fit result
         """
         maxiter = options.pop('maxiter', self.maxiter)
-        # int(not do_grad) results in iminuit.Minuit.strategy of either:
+        # do_grad value results in iminuit.Minuit.strategy of either:
         #   0: Fast. Does not check a user-provided gradient.
         #   1: Default. Checks user-provided gradient against numerical gradient.
         strategy = options.pop("strategy", self.strategy)
         # Guard against None from either self.strategy defaulting to None or
         # passing strategy=None as options kwarg
         if strategy is None:
-            strategy = int(not do_grad)
+            strategy = 0 if do_grad else 1
         tolerance = options.pop('tolerance', self.tolerance)
         if options:
             raise exceptions.Unsupported(

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -105,10 +105,8 @@ class minuit_optimizer(OptimizerMixin):
         # int(not do_grad) results in iminuit.Minuit.strategy of either:
         #   0: Fast. Does not check a user-provided gradient.
         #   1: Default. Checks user-provided gradient against numerical gradient.
-        strategy = options.pop(
-            'strategy', self.strategy if self.strategy is not None else int(not do_grad)
-        )
-        # Passing strategy=None as options kwarg requires another check to guard against None
+        strategy = options.pop("strategy", self.strategy)
+        # Passing strategy=None as options kwarg requires check to guard against None
         if strategy is None:
             strategy = int(not do_grad)
         tolerance = options.pop('tolerance', self.tolerance)

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -173,7 +173,7 @@ def test_minuit_strategy_do_grad(mocker, backend):
     assert spy.spy_return.minuit.strategy == 1
 
 
-@pytest.mark.parametrize('strategy', [0, 1])
+@pytest.mark.parametrize('strategy', [0, 1, 2])
 def test_minuit_strategy_global(mocker, backend, strategy):
     pyhf.set_backend(
         pyhf.tensorlib, pyhf.optimize.minuit_optimizer(strategy=strategy, tolerance=0.2)
@@ -193,6 +193,10 @@ def test_minuit_strategy_global(mocker, backend, strategy):
     pyhf.infer.mle.fit(data, m, strategy=1)
     assert spy.call_count == 3
     assert spy.spy_return.minuit.strategy == 1
+
+    pyhf.infer.mle.fit(data, m, strategy=2)
+    assert spy.call_count == 4
+    assert spy.spy_return.minuit.strategy == 2
 
 
 def test_set_tolerance(backend):

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -179,23 +179,27 @@ def test_minuit_strategy_global(mocker, backend, strategy):
         pyhf.tensorlib, pyhf.optimize.minuit_optimizer(strategy=strategy, tolerance=0.2)
     )
     spy = mocker.spy(pyhf.optimize.minuit_optimizer, '_minimize')
-    m = pyhf.simplemodels.uncorrelated_background([50.0], [100.0], [10.0])
-    data = pyhf.tensorlib.astensor([125.0] + m.config.auxdata)
+    model = pyhf.simplemodels.uncorrelated_background([50.0], [100.0], [10.0])
+    data = pyhf.tensorlib.astensor([125.0] + model.config.auxdata)
 
-    pyhf.infer.mle.fit(data, m)
+    pyhf.infer.mle.fit(data, model)
     assert spy.call_count == 1
     assert spy.spy_return.minuit.strategy == strategy
 
-    pyhf.infer.mle.fit(data, m, strategy=0)
+    pyhf.infer.mle.fit(data, model, strategy=None)
     assert spy.call_count == 2
+    assert spy.spy_return.minuit.strategy == int(not pyhf.tensorlib.default_do_grad)
+
+    pyhf.infer.mle.fit(data, model, strategy=0)
+    assert spy.call_count == 3
     assert spy.spy_return.minuit.strategy == 0
 
-    pyhf.infer.mle.fit(data, m, strategy=1)
-    assert spy.call_count == 3
+    pyhf.infer.mle.fit(data, model, strategy=1)
+    assert spy.call_count == 4
     assert spy.spy_return.minuit.strategy == 1
 
-    pyhf.infer.mle.fit(data, m, strategy=2)
-    assert spy.call_count == 4
+    pyhf.infer.mle.fit(data, model, strategy=2)
+    assert spy.call_count == 5
     assert spy.spy_return.minuit.strategy == 2
 
 


### PR DESCRIPTION
# Description

* Fixes #1785
* Amends PR https://github.com/scikit-hep/pyhf/pull/2277

Guard Minuit optimizer strategy from None by first attempting to get a not-None result from the options kwargs and then falling back to assigning the strategy through `int(not do_grad)`. In the process this simplifies the logic required and supersedes PR https://github.com/scikit-hep/pyhf/pull/2277.

Add tests to `test_minuit_strategy_global` for `strategy=None` and `strategy=2` (`2` is a valid `iminuit.Minuit.strategy` strategy but not used often, so done just for good measure).

Add a very brief explanation to docs of what using `strategy=None` means in terms of evaluation to 0 or 1 from `int(pyhf.tensorlib.default_do_grad)`.


This extended example from @alexander-held in Issue #1785 now runs with this PR:

```python
# issue-1785.py
import pyhf

model = pyhf.simplemodels.uncorrelated_background(
    signal=[12.0, 11.0], bkg=[50.0, 52.0], bkg_uncertainty=[3.0, 7.0]
)
data = [51, 48] + model.config.auxdata
pyhf.set_backend("numpy", "minuit")
pyhf.infer.mle.fit(data, model)

strategies = [None, 0, 1, 2]
for strategy in strategies:
    pyhf.infer.mle.fit(data, model, strategy=strategy)
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Guard Minuit optimizer strategy from None by first attempting to get a
  not-None result from the options kwargs and then falling back to
  assigning the strategy through the equivalent of `int(not do_grad)`.
  In the process this simplifies the logic required and supersedes PR
  https://github.com/scikit-hep/pyhf/pull/2277.
   - Cast the truthiness of `do_grad` as an integer for human
     readability in debugging.
* Update the comments on `do_grad` strategy with definitions from
  iMinuit v2.24.0 docs.
* Add tests to test_minuit_strategy_global for strategy=None and strategy=2
  (2 is a valid iminuit.Minuit.strategy strategy but not used often).
* Add brief explanation to docs of what using strategy=None means in
  terms of evaluation to 0 or 1 from `int(pyhf.tensorlib.default_do_grad)`.
```