### PR TITLE
feat: New schema for HS3 Support

### DIFF
--- a/src/pyhf/schemas/1.1.0/defs.json
+++ b/src/pyhf/schemas/1.1.0/defs.json
@@ -1,0 +1,333 @@
+{
+    "$schema": "http://json-schema.org/draft/2020-12/schema#",
+    "$id": "https://scikit-hep.org/pyhf/schemas/1.1.0/defs.json",
+    "definitions": {
+        "workspace": {
+          "type": "object",
+          "properties": {
+              "distributions": { "type": "array", "items": {"$ref": "#/definitions/distribution"}, "minItems": 1 },
+              "measurements": { "type": "array", "items": {"$ref": "#/definitions/measurement"}, "minItems": 1 },
+              "observations": { "type": "array", "items": {"$ref": "#/definitions/observation" }, "minItems": 1 },
+              "type": { "const": "histfactory_dist" },
+              "version": { "const": "1.1.0" }
+          },
+          "additionalProperties": false,
+          "required": ["distributions", "measurements", "observations", "version"]
+        },
+        "model": {
+          "type": "object",
+          "properties": {
+              "channels": { "type": "array", "items": {"$ref": "#/definitions/distribution"}, "minItems": 1 },
+              "parameters": { "type": "array", "items": {"$ref": "#/definitions/parameter"} }
+          },
+          "additionalProperties": false,
+          "required": ["channels"]
+        },
+        "observation": {
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "data": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
+            },
+            "required": ["name", "data"],
+            "additionalProperties": false
+        },
+        "measurement": {
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "config": { "$ref": "#/definitions/config" }
+            },
+            "required": ["name", "config"],
+            "additionalProperties": false
+        },
+        "config": {
+            "type": "object",
+            "properties": {
+                "poi": { "type" : "string" },
+                "parameters": { "type": "array", "items": {"$ref": "#/definitions/parameter"} }
+            },
+            "required": ["poi", "parameters"],
+            "additionalProperties": false
+        },
+        "parameter": {
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "inits": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
+                "bounds": { "type": "array", "items": {"type": "array", "items": {"type": "number", "minItems": 2, "maxItems": 2}}, "minItems": 1 },
+                "auxdata": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
+                "factors": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
+                "sigmas": { "type": "array", "items": {"type": "number"}, "minItems": 1},
+                "fixed": { "type": "boolean" }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        },
+        "distribution": {
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "samples": { "type": "array", "items": {"$ref": "#/definitions/sample"}, "minItems": 1 },
+                "axes": { "type": "array", "items": {"$ref": "#/definitions/axis"}, "minItems": 1, "maxItems": 1}
+            },
+            "required": ["name", "samples"],
+            "additionalProperties": false
+        },
+        "axis": {
+            "type": "object",
+            "MAKE THIS ONEOF": "",
+            "(A)": "",
+              "properties_oneof": {
+                  "name": { "type": "string", "pattern": "^[a-zA-Z0-9_]+$" },
+                  "max": { "type": "number" },
+                  "min": { "type": "number" },
+                  "nbins": { "type": "number" }
+              },
+            "(B)": "",
+              "properties": {
+                  "name": { "type": "string", "pattern": "^[a-zA-Z0-9_]+$" },
+                  "edges": { "type": "array", "items": { "type": "number", "minItems": 2 } }
+              }
+        },
+        "sample": {
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "data": { "type": "object", "properties": { "contents": { "type": "array", "items": {"type": "number"}, "minItems": 1 }} },
+                "modifiers": {
+                    "type": "array",
+                    "items": {
+                        "anyOf": [
+                            { "$ref": "#/definitions/modifier/histosys" },
+                            { "$ref": "#/definitions/modifier/lumi" },
+                            { "$ref": "#/definitions/modifier/normfactor" },
+                            { "$ref": "#/definitions/modifier/normsys" },
+                            { "$ref": "#/definitions/modifier/shapefactor" },
+                            { "$ref": "#/definitions/modifier/shapesys" },
+                            { "$ref": "#/definitions/modifier/staterror" }
+                        ]
+                    }
+                }
+            },
+            "required": ["name", "data", "modifiers"],
+            "additionalProperties": false
+        },
+        "modifier": {
+            "histosys": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "type": { "const": "histosys" },
+                    "data": {
+                        "type": "object",
+                        "properties": {
+                            "lo_data": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
+                            "hi_data": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
+                        },
+                        "required": ["lo_data", "hi_data"],
+                        "additionalProperties": false
+                    }
+                },
+                "required": ["name", "type", "data"],
+                "additionalProperties": false
+            },
+            "lumi": {
+                "type": "object",
+                "properties": {
+                    "name": { "const": "lumi" },
+                    "type": { "const": "lumi" },
+                    "data": { "type": "null" }
+                },
+                "required": ["name", "type", "data"],
+                "additionalProperties": false
+            },
+            "normfactor": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "type": { "const": "normfactor" },
+                    "data": { "type": "null" }
+                },
+                "required": ["name", "type", "data"],
+                "additionalProperties": false
+            },
+            "normsys": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "type": { "const": "normsys" },
+                    "data": {
+                        "type": "object",
+                        "properties": {
+                            "lo": { "type": "number" },
+                            "hi": { "type": "number"}
+                        },
+                        "required": ["lo", "hi"],
+                        "additionalProperties": false
+                    }
+                },
+                "required": ["name", "type", "data"],
+                "additionalProperties": false
+            },
+            "shapefactor": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "type": { "const": "shapefactor" },
+                    "data": { "type": "null" }
+                },
+                "required": ["name", "type", "data"],
+                "additionalProperties": false
+            },
+            "shapesys": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "type": { "const": "shapesys" },
+                    "data": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
+                },
+                "required": ["name", "type", "data"],
+                "additionalProperties": false
+            },
+            "staterror": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "type": { "const": "staterror" },
+                    "data": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
+                },
+                "required": ["name", "type", "data"],
+                "additionalProperties": false
+            }
+        },
+        "jsonpatch": {
+            "description": "an array of patch operations (copied from http://json.schemastore.org/json-patch)",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/jsonpatch/operation"
+            },
+            "operation": {
+                "type": "object",
+                "required": [ "op", "path" ],
+                "allOf": [ { "$ref": "#/definitions/jsonpatch/path" } ],
+                "oneOf": [
+                    {
+                        "required": [ "value" ],
+                        "properties": {
+                            "op": {
+                                "description": "The operation to perform.",
+                                "type": "string",
+                                "enum": [ "add", "replace", "test" ]
+                            },
+                            "value": {
+                                "description": "The value to add, replace or test."
+                            }
+                        }
+                    },
+                    {
+                        "properties": {
+                            "op": {
+                                "description": "The operation to perform.",
+                                "type": "string",
+                                "enum": [ "remove" ]
+                            }
+                        }
+                    },
+                    {
+                        "required": [ "from" ],
+                        "properties": {
+                            "op": {
+                                "description": "The operation to perform.",
+                                "type": "string",
+                                "enum": [ "move", "copy" ]
+                            },
+                            "from": {
+                                "description": "A JSON Pointer path pointing to the location to move/copy from.",
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
+            },
+            "path": {
+                "properties": {
+                    "path": {
+                        "description": "A JSON Pointer path.",
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "patchset": {
+            "description": "A set of JSONPatch patches which modify a pyhf workspace",
+            "type": "object",
+            "properties": {
+                "patches": { "$ref": "#/definitions/patchset/patches" },
+                "metadata": { "$ref": "#/definitions/patchset/metadata" },
+                "version": { "const": "1.1.0" }
+            },
+            "additionalProperties": false,
+            "required": ["patches", "metadata", "version"],
+            "references": {
+                "type": "object",
+                "properties": {
+                    "hepdata": { "type": "string", "pattern": "^ins[0-9]{7}$" }
+                },
+                "additionalProperties": false,
+                "minProperties": 1
+            },
+            "digests": {
+                "type": "object",
+                "properties": {
+                    "md5": { "type": "string", "pattern": "^[a-f0-9]{32}$" },
+                    "sha256": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" }
+                },
+                "additionalProperties": false,
+                "minProperties": 1
+            },
+            "patches": {
+                "type": "array",
+                "items": { "$ref": "#/definitions/patchset/patch" },
+                "minItems": 1
+            },
+            "patch": {
+                "type": "object",
+                "properties": {
+                    "patch": { "$ref": "#/definitions/jsonpatch" },
+                    "metadata": {
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string", "pattern": "^[a-zA-Z0-9_]+$" },
+                            "values": {
+                                "type": "array",
+                                "items": {
+                                    "anyOf": [{"type": "number"}, {"type": "string"}]
+                                }
+                            }
+                        },
+                        "required": ["name", "values"],
+                        "additionalProperties": true
+                    }
+                },
+                "required": ["metadata", "patch"],
+                "additionalProperties": false
+            },
+            "metadata": {
+                "type": "object",
+                "properties": {
+                    "digests": { "$ref": "#/definitions/patchset/digests" },
+                    "labels": {
+                        "type": "array",
+                        "items": { "type": "string", "pattern": "^[a-zA-Z0-9_]+$" },
+                        "minItems": 1
+                    },
+                    "description": { "type": "string" },
+                    "references": { "$ref": "#/definitions/patchset/references" }
+                },
+                "required": ["references", "digests", "labels", "description"],
+                "additionalProperties": true
+            }
+        }
+    }
+}

--- a/src/pyhf/schemas/1.1.0/defs.json
+++ b/src/pyhf/schemas/1.1.0/defs.json
@@ -76,25 +76,46 @@
         },
         "axis": {
             "type": "object",
-            "MAKE THIS ONEOF": "",
-            "(A)": "",
-              "properties_oneof": {
-                  "name": { "type": "string", "pattern": "^[a-zA-Z0-9_]+$" },
-                  "max": { "type": "number" },
-                  "min": { "type": "number" },
-                  "nbins": { "type": "number" }
-              },
-            "(B)": "",
-              "properties": {
-                  "name": { "type": "string", "pattern": "^[a-zA-Z0-9_]+$" },
-                  "edges": { "type": "array", "items": { "type": "number", "minItems": 2 } }
-              }
+            "oneOf": [
+                {
+                    "required": [ "value" ],
+                    "properties": {
+                        "name": { "type": "string", "pattern": "^[a-zA-Z0-9_]+$" },
+                        "max": { "type": "number" },
+                        "min": { "type": "number" },
+                        "nbins": { "type": "number" }
+                    }
+                  },
+                {
+                  "properties": {
+                      "name": { "type": "string", "pattern": "^[a-zA-Z0-9_]+$" },
+                      "edges": { "type": "array", "items": { "type": "number", "minItems": 2 } }
+                  }
+                }
+              ]
+        },
+        "histogram": {
+            "type": "object",
+            "properties": {
+              "contents": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
+            },
+            "required": ["contents"],
+            "additionalProperties": false
+        },
+        "histogramWithErrors": {
+            "type": "object",
+            "properties": {
+              "contents": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
+              "errors": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
+            },
+            "required": ["contents"],
+            "additionalProperties": false
         },
         "sample": {
             "type": "object",
             "properties": {
                 "name": { "type": "string" },
-                "data": { "type": "object", "properties": { "contents": { "type": "array", "items": {"type": "number"}, "minItems": 1 }} },
+                "data": { "type": "object", "$ref": "#/definitions/histogramWithErrors" },
                 "modifiers": {
                     "type": "array",
                     "items": {
@@ -122,12 +143,13 @@
                     "data": {
                         "type": "object",
                         "properties": {
-                            "lo_data": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
-                            "hi_data": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
+                            "lo": { "type": "object", "$ref": "#/definitions/histogram" },
+                            "hi": { "type": "object", "$ref": "#/definitions/histogram" }
                         },
                         "required": ["lo_data", "hi_data"],
                         "additionalProperties": false
-                    }
+                    },
+                    "parameter": { "type": "string" }
                 },
                 "required": ["name", "type", "data"],
                 "additionalProperties": false
@@ -137,7 +159,8 @@
                 "properties": {
                     "name": { "const": "lumi" },
                     "type": { "const": "lumi" },
-                    "data": { "type": "null" }
+                    "data": { "type": "null" },
+                    "parameter": { "type": "string" }
                 },
                 "required": ["name", "type", "data"],
                 "additionalProperties": false
@@ -147,9 +170,10 @@
                 "properties": {
                     "name": { "type": "string" },
                     "type": { "const": "normfactor" },
-                    "data": { "type": "null" }
+                    "data": { "type": "null" },
+                    "parameter": { "type": "string" }
                 },
-                "required": ["name", "type", "data"],
+                "required": ["name", "type"],
                 "additionalProperties": false
             },
             "normsys": {
@@ -165,7 +189,8 @@
                         },
                         "required": ["lo", "hi"],
                         "additionalProperties": false
-                    }
+                    },
+                    "parameter": { "type": "string" }
                 },
                 "required": ["name", "type", "data"],
                 "additionalProperties": false
@@ -175,9 +200,10 @@
                 "properties": {
                     "name": { "type": "string" },
                     "type": { "const": "shapefactor" },
-                    "data": { "type": "null" }
+                    "data": { "type": "null" },
+                    "parameters": { "type": "array", "items": { "type": "string" }}
                 },
-                "required": ["name", "type", "data"],
+                "required": ["name", "type"],
                 "additionalProperties": false
             },
             "shapesys": {
@@ -185,7 +211,8 @@
                 "properties": {
                     "name": { "type": "string" },
                     "type": { "const": "shapesys" },
-                    "data": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
+                    "data": { "type": "object", "$ref": "#/definitions/histogram" },
+                    "parameters": { "type": "array", "items": { "type": "string" }}
                 },
                 "required": ["name", "type", "data"],
                 "additionalProperties": false
@@ -195,9 +222,9 @@
                 "properties": {
                     "name": { "type": "string" },
                     "type": { "const": "staterror" },
-                    "data": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
+                    "parameters": { "type": "array", "items": { "type": "string" }}
                 },
-                "required": ["name", "type", "data"],
+                "required": ["name", "type"],
                 "additionalProperties": false
             }
         },

--- a/src/pyhf/schemas/1.1.0/jsonpatch.json
+++ b/src/pyhf/schemas/1.1.0/jsonpatch.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "http://json-schema.org/draft/2020-12/schema#",
+    "$id": "https://scikit-hep.org/pyhf/schemas/1.1.0/jsonpatch.json",
+    "$ref": "defs.json#/definitions/jsonpatch"
+}

--- a/src/pyhf/schemas/1.1.0/measurement.json
+++ b/src/pyhf/schemas/1.1.0/measurement.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "http://json-schema.org/draft/2020-12/schema#",
+    "$id": "https://scikit-hep.org/pyhf/schemas/1.1.0/measurement.json",
+    "$ref": "defs.json#/definitions/measurement"
+}

--- a/src/pyhf/schemas/1.1.0/model.json
+++ b/src/pyhf/schemas/1.1.0/model.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "http://json-schema.org/draft/2020-12/schema#",
+    "$id": "https://scikit-hep.org/pyhf/schemas/1.1.0/model.json",
+    "$ref": "defs.json#/definitions/model"
+}

--- a/src/pyhf/schemas/1.1.0/patchset.json
+++ b/src/pyhf/schemas/1.1.0/patchset.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "http://json-schema.org/draft/2020-12/schema#",
+    "$id": "https://scikit-hep.org/pyhf/schemas/1.1.0/patchset.json",
+    "$ref": "defs.json#/definitions/patchset"
+}

--- a/src/pyhf/schemas/1.1.0/workspace.json
+++ b/src/pyhf/schemas/1.1.0/workspace.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "http://json-schema.org/draft/2020-12/schema#",
+    "$id": "https://scikit-hep.org/pyhf/schemas/1.1.0/workspace.json",
+    "$ref": "defs.json#/definitions/workspace"
+}


### PR DESCRIPTION
Runtime validations:
- check that `staterror` is only defined once per sample
- check that if `staterror` is defined, that the sample has defined `errors`
- check that `contents` and `errors` have the same shape if `errors` is defined

Accepted Defaults:
- axes has min=0, max=1 (or edges = [0, 1])
- parameter/parameters is just the name of the parameter(s)
- staterror data is moved to the sample `errors`

To Dos:
- [ ] drop luminosity when customizable constraints can be supported (#1829)
- [ ] support schema migration (#1978)

References:
- https://github.com/hep-statistics-serialization-standard/hep-statistics-serialization-standard/discussions/30
- https://github.com/root-project/root/blob/master/tutorials/roofit/rf515_hfJSON.json

# Pull Request Description

Please first read [CONTRIBUTING.md](https://github.com/scikit-hep/pyhf/tree/main/CONTRIBUTING.md).

Please describe the purpose of this pull request in some detail and what the specific feature being added will do. Reference and link to any relevant issues or pull requests (such as the issue in which this feature was first suggested).

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
- [ ] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR
