### PR TITLE
docs: Update citations references with journal pubs through 2023-08

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -321,9 +321,11 @@
     archivePrefix = "arXiv",
     primaryClass = "hep-ex",
     reportNumber = "CERN-EP-2022-029",
-    month = "5",
-    year = "2022",
-    journal = ""
+    doi = "10.1007/JHEP06(2023)158",
+    journal = "JHEP",
+    volume = "2306",
+    pages = "158",
+    year = "2023"
 }
 
 % 2022-03-28


### PR DESCRIPTION
# Description

* Update use citations references to include their journal publication information.

   - 'Search for heavy, long-lived, charged particles with large ionisation energy loss in pp collisions at s√=13 TeV using the ATLAS experiment and the full Run 2 dataset' is published as JHEP 2306 (2023) 158. https://doi.org/10.1007/JHEP06(2023)158

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update use citations references to include their journal publication information.

   - 'Search for heavy, long-lived, charged particles with large
     ionisation energy loss in pp collisions at s√=13 TeV using the
     ATLAS experiment and the full Run 2 dataset' is published as
     JHEP 2306 (2023) 158.
     https://doi.org/10.1007/JHEP06(2023)158
```