### PR TITLE
docs: Add use citation from AGC CHEP 2023 proceedings

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -1,3 +1,15 @@
+% 2024-01-05
+@article{Held:2024gwj,
+    author = "Held, Alexander and Kauffman, Elliott and Shadura, Oksana and Wightman, Andrew",
+    title = "{Physics analysis for the HL-LHC: concepts and pipelines in practice with the Analysis Grand Challenge}",
+    eprint = "2401.02766",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    month = "1",
+    year = "2024",
+    journal = ""
+}
+
 % 2024-01-03
 @article{Kauffman:2024bov,
     author = "Kauffman, Elliott and Held, Alexander and Shadura, Oksana",


### PR DESCRIPTION
# Description

Adding a use citation from the AGC CHEP 2023 proceedings: https://arxiv.org/abs/2401.02766 / https://inspirehep.net/literature/2743608.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
- [ ] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR
