### PR TITLE
ci: Use uv for all pip installs

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -205,8 +205,8 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --upgrade pip setuptools wheel
-        python -m uv pip install tbump
+        python -m uv pip install --system --upgrade pip setuptools wheel
+        python -m uv pip install --system tbump
         python -m pip list
 
     - name: Setup Git user to push new tag

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -204,6 +204,7 @@ jobs:
 
     - name: Install Python dependencies
       run: |
+        python -m pip install uv
         python -m uv pip install --upgrade pip setuptools wheel
         python -m uv pip install tbump
         python -m pip list

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -204,8 +204,8 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install tbump
+        python -m uv pip install --upgrade pip setuptools wheel
+        python -m uv pip install tbump
         python -m pip list
 
     - name: Setup Git user to push new tag

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -205,8 +205,8 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip install --system tbump
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system tbump
         python -m pip list
 
     - name: Setup Git user to push new tag

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -30,8 +30,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip install --system --upgrade '.[all,test]'
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade '.[all,test]'
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -29,6 +29,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        python -m pip install uv
         python -m uv pip install --upgrade pip setuptools wheel
         python -m uv pip install --upgrade '.[all,test]'
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -29,8 +29,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade '.[all,test]'
+        python -m uv pip install --upgrade pip setuptools wheel
+        python -m uv pip install --upgrade '.[all,test]'
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip install --system --upgrade '.[all,test]'
+        python -m uv pip install --system --upgrade "pyhf[all,test] @ ."
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip install --system --upgrade "pyhf[all,test] @ ."
+        python -m uv pip install --system --upgrade '.[all,test]'
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -30,8 +30,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --upgrade pip setuptools wheel
-        python -m uv pip install --upgrade '.[all,test]'
+        python -m uv pip install --system --upgrade pip setuptools wheel
+        python -m uv pip install --system --upgrade '.[all,test]'
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        python -m pip install uv
         python -m uv pip install --upgrade pip setuptools wheel
         python -m uv pip install --upgrade ".[all,test]"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade ".[all,test]"
+        python -m uv pip install --upgrade pip setuptools wheel
+        python -m uv pip install --upgrade ".[all,test]"
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,18 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
+      if: matrix.python-version != '3.8'
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
         python -m uv pip install --system --upgrade ".[all,test]"
+
+      # c.f. https://github.com/astral-sh/uv/issues/2062
+    - name: Install dependencies (Python 3.8)
+      if: matrix.python-version == '3.8'
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade ".[all,test]"
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --upgrade pip setuptools wheel
-        python -m uv pip install --upgrade ".[all,test]"
+        python -m uv pip install --system --upgrade pip setuptools wheel
+        python -m uv pip install --system --upgrade ".[all,test]"
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,8 @@ jobs:
       if: matrix.python-version != '3.8'
       run: |
         python -m pip install uv
-        python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip install --system --upgrade ".[all,test]"
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade ".[all,test]"
 
       # c.f. https://github.com/astral-sh/uv/issues/2062
     - name: Install dependencies (Python 3.8)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip install --system --upgrade "pyhf[all,test] @ ."
+        python -m uv pip install --system --upgrade ".[all,test]"
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip install --system --upgrade ".[all,test]"
+        python -m uv pip install --system --upgrade "pyhf[all,test] @ ."
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -30,8 +30,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache --quiet install --system --upgrade --pre ".[all,test]"
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip --no-cache --quiet install --system --upgrade --pre ".[all,test]"
         python -m pip list
 
     - name: List release candidates, alpha, and beta releases
@@ -63,10 +63,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
-        python -m uv pip uninstall --yes scipy
-        python -m uv pip install --system --upgrade --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
+        uv pip uninstall --yes scipy
+        uv pip install --system --upgrade --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
         python -m pip list
 
     - name: Test with pytest
@@ -90,11 +90,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
-        python -m uv pip uninstall --yes iminuit
-        python -m uv pip install --system --upgrade cython
-        python -m uv pip install --system --upgrade git+https://github.com/scikit-hep/iminuit.git
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
+        uv pip uninstall --yes iminuit
+        uv pip install --system --upgrade cython
+        uv pip install --system --upgrade git+https://github.com/scikit-hep/iminuit.git
         python -m pip list
     - name: Test with pytest
       run: |
@@ -117,10 +117,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
-        python -m uv pip uninstall --yes uproot
-        python -m uv pip install --system --upgrade git+https://github.com/scikit-hep/uproot5.git
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
+        uv pip uninstall --yes uproot
+        uv pip install --system --upgrade git+https://github.com/scikit-hep/uproot5.git
         python -m pip list
     - name: Test with pytest
       run: |
@@ -145,12 +145,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
-        python -m uv pip uninstall --yes matplotlib
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
+        uv pip uninstall --yes matplotlib
         # Need to use --extra-index-url as dependencies aren't on scientific-python-nightly-wheels package index.
         # Need to use --pre as dev releases will need priority over stable releases.
-        python -m uv pip install --system \
+        uv pip install --system \
           --upgrade \
           --pre \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
@@ -181,10 +181,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
-        python -m uv pip uninstall --yes pytest
-        python -m uv pip install --system --upgrade git+https://github.com/pytest-dev/pytest.git
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
+        uv pip uninstall --yes pytest
+        uv pip install --system --upgrade git+https://github.com/pytest-dev/pytest.git
         python -m pip list
     - name: Test with pytest
       run: |

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -65,7 +65,7 @@ jobs:
         python -m pip install uv
         uv pip install --system --upgrade pip setuptools wheel
         uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
-        uv pip uninstall --yes scipy
+        uv pip uninstall --system scipy
         uv pip install --system --upgrade --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
         python -m pip list
 
@@ -92,7 +92,7 @@ jobs:
         python -m pip install uv
         uv pip install --system --upgrade pip setuptools wheel
         uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
-        uv pip uninstall --yes iminuit
+        uv pip uninstall --system iminuit
         uv pip install --system --upgrade cython
         uv pip install --system --upgrade git+https://github.com/scikit-hep/iminuit.git
         python -m pip list
@@ -119,7 +119,7 @@ jobs:
         python -m pip install uv
         uv pip install --system --upgrade pip setuptools wheel
         uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
-        uv pip uninstall --yes uproot
+        uv pip uninstall --system uproot
         uv pip install --system --upgrade git+https://github.com/scikit-hep/uproot5.git
         python -m pip list
     - name: Test with pytest
@@ -147,7 +147,7 @@ jobs:
         python -m pip install uv
         uv pip install --system --upgrade pip setuptools wheel
         uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
-        uv pip uninstall --yes matplotlib
+        uv pip uninstall --system matplotlib
         # Need to use --extra-index-url as dependencies aren't on scientific-python-nightly-wheels package index.
         # Need to use --pre as dev releases will need priority over stable releases.
         uv pip install --system \
@@ -183,7 +183,7 @@ jobs:
         python -m pip install uv
         uv pip install --system --upgrade pip setuptools wheel
         uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
-        uv pip uninstall --yes pytest
+        uv pip uninstall --system pytest
         uv pip install --system --upgrade git+https://github.com/pytest-dev/pytest.git
         python -m pip list
     - name: Test with pytest

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -58,15 +58,14 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    # Use nightly SciPy wheels from Anaconda's PyPI
-    # c.f. https://twitter.com/ralfgommers/status/1419917265781334025
     - name: Install dependencies
       run: |
         python -m pip install uv
         uv pip install --system --upgrade pip setuptools wheel
         uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
         uv pip uninstall --system scipy
-        uv pip install --system --upgrade --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
+        # uv wants to upgrade dependencies (numpy) to a dev release too, so don't --upgrade
+        uv pip install --system --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
         python -m pip list
 
     - name: Test with pytest

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache-dir --quiet install --system --upgrade --pre ".[all,test]"
+        python -m uv pip --no-cache --quiet install --system --upgrade --pre ".[all,test]"
         python -m pip list
 
     - name: List release candidates, alpha, and beta releases
@@ -64,7 +64,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache-dir --quiet install --system --upgrade ".[all,test]"
+        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
         python -m uv pip uninstall --yes scipy
         python -m uv pip install --system --upgrade --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
         python -m pip list
@@ -91,7 +91,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache-dir --quiet install --system --upgrade ".[all,test]"
+        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
         python -m uv pip uninstall --yes iminuit
         python -m uv pip install --system --upgrade cython
         python -m uv pip install --system --upgrade git+https://github.com/scikit-hep/iminuit.git
@@ -118,7 +118,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache-dir --quiet install --system --upgrade ".[all,test]"
+        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
         python -m uv pip uninstall --yes uproot
         python -m uv pip install --system --upgrade git+https://github.com/scikit-hep/uproot5.git
         python -m pip list
@@ -146,7 +146,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache-dir --quiet install --system --upgrade ".[all,test]"
+        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
         python -m uv pip uninstall --yes matplotlib
         # Need to use --extra-index-url as dependencies aren't on scientific-python-nightly-wheels package index.
         # Need to use --pre as dev releases will need priority over stable releases.
@@ -182,7 +182,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache-dir --quiet install --system --upgrade ".[all,test]"
+        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
         python -m uv pip uninstall --yes pytest
         python -m uv pip install --system --upgrade git+https://github.com/pytest-dev/pytest.git
         python -m pip list

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m uv pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade --pre ".[all,test]"
         python -m pip list
 
@@ -61,10 +61,10 @@ jobs:
     # c.f. https://twitter.com/ralfgommers/status/1419917265781334025
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m uv pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m pip uninstall --yes scipy
-        python -m pip install --upgrade --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
+        python -m uv pip install --upgrade --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
         python -m pip list
 
     - name: Test with pytest
@@ -87,11 +87,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m uv pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m pip uninstall --yes iminuit
-        python -m pip install --upgrade cython
-        python -m pip install --upgrade git+https://github.com/scikit-hep/iminuit.git
+        python -m uv pip install --upgrade cython
+        python -m uv pip install --upgrade git+https://github.com/scikit-hep/iminuit.git
         python -m pip list
     - name: Test with pytest
       run: |
@@ -113,10 +113,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m uv pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m pip uninstall --yes uproot
-        python -m pip install --upgrade git+https://github.com/scikit-hep/uproot5.git
+        python -m uv pip install --upgrade git+https://github.com/scikit-hep/uproot5.git
         python -m pip list
     - name: Test with pytest
       run: |
@@ -140,12 +140,12 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m uv pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m pip uninstall --yes matplotlib
         # Need to use --extra-index-url as dependencies aren't on scientific-python-nightly-wheels package index.
         # Need to use --pre as dev releases will need priority over stable releases.
-        python -m pip install \
+        python -m uv pip install \
           --upgrade \
           --pre \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
@@ -175,10 +175,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m uv pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m pip uninstall --yes pytest
-        python -m pip install --upgrade git+https://github.com/pytest-dev/pytest.git
+        python -m uv pip install --upgrade git+https://github.com/pytest-dev/pytest.git
         python -m pip list
     - name: Test with pytest
       run: |

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache --quiet install --system --upgrade --pre "pyhf[all,test] @ ."
+        python -m uv pip --no-cache --quiet install --system --upgrade --pre ".[all,test]"
         python -m pip list
 
     - name: List release candidates, alpha, and beta releases
@@ -64,7 +64,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache --quiet install --system --upgrade "pyhf[all,test] @ ."
+        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
         python -m uv pip uninstall --yes scipy
         python -m uv pip install --system --upgrade --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
         python -m pip list
@@ -91,7 +91,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache --quiet install --system --upgrade "pyhf[all,test] @ ."
+        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
         python -m uv pip uninstall --yes iminuit
         python -m uv pip install --system --upgrade cython
         python -m uv pip install --system --upgrade git+https://github.com/scikit-hep/iminuit.git
@@ -118,7 +118,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache --quiet install --system --upgrade "pyhf[all,test] @ ."
+        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
         python -m uv pip uninstall --yes uproot
         python -m uv pip install --system --upgrade git+https://github.com/scikit-hep/uproot5.git
         python -m pip list
@@ -146,7 +146,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache --quiet install --system --upgrade "pyhf[all,test] @ ."
+        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
         python -m uv pip uninstall --yes matplotlib
         # Need to use --extra-index-url as dependencies aren't on scientific-python-nightly-wheels package index.
         # Need to use --pre as dev releases will need priority over stable releases.
@@ -182,7 +182,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache --quiet install --system --upgrade "pyhf[all,test] @ ."
+        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
         python -m uv pip uninstall --yes pytest
         python -m uv pip install --system --upgrade git+https://github.com/pytest-dev/pytest.git
         python -m pip list

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache --quiet install --system --upgrade --pre ".[all,test]"
+        python -m uv pip --no-cache --quiet install --system --upgrade --pre "pyhf[all,test] @ ."
         python -m pip list
 
     - name: List release candidates, alpha, and beta releases
@@ -64,7 +64,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
+        python -m uv pip --no-cache --quiet install --system --upgrade "pyhf[all,test] @ ."
         python -m uv pip uninstall --yes scipy
         python -m uv pip install --system --upgrade --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
         python -m pip list
@@ -91,7 +91,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
+        python -m uv pip --no-cache --quiet install --system --upgrade "pyhf[all,test] @ ."
         python -m uv pip uninstall --yes iminuit
         python -m uv pip install --system --upgrade cython
         python -m uv pip install --system --upgrade git+https://github.com/scikit-hep/iminuit.git
@@ -118,7 +118,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
+        python -m uv pip --no-cache --quiet install --system --upgrade "pyhf[all,test] @ ."
         python -m uv pip uninstall --yes uproot
         python -m uv pip install --system --upgrade git+https://github.com/scikit-hep/uproot5.git
         python -m pip list
@@ -146,7 +146,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
+        python -m uv pip --no-cache --quiet install --system --upgrade "pyhf[all,test] @ ."
         python -m uv pip uninstall --yes matplotlib
         # Need to use --extra-index-url as dependencies aren't on scientific-python-nightly-wheels package index.
         # Need to use --pre as dev releases will need priority over stable releases.
@@ -182,7 +182,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
+        python -m uv pip --no-cache --quiet install --system --upgrade "pyhf[all,test] @ ."
         python -m uv pip uninstall --yes pytest
         python -m uv pip install --system --upgrade git+https://github.com/pytest-dev/pytest.git
         python -m pip list

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -89,6 +89,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        python -m pip install uv
         python -m uv pip install --upgrade pip setuptools wheel
         python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m uv pip uninstall --yes iminuit
@@ -115,6 +116,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        python -m pip install uv
         python -m uv pip install --upgrade pip setuptools wheel
         python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m uv pip uninstall --yes uproot
@@ -142,6 +144,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        python -m pip install uv
         python -m uv pip install --upgrade pip setuptools wheel
         python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m uv pip uninstall --yes matplotlib
@@ -177,6 +180,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        python -m pip install uv
         python -m uv pip install --upgrade pip setuptools wheel
         python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m uv pip uninstall --yes pytest

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -30,8 +30,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --upgrade pip setuptools wheel
-        python -m uv pip --no-cache-dir --quiet install --upgrade --pre ".[all,test]"
+        python -m uv pip install --system --upgrade pip setuptools wheel
+        python -m uv pip --no-cache-dir --quiet install --system --upgrade --pre ".[all,test]"
         python -m pip list
 
     - name: List release candidates, alpha, and beta releases
@@ -63,10 +63,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --upgrade pip setuptools wheel
-        python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
+        python -m uv pip install --system --upgrade pip setuptools wheel
+        python -m uv pip --no-cache-dir --quiet install --system --upgrade ".[all,test]"
         python -m uv pip uninstall --yes scipy
-        python -m uv pip install --upgrade --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
+        python -m uv pip install --system --upgrade --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
         python -m pip list
 
     - name: Test with pytest
@@ -90,11 +90,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --upgrade pip setuptools wheel
-        python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
+        python -m uv pip install --system --upgrade pip setuptools wheel
+        python -m uv pip --no-cache-dir --quiet install --system --upgrade ".[all,test]"
         python -m uv pip uninstall --yes iminuit
-        python -m uv pip install --upgrade cython
-        python -m uv pip install --upgrade git+https://github.com/scikit-hep/iminuit.git
+        python -m uv pip install --system --upgrade cython
+        python -m uv pip install --system --upgrade git+https://github.com/scikit-hep/iminuit.git
         python -m pip list
     - name: Test with pytest
       run: |
@@ -117,10 +117,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --upgrade pip setuptools wheel
-        python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
+        python -m uv pip install --system --upgrade pip setuptools wheel
+        python -m uv pip --no-cache-dir --quiet install --system --upgrade ".[all,test]"
         python -m uv pip uninstall --yes uproot
-        python -m uv pip install --upgrade git+https://github.com/scikit-hep/uproot5.git
+        python -m uv pip install --system --upgrade git+https://github.com/scikit-hep/uproot5.git
         python -m pip list
     - name: Test with pytest
       run: |
@@ -145,12 +145,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --upgrade pip setuptools wheel
-        python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
+        python -m uv pip install --system --upgrade pip setuptools wheel
+        python -m uv pip --no-cache-dir --quiet install --system --upgrade ".[all,test]"
         python -m uv pip uninstall --yes matplotlib
         # Need to use --extra-index-url as dependencies aren't on scientific-python-nightly-wheels package index.
         # Need to use --pre as dev releases will need priority over stable releases.
-        python -m uv pip install \
+        python -m uv pip install --system \
           --upgrade \
           --pre \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
@@ -181,10 +181,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --upgrade pip setuptools wheel
-        python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
+        python -m uv pip install --system --upgrade pip setuptools wheel
+        python -m uv pip --no-cache-dir --quiet install --system --upgrade ".[all,test]"
         python -m uv pip uninstall --yes pytest
-        python -m uv pip install --upgrade git+https://github.com/pytest-dev/pytest.git
+        python -m uv pip install --system --upgrade git+https://github.com/pytest-dev/pytest.git
         python -m pip list
     - name: Test with pytest
       run: |

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -65,7 +65,7 @@ jobs:
         python -m pip install uv
         python -m uv pip install --upgrade pip setuptools wheel
         python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
-        python -m pip uninstall --yes scipy
+        python -m uv pip uninstall --yes scipy
         python -m uv pip install --upgrade --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
         python -m pip list
 
@@ -91,7 +91,7 @@ jobs:
       run: |
         python -m uv pip install --upgrade pip setuptools wheel
         python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
-        python -m pip uninstall --yes iminuit
+        python -m uv pip uninstall --yes iminuit
         python -m uv pip install --upgrade cython
         python -m uv pip install --upgrade git+https://github.com/scikit-hep/iminuit.git
         python -m pip list
@@ -117,7 +117,7 @@ jobs:
       run: |
         python -m uv pip install --upgrade pip setuptools wheel
         python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
-        python -m pip uninstall --yes uproot
+        python -m uv pip uninstall --yes uproot
         python -m uv pip install --upgrade git+https://github.com/scikit-hep/uproot5.git
         python -m pip list
     - name: Test with pytest
@@ -144,7 +144,7 @@ jobs:
       run: |
         python -m uv pip install --upgrade pip setuptools wheel
         python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
-        python -m pip uninstall --yes matplotlib
+        python -m uv pip uninstall --yes matplotlib
         # Need to use --extra-index-url as dependencies aren't on scientific-python-nightly-wheels package index.
         # Need to use --pre as dev releases will need priority over stable releases.
         python -m uv pip install \
@@ -179,7 +179,7 @@ jobs:
       run: |
         python -m uv pip install --upgrade pip setuptools wheel
         python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
-        python -m pip uninstall --yes pytest
+        python -m uv pip uninstall --yes pytest
         python -m uv pip install --upgrade git+https://github.com/pytest-dev/pytest.git
         python -m pip list
     - name: Test with pytest

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -147,13 +147,14 @@ jobs:
         uv pip install --system --upgrade pip setuptools wheel
         uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
         uv pip uninstall --system matplotlib
-        # Need to use --extra-index-url as dependencies aren't on scientific-python-nightly-wheels package index.
+        # Need to use --extra-index-url as all dependencies aren't on scientific-python-nightly-wheels package index.
         # Need to use --pre as dev releases will need priority over stable releases.
+        # Note that uv and pip differ on --extra-index-url priority
+        # c.f. https://github.com/scientific-python/upload-nightly-action/issues/76
         uv pip install --system \
-          --upgrade \
           --pre \
-          --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
-          --extra-index-url https://pypi.org/simple/ \
+          --index-url https://pypi.org/simple/ \
+          --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
           matplotlib
 
     - name: List installed Python packages

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -29,8 +29,9 @@ jobs:
 
     - name: Install dependencies
       run: |
+        python -m pip install uv
         python -m uv pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade --pre ".[all,test]"
+        python -m uv pip --no-cache-dir --quiet install --upgrade --pre ".[all,test]"
         python -m pip list
 
     - name: List release candidates, alpha, and beta releases
@@ -61,8 +62,9 @@ jobs:
     # c.f. https://twitter.com/ralfgommers/status/1419917265781334025
     - name: Install dependencies
       run: |
+        python -m pip install uv
         python -m uv pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade ".[all,test]"
+        python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m pip uninstall --yes scipy
         python -m uv pip install --upgrade --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy
         python -m pip list
@@ -88,7 +90,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m uv pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade ".[all,test]"
+        python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m pip uninstall --yes iminuit
         python -m uv pip install --upgrade cython
         python -m uv pip install --upgrade git+https://github.com/scikit-hep/iminuit.git
@@ -114,7 +116,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m uv pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade ".[all,test]"
+        python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m pip uninstall --yes uproot
         python -m uv pip install --upgrade git+https://github.com/scikit-hep/uproot5.git
         python -m pip list
@@ -141,7 +143,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m uv pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade ".[all,test]"
+        python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m pip uninstall --yes matplotlib
         # Need to use --extra-index-url as dependencies aren't on scientific-python-nightly-wheels package index.
         # Need to use --pre as dev releases will need priority over stable releases.
@@ -176,7 +178,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m uv pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade ".[all,test]"
+        python -m uv pip --no-cache-dir --quiet install --upgrade ".[all,test]"
         python -m pip uninstall --yes pytest
         python -m uv pip install --upgrade git+https://github.com/pytest-dev/pytest.git
         python -m pip list

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --quiet install --system --upgrade "pyhf[docs,test] @ ."
+        python -m uv pip --quiet install --system --upgrade .[docs,test]
         python -m uv pip install --system yq
         python -m pip list
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,9 +29,9 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --quiet install --system --upgrade ".[docs,test]"
-        python -m uv pip install --system yq
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip --quiet install --system --upgrade ".[docs,test]"
+        uv pip install --system yq
         python -m pip list
 
     - name: Install apt-get dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --quiet install --system --upgrade .[docs,test]
+        python -m uv pip --quiet install --system --upgrade ".[docs,test]"
         python -m uv pip install --system yq
         python -m pip list
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,9 +29,9 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --upgrade pip setuptools wheel
-        python -m uv pip --quiet install --upgrade .[docs,test]
-        python -m uv pip install yq
+        python -m uv pip install --system --upgrade pip setuptools wheel
+        python -m uv pip --quiet install --system --upgrade .[docs,test]
+        python -m uv pip install --system yq
         python -m pip list
 
     - name: Install apt-get dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --quiet install --system --upgrade .[docs,test]
+        python -m uv pip --quiet install --system --upgrade "pyhf[docs,test] @ ."
         python -m uv pip install --system yq
         python -m pip list
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,9 +28,9 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m uv pip install --upgrade pip setuptools wheel
         python -m pip --quiet install --upgrade .[docs,test]
-        python -m pip install yq
+        python -m uv pip install yq
         python -m pip list
 
     - name: Install apt-get dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,8 +28,9 @@ jobs:
 
     - name: Install Python dependencies
       run: |
+        python -m pip install uv
         python -m uv pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install --upgrade .[docs,test]
+        python -m uv pip --quiet install --upgrade .[docs,test]
         python -m uv pip install yq
         python -m pip list
 

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -27,8 +27,8 @@ jobs:
     - name: Install dependencies and force lowest bound
       run: |
         python -m pip install uv
-        python -m uv pip install --upgrade pip setuptools wheel
-        python -m uv pip --no-cache-dir install --constraint tests/constraints.txt ".[all,test]"
+        python -m uv pip install --system --upgrade pip setuptools wheel
+        python -m uv pip --no-cache-dir install --system --constraint tests/constraints.txt ".[all,test]"
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache-dir install --system --constraint tests/constraints.txt ".[all,test]"
+        python -m uv pip --no-cache install --system --constraint tests/constraints.txt ".[all,test]"
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -27,8 +27,8 @@ jobs:
     - name: Install dependencies and force lowest bound
       run: |
         python -m pip install uv
-        python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache install --system --constraint tests/constraints.txt ".[all,test]"
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip --no-cache install --system --constraint tests/constraints.txt ".[all,test]"
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache install --system --constraint tests/constraints.txt ".[all,test]"
+        python -m uv pip --no-cache install --system --constraint tests/constraints.txt "pyhf[all,test] @ ."
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Install dependencies and force lowest bound
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m uv pip install --upgrade pip setuptools wheel
         python -m pip --no-cache-dir install --constraint tests/constraints.txt ".[all,test]"
 
     - name: List installed Python packages

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip --no-cache install --system --constraint tests/constraints.txt "pyhf[all,test] @ ."
+        python -m uv pip --no-cache install --system --constraint tests/constraints.txt ".[all,test]"
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -26,8 +26,9 @@ jobs:
 
     - name: Install dependencies and force lowest bound
       run: |
+        python -m pip install uv
         python -m uv pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir install --constraint tests/constraints.txt ".[all,test]"
+        python -m uv pip --no-cache-dir install --constraint tests/constraints.txt ".[all,test]"
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -29,9 +29,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip setuptools wheel
         # FIXME: c.f. https://github.com/scikit-hep/pyhf/issues/2104
-        python -m uv pip install --system --upgrade ".[all,test]" 'jupyter-client<8.0.0'
+        uv pip install --system --upgrade ".[all,test]" 'jupyter-client<8.0.0'
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -29,9 +29,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        python -m uv pip install --upgrade pip setuptools wheel
+        python -m uv pip install --system --upgrade pip setuptools wheel
         # FIXME: c.f. https://github.com/scikit-hep/pyhf/issues/2104
-        python -m uv pip install --upgrade ".[all,test]" 'jupyter-client<8.0.0'
+        python -m uv pip install --system --upgrade ".[all,test]" 'jupyter-client<8.0.0'
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -31,7 +31,7 @@ jobs:
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
         # FIXME: c.f. https://github.com/scikit-hep/pyhf/issues/2104
-        python -m uv pip install --system --upgrade ".[all,test]" 'jupyter-client<8.0.0'
+        python -m uv pip install --system --upgrade "pyhf[all,test] @ ." 'jupyter-client<8.0.0'
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -28,6 +28,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        python -m pip install uv
         python -m uv pip install --upgrade pip setuptools wheel
         # FIXME: c.f. https://github.com/scikit-hep/pyhf/issues/2104
         python -m uv pip install --upgrade ".[all,test]" 'jupyter-client<8.0.0'

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -28,9 +28,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m uv pip install --upgrade pip setuptools wheel
         # FIXME: c.f. https://github.com/scikit-hep/pyhf/issues/2104
-        python -m pip install --upgrade ".[all,test]" 'jupyter-client<8.0.0'
+        python -m uv pip install --upgrade ".[all,test]" 'jupyter-client<8.0.0'
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -31,7 +31,7 @@ jobs:
         python -m pip install uv
         python -m uv pip install --system --upgrade pip setuptools wheel
         # FIXME: c.f. https://github.com/scikit-hep/pyhf/issues/2104
-        python -m uv pip install --system --upgrade "pyhf[all,test] @ ." 'jupyter-client<8.0.0'
+        python -m uv pip install --system --upgrade ".[all,test]" 'jupyter-client<8.0.0'
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -44,8 +44,8 @@ jobs:
     - name: Install python-build and twine
       run: |
         python -m pip install uv
-        python -m uv pip install --upgrade pip
-        python -m uv pip install build twine
+        python -m uv pip install --system --upgrade pip
+        python -m uv pip install --system build twine
         python -m pip list
 
     - name: Build a sdist and wheel

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -43,6 +43,7 @@ jobs:
 
     - name: Install python-build and twine
       run: |
+        python -m pip install uv
         python -m uv pip install --upgrade pip
         python -m uv pip install build twine
         python -m pip list

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -44,8 +44,8 @@ jobs:
     - name: Install python-build and twine
       run: |
         python -m pip install uv
-        python -m uv pip install --system --upgrade pip
-        python -m uv pip install --system build twine
+        uv pip install --system --upgrade pip
+        uv pip install --system build twine
         python -m pip list
 
     - name: Build a sdist and wheel

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Build a sdist and wheel and check for warnings
       if: github.event_name == 'schedule'
       run: |
-        PYTHONWARNINGS=error,default::DeprecationWarning build --installer uv -m build .
+        PYTHONWARNINGS=error,default::DeprecationWarning python -m build --installer uv .
 
     - name: Verify untagged commits have dev versions
       if: "!startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -51,12 +51,12 @@ jobs:
     - name: Build a sdist and wheel
       if: github.event_name != 'schedule'
       run: |
-        python -m build .
+        python -m build --installer uv .
 
     - name: Build a sdist and wheel and check for warnings
       if: github.event_name == 'schedule'
       run: |
-        PYTHONWARNINGS=error,default::DeprecationWarning python -m build .
+        PYTHONWARNINGS=error,default::DeprecationWarning build --installer uv -m build .
 
     - name: Verify untagged commits have dev versions
       if: "!startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -43,8 +43,8 @@ jobs:
 
     - name: Install python-build and twine
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install build twine
+        python -m uv pip install --upgrade pip
+        python -m uv pip install build twine
         python -m pip list
 
     - name: Build a sdist and wheel

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -37,9 +37,9 @@ jobs:
     - name: Install from PyPI
       run: |
         python -m pip install uv
-        python -m uv pip install --system --upgrade pip setuptools wheel
-        python -m uv pip install --system --pre 'pyhf[backends,xmlio]'
-        python -m uv pip install --system pytest
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --pre 'pyhf[backends,xmlio]'
+        uv pip install --system pytest
         python -m pip list
 
     - name: Canary test public API
@@ -49,6 +49,6 @@ jobs:
       # FIXME: c.f. https://github.com/proycon/codemetapy/issues/24
     - name: Verify requirements in codemeta.json
       run: |
-        python -m uv pip install --system jq "codemetapy>=2.3.0"
+        uv pip install --system jq "codemetapy>=2.3.0"
         codemetapy --inputtype python --no-extras pyhf > codemeta_generated.json
         diff <(jq -S .softwareRequirements codemeta.json) <(jq -S .softwareRequirements codemeta_generated.json)

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -36,9 +36,9 @@ jobs:
 
     - name: Install from PyPI
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --pre 'pyhf[backends,xmlio]'
-        python -m pip install pytest
+        python -m uv pip install --upgrade pip setuptools wheel
+        python -m uv pip install --pre 'pyhf[backends,xmlio]'
+        python -m uv pip install pytest
         python -m pip list
 
     - name: Canary test public API
@@ -48,6 +48,6 @@ jobs:
       # FIXME: c.f. https://github.com/proycon/codemetapy/issues/24
     - name: Verify requirements in codemeta.json
       run: |
-        python -m pip install jq "codemetapy>=2.3.0"
+        python -m uv pip install jq "codemetapy>=2.3.0"
         codemetapy --inputtype python --no-extras pyhf > codemeta_generated.json
         diff <(jq -S .softwareRequirements codemeta.json) <(jq -S .softwareRequirements codemeta_generated.json)

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -37,9 +37,9 @@ jobs:
     - name: Install from PyPI
       run: |
         python -m pip install uv
-        python -m uv pip install --upgrade pip setuptools wheel
-        python -m uv pip install --pre 'pyhf[backends,xmlio]'
-        python -m uv pip install pytest
+        python -m uv pip install --system --upgrade pip setuptools wheel
+        python -m uv pip install --system --pre 'pyhf[backends,xmlio]'
+        python -m uv pip install --system pytest
         python -m pip list
 
     - name: Canary test public API
@@ -49,6 +49,6 @@ jobs:
       # FIXME: c.f. https://github.com/proycon/codemetapy/issues/24
     - name: Verify requirements in codemeta.json
       run: |
-        python -m uv pip install jq "codemetapy>=2.3.0"
+        python -m uv pip install --system jq "codemetapy>=2.3.0"
         codemetapy --inputtype python --no-extras pyhf > codemeta_generated.json
         diff <(jq -S .softwareRequirements codemeta.json) <(jq -S .softwareRequirements codemeta_generated.json)

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -36,6 +36,7 @@ jobs:
 
     - name: Install from PyPI
       run: |
+        python -m pip install uv
         python -m uv pip install --upgrade pip setuptools wheel
         python -m uv pip install --pre 'pyhf[backends,xmlio]'
         python -m uv pip install pytest

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,7 +21,7 @@ sphinx:
 # If using Sphinx, optionally build your docs in additional formats such as PDF and ePub
 formats: all
 
-# python -m pip install .[docs]
+# python -m pip install '.[docs]'
 python:
   install:
     - method: pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ develop = [
     "pre-commit",
     "nox",
     "codemetapy>=2.3.0",
+    "uv>=0.1.2"
 ]
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ develop = [
     "pre-commit",
     "nox",
     "codemetapy>=2.3.0",
-    "uv>=0.1.25"
+    "uv>=0.1.39"
 ]
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ develop = [
     "pre-commit",
     "nox",
     "codemetapy>=2.3.0",
-    "uv>=0.1.2"
+    "uv>=0.1.12"
 ]
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ develop = [
     "pre-commit",
     "nox",
     "codemetapy>=2.3.0",
-    "uv>=0.1.12"
+    "uv>=0.1.25"
 ]
 
 [tool.hatch.version]


### PR DESCRIPTION
# Description

Use `uv` to try to speed up the installs of all the Python dependencies.

Fall back to using `pip` for Python 3.8 until https://github.com/astral-sh/uv/issues/2062 is resolved.

Apply subtle changes to install commands in .github/workflows/dependencies-head.yml.
* `uv pip install --upgrade` will try to upgrade all dependencies of the target package as well, which for the dependencies-head workflow isn't the goal. So remove the `--upgrade` from calls that also install from the scientific-python-nightly-wheels package index when testing only particular packages.
* `up pip` and `pip` have different behavior with regards to `--extra-index-url`, as `uv pip` gives `--extra-index-url` priority over `--index-url`, where `pip` does not give priority to either. Use this with `uv pip` to give priority to the scientific-python-nightly-wheels package index.
   - c.f. https://github.com/scientific-python/upload-nightly-action/issues/76

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use 'uv pip' for all calls to 'pip install' and 'pip uninstall' in
  CI workflows.
   - c.f. https://github.com/astral-sh/uv/
   - Still use pip for Python 3.8 until https://github.com/astral-sh/uv/issues/2062
     is resolved.
* Apply subtle changes to install commands in .github/workflows/dependencies-head.yml.
   - 'uv pip install --upgrade' will try to upgrade all dependencies of the target
     package as well, which for the dependencies-head workflow isn't the goal. So
     remove the '--upgrade' from calls that also install from the
     scientific-python-nightly-wheels package index when testing only particular packages.
   - 'up pip' and 'pip' have different behavior with regards to --extra-index-url, as
     'uv pip' gives --extra-index-url priority over --index-url, where 'pip' does
     not give priority to either. Use this with 'uv pip' to give priority to the
     scientific-python-nightly-wheels package index.
* Add uv to the 'develop' extras.
```