### PR TITLE
docs: Add use citation from extended SPANet paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,15 @@
+% 2023-09-04
+@article{Fenton:2023ikr,
+    author = "Fenton, Michael James and Shmakov, Alexander and Okawa, Hideki and Li, Yuji and Hsiao, Ko-Yang and Hsu, Shih-Chieh and Whiteson, Daniel and Baldi, Pierre",
+    title = "{Extended Symmetry Preserving Attention Networks for LHC Analysis}",
+    eprint = "2309.01886",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    month = "9",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-08-18
 @booklet{ATLAS-CONF-2023-040,
     author = "{ATLAS Collaboration}",


### PR DESCRIPTION
# Description

Add use citation from [Extended Symmetry Preserving Attention Networks for LHC Analysis](https://inspirehep.net/literature/2693496) by Michael James Fenton, @Alexanders101, Hideki Okawa, Yuji Li, Ko-Yang Hsiao, @schsu, @danielwhiteson, Pierre Baldi.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Extended Symmetry Preserving Attention Networks
  for LHC Analysis'.
   - c.f. https://inspirehep.net/literature/2693496
```