### PR TITLE
docs: Add v0.7.4 release notes

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -2,6 +2,7 @@
 Release Notes
 =============
 
+.. include:: release-notes/v0.7.4.rst
 .. include:: release-notes/v0.7.3.rst
 .. include:: release-notes/v0.7.2.rst
 .. include:: release-notes/v0.7.1.rst

--- a/docs/release-notes/v0.7.4.rst
+++ b/docs/release-notes/v0.7.4.rst
@@ -1,0 +1,28 @@
+|release v0.7.4|_
+=================
+
+This is a patch release from ``v0.7.3`` → ``v0.7.4``.
+
+Fixes
+-----
+
+* Skip callbacks with dead weakrefs while iterating over callbacks in ``pyhf``
+  events, like :func:`pyhf.set_backend`, to avoid the possibility of accessing
+  dead weakrefs before they could be garbage collected.
+  (PR :pr:`2310`)
+
+  The fixed bug was subtle and occurred nondeterministically when the
+  :class:`pyhf.tensorlib` was changed repeatedly causing dead weakrefs
+  to be accessed before Python's garbage collection could remove them.
+  Most users should be unaffected.
+
+Contributors
+------------
+
+``v0.7.4`` benefited from contributions from:
+
+* Daniel Werner
+* Jonas Rembser
+
+.. |release v0.7.4| replace:: ``v0.7.4``
+.. _`release v0.7.4`: https://github.com/scikit-hep/pyhf/releases/tag/v0.7.4


### PR DESCRIPTION
# Description

* Forward port PR #2322 from `release/v0.7.x` to `main`.
* Add release notes for pyhf `v0.7.4`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Forward port PR #2322 from release/v0.7.x to main.
* Add release notes for pyhf v0.7.4.
```