### PR TITLE
feat: Allow for disabling backend when running tests via pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,13 @@ def backend(request):
 
     if disable_backend:
         pytest.skip(
-            f"skipping {func_name} as the backend is disabled via --disable-backend"
+            f"skipping {func_name} as the backend is disabled via "
+            + " ".join(
+                [
+                    f"--disable-backend {choice}"
+                    for choice in request.config.option.disable_backend
+                ]
+            )
         )
     elif skip_backend:
         pytest.skip(f"skipping {func_name} as specified")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,7 +99,7 @@ def backend(request):
         pid for pid in param_ids if request.node.get_closest_marker(f'only_{pid}')
     ]
     disable_backend = any(
-        backend in param_id for backend in request.config.disable_backend
+        backend in param_id for backend in request.config.option.disable_backend
     )
 
     if skip_backend and (param_id in only_backends):
@@ -109,7 +109,7 @@ def backend(request):
 
     if disable_backend:
         pytest.skip(
-            f"skipping {func_name} as the backend is disabled: {request.config.disable_backend}"
+            f"skipping {func_name} as the backend is disabled: {request.config.option.disable_backend}"
         )
     elif skip_backend:
         pytest.skip(f"skipping {func_name} as specified")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,17 @@ from setuptools._distutils import dir_util
 import pyhf
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--disable-backend",
+        action="append",
+        type=str,
+        default=[],
+        choices=["tensorflow", "pytorch", "jax", "minuit"],
+        help="list of backends to disable in tests",
+    )
+
+
 # Factory as fixture pattern
 @pytest.fixture
 def get_json_from_tarfile():
@@ -59,14 +70,14 @@ def reset_backend():
 @pytest.fixture(
     scope='function',
     params=[
-        (pyhf.tensor.numpy_backend(), None),
-        (pyhf.tensor.pytorch_backend(), None),
-        (pyhf.tensor.pytorch_backend(precision='64b'), None),
-        (pyhf.tensor.tensorflow_backend(), None),
-        (pyhf.tensor.jax_backend(), None),
+        (("numpy_backend", dict()), ("scipy_optimizer", dict())),
+        (("pytorch_backend", dict()), ("scipy_optimizer", dict())),
+        (("pytorch_backend", dict(precision="64b")), ("scipy_optimizer", dict())),
+        (("tensorflow_backend", dict()), ("scipy_optimizer", dict())),
+        (("jax_backend", dict()), ("scipy_optimizer", dict())),
         (
-            pyhf.tensor.numpy_backend(poisson_from_normal=True),
-            pyhf.optimize.minuit_optimizer(),
+            ("numpy_backend", dict(poisson_from_normal=True)),
+            ("minuit_optimizer", dict()),
         ),
     ],
     ids=['numpy', 'pytorch', 'pytorch64', 'tensorflow', 'jax', 'numpy_minuit'],
@@ -87,13 +98,20 @@ def backend(request):
     only_backends = [
         pid for pid in param_ids if request.node.get_closest_marker(f'only_{pid}')
     ]
+    disable_backend = any(
+        backend in param_id for backend in request.config.disable_backend
+    )
 
     if skip_backend and (param_id in only_backends):
         raise ValueError(
             f"Must specify skip_{param_id} or only_{param_id} but not both!"
         )
 
-    if skip_backend:
+    if disable_backend:
+        pytest.skip(
+            f"skipping {func_name} as the backend is disabled: {request.config.disable_backend}"
+        )
+    elif skip_backend:
         pytest.skip(f"skipping {func_name} as specified")
     elif only_backends and param_id not in only_backends:
         pytest.skip(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,7 @@ def backend(request):
 
     if disable_backend:
         pytest.skip(
-            f"skipping {func_name} as the backend is disabled: {request.config.option.disable_backend}"
+            f"skipping {func_name} as the backend is disabled via --disable-backend"
         )
     elif skip_backend:
         pytest.skip(f"skipping {func_name} as specified")
@@ -127,10 +127,14 @@ def backend(request):
             pytest.mark.xfail(reason=f"expect {func_name} to fail as specified")
         )
 
-    # actual execution here, after all checks is done
-    pyhf.set_backend(*request.param)
+    tensor_config, optimizer_config = request.param
 
-    yield request.param
+    tensor = getattr(pyhf.tensor, tensor_config[0])(**tensor_config[1])
+    optimizer = getattr(pyhf.optimize, optimizer_config[0])(**optimizer_config[1])
+    # actual execution here, after all checks is done
+    pyhf.set_backend(tensor, optimizer)
+
+    yield (tensor, optimizer)
 
 
 @pytest.fixture(


### PR DESCRIPTION
# Pull Request Description

Resolves #1454. This adds `--disable-backend` that can be specified to skip those backends as part of the testing suite.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Add pytest configuration `--disable-backend` that will skip tests that use
  that backend choice.
```
