### PR TITLE
feat(backport): Use non-root default user for Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.nox
+.*cache

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,12 +20,43 @@ RUN apt-get -qq -y update && \
     python -m pip list
 
 FROM base
+
+USER root
+
+SHELL [ "/bin/bash", "-c" ]
 ENV PATH=/usr/local/venv/bin:"${PATH}"
+
 RUN apt-get -qq -y update && \
     apt-get -qq -y install --no-install-recommends \
         curl && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=builder /usr/local/venv /usr/local/venv
+
+# Create non-root user "moby" with uid 1000
+RUN adduser \
+      --shell /bin/bash \
+      --gecos "default user" \
+      --uid 1000 \
+      --disabled-password \
+      moby && \
+    chown -R moby /home/moby && \
+    mkdir /work && \
+    chown -R moby /work && \
+    echo -e "\nexport PATH=/usr/local/venv/bin:${PATH}\n" >> /home/moby/.bashrc
+
+COPY --from=builder --chown=moby /usr/local/venv /usr/local/venv/
+
+USER moby
+
+ENV USER ${USER}
+ENV HOME /home/moby
+WORKDIR ${HOME}/work
+
+# Use C.UTF-8 locale to avoid issues with ASCII encoding
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+ENV PATH=${HOME}/.local/bin:${PATH}
+
 ENTRYPOINT ["/usr/local/venv/bin/pyhf"]


### PR DESCRIPTION
# Description

* Backport PR https://github.com/scikit-hep/pyhf/pull/2243
* Add non-root default user 'moby' with uid 1000 that owns the Python virtual environment.
   - Set default working directory to /home/moby/work/.
* Add .dockerignore for local builds.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Backport PR https://github.com/scikit-hep/pyhf/pull/2243
* Add non-root default user 'moby' with uid 1000 that owns the Python virtual environment.
   - Set default working directory to /home/moby/work/.
* Add .dockerignore for local builds.
```