### PR TITLE
docs: Add ATLAS single-top-quark production observation statistical model record

### DIFF
--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -1,3 +1,13 @@
+% 2023-02-02
+@misc{ins2628980,
+    title = "{Observation of single-top-quark production in association with a photon using the ATLAS detector}",
+    doi = "10.17182/hepdata.134244",
+    url = "https://doi.org/10.17182/hepdata.134244",
+    year = "2023",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
 % 2022-11-15
 @misc{ins2182381,
     title = "{Search for supersymmetry in final states with missing transverse momentum and three or more b-jets in $139~\text{fb}^{-1}$ of proton-proton collisions at $\sqrt{s} = 13$ TeV with the ATLAS detector}",


### PR DESCRIPTION
# Description

* Add ATLAS observation of single-top-quark production in association with a photon statistical model HEPDdata record.
   - c.f. https://www.hepdata.net/record/ins2628980
   - Corresponding INSPIRE record: https://inspirehep.net/literature/2628980

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add ATLAS observation of single-top-quark production in association with a photon
  statistical model HEPDdata record.
   - c.f. https://www.hepdata.net/record/ins2628980
   - Corresponding INSPIRE record: https://inspirehep.net/literature/2628980
```