### PR TITLE
fix(backport): Skip callbacks with dead weakrefs while iterating over callbacks

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -32,3 +32,4 @@ Contributors include:
 - Nathan Simpson
 - Beojan Stanislaus
 - Daniel Werner
+- Jonas Rembser


### PR DESCRIPTION
# Description

* Backport PR https://github.com/scikit-hep/pyhf/pull/2310
* Check refs while processing callbacks in case a callee is de-ref'd during the callback process.
* Additionally flush after processing callbacks in case any callback de-ref's a callee.
* Note that no additional tests are added for this case as the problem arises from and intermediate callback triggering a garbage-collect. It is unclear how to force this scenario deterministically in testing.
* Add Jonas Rembser to contributors list.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Backport PR https://github.com/scikit-hep/pyhf/pull/2310
* Check refs while processing callbacks in case a callee is de-ref'd during
  the callback process.
* Additionally flush after processing callbacks in case any callback de-ref's
  a callee.
* Note that no additional tests are added for this case as the problem arises from
  and intermediate callback triggering a garbage-collect. It is unclear how to force
  this scenario deterministically in testing.
* Add Jonas Rembser to contributors list.
```