### PR TITLE
fix: Skip callbacks with dead weakrefs while iterating over callbacks

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -32,3 +32,4 @@ Contributors include:
 - Nathan Simpson
 - Beojan Stanislaus
 - Daniel Werner
+- Jonas Rembser

--- a/src/pyhf/events.py
+++ b/src/pyhf/events.py
@@ -64,12 +64,19 @@ class Callables:
         self._callbacks = _callbacks
 
     def __call__(self, *args, **kwargs):
-        for func, arg in self.callbacks:
+        for func, arg in self._callbacks:
             # weakref: needs to be de-ref'd first before calling
             if arg is not None:
-                func()(arg(), *args, **kwargs)
+                arg_ref = arg()
+                if arg_ref is not None:
+                    func()(arg_ref, *args, **kwargs)
             else:
                 func()(*args, **kwargs)
+        # We have to flush after calling all the callbacks, not before. That's
+        # beacause, earlier callbacks might cause new dead arg weakrefs in
+        # later callbacks. So we check for dead weakrefs in each iteration
+        # and then we flush at the end.
+        self._flush()
 
     def __iter__(self):
         return iter(self.callbacks)

--- a/src/pyhf/events.py
+++ b/src/pyhf/events.py
@@ -73,7 +73,7 @@ class Callables:
             else:
                 func()(*args, **kwargs)
         # We have to flush after calling all the callbacks, not before. That's
-        # beacause, earlier callbacks might cause new dead arg weakrefs in
+        # because, earlier callbacks might cause new dead arg weakrefs in
         # later callbacks. So we check for dead weakrefs in each iteration
         # and then we flush at the end.
         self._flush()

--- a/src/pyhf/events.py
+++ b/src/pyhf/events.py
@@ -72,10 +72,9 @@ class Callables:
                     func()(arg_ref, *args, **kwargs)
             else:
                 func()(*args, **kwargs)
-        # We have to flush after calling all the callbacks, not before. That's
-        # because, earlier callbacks might cause new dead arg weakrefs in
-        # later callbacks. So we check for dead weakrefs in each iteration
-        # and then we flush at the end.
+        # flush after calling all the callbacks, not before, as earlier
+        # callbacks might cause new dead arg weakrefs in later callbacks.
+        # So check for dead weakrefs in each iteration and flush at the end.
         self._flush()
 
     def __iter__(self):

--- a/src/pyhf/events.py
+++ b/src/pyhf/events.py
@@ -72,9 +72,11 @@ class Callables:
                     func()(arg_ref, *args, **kwargs)
             else:
                 func()(*args, **kwargs)
-        # flush after calling all the callbacks, not before, as earlier
-        # callbacks might cause new dead arg weakrefs in later callbacks.
-        # So check for dead weakrefs in each iteration and flush at the end.
+        # Flush after calling all the callbacks, not before, as callbacks in the
+        # beginning of the iteration might cause new dead arg weakrefs in
+        # callbacks that are iterated over later.
+        # Checking for dead weakrefs in each iteration and flushing at the end
+        # avoids redundant dead weakref checking in subsequent calls.
         self._flush()
 
     def __iter__(self):


### PR DESCRIPTION
# Description

Resolves #2311 

The bug fixed by this PR occured in my work in the repository https://gitlab.cern.ch/dawerner/statanabenchmark.
I am currently working on a summer student project at CERN benchmarking statistical analysis tools in python including pyhf.
When performing these benchmarks, pyhf is called multiple times in a row with different backends. In some cases an error occurs then as objects are called through weakrefs that are already dead and thus `NoneType` objects.

When events (such as 'tensorlib_changed') are called, a bug occured previously where objects (i.e. the `TensorViewer`) are already dead. In this case an error occured when member functions where using attributes such as `self._sorted_indices` in `src/pyhf/tensor/common.py:33`.

This bug is fixed by catching the cases, in which the object is invalidated by earlier callbacks.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Check refs while processing callbacks in case a callee is de-ref'd during
  the callback process.
* Additionally flush after processing callbacks in case any callback de-ref's
  a callee.
* Note that no additional tests are added for this case as the problem arises from
  and intermediate callback triggering a garbage-collect. It is unclear how to force
  this scenario deterministically in testing.
* Add Jonas Rembser to contributors list.

Co-authored-by: Jonas Rembser <jonas.rembser@cern.ch>
```