### PR TITLE
chore: Update blackend-docs repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     hooks:
     - id: black-jupyter
 
--   repo: https://github.com/asottile/blacken-docs
+-   repo: https://github.com/adamchainz/blacken-docs
     rev: 1.15.0
     hooks:
     - id: blacken-docs


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

```
* Update blackend-docs pre-commit hook repo to
  https://github.com/adamchainz/blacken-docs.
```