### PR TITLE
docs: Add use citation from Belle II evidence for B+→K+νν¯ decays paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -11,6 +11,19 @@
     journal = ""
 }
 
+% 2023-11-24
+@article{Belle-II:2023esi,
+    author = "Belle II Collaboration",
+    title = "{Evidence for $B^{+}\to K^{+}\nu\bar{\nu}$ Decays}",
+    eprint = "2311.14647",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    reportNumber = "Belle II Preprint 2023-017, KEK Preprint 2023-35",
+    month = "11",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-11-22
 @article{Holder:2023jbt,
     author = "Holder, Ryan and Reddick, John and Cremonesi, Matteo and Berry, Doug and Cheng, Kun and Low, Matthew and Tait, Tim M. P. and Whiteson, Daniel",


### PR DESCRIPTION
# Description

Add use citation from [Evidence for B+→K+νν¯ Decays](https://inspirehep.net/literature/2725943).

Congratulations to the Belle II collaboration on this excellent result!

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Evidence for B+→K+νν¯ Decays'.
   - c.f. https://inspirehep.net/literature/2725943
   - Congratulations to the Belle II collaboration on this excellent result!
```