### PR TITLE
fix: Use Path object for jupyterlite-sphinx jupyterlite_dir config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -529,4 +529,5 @@ linkcheck_ignore = [
 linkcheck_retries = 50
 
 # JupyterLite configuration
-jupyterlite_dir = "lite"
+# Use Path as jupyterlite-sphinx expects PosixPath
+jupyterlite_dir = Path("lite")


### PR DESCRIPTION
# Description

Resolves #2299 

To avoid warning

```
WARNING: The config value `jupyterlite_dir' has type `str', defaults to `PosixPath'.
```

use a `pathlib.Path` for the `jupyterlite-sphinx` `v0.9.1` `jupyterlite_dir` config option.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* To avoid warning

WARNING: The config value `jupyterlite_dir' has type `str', defaults to `PosixPath'.

 use a pathlib.Path for the jupyterlite-sphinx v0.9.1 jupyterlite_dir config
 option.
```
