### PR TITLE
feat(backport): Improve warnings for qmu and qmu_tilde for the set POI bounds

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -33,3 +33,4 @@ Contributors include:
 - Beojan Stanislaus
 - Daniel Werner
 - Jonas Rembser
+- Lorenz Gaertner

--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -134,7 +134,8 @@ def qmu(mu, data, pdf, init_pars, par_bounds, fixed_params, return_fitted_pars=F
     if par_bounds[pdf.config.poi_index][0] == 0:
         log.warning(
             'qmu test statistic used for fit configuration with POI bounded at zero.\n'
-            + 'Use the qmu_tilde test statistic (pyhf.infer.test_statistics.qmu_tilde) instead.'
+            + 'Use the qmu_tilde test statistic (pyhf.infer.test_statistics.qmu_tilde) instead.\n'
+            + 'If you called this from pyhf.infer.mle or pyhf.infer.hypotest, set test_stat="qtilde".'
         )
     return _qmu_like(
         mu,
@@ -229,7 +230,8 @@ def qmu_tilde(
     if par_bounds[pdf.config.poi_index][0] != 0:
         log.warning(
             'qmu_tilde test statistic used for fit configuration with POI not bounded at zero.\n'
-            + 'Use the qmu test statistic (pyhf.infer.test_statistics.qmu) instead.'
+            + 'Use the qmu test statistic (pyhf.infer.test_statistics.qmu) instead.\n'
+            + 'If you called this from pyhf.infer.mle or pyhf.infer.hypotest, set test_stat="q".'
         )
     return _qmu_like(
         mu,


### PR DESCRIPTION
# Description

* Backport PR https://github.com/scikit-hep/pyhf/pull/2390
* Add Lorenz Gaertner to contributors list.

Please describe the purpose of this pull request in some detail. Reference and link to any relevant issues or pull requests.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Backport PR https://github.com/scikit-hep/pyhf/pull/2390
* Add Lorenz Gaertner to contributors list.
```