### PR TITLE
docs: Update citations references with journal pubs through 2023-07

### DIFF
--- a/docs/bib/general_citations.bib
+++ b/docs/bib/general_citations.bib
@@ -60,15 +60,17 @@
 }
 
 % 2022-03-22
-@article{Dorigo:2022gqm,
-    author = "Dorigo, Tommaso and others",
-    title = "{Toward the End-to-End Optimization of Particle Physics Instruments with Differentiable Programming: a White Paper}",
+@article{MODE:2022znx,
+    author = "{MODE Collaboration}",
+    title = "{Toward the end-to-end optimization of particle physics instruments with differentiable programming}",
     eprint = "2203.13818",
     archivePrefix = "arXiv",
     primaryClass = "physics.ins-det",
-    month = "3",
-    year = "2022",
-    journal = ""
+    doi = "10.1016/j.revip.2023.100085",
+    journal = "Rev. Phys.",
+    volume = "10",
+    pages = "100085",
+    year = "2023"
 }
 
 % 2022-03-09

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -112,26 +112,31 @@
 % 2023-02-10
 @article{Chan:2023tbf,
     author = "Chan, Jay and Nachman, Benjamin",
-    title = "{Unbinned Profiled Unfolding}",
+    title = "{Unbinned profiled unfolding}",
     eprint = "2302.05390",
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
-    month = "2",
-    year = "2023",
-    journal = ""
+    doi = "10.1103/PhysRevD.108.016002",
+    journal = "Phys. Rev. D",
+    volume = "108",
+    number = "1",
+    pages = "016002",
+    year = "2023"
 }
 
 % 2023-01-31
 @article{ATLAS:2023oti,
     author = "{ATLAS Collaboration}",
-    title = "{Search for long-lived, massive particles in events with displaced vertices and multiple jets in $pp$ collisions at $\sqrt{s} = 13$ TeV with the ATLAS detector}",
+    title = "{Search for long-lived, massive particles in events with displaced vertices and multiple jets in pp collisions at $ \sqrt{s} $ = 13 TeV with the ATLAS detector}",
     eprint = "2301.13866",
     archivePrefix = "arXiv",
     primaryClass = "hep-ex",
     reportNumber = "CERN-EP-2023-002",
-    month = "1",
-    year = "2023",
-    journal = ""
+    doi = "10.1007/JHEP06(2023)200",
+    journal = "JHEP",
+    volume = "2306",
+    pages = "200",
+    year = "2023"
 }
 
 % 2023-01-13
@@ -151,14 +156,17 @@
 % 2022-12-06
 @article{Belle-II:2022yaw,
     author = "Belle II Collaboration",
-    title = "{Search for an invisible $Z^\prime$ in a final state with two muons and missing energy at Belle II}",
+    title = "{Search for an Invisible Z' in a Final State with Two Muons and Missing Energy at Belle II}",
     eprint = "2212.03066",
     archivePrefix = "arXiv",
     primaryClass = "hep-ex",
     reportNumber = "Belle II Preprint 2022-008, KEK Preprint 2022-40",
-    month = "12",
-    year = "2022",
-    journal = ""
+    doi = "10.1103/PhysRevLett.130.231801",
+    journal = "Phys. Rev. Lett.",
+    volume = "130",
+    number = "23",
+    pages = "231801",
+    year = "2023"
 }
 
 % 2022-11-26
@@ -223,9 +231,12 @@
     eprint = "2208.04342",
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
-    month = "8",
-    year = "2022",
-    journal = ""
+    doi = "10.1103/PhysRevD.107.095021",
+    journal = "Phys. Rev. D",
+    volume = "107",
+    number = "9",
+    pages = "095021",
+    year = "2023"
 }
 
 % 2022-07-21


### PR DESCRIPTION
# Description

Update use citations references to include their journal publication information.

   - 'Unbinned profiled unfolding' is published as [Phys.Rev.D 108 (2023) 1, 016002](https://doi.org/10.1103/PhysRevD.108.016002).
   - 'Search for long-lived, massive particles in events with displaced vertices and multiple jets in pp collisions at s√=13 TeV with the ATLAS detector' is published as [JHEP 2306 (2023) 200](https://doi.org/10.1007/JHEP06(2023)200).
   - 'Search for an invisible Z′ in a final state with two muons and missing energy at Belle II' is published as [Phys.Rev.Lett. 130 (2023) 23, 231801](https://doi.org/10.1103/PhysRevLett.130.231801).
   - 'Toward the end-to-end optimization of particle physics instruments with differentiable programming' is published as [Rev.Phys. 10 (2023) 100085](https://doi.org/10.1016/j.revip.2023.100085).
   - 'LHC constraints on electroweakino dark matter revisited' is published as [Phys.Rev.D 107 (2023) 9, 095021](https://doi.org/10.1103/PhysRevD.107.095021).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update use citations references to include their journal publication information.

   - 'Unbinned profiled unfolding' is published as Phys.Rev.D 108 (2023)
     1, 016002.
     https://doi.org/10.1103/PhysRevD.108.016002
   - 'Search for long-lived, massive particles in events with displaced vertices
     and multiple jets in pp collisions at s√=13 TeV with the ATLAS detector' is
     published as JHEP 2306 (2023) 200.
     https://doi.org/10.1007/JHEP06(2023)200
   - 'Search for an invisible Z′ in a final state with two muons and missing energy
     at Belle II' is published as Phys.Rev.Lett. 130 (2023) 23, 231801.
     https://doi.org/10.1103/PhysRevLett.130.231801
   - 'Toward the end-to-end optimization of particle physics instruments
     with differentiable programming' is published as Rev.Phys. 10
     (2023) 100085.
     https://doi.org/10.1016/j.revip.2023.100085
   - 'LHC constraints on electroweakino dark matter revisited' is
     published as Phys.Rev.D 107 (2023) 9, 095021.
     https://doi.org/10.1103/PhysRevD.107.095021
```