### PR TITLE
fix(backport): Access jax.config from jax

### DIFF
--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -1,4 +1,4 @@
-from jax.config import config
+from jax import config
 
 config.update('jax_enable_x64', True)
 


### PR DESCRIPTION
# Description

Backport PR https://github.com/scikit-hep/pyhf/pull/2376

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

~~~
* Backport PR https://github.com/scikit-hep/pyhf/pull/2376
* As of jax and jaxlib v0.4.20 accessing jax.config from the jax.config
  submodule is deprecated and it should be accessed from the jax top
  level API instead.

   ```
   >>> from jax.config import config
   <stdin>:1: DeprecationWarning: Accessing jax.config via the jax.config submodule is deprecated
   ```
~~~