### PR TITLE
fix(backport): Replace deprecated np.product by np.prod

### DIFF
--- a/docs/examples/notebooks/pytorch_tests_onoff.ipynb
+++ b/docs/examples/notebooks/pytorch_tests_onoff.ipynb
@@ -35,7 +35,7 @@
     "            self.auxdata.append(bkg_over_bsq)\n",
     "\n",
     "    def alphas(self, pars):\n",
-    "        return np.product([pars, self.bkg_over_db_squared], axis=0)\n",
+    "        return np.prod([pars, self.bkg_over_db_squared], axis=0)\n",
     "\n",
     "    def logpdf(self, a, alpha):\n",
     "        return _log_poisson_impl(a, alpha)\n",

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -254,7 +254,7 @@ class numpy_backend(Generic[T]):
         return np.sum(tensor_in, axis=axis)
 
     def product(self, tensor_in: Tensor[T], axis: Shape | None = None) -> ArrayLike:
-        return np.product(tensor_in, axis=axis)  # type: ignore[arg-type]
+        return np.prod(tensor_in, axis=axis)  # type: ignore[arg-type]
 
     def abs(self, tensor: Tensor[T]) -> ArrayLike:
         return np.abs(tensor)


### PR DESCRIPTION
# Description

* Backport PR https://github.com/scikit-hep/pyhf/pull/2242
* Use np.prod API over np.product as np.product is deprecated as of NumPy v1.25.0.
   - c.f. https://numpy.org/devdocs/release/1.25.0-notes.html#deprecations

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Backport PR https://github.com/scikit-hep/pyhf/pull/2242
* Use np.prod API over np.product as np.product is deprecated
  as of NumPy v1.25.0.
   - c.f. https://numpy.org/devdocs/release/1.25.0-notes.html#deprecations
```