### PR TITLE
build: Remove installation of backends from 'test' extra

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade '.[test]'
+        python -m pip install --upgrade '.[all,test]'
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade .[test]
+        python -m pip install --upgrade ".[all,test]"
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade --pre .[test]
+        python -m pip --no-cache-dir --quiet install --upgrade --pre ".[all,test]"
         python -m pip list
 
     - name: List release candidates, alpha, and beta releases
@@ -62,7 +62,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade .[test]
+        python -m pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m pip uninstall --yes scipy
         python -m pip install --upgrade --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
         python -m pip list
@@ -88,7 +88,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade .[test]
+        python -m pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m pip uninstall --yes iminuit
         python -m pip install --upgrade cython
         python -m pip install --upgrade git+https://github.com/scikit-hep/iminuit.git
@@ -114,7 +114,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade .[test]
+        python -m pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m pip uninstall --yes uproot
         python -m pip install --upgrade git+https://github.com/scikit-hep/uproot5.git
         python -m pip list
@@ -141,7 +141,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade .[test]
+        python -m pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m pip uninstall --yes matplotlib
         # Need to use --extra-index-url as dependencies aren't on scientific-python-nightly-wheels package index.
         # Need to use --pre as dev releases will need priority over stable releases.
@@ -176,7 +176,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade .[test]
+        python -m pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m pip uninstall --yes pytest
         python -m pip install --upgrade git+https://github.com/pytest-dev/pytest.git
         python -m pip list

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies and force lowest bound
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir install --constraint tests/constraints.txt .[test]
+        python -m pip --no-cache-dir install --constraint tests/constraints.txt ".[all,test]"
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         # FIXME: c.f. https://github.com/scikit-hep/pyhf/issues/2104
-        python -m pip install --upgrade .[test] 'jupyter-client<8.0.0'
+        python -m pip install --upgrade ".[all,test]" 'jupyter-client<8.0.0'
 
     - name: List installed Python packages
       run: python -m pip list

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,7 +35,7 @@ def tests(session):
         $ nox --session tests --python 3.11 -- tests/test_tensor.py  # run specific tests
         $ nox --session tests --python 3.11 -- coverage  # run with coverage but slower
     """
-    session.install("--upgrade", "--editable", ".[test]")
+    session.install("--upgrade", "--editable", ".[all,test]")
     session.install("--upgrade", "pytest")
 
     # Allow tests to be run with coverage
@@ -107,7 +107,7 @@ def regenerate(session):
     """
     Regenerate Matplotlib images.
     """
-    session.install("--upgrade", "--editable", ".[test]")
+    session.install("--upgrade", "--editable", ".[all,test]")
     session.install("--upgrade", "pytest", "matplotlib")
     if not sys.platform.startswith("linux"):
         session.error(
@@ -182,7 +182,7 @@ def notebooks(session: nox.Session):
     """
     Run the notebook tests.
     """
-    session.install("--upgrade", "--editable", ".[test]")
+    session.install("--upgrade", "--editable", ".[all,test]")
     session.run(
         "pytest",
         "--override-ini",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,6 @@ all = ["pyhf[backends,xmlio,contrib,shellcomplete]"]
 
 # Developer extras
 test = [
-    "pyhf[all]",
     "scikit-hep-testdata>=0.4.11",
     "pytest>=6.0",
     "coverage[toml]>=6.0.0",
@@ -121,7 +120,7 @@ docs = [
     "ipython!=8.7.0",  # c.f. https://github.com/scikit-hep/pyhf/pull/2068
 ]
 develop = [
-    "pyhf[test,docs]",
+    "pyhf[all,test,docs]",
     "tbump>=6.7.0",
     "pre-commit",
     "nox",


### PR DESCRIPTION
# Description

To be able to take advantage of PR #2340 in CI it requires the ability to select a subset of dependencies to install as well (c.f. Issue #2372). To do this, this PR decouples the installation of the test dependendies in the 'test' extra from the backends that are installed in the 'all' extra and now requires 'all' to be explicitly given.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove the 'all' extra from the 'test' extra installs and add 'all' to 
  the 'develop' extra.
* Add the 'all' extra to all install commands that also install the 'test' extra.
```