### PR TITLE
docs: Add ATLAS s-channel single top cross-section statistical model record

### DIFF
--- a/docs/bib/HEPData_likelihoods.bib
+++ b/docs/bib/HEPData_likelihoods.bib
@@ -18,6 +18,16 @@
     collaboration = "ATLAS",
 }
 
+% 2022-09-19
+@misc{ins2153660,
+    title = "{Measurement of single top-quark production in the s-channel in proton$-$proton collisions at $\mathrm{\sqrt{s}=13}$ TeV with the ATLAS detector}",
+    doi = "10.17182/hepdata.133620",
+    url = "https://doi.org/10.17182/hepdata.133620",
+    year = "2023",
+    type = "Data Collection",
+    collaboration = "ATLAS",
+}
+
 % 2022-05-05
 @misc{ins2077557,
     title = "{Search for flavour-changing neutral-current couplings between the top quark and the photon with the ATLAS detector at $\sqrt{s} = 13$ TeV}",


### PR DESCRIPTION
# Description

* Add ATLAS measurement of the s-channel single top cross-section at 13 TeV statistical model HEPDdata record.
   - c.f. https://www.hepdata.net/record/ins2153660
   - Corresponding INSPIRE record: https://inspirehep.net/literature/2153660

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add ATLAS measurement of the s-channel single top cross-section at 13 TeV
  statistical model HEPDdata record.
   - c.f. https://www.hepdata.net/record/ins2153660
   - Corresponding INSPIRE record: https://inspirehep.net/literature/2153660
```