### PR TITLE
docs: Add November 2023 use and general citations

### DIFF
--- a/docs/bib/general_citations.bib
+++ b/docs/bib/general_citations.bib
@@ -1,3 +1,15 @@
+% 2023-11-28
+@article{Agin:2023yoq,
+    author = "Agin, Diyar and Fuks, Benjamin and Goodsell, Mark D. and Murphy, Taylor",
+    title = "{Monojets reveal overlapping excesses for light compressed higgsinos}",
+    eprint = "2311.17149",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    month = "11",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-10-19
 @article{Smith:2023ssh,
     author = "Smith, Rachel E. C. and Ochoa, In\^es and In\'acio, R\'uben and Shoemaker, Jonathan and Kagan, Michael",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,16 @@
+% 2023-11-22
+@article{Holder:2023jbt,
+    author = "Holder, Ryan and Reddick, John and Cremonesi, Matteo and Berry, Doug and Cheng, Kun and Low, Matthew and Tait, Tim M. P. and Whiteson, Daniel",
+    title = "{Hadronic Mono-$W'$ Probes of Dark Matter at Colliders}",
+    eprint = "2311.13578",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "FERMILAB-PUB-23-764-PPD",
+    month = "11",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-10-31
 @article{Tong:2023lms,
     author = "Tong, Shelley and Corcoran, James and Fieg, Max and Fenton, Michael and Whiteson, Daniel",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,16 @@
+% 2023-11-24
+@article{Altmannshofer:2023hkn,
+    author = "Altmannshofer, Wolfgang and Crivellin, Andreas and Haigh, Huw and Inguglia, Gianluca and Martin Camalich, Jorge",
+    title = "{Light New Physics in $B\to K^{(*)}\nu\bar\nu$?}",
+    eprint = "2311.14629",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "PSI-PR-23-46, ZU-TH 77/23",
+    month = "11",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-11-22
 @article{Holder:2023jbt,
     author = "Holder, Ryan and Reddick, John and Cremonesi, Matteo and Berry, Doug and Cheng, Kun and Low, Matthew and Tait, Tim M. P. and Whiteson, Daniel",


### PR DESCRIPTION
# Description

Add use citations from

* [Hadronic Mono-W′ Probes of Dark Matter at Colliders](https://inspirehep.net/literature/2725449) by Ryan Holder, John Reddick, Matteo Cremonesi, Doug Berry, Kun Cheng, Matthew Low, Tim M.P. Tait, Daniel Whiteson.
* [Light New Physics in B→K(∗)νν¯?](https://inspirehep.net/literature/2725980) by Wolfgang Altmannshofer, Andreas Crivellin, Huw Haigh, Gianluca Inguglia, Jorge Martin Camalich.

Add general citation from

* [Monojets reveal overlapping excesses for light compressed higgsinos](https://inspirehep.net/literature/2727900) by Diyar Agin, @BFuks, Mark D. Goodsell, Taylor Murphy.


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Hadronic Mono-W′ Probes of Dark Matter at Colliders'.
   - c.f. https://inspirehep.net/literature/2725449
* Add use citation from 'Light New Physics in B→K(∗)νν¯?'.
   - c.f. https://inspirehep.net/literature/2725980
* Add general citation from 'Monojets reveal overlapping excesses for
  light compressed higgsinos'.
   - c.f. https://inspirehep.net/literature/2727900
```