### PR TITLE
docs(backport): Update citations references with journal pubs through 2023-10

### DIFF
--- a/docs/bib/general_citations.bib
+++ b/docs/bib/general_citations.bib
@@ -36,14 +36,17 @@
 
 % 2023-06-06
 @article{Eschle:2023ikn,
-    author = "Eschle, J. and others",
-    title = "{Potential of the Julia programming language for high energy physics computing}",
+    author = "Eschle, Jonas and others",
+    title = "{Potential of the Julia Programming Language for High Energy Physics Computing}",
     eprint = "2306.03675",
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
-    month = "6",
-    year = "2023",
-    journal = ""
+    doi = "10.1007/s41781-023-00104-x",
+    journal = "Comput. Softw. Big Sci.",
+    volume = "7",
+    number = "1",
+    pages = "10",
+    year = "2023"
 }
 
 % 2023-02-02

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -159,13 +159,16 @@
 % 2023-04-04
 @article{Guo:2023jkz,
     author = "Guo, Qilong and Gao, Leyun and Mao, Yajun and Li, Qiang",
-    title = "{Search for vector-like leptons at a Muon Collider}",
+    title = "{Vector-like lepton searches at a muon collider in the context of the 4321 model*}",
     eprint = "2304.01885",
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
-    month = "4",
-    year = "2023",
-    journal = ""
+    doi = "10.1088/1674-1137/ace5a7",
+    journal = "Chin. Phys. C",
+    volume = "47",
+    number = "10",
+    pages = "103106",
+    year = "2023"
 }
 
 % 2023-02-24


### PR DESCRIPTION
# Description

Backport PR https://github.com/scikit-hep/pyhf/pull/2367

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Backport PR https://github.com/scikit-hep/pyhf/pull/2367
* Update use citations references to include their journal publication information.

   - 'Vector-like lepton searches at a muon collider in the context of
     the 4321 model*'.
     https://doi.org/10.1088/1674-1137/ace5a7

   - 'Potential of the Julia Programming Language for High Energy
     Physics Computing'.
     https://doi.org/10.1007/s41781-023-00104-x
```