### PR TITLE
fix: Remove os-dependent pieces of schema validation

### DIFF
--- a/src/pyhf/schema/loader.py
+++ b/src/pyhf/schema/loader.py
@@ -19,7 +19,7 @@ def load_schema(schema_id: str):
     Args:
         schema_id (str): Relative path to schema from :attr:`pyhf.schema.path`
 
-    Examples:
+    Example:
         >>> import pyhf
         >>> schema = pyhf.schema.load_schema("1.0.0/defs.json")
         >>> type(schema)
@@ -27,18 +27,6 @@ def load_schema(schema_id: str):
         >>> schema.keys()
         dict_keys(['$schema', '$id', 'definitions'])
         >>> pyhf.schema.load_schema("0.0.0/defs.json")  # doctest: +ELLIPSIS
-        Traceback (most recent call last):
-            ...
-        pyhf.exceptions.SchemaNotFound: ...
-
-        >>> import pyhf
-        >>> import os
-        >>> schema = pyhf.schema.load_schema(f"1.0.0{os.sep}defs.json")
-        >>> type(schema)
-        <class 'dict'>
-        >>> schema.keys()
-        dict_keys(['$schema', '$id', 'definitions'])
-        >>> pyhf.schema.load_schema(f"0.0.0{os.sep}defs.json")  # doctest: +ELLIPSIS
         Traceback (most recent call last):
             ...
         pyhf.exceptions.SchemaNotFound: ...

--- a/src/pyhf/schema/loader.py
+++ b/src/pyhf/schema/loader.py
@@ -19,7 +19,7 @@ def load_schema(schema_id: str):
     Args:
         schema_id (str): Relative path to schema from :attr:`pyhf.schema.path`
 
-    Example:
+    Examples:
         >>> import pyhf
         >>> schema = pyhf.schema.load_schema("1.0.0/defs.json")
         >>> type(schema)
@@ -27,6 +27,18 @@ def load_schema(schema_id: str):
         >>> schema.keys()
         dict_keys(['$schema', '$id', 'definitions'])
         >>> pyhf.schema.load_schema("0.0.0/defs.json")  # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+            ...
+        pyhf.exceptions.SchemaNotFound: ...
+
+        >>> import pyhf
+        >>> import os
+        >>> schema = pyhf.schema.load_schema(f"1.0.0{os.sep}defs.json")
+        >>> type(schema)
+        <class 'dict'>
+        >>> schema.keys()
+        dict_keys(['$schema', '$id', 'definitions'])
+        >>> pyhf.schema.load_schema(f"0.0.0{os.sep}defs.json")  # doctest: +ELLIPSIS
         Traceback (most recent call last):
             ...
         pyhf.exceptions.SchemaNotFound: ...

--- a/src/pyhf/schema/validator.py
+++ b/src/pyhf/schema/validator.py
@@ -75,8 +75,9 @@ def validate(
     schema = load_schema(str(Path(version).joinpath(schema_name)))
 
     # note: trailing slash needed for RefResolver to resolve correctly and by
-    # design, pathlib strips trailing slashes. See ref bewlow:
-    # - https://bugs.python.org/issue21039
+    # design, pathlib strips trailing slashes. See ref below:
+    # * https://bugs.python.org/issue21039
+    # * https://github.com/python/cpython/issues/65238
     resolver = jsonschema.RefResolver(
         base_uri=f"{Path(variables.schemas).joinpath(version).as_uri()}{os.sep}",
         referrer=schema_name,

--- a/src/pyhf/schema/validator.py
+++ b/src/pyhf/schema/validator.py
@@ -1,4 +1,6 @@
 import numbers
+import os
+from pathlib import Path
 from typing import Mapping, Union
 
 import jsonschema
@@ -7,8 +9,6 @@ import pyhf.exceptions
 from pyhf import tensor
 from pyhf.schema import variables
 from pyhf.schema.loader import load_schema
-from pathlib import Path
-import os
 
 
 def _is_array_or_tensor(checker, instance):

--- a/src/pyhf/schema/validator.py
+++ b/src/pyhf/schema/validator.py
@@ -7,6 +7,8 @@ import pyhf.exceptions
 from pyhf import tensor
 from pyhf.schema import variables
 from pyhf.schema.loader import load_schema
+from pathlib import Path
+import os
 
 
 def _is_array_or_tensor(checker, instance):
@@ -70,12 +72,14 @@ def validate(
 
     version = version or variables.SCHEMA_VERSION
 
-    schema = load_schema(f'{version}/{schema_name}')
+    schema = load_schema(str(Path(version).joinpath(schema_name)))
 
-    # note: trailing slash needed for RefResolver to resolve correctly
+    # note: trailing slash needed for RefResolver to resolve correctly and by
+    # design, pathlib strips trailing slashes. See ref bewlow:
+    # - https://bugs.python.org/issue21039
     resolver = jsonschema.RefResolver(
-        base_uri=f"file://{variables.schemas}/{version}/",
-        referrer=f"{schema_name}",
+        base_uri=f"{Path(variables.schemas).joinpath(version).as_uri()}{os.sep}",
+        referrer=schema_name,
         store=variables.SCHEMA_CACHE,
     )
 

--- a/src/pyhf/schema/validator.py
+++ b/src/pyhf/schema/validator.py
@@ -1,5 +1,4 @@
 import numbers
-import os
 from pathlib import Path
 from typing import Mapping, Union
 
@@ -79,7 +78,7 @@ def validate(
     # * https://bugs.python.org/issue21039
     # * https://github.com/python/cpython/issues/65238
     resolver = jsonschema.RefResolver(
-        base_uri=f"{Path(variables.schemas).joinpath(version).as_uri()}{os.sep}",
+        base_uri=f"{Path(variables.schemas).joinpath(version).as_uri()}/",
         referrer=schema_name,
         store=variables.SCHEMA_CACHE,
     )


### PR DESCRIPTION
# Pull Request Description

Resolves #2353. To allow `pyhf` to work a little bit better, at least on schemas on Windows, need to rely either on `pathlib` more fully or `os.sep` in order to build the paths correctly.

- fix schema loading by making it strictly os-independent
- ~~add an additional example that is os-independent~~

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Use pathlib to build the stem for the schema to use (version + type of schema).
   - c.f. https://github.com/python/cpython/issues/65238
```
