### PR TITLE
fix(backport): Remove os-dependent pieces of schema validation

### DIFF
--- a/src/pyhf/schema/validator.py
+++ b/src/pyhf/schema/validator.py
@@ -1,4 +1,5 @@
 import numbers
+from pathlib import Path
 from typing import Mapping, Union
 
 import jsonschema
@@ -70,12 +71,15 @@ def validate(
 
     version = version or variables.SCHEMA_VERSION
 
-    schema = load_schema(f'{version}/{schema_name}')
+    schema = load_schema(str(Path(version).joinpath(schema_name)))
 
-    # note: trailing slash needed for RefResolver to resolve correctly
+    # note: trailing slash needed for RefResolver to resolve correctly and by
+    # design, pathlib strips trailing slashes. See ref below:
+    # * https://bugs.python.org/issue21039
+    # * https://github.com/python/cpython/issues/65238
     resolver = jsonschema.RefResolver(
-        base_uri=f"file://{variables.schemas}/{version}/",
-        referrer=f"{schema_name}",
+        base_uri=f"{Path(variables.schemas).joinpath(version).as_uri()}/",
+        referrer=schema_name,
         store=variables.SCHEMA_CACHE,
     )
 


### PR DESCRIPTION
# Description

* Backport PR https://github.com/scikit-hep/pyhf/pull/2357
* Use pathlib to build the stem for the schema to use (version + type of schema).
   - c.f. https://github.com/python/cpython/issues/65238

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Backport PR https://github.com/scikit-hep/pyhf/pull/2357
* Use pathlib to build the stem for the schema to use (version + type of schema).
   - c.f. https://github.com/python/cpython/issues/65238
```