### PR TITLE
docs: Add general use citation from differentiable vertex fitting paper

### DIFF
--- a/docs/bib/general_citations.bib
+++ b/docs/bib/general_citations.bib
@@ -1,3 +1,15 @@
+% 2023-10-19
+@article{Smith:2023ssh,
+    author = "Smith, Rachel E. C. and Ochoa, In\^es and In\'acio, R\'uben and Shoemaker, Jonathan and Kagan, Michael",
+    title = "{Differentiable Vertex Fitting for Jet Flavour Tagging}",
+    eprint = "2310.12804",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    month = "10",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-09-25
 @inproceedings{Feickert:2023ajm,
     author = "Feickert, Matthew and Katz, Daniel S. and Neubauer, Mark S. and Sexton-Kennedy, Elizabeth and Stewart, Graeme A.",


### PR DESCRIPTION
# Description

Add general citation from [Differentiable Vertex Fitting for Jet Flavour Tagging](https://inspirehep.net/literature/2712691) by Rachel Smith, Inês Ochoa, Rúben Inácio, Jonathan Shoemaker, Michael Kagan.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add general citation from 'Differentiable Vertex Fitting for Jet
  Flavour Tagging'.
   - c.f. https://inspirehep.net/literature/2712691
```