### PR TITLE
docs: Add use citation from inert triplet model paper

### DIFF
--- a/docs/bib/use_citations.bib
+++ b/docs/bib/use_citations.bib
@@ -10,6 +10,19 @@
     journal = ""
 }
 
+% 2024-01-05
+@article{Bandyopadhyay:2024plc,
+    author = "Bandyopadhyay, Priyotosh and Parashar, Snehashis and Sen, Chandrima and Song, Jeonghyeon",
+    title = "{Probing Inert Triplet Model at a multi-TeV muon collider via vector boson fusion with forward muon tagging}",
+    eprint = "2401.02697",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "IITH-PH-0002/23, KIAS-P23063",
+    month = "1",
+    year = "2024",
+    journal = ""
+}
+
 % 2024-01-03
 @article{Kauffman:2024bov,
     author = "Kauffman, Elliott and Held, Alexander and Shadura, Oksana",


### PR DESCRIPTION
# Description

Add use citation from [Probing Inert Triplet Model at a multi-TeV muon collider via vector boson fusion with forward muon tagging](https://inspirehep.net/literature/2743639
) by Priyotosh Bandyopadhyay, Snehashis Parashar, Chandrima Sen, Jeonghyeon Song.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add use citation from 'Probing Inert Triplet Model at a multi-TeV muon
  collider via vector boson fusion with forward muon tagging'.
   - c.f. https://inspirehep.net/literature/2743639
```