### PR TITLE
ci: Use --find-links to install jax and jaxlib on Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,14 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install dependencies (Python 3.7)
+      if: matrix.python-version == '3.7'
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --find-links https://storage.googleapis.com/jax-releases/jax_releases.html --upgrade .[test]
+
     - name: Install dependencies
+      if: matrix.python-version != '3.7'
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --upgrade .[test]


### PR DESCRIPTION
# Description

As PyPI no longer supports any Python 3.7 versions of jax and jaxlib use the --find-links option and the Google archive of jax release wheels to install the dependencies.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* As Python 3.7 versions of jax and jaxlib are no longer hosted on PyPI, use
  the --find-links option and the Google archive of jax release wheels to
  install the dependencies.
```