### PR TITLE
chore: Use native Ruff Jupyter support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,6 @@ repos:
     hooks:
     - id: black-jupyter
       types_or: [python, pyi, jupyter]
-      types_or: [python, pyi, jupyter]
 
 -   repo: https://github.com/adamchainz/blacken-docs
     rev: 1.16.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     - id: rst-inline-touching-normal
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: "v0.1.4"
+  rev: "v0.1.6"
   hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]
@@ -44,6 +44,8 @@ repos:
     rev: 23.10.1
     hooks:
     - id: black-jupyter
+      types_or: [python, pyi, jupyter]
+      types_or: [python, pyi, jupyter]
 
 -   repo: https://github.com/adamchainz/blacken-docs
     rev: 1.16.0
@@ -65,13 +67,6 @@ repos:
       - <<: *mypy
         name: mypy with Python 3.11
         args: ["--python-version=3.11"]
-
--   repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.7.0
-    hooks:
-    - id: nbqa-ruff
-      additional_dependencies: [ruff==v0.1.4]
-      args: ["--extend-ignore=F821,F401,F841,F811"]
 
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.2.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -308,3 +308,4 @@ flake8-tidy-imports.ban-relative-imports = "all"
 
 [tool.ruff.lint.per-file-ignores]
 "docs/lite/jupyterlite.py" = ["F401", "F704"]
+"**.ipynb" = ["F821", "F401", "F841", "F811", "E703"]


### PR DESCRIPTION
This is a quick update to pre-commit to use the native notebook support in Ruff rather than an adaptor.

I was looking at ruff-format, but can't use it due to the mix of single and double quotes. Ruff has options for both, but not a "let me mix and match" mode like black.

```
* Remove github.com/nbQA-dev/nbQA in favor of native Ruff Jupyter support.
* Add support for python, pyi, jupyter types to black-jupyter hook.
* Update github.com/astral-sh/ruff-pre-commit: v0.1.4 → v0.1.6.
```