### PR TITLE
docs: Add use citation from ML for columnar HEP paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,15 @@
+% 2024-01-03
+@article{Kauffman:2024bov,
+    author = "Kauffman, Elliott and Held, Alexander and Shadura, Oksana",
+    title = "{Machine Learning for Columnar High Energy Physics Analysis}",
+    eprint = "2401.01802",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    month = "1",
+    year = "2024",
+    journal = ""
+}
+
 % 2023-12-27
 @article{Altakach:2023tsd,
     author = "Altakach, Mohammad Mahdi and Kraml, Sabine and Lessa, Andre and Narasimha, Sahana and Pascal, Timoth\'ee and Reymermier, Th\'eo and Waltenberger, Wolfgang",


### PR DESCRIPTION
# Description

Add use citation from [Machine Learning for Columnar High Energy Physics Analysis](https://inspirehep.net/literature/2743013) by @ekauffma, @alexander-held, @oshadura.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Machine Learning for Columnar High Energy
  Physics Analysis'.
   - c.f. https://inspirehep.net/literature/2743013
* First citation from 2024!
```