### PR TITLE
docs: Add use citation from MicroBooNE heavy neutral leptons paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,16 @@
+% 2023-10-11
+@article{MicroBooNE:2023icy,
+    author = "{MicroBooNE Collaboration}",
+    title = "{Search for heavy neutral leptons in electron-positron and neutral-pion final states with the MicroBooNE detector}",
+    eprint = "2310.07660",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    reportNumber = "FERMILAB-PUB-23-574-ND",
+    month = "10",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-09-29
 @inproceedings{Feickert:2023hhr,
     author = "Feickert, Matthew and Heinrich, Lukas and Horstmann, Malin",


### PR DESCRIPTION
# Description

Add use citation from [Search for heavy neutral leptons in electron-positron and neutral-pion final states with the MicroBooNE detector](https://inspirehep.net/literature/2709095) by the MicroBooNE collaboration.

This is the first use citation from MicroBooNE.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Search for heavy neutral leptons in
  electron-positron and neutral-pion final states with the MicroBooNE
  detector'.
   - c.f. https://inspirehep.net/literature/2709095
* This is the first use citation of pyhf from a neutrino experiment.
```