### PR TITLE
ci: Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
     labels:
       - "github-actions"
       - "dependencies"


### PR DESCRIPTION
# Description

* Group dependabot updates to reduce the number of PRs.
   - c.f. sp-repo-review [GH212: Require GHA update grouping](https://learn.scientific-python.org/development/guides/gha-basic/#GH212)

c.f. https://github.com/scientific-python/cookie/pull/348

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Group dependabot updates to reduce the number of PRs.
   - c.f. sp-repo-review GH212: Require GHA update grouping
     https://learn.scientific-python.org/development/guides/gha-basic/#GH212
```