### PR TITLE
fix: Add poi_name to Model construction in notebooks

### DIFF
--- a/docs/examples/notebooks/ShapeFactor.ipynb
+++ b/docs/examples/notebooks/ShapeFactor.ipynb
@@ -74,7 +74,7 @@
     "            },\n",
     "        ]\n",
     "    }\n",
-    "    pdf = pyhf.Model(spec)\n",
+    "    pdf = pyhf.Model(spec, poi_name=\"mu\")\n",
     "    data = []\n",
     "    for channel in pdf.config.channels:\n",
     "        data += sourcedata[channel]['bindata']['data']\n",

--- a/docs/examples/notebooks/StatError.ipynb
+++ b/docs/examples/notebooks/StatError.ipynb
@@ -72,7 +72,7 @@
     "        #         }\n",
     "    ]\n",
     "}\n",
-    "p = pyhf.Model(spec)"
+    "p = pyhf.Model(spec, poi_name=\"mu\")"
    ]
   },
   {

--- a/docs/examples/notebooks/histogrammar.ipynb
+++ b/docs/examples/notebooks/histogrammar.ipynb
@@ -156,7 +156,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "p = pyhf.Model(spec)\n",
+    "p = pyhf.Model(spec, poi_name=\"mu\")\n",
     "\n",
     "data = data_histogram.toJson()['data']['values'] + p.config.auxdata"
    ]

--- a/docs/examples/notebooks/histosys.ipynb
+++ b/docs/examples/notebooks/histosys.ipynb
@@ -56,7 +56,7 @@
     "            },\n",
     "        }\n",
     "    }\n",
-    "    pdf = Model(spec)\n",
+    "    pdf = Model(spec, poi_name=\"mu\")\n",
     "    data = source['bindata']['data'] + pdf.config.auxdata\n",
     "    return data, pdf"
    ]

--- a/docs/examples/notebooks/multichannel-coupled-histo.ipynb
+++ b/docs/examples/notebooks/multichannel-coupled-histo.ipynb
@@ -108,7 +108,7 @@
     "            },\n",
     "        ]\n",
     "    }\n",
-    "    pdf = Model(spec)\n",
+    "    pdf = Model(spec, poi_name=\"mu\")\n",
     "    data = []\n",
     "    for channel in pdf.config.channels:\n",
     "        data += sourcedata[channel][\"bindata\"][\"data\"]\n",

--- a/docs/examples/notebooks/multichannel-coupled-normsys.ipynb
+++ b/docs/examples/notebooks/multichannel-coupled-normsys.ipynb
@@ -78,7 +78,7 @@
     "            }\n",
     "        },\n",
     "    }\n",
-    "    pdf = Model(spec)\n",
+    "    pdf = Model(spec, poi_name=\"mu\")\n",
     "    data = []\n",
     "    for c in pdf.config.channel_order:\n",
     "        data += sourcedata[c]['bindata']['data']\n",

--- a/docs/examples/notebooks/normsys.ipynb
+++ b/docs/examples/notebooks/normsys.ipynb
@@ -53,7 +53,7 @@
     "            },\n",
     "        }\n",
     "    }\n",
-    "    pdf = Model(spec)\n",
+    "    pdf = Model(spec, poi_name=\"mu\")\n",
     "    data = observed_counts + pdf.config.auxdata\n",
     "    return data, pdf"
    ]


### PR DESCRIPTION
# Description

* Ensure all pyhf.Model calls in the example notebooks that don't already have a poi_name definied have `poi_name="mu"` set.
* Amends PR https://github.com/scikit-hep/pyhf/pull/2328

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Ensure all pyhf.Model calls in the example notebooks that don't
  already have a poi_name definied have `poi_name="mu"` set.
* Amends PR https://github.com/scikit-hep/pyhf/pull/2328
```