### PR TITLE
docs: Add use citation from ATLAS axion-like search in H->aa->4γ paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,16 @@
+% 2023-12-06
+@article{ATLAS:2023ian,
+    author = "{ATLAS Collaboration}",
+    title = "{Search for short- and long-lived axion-like particles in $H\rightarrow a a \rightarrow 4\gamma$ decays with the ATLAS experiment at the LHC}",
+    eprint = "2312.03306",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    reportNumber = "CERN-EP-2023-202",
+    month = "12",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-11-24
 @article{Altmannshofer:2023hkn,
     author = "Altmannshofer, Wolfgang and Crivellin, Andreas and Haigh, Huw and Inguglia, Gianluca and Martin Camalich, Jorge",


### PR DESCRIPTION
# Description

Add use citation from [Search for short- and long-lived axion-like particles in H→aa→4γ decays with the ATLAS experiment at the LHC](https://inspirehep.net/literature/2731621).
   - ATLAS paper: HDBS-2019-19

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Search for short- and long-lived axion-like
  particles in H→aa→4γ decays with the ATLAS experiment at the LHC'.
   - ATLAS paper: HDBS-2019-19
   - c.f. https://inspirehep.net/literature/2731621
```