### PR TITLE
docs: Add use citation from right-handed charged gauge bosons paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,16 @@
+% 2023-12-13
+@article{Frank:2023epx,
+    author = "Frank, Mariana and Fuks, Benjamin and Jueid, Adil and Moretti, Stefano and Ozdal, Ozer",
+    title = "{A novel search strategy for right-handed charged gauge bosons at the Large Hadron Collider}",
+    eprint = "2312.08521",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "CTPU-PTC-23-43",
+    month = "12",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-12-06
 @article{ATLAS:2023ian,
     author = "{ATLAS Collaboration}",


### PR DESCRIPTION
# Description

Add use citation from [A novel search strategy for right-handed charged gauge bosons at the Large Hadron Collider](https://inspirehep.net/literature/2737265) by Mariana Frank, @BFuks, @ajueid, Stefano Moretti, @oozdal.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'A novel search strategy for right-handed
  charged gauge bosons at the Large Hadron Collider'.
   - c.f. https://inspirehep.net/literature/2737265
```