### PR TITLE
docs: Add use citation from dark matter at muon colliders paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,16 @@
+% 2023-09-30
+@article{Belfkir:2023vpo,
+    author = "Belfkir, Mohamed and Jueid, Adil and Nasri, Salah",
+    title = "{Boosting dark matter searches at muon colliders with Machine Learning: the mono-Higgs channel as a case study}",
+    eprint = "2309.11241",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "CTPU-PTC-23-37",
+    month = "9",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-09-04
 @article{Fenton:2023ikr,
     author = "Fenton, Michael James and Shmakov, Alexander and Okawa, Hideki and Li, Yuji and Hsiao, Ko-Yang and Hsu, Shih-Chieh and Whiteson, Daniel and Baldi, Pierre",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,4 +1,4 @@
-% 2023-09-30
+% 2023-09-20
 @article{Belfkir:2023vpo,
     author = "Belfkir, Mohamed and Jueid, Adil and Nasri, Salah",
     title = "{Boosting dark matter searches at muon colliders with Machine Learning: the mono-Higgs channel as a case study}",


### PR DESCRIPTION
# Description

Add use citation from [Boosting dark matter searches at muon colliders with Machine Learning: the mono-Higgs channel as a case study](https://inspirehep.net/literature/2700441).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Boosting dark matter searches at muon colliders
  with Machine Learning: the mono-Higgs channel as a case study'.
   - c.f. https://inspirehep.net/literature/2700441
```