### PR TITLE
docs: Update citations references with journal pubs through 2023-12

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -226,9 +226,11 @@
     eprint = "2306.17676",
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
-    month = "6",
-    year = "2023",
-    journal = ""
+    doi = "10.21468/SciPostPhys.15.5.185",
+    journal = "SciPost Phys.",
+    volume = "15",
+    pages = "185",
+    year = "2023"
 }
 
 % 2023-06-19

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -301,6 +301,20 @@
     year = "2023"
 }
 
+% 2023-03-07
+@article{Zhang:2023jvh,
+    author = "Zhang, Wenxing and Li, Hao-Lin and Liu, Kun and Ramsey-Musolf, Michael J. and Zeng, Yonghao and Arunasalam, Suntharan",
+    title = "{Probing electroweak phase transition in the singlet Standard Model via bb\ensuremath{\gamma}\ensuremath{\gamma} and 4l channels}",
+    eprint = "2303.03612",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    doi = "10.1007/JHEP12(2023)018",
+    journal = "JHEP",
+    volume = "12",
+    pages = "018",
+    year = "2023"
+}
+
 % 2023-02-24
 @article{Behera:2023eeo,
     author = "Behera, Subhasish and Hageluken, Manuel and Schott, Matthias",

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -163,14 +163,18 @@
 % 2023-09-20
 @article{Belfkir:2023vpo,
     author = "Belfkir, Mohamed and Jueid, Adil and Nasri, Salah",
-    title = "{Boosting dark matter searches at muon colliders with Machine Learning: the mono-Higgs channel as a case study}",
+    title = "{Boosting dark matter searches at muon colliders with machine learning: The mono-Higgs channel as a case study}",
     eprint = "2309.11241",
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
     reportNumber = "CTPU-PTC-23-37",
-    month = "9",
-    year = "2023",
-    journal = ""
+    doi = "10.1093/ptep/ptad144",
+    journal = "Progress of Theoretical and Experimental Physics",
+    volume = "2023",
+    number = "12",
+    pages = "123B03",
+    month = "12",
+    year = "2023"
 }
 
 % 2023-09-04

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -176,13 +176,12 @@
 % 2023-09-04
 @article{Fenton:2023ikr,
     author = "Fenton, Michael James and Shmakov, Alexander and Okawa, Hideki and Li, Yuji and Hsiao, Ko-Yang and Hsu, Shih-Chieh and Whiteson, Daniel and Baldi, Pierre",
-    title = "{Extended Symmetry Preserving Attention Networks for LHC Analysis}",
+    title = "{Reconstruction of Unstable Heavy Particles Using Deep Symmetry-Preserving Attention Networks}",
     eprint = "2309.01886",
     archivePrefix = "arXiv",
     primaryClass = "hep-ex",
     month = "9",
-    year = "2023",
-    journal = ""
+    year = "2023"
 }
 
 % 2023-08-18

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -185,7 +185,8 @@
     archivePrefix = "arXiv",
     primaryClass = "hep-ex",
     month = "9",
-    year = "2023"
+    year = "2023",
+    journal = ""
 }
 
 % 2023-08-18

--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -353,6 +353,22 @@
     year = "2023"
 }
 
+% 2022-12-20
+@article{Belle:2022tfo,
+    author = "Belle Collaboration",
+    title = "{Search for a Heavy Neutrino in \ensuremath{\tau} Decays at Belle}",
+    eprint = "2212.10095",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    reportNumber = "Belle Preprint 2022-27, KEK Preprint 2022-36",
+    doi = "10.1103/PhysRevLett.131.211802",
+    journal = "Phys. Rev. Lett.",
+    volume = "131",
+    number = "21",
+    pages = "211802",
+    year = "2023"
+}
+
 % 2022-12-06
 @article{Belle-II:2022yaw,
     author = "Belle II Collaboration",
@@ -461,7 +477,7 @@
     eprint = "2207.07476",
     archivePrefix = "arXiv",
     primaryClass = "hep-ex",
-    reportNumber = "BELLE-CONF-2201",
+    reportNumber = "BELLE-CONF-2201, Belle Preprint 2023-13, KEK Preprint 2023-17",
     month = "7",
     year = "2022",
     journal = ""


### PR DESCRIPTION
# Description

* Add use citation from [Search for a Heavy Neutrino in \ensuremath{\tau} Decays at Belle](https://inspirehep.net/literature/2616299).

* Add use citation from [Probing electroweak phase transition in the singlet
  Standard Model via bbγγ and 4l channels](https://inspirehep.net/literature/2639009).

* Update use citations references to include their journal publication information.

   - [SModelS v2.3: enabling global likelihood analyses](https://doi.org/10.21468/SciPostPhys.15.5.185).

   - [Boosting dark matter searches at muon colliders with machine
     learning: The mono-Higgs channel as a case study](https://doi.org/10.1093/ptep/ptad144)


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Search for a Heavy Neutrino in \ensuremath{\tau}
  Decays at Belle'.
   - c.f. https://inspirehep.net/literature/2616299

* Add use citation from 'Probing electroweak phase transition in the singlet
  Standard Model via bbγγ and 4l channels'.
   - c.f. https://inspirehep.net/literature/2639009

* Update use citations references to include their journal publication information.

   - 'SModelS v2.3: enabling global likelihood analyses'.
     https://doi.org/10.21468/SciPostPhys.15.5.185

   - 'Boosting dark matter searches at muon colliders with machine
     learning: The mono-Higgs channel as a case study'.
     https://doi.org/10.1093/ptep/ptad144
```