### PR TITLE
docs: Correct PR number in release notes

### DIFF
--- a/docs/release-notes/v0.7.6.rst
+++ b/docs/release-notes/v0.7.6.rst
@@ -19,7 +19,7 @@ Fixes
   (PR :pr:`2411`)
 * In the ``pyhf.infer`` module, correct the ``fixed_params`` type in the docs
   to be to :obj:`tuple` or :obj:`list`.
-  (PR :pr:`2428`)
+  (PR :pr:`2420`)
 
 Contributors
 ------------


### PR DESCRIPTION
# Description

* The original PR was PR #2420 and the backport PR was PR #2428.
* Amends PR #2430.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* The original PR was PR #2420 and the backport PR was PR #2428.
* Amends PR #2430.
```