### PR TITLE
chore: Use Ruff lint config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -284,25 +284,27 @@ module = [
 ignore_errors = true
 
 [tool.ruff]
+src = ["src"]
+line-length = 88
+
+[tool.ruff.lint]
 select = [
   "E", "F", "W", # flake8
   "UP",          # pyupgrade
   "RUF",         # Ruff-specific
   "TID",         # flake8-tidy-imports
 ]
-line-length = 88
 ignore = [
   "E402",
   "E501",
   "RUF001", # String contains ambiguous unicode character
   "RUF005", # unpack-instead-of-concatenating-to-collection-literal
 ]
-src = ["src"]
 typing-modules = ["pyhf.typing"]
 unfixable = [
   "F841", # Removes unused variables
 ]
 flake8-tidy-imports.ban-relative-imports = "all"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "docs/lite/jupyterlite.py" = ["F401", "F704"]


### PR DESCRIPTION
# Description

Use the Ruff lint config option as [recommended in the Scientific Python Development Guide](https://learn.scientific-python.org/development/guides/style/#ruff).
   - RF202: Use (new) lint config section.

Thanks for adding this to repo-review, @henryiii!

```console
$ pipx run 'sp-repo-review[cli]' . | tail -n 10
├── RF103 pyupgrade must be selected ✅
├── RF201 Avoid using deprecated config settings ✅
└── RF202 Use (new) lint config section ✅

Documentation:
├── RTD100 Uses ReadTheDocs (pyproject config) ✅
├── RTD101 You have to set the RTD version number to 2 ✅
├── RTD102 You have to set the RTD build image ✅
└── RTD103 You have to set the RTD python version ✅
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use the Ruff lint config option as recommended in the Scientific
  Python Development Guide.
   - RF202: Use (new) lint config section.
   - c.f. https://learn.scientific-python.org/development/guides/style/#ruff
```