### PR TITLE
revert: Remove disallow of TensorFlow v2.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,8 @@ Homepage = "https://github.com/scikit-hep/pyhf"
 [project.optional-dependencies]
 shellcomplete = ["click_completion"]
 tensorflow = [
-    "tensorflow>=2.7.0,!=2.14.0; platform_machine != 'arm64'",  # c.f. PR #1962
-    "tensorflow-macos>=2.7.0,!=2.14.0; platform_machine == 'arm64' and platform_system == 'Darwin'",  # c.f. PR #2119
+    "tensorflow>=2.7.0; platform_machine != 'arm64'",  # c.f. PR #1962
+    "tensorflow-macos>=2.7.0; platform_machine == 'arm64' and platform_system == 'Darwin'",  # c.f. PR #2119
     "tensorflow-probability>=0.11.0",  # c.f. PR #1657
 ]
 torch = ["torch>=1.10.0"]  # c.f. PR #1657


### PR DESCRIPTION
# Description

* With the release of tensorflow-probability v0.22.0, tensorflow v2.14.0 can be used and is required for tensorflow-probability v0.22.0+.
   - c.f. https://github.com/tensorflow/probability/releases/tag/v0.22.0
* Reverts PR #2342

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* With the release of tensorflow-probability v0.22.0, tensorflow v2.14.0
  can be used and is required for tensorflow-probability v0.22.0+.
   - c.f. https://github.com/tensorflow/probability/releases/tag/v0.22.0
* Reverts PR https://github.com/scikit-hep/pyhf/pull/2342
```