### PR TITLE
ci: Move PYTHONWARNINGS filter on build to weekly cron job

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Build a wheel and a sdist
       run: |
-        PYTHONWARNINGS=error,default::DeprecationWarning python -m build .
+        python -m build .
 
     - name: Verify untagged commits have dev versions
       if: "!startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -11,6 +11,9 @@ on:
     - release/v*
   release:
     types: [published]
+  # Run weekly at 1:23 UTC
+  schedule:
+  - cron:  '23 1 * * 0'
   workflow_dispatch:
     inputs:
       publish:
@@ -44,9 +47,15 @@ jobs:
         python -m pip install build twine
         python -m pip list
 
-    - name: Build a wheel and a sdist
+    - name: Build a sdist and wheel
+      if: github.event_name != 'schedule'
       run: |
         python -m build .
+
+    - name: Build a sdist and wheel and check for warnings
+      if: github.event_name == 'schedule'
+      run: |
+        PYTHONWARNINGS=error,default::DeprecationWarning python -m build .
 
     - name: Verify untagged commits have dev versions
       if: "!startsWith(github.ref, 'refs/tags/')"


### PR DESCRIPTION
# Description

`python -m build` is currenlty giving

```pytb
* Creating venv isolated environment...
* Installing packages in isolated environment... (hatch-vcs>=0.3.0, hatchling>=1.13.0)
* Getting build dependencies for sdist...
* Building sdist...
/tmp/build-env-d8uvwaf0/lib/python3.11/site-packages/setuptools_scm/_get_version_impl.py:[15](https://github.com/scikit-hep/pyhf/actions/runs/6250968975/job/16971014904?pr=2336#step:5:16)3: DeprecationWarning: empty regex for tag regex is invalid, using default
  warnings.warn(
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.11.5/x64/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
    main()
  File "/opt/hostedtoolcache/Python/3.11.5/x64/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 335, in main
    json_out['return_val'] = hook(**hook_input['kwargs'])
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.5/x64/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 304, in build_sdist
    return backend.build_sdist(sdist_directory, config_settings)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/build-env-d8uvwaf0/lib/python3.11/site-packages/hatchling/build.py", line 34, in build_sdist
    return os.path.basename(next(builder.build(sdist_directory, ['standard'])))
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/build-env-d8uvwaf0/lib/python3.11/site-packages/hatchling/builders/plugin/interface.py", line 150, in build
    build_hook.initialize(version, build_data)
  File "/tmp/build-env-d8uvwaf0/lib/python3.11/site-packages/hatch_vcs/build_hook.py", line 43, in initialize
    dump_version(self.root, self.metadata.version, self.config_version_file, template=self.config_template)
  File "/tmp/build-env-d8uvwaf0/lib/python3.11/site-packages/setuptools_scm/_integration/dump_version.py", line 38, in dump_version
    write_version_to_path(
  File "/tmp/build-env-d8uvwaf0/lib/python3.11/site-packages/setuptools_scm/_integration/dump_version.py", line 62, in write_version_to_path
    final_template = _validate_template(target, template)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/build-env-d8uvwaf0/lib/python3.11/site-packages/setuptools_scm/_integration/dump_version.py", line 45, in _validate_template
    warnings.warn(f"{template=} looks like a error, using default instead")
UserWarning: template='' looks like a error, using default instead
```

Instead of breaking on regular CI workflows, which isn't helpful, move the warning filter to a weekly CRON job so we can still check for possible warnings.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Move PYTHONWARNINGS filter to run on a weekly cron job to avoid interrupting
  normal development with errors due to warnings outside of direct user control.
```