### PR TITLE
test: Ignore World Scientific journal URLs during Sphinx linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -519,6 +519,8 @@ linkcheck_ignore = [
     r'https://indico.desy.de/event/22731/.*',
     # https://indico.belle2.org/event/8470/contributions/55871/ is frequently generating 403 Client Error
     r'https://indico.belle2.org/event/8470/.*',
+    # https://doi.org/10.1142/S0217732321020016 is frequently generating 403 Client Error
+    r'https://doi\.org/10.1142/.*',
     # CERN doesn't maintain its SSL certs well enough to not have SSLErrors
     r'https://twiki.cern.ch/.*',
     # tags for a release won't exist until it is made, but the release notes


### PR DESCRIPTION
# Description

* Ignore URLs for World Scientific journal article https://doi.org/10.1142/S0217732321020016 from Sphinx linkcheck tests.

 Avoids:

```
403 Client Error: Forbidden for url: https://www.worldscientific.com/doi/abs/10.1142/S0217732321020016
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Ignore URLs for World Scientific journal article
 https://doi.org/10.1142/S0217732321020016 from Sphinx linkcheck tests.

 Avoids:

403 Client Error: Forbidden for url:
https://www.worldscientific.com/doi/abs/10.1142/S0217732321020016
```