### PR TITLE
chore: Remove Mypy 'show_error_codes' as now default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,7 +237,6 @@ files = "src"
 python_version = "3.11"
 warn_unused_configs = true
 strict = true
-show_error_codes = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true
 


### PR DESCRIPTION
# Description

sp-repo-review MY102: Mypy show_error_codes deprecated: Must not have `show_error_codes`. Use `hide_error_codes` instead (since Mypy v0.990).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* sp-repo-review MY102: Mypy show_error_codes deprecated
  Must not have show_error_codes. Use hide_error_codes instead (since Mypy v0.990).
```