### PR TITLE
chore: Add pre-commit/pygrep-hooks to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,13 @@ repos:
       # exclude generated files
       exclude: ^validation/|\.dtd$|\.xml$
 
+- repo: https://github.com/pre-commit/pygrep-hooks
+  rev: "v1.10.0"
+  hooks:
+    - id: rst-backticks
+    - id: rst-directive-colons
+    - id: rst-inline-touching-normal
+
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: "v0.1.4"
   hooks:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 .. pyhf documentation master file, created by
    sphinx-quickstart on Fri Feb  9 11:58:49 2018.
    You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+   contain the root ``toctree`` directive.
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
# Description

Impliment repo-review PC170: [Uses PyGrep hooks (only needed if RST present)](https://learn.scientific-python.org/development/guides/style/#PC170).

<tr style="color: green;">
<td><span role="img" aria-label="Passed">&#9989;</span></td>
<td>PC170</td>
<td><a href="https://learn.scientific-python.org/development/guides/style#PC170">Uses PyGrep hooks (only needed if RST present)</a></td>
</tr>


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Impliment repo-review PC170: Uses PyGrep hooks (only needed if RST present).
   - c.f. https://learn.scientific-python.org/development/guides/style/#PC170
```