### PR TITLE
docs: Add use citation from HH at HL-LHC paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,15 @@
+% 2023-12-20
+@article{DaRold:2023hst,
+    author = "Da Rold, Leandro and Epele, Manuel and Medina, Anibal D. and Mileo, Nicol\'as I. and Szynkman, Alejandro",
+    title = "{Double Higgs production at the HL-LHC: probing a loop-enhanced model with kinematical distributions}",
+    eprint = "2312.13149",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    month = "12",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-12-13
 @article{Frank:2023epx,
     author = "Frank, Mariana and Fuks, Benjamin and Jueid, Adil and Moretti, Stefano and Ozdal, Ozer",


### PR DESCRIPTION
# Description

Add use citation from [Double Higgs production at the HL-LHC: probing a loop-enhanced model with kinematical distributions](https://inspirehep.net/literature/2739283) by Leandro Da Rold, Manuel Epele, Anibal D. Medina, Nicolás I. Mileo, Alejandro Szynkman.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Double Higgs production at the HL-LHC: probing
  a loop-enhanced model with kinematical distributions'.
   - c.f. https://inspirehep.net/literature/2739283
```