### PR TITLE
docs: Add v0.7.2 failing example to v0.7.3 release notes

### DIFF
--- a/docs/release-notes/v0.7.3.rst
+++ b/docs/release-notes/v0.7.3.rst
@@ -19,35 +19,36 @@ Fixes
   To determine if you might have been affected by it see if you used a setup
   like the following in any part of your code
 
-  ```python
-  pyhf.set_backend("jax", pyhf.optimize.minuit_optimizer(strategy=0))
-  ...
-  fit_result, opt_result = pyhf.infer.mle.fit(
-      data, model, return_result_obj=True, do_grad=False
-  )
-  assert opt_result.minuit.strategy.strategy == 0  # fails
-  ```
+  .. code:: python
 
-  Full example that fails in ``pyhf`` ``v0.7.2``
+    ...
+    pyhf.set_backend("jax", pyhf.optimize.minuit_optimizer(strategy=0))
+    ...
+    fit_result, opt_result = pyhf.infer.mle.fit(
+        data, model, return_result_obj=True, do_grad=False
+    )
+    assert opt_result.minuit.strategy.strategy == 0  # fails for pyhf v0.7.2
 
-  ```python
-  import pyhf
+  Full example that fails in ``pyhf`` ``v0.7.2``:
 
-  pyhf.set_backend("jax", pyhf.optimize.minuit_optimizer(strategy=0))
+  .. code:: python
 
-  model = pyhf.simplemodels.uncorrelated_background(
-      signal=[12.0, 11.0], bkg=[50.0, 52.0], bkg_uncertainty=[3.0, 7.0]
-  )
-  data = [51, 48] + model.config.auxdata
+    import pyhf
 
-  # strategy kwarg not given
-  fit_result, opt_result = pyhf.infer.mle.fit(
-      data, model, return_result_obj=True, do_grad=False
-  )
-  minuit_strategy = opt_result.minuit.strategy.strategy
-  print(f"# Minuit minimization strategy: {minuit_strategy}")
-  assert minuit_strategy == 0  # fails for pyhf v0.7.2
-  ```
+    pyhf.set_backend("jax", pyhf.optimize.minuit_optimizer(strategy=0))
+
+    model = pyhf.simplemodels.uncorrelated_background(
+        signal=[12.0, 11.0], bkg=[50.0, 52.0], bkg_uncertainty=[3.0, 7.0]
+    )
+    data = [51, 48] + model.config.auxdata
+
+    # strategy kwarg not given
+    fit_result, opt_result = pyhf.infer.mle.fit(
+        data, model, return_result_obj=True, do_grad=False
+    )
+    minuit_strategy = opt_result.minuit.strategy.strategy
+    print(f"# Minuit minimization strategy: {minuit_strategy}")
+    assert minuit_strategy == 0  # fails for pyhf v0.7.2
 
 Contributors
 ------------

--- a/docs/release-notes/v0.7.3.rst
+++ b/docs/release-notes/v0.7.3.rst
@@ -15,12 +15,16 @@ Fixes
   (PRs :pr:`2277`, :pr:`2278`)
 
   The fixed bug was subtle and only occurred for specific configurations of
-  settings and arguments.
-  To determine if you might have been affected by it see if you used a setup
-  like the following in any part of your code
+  settings and arguments where ``do_grad=False`` was used (either explicitly
+  by provided kwarg or implicitly through defaults).
+  To determine if you might have been affected by it, check your code for
+  setups like the following.
 
   .. code:: python
 
+    # Bug is backend independent. JAX is selected as an example where
+    # do_grad=False might be selected in response to the backend's value of
+    # pyhf.tensorlib.default_do_grad being True.
     pyhf.set_backend("jax", pyhf.optimize.minuit_optimizer(strategy=0))
 
     ...
@@ -42,6 +46,14 @@ Fixes
         signal=[12.0, 11.0], bkg=[50.0, 52.0], bkg_uncertainty=[3.0, 7.0]
     )
     data = [51, 48] + model.config.auxdata
+
+    # passing with strategy kwarg explicitly given
+    fit_result, opt_result = pyhf.infer.mle.fit(
+        data, model, return_result_obj=True, do_grad=False, strategy=0
+    )
+    minuit_strategy = opt_result.minuit.strategy.strategy
+    print(f"# Minuit minimization strategy: {minuit_strategy}")
+    assert minuit_strategy == 0
 
     # strategy kwarg not given
     fit_result, opt_result = pyhf.infer.mle.fit(

--- a/docs/release-notes/v0.7.3.rst
+++ b/docs/release-notes/v0.7.3.rst
@@ -21,9 +21,10 @@ Fixes
 
   .. code:: python
 
-    ...
     pyhf.set_backend("jax", pyhf.optimize.minuit_optimizer(strategy=0))
+
     ...
+
     fit_result, opt_result = pyhf.infer.mle.fit(
         data, model, return_result_obj=True, do_grad=False
     )

--- a/docs/release-notes/v0.7.3.rst
+++ b/docs/release-notes/v0.7.3.rst
@@ -14,6 +14,41 @@ Fixes
   are correctly handled.
   (PRs :pr:`2277`, :pr:`2278`)
 
+  The fixed bug was subtle and only occurred for specific configurations of
+  settings and arguments.
+  To determine if you might have been affected by it see if you used a setup
+  like the following in any part of your code
+
+  ```python
+  pyhf.set_backend("jax", pyhf.optimize.minuit_optimizer(strategy=0))
+  ...
+  fit_result, opt_result = pyhf.infer.mle.fit(
+      data, model, return_result_obj=True, do_grad=False
+  )
+  assert opt_result.minuit.strategy.strategy == 0  # fails
+  ```
+
+  Full example that fails in ``pyhf`` ``v0.7.2``
+
+  ```python
+  import pyhf
+
+  pyhf.set_backend("jax", pyhf.optimize.minuit_optimizer(strategy=0))
+
+  model = pyhf.simplemodels.uncorrelated_background(
+      signal=[12.0, 11.0], bkg=[50.0, 52.0], bkg_uncertainty=[3.0, 7.0]
+  )
+  data = [51, 48] + model.config.auxdata
+
+  # strategy kwarg not given
+  fit_result, opt_result = pyhf.infer.mle.fit(
+      data, model, return_result_obj=True, do_grad=False
+  )
+  minuit_strategy = opt_result.minuit.strategy.strategy
+  print(f"# Minuit minimization strategy: {minuit_strategy}")
+  assert minuit_strategy == 0  # fails for pyhf v0.7.2
+  ```
+
 Contributors
 ------------
 


### PR DESCRIPTION
# Description

As the bug that was fixed in PR #2278 was subtle add an example to the pyhf v0.7.3 release notes that people can use to see if they were affected by it.

Amends PR #2290 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* As the bug that was fixed in PR #2278 was subtle add an example to
the pyhf v0.7.3 release notes that people can use to see if they
were affected by it.
* Amends PR https://github.com/scikit-hep/pyhf/pull/2290
```