### PR TITLE
chore: Install pandoc manually from GitHub release binaries

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,10 @@ jobs:
     - name: Install apt-get dependencies
       run: |
         sudo apt-get update
-        sudo apt-get -qq install pandoc
+        # Ubuntu 22.04's pandoc is too old (2.9.2.x), so install manually
+        # until the ubuntu-latest updates.
+        curl --silent --location --remote-name https://github.com/jgm/pandoc/releases/download/3.1.6.2/pandoc-3.1.6.2-1-amd64.deb
+        sudo apt-get install ./pandoc-*amd64.deb
 
     - name: Check docstrings
       run: |


### PR DESCRIPTION
# Description

* Ubuntu 22.04 (current operating system for GitHub Actions runners for 'ubuntu-latest') will install pandoc v2.9.2.1 through apt-get which is too old for modern versions of nbsphinx. Installing directly from binaries provided on GitHub allows a workaround for getting newer versions of pandoc on runners until the GitHub Actions runner environment updates.
   - Avoids

```
RuntimeWarning: You are using an unsupported version of pandoc (2.9.2.1).
Your version must be at least (2.14.2) but less than (4.0.0).
```

   from nbsphinx.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Ubuntu 22.04 (current operating system for GitHub Actions runners for
  'ubuntu-latest') will install pandoc v2.9.2.1 through apt-get which is
  too old for modern versions of nbsphinx. Installing directly from
  binaries provided on GitHub allows a workaround for getting newer versions
  of pandoc on runners until the GitHub Actions runner environment
  updates.
   - Avoids

---
RuntimeWarning: You are using an unsupported version of pandoc (2.9.2.1).
Your version must be at least (2.14.2) but less than (4.0.0).
---

   from nbsphinx.
```