### PR TITLE
docs: Add MRs to ATLAS StatAnalysis to release checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/~release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/~release-checklist.md
@@ -62,5 +62,6 @@ For a video walkthrough consult the [``pyhf`` ``v0.7.1`` release recording](http
 * [ ] Update the [tutorial](https://github.com/pyhf/pyhf-tutorial) to use the new release number and API.
 * [ ] Make a PR to use the new release in the [CUDA enabled Docker images](https://github.com/pyhf/cuda-images).
 * [ ] Open a ticket on the CERN [Software Process and Infrastructure JIRA](https://sft.its.cern.ch/jira/browse/SPI) to update the version of `pyhf` available in the next LCG release.
-   - c.f. the [`v0.6.3` request ticket](https://sft.its.cern.ch/jira/browse/SPI-2086) and the [`v0.7.1` request ticket](https://sft.its.cern.ch/jira/browse/SPI-2333) as examples.
+   - c.f. the [`v0.7.3` request ticket](https://sft.its.cern.ch/jira/browse/SPI-2408) as an example.
+* [ ] Make a MR to use the new release in [ATLAS `StatAnalysis`](https://gitlab.cern.ch/atlas/StatAnalysis).
 * [ ] Close the [release GitHub Project board](https://github.com/scikit-hep/pyhf/projects/).


### PR DESCRIPTION
# Description

* Update the maintainer release checklist to include opening MRs to https://gitlab.cern.ch/atlas/StatAnalysis to update the pyhf version.
   - c.f. https://github.com/scikit-hep/pyhf/issues/2289#issuecomment-1683073278
* Use the pyhf v0.7.3 release as an example of a CERN Software Process and Infrastructure JIRA request ticket.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update the maintainer release checklist to include opening MRs to
  https://gitlab.cern.ch/atlas/StatAnalysis to update the pyhf version.
* Use the pyhf v0.7.3 release as an example of a CERN Software Process
  and Infrastructure JIRA request ticket.
```