### PR TITLE
feat: Improve warnings for qmu and qmu_tilde for the set POI bounds

### DIFF
--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -134,7 +134,7 @@ def qmu(mu, data, pdf, init_pars, par_bounds, fixed_params, return_fitted_pars=F
     if par_bounds[pdf.config.poi_index][0] == 0:
         log.warning(
             'qmu test statistic used for fit configuration with POI bounded at zero.\n'
-            + 'Use the qmu_tilde test statistic (pyhf.infer.test_statistics.qmu_tilde) instead.'
+            + 'Use the qmu_tilde test statistic (pyhf.infer.test_statistics.qmu_tilde) instead. Set test_stat="qtilde".'
         )
     return _qmu_like(
         mu,
@@ -229,7 +229,7 @@ def qmu_tilde(
     if par_bounds[pdf.config.poi_index][0] != 0:
         log.warning(
             'qmu_tilde test statistic used for fit configuration with POI not bounded at zero.\n'
-            + 'Use the qmu test statistic (pyhf.infer.test_statistics.qmu) instead.'
+            + 'Use the qmu test statistic (pyhf.infer.test_statistics.qmu) instead. Set test_stat="q".'
         )
     return _qmu_like(
         mu,

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -134,7 +134,8 @@ def qmu(mu, data, pdf, init_pars, par_bounds, fixed_params, return_fitted_pars=F
     if par_bounds[pdf.config.poi_index][0] == 0:
         log.warning(
             'qmu test statistic used for fit configuration with POI bounded at zero.\n'
-            + 'Use the qmu_tilde test statistic (pyhf.infer.test_statistics.qmu_tilde) instead. Set test_stat="qtilde".'
+            + 'Use the qmu_tilde test statistic (pyhf.infer.test_statistics.qmu_tilde) instead.\n'
+            + 'If you called this from pyhf.infer.mle or pyhf.infer.hypotest, set test_stat="qtilde".'
         )
     return _qmu_like(
         mu,
@@ -229,7 +230,8 @@ def qmu_tilde(
     if par_bounds[pdf.config.poi_index][0] != 0:
         log.warning(
             'qmu_tilde test statistic used for fit configuration with POI not bounded at zero.\n'
-            + 'Use the qmu test statistic (pyhf.infer.test_statistics.qmu) instead. Set test_stat="q".'
+            + 'Use the qmu test statistic (pyhf.infer.test_statistics.qmu) instead.\n'
+            + 'If you called this from pyhf.infer.mle or pyhf.infer.hypotest, set test_stat="q".'
         )
     return _qmu_like(
         mu,


### PR DESCRIPTION
# Description

When running 
```python
model = pyhf.simplemodels.uncorrelated_background(signal=[5.0, 10.0], bkg=[50.0, 60.0], bkg_uncertainty=[5.0, 12.0])
pyhf.infer.hypotest(1.0, [53.0, 65.0] + model.config.auxdata, model, test_stat="qmu")
```
we get a warning
```
qmu test statistic used for fit configuration with POI bounded at zero.
Use the qmu_tilde test statistic (pyhf.infer.test_statistics.qmu_tilde) instead.
```
and vice versa for POIs not bounded at 0. 

But this should also tell you to set `test_stat="qtilde"` or (`test_stat="q"`).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add information to the user in the warning that provides them with the
  higher level pyhf.infer APIs kwarg to set the correct test statistic.
```