### PR TITLE
docs: Add use citation from H->aa ATLAS CONF note

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,12 @@
+% 2023-08-18
+@booklet{ATLAS-CONF-2023-040,
+    author = "{ATLAS Collaboration}",
+    title = "{Search for short- and long-lived axion-like particles in $H\rightarrow a a \rightarrow 4\gamma$ decays with the ATLAS experiment at the LHC}",
+    howpublished = "{ATLAS-CONF-2023-040}",
+    url = "https://cds.cern.ch/record/2867933",
+    year = "2023"
+}
+
 % 2023-07-18
 @article{Darme:2023nsy,
     author = "Darm\'e, Luc and Deandrea, Aldo and Mahmoudi, Farvah",


### PR DESCRIPTION
# Description

Add use citation from '[Search for short- and long-lived axion-like particles in H → a a → 4 γ decays with the ATLAS experiment at the LHC](http://cds.cern.ch/record/2867933)'
   - c.f. https://inspirehep.net/literature/2691210
   - http://cds.cern.ch/record/2867933
   - [ATLAS-CONF-2023-040](https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/CONFNOTES/ATLAS-CONF-2023-040/)


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Search for short- and long-lived axion-like particles
  in H → a a → 4 γ decays with the ATLAS experiment at the LHC'.
   - https://inspirehep.net/literature/2691210
   - http://cds.cern.ch/record/2867933
   - ATLAS-CONF-2023-040
```