### PR TITLE
docs: Add use citation from global LHC constraints SModelS paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,15 @@
+% 2023-12-27
+@article{Altakach:2023tsd,
+    author = "Altakach, Mohammad Mahdi and Kraml, Sabine and Lessa, Andre and Narasimha, Sahana and Pascal, Timoth\'ee and Reymermier, Th\'eo and Waltenberger, Wolfgang",
+    title = "{Global LHC constraints on electroweak-inos with SModelS v2.3}",
+    eprint = "2312.16635",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    month = "12",
+    year = "2023",
+    journal = ""
+}
+
 % 2023-12-21
 @article{MicroBooNE:2023sds,
     author = "{MicroBooNE Collaboration}",


### PR DESCRIPTION
# Description

Add use citation from [Global LHC constraints on electroweak-inos with SModelS v2.3](https://inspirehep.net/literature/2741235) by Mohammad Mahdi Altakach, @sabinekraml, Andre Lessa, Sahana Narasimha, Timothée Pascal, Théo Reymermier, @WolfgangWaltenberger.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Global LHC constraints on electroweak-inos with
  SModelS v2.3'.
   - c.f. https://inspirehep.net/literature/2741235
```