### PR TITLE
fix(backport): Correct variable assignment for limit band artists

### DIFF
--- a/src/pyhf/contrib/viz/brazil.py
+++ b/src/pyhf/contrib/viz/brazil.py
@@ -129,14 +129,14 @@ def plot_brazil_band(test_pois, cls_obs, cls_exp, test_size, ax, **kwargs):
             label=None if idx != 2 else r"$\mathrm{CL}_{s,\mathrm{exp}}$",
         )
         cls_exp_lines.append(_cls_exp_line)
-    one_sigma_band = ax.fill_between(
+    two_sigma_band = ax.fill_between(
         test_pois,
         cls_exp[0],
         cls_exp[-1],
         facecolor="yellow",
         label=r"$\pm2\sigma$ $\mathrm{CL}_{s,\mathrm{exp}}$",
     )
-    two_sigma_band = ax.fill_between(
+    one_sigma_band = ax.fill_between(
         test_pois,
         cls_exp[1],
         cls_exp[-2],


### PR DESCRIPTION
# Description

* Backport PR https://github.com/scikit-hep/pyhf/pull/2411
* Assign the one and two sigma band artists to the correct objects.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Backport PR https://github.com/scikit-hep/pyhf/pull/2411
* Assign the one and two sigma band artists to the correct objects.
```