### PR TITLE
fix: Add filterwarnings ignore for virtualized device UserWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,6 +216,7 @@ filterwarnings = [
     "ignore:module 'sre_constants' is deprecated:DeprecationWarning",  # tensorflow v2.12.0+ for Python 3.11+
     "ignore:ml_dtypes.float8_e4m3b11 is deprecated.",  #FIXME: Can remove when jaxlib>=0.4.12
     "ignore:jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the:DeprecationWarning",  # Issue #2139
+    "ignore:Skipping device Apple Paravirtual device that does not support Metal 2.0:UserWarning",  # Can't fix given hardware/virtualized device
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
# Description

Add an ignore to filterwarnings to avoid PyTorch virtualized device UserWarning on virtualized Apple hardware.

> UserWarning: Skipping device Apple Paravirtual device that does not support Metal 2.0.

   - c.f. https://github.com/pytorch/pytorch/pull/111576

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add an ignore to filterwarnings to avoid PyTorch virtualized device
  UserWarning on virtualized Apple hardware.

  > UserWarning: Skipping device Apple Paravirtual device that does not
  > support Metal 2.0.

   - c.f. https://github.com/pytorch/pytorch/pull/111576
```