### PR TITLE
ci: Add Apple silicon macOS to CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
         include:
           - os: macos-latest
             python-version: '3.11'
+          # Apple silicon runner
+          - os: macos-latest-xlarge
+            python-version: '3.11'
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           - os: macos-latest
             python-version: '3.11'
           # Apple silicon runner
-          - os: macos-latest-xlarge
+          - os: macos-14
             python-version: '3.11'
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,11 +95,12 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Test docstring examples with doctest
-      if: matrix.python-version == '3.11'
+      # TODO: Don't currently try to match amd64 and arm64 floating point for docs, but will in the future.
+      if: matrix.python-version == '3.11' && matrix.os != 'macos-14'
       run: coverage run --data-file=.coverage-doctest --module pytest src/ README.rst
 
     - name: Coverage report for doctest only
-      if: matrix.python-version == '3.11'
+      if: matrix.python-version == '3.11' && matrix.os != 'macos-14'
       run: |
         coverage report --data-file=.coverage-doctest
         coverage xml --data-file=.coverage-doctest -o doctest-coverage.xml

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -84,6 +84,7 @@ def test_asymptotic_calculator_has_fitted_pars(test_stat):
         assert pytest.approx([1.0, 1.0], rel=rtol) == pyhf.tensorlib.tolist(
             fitted_pars.free_fit_to_data
         )
+        # lower tolerance for amd64 and arm64 to agree
         assert pytest.approx(
-            [7.6470499e-05, 1.4997178], rel=rtol
+            [7.6470499e-05, 1.4997178], rel=1e-3
         ) == pyhf.tensorlib.tolist(fitted_pars.free_fit_to_asimov)


### PR DESCRIPTION
# Description

* Add Apple M1 runner to tests using 'macos-14' for the 'runs-on' key.
   - c.f. https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
* Lower the tolerance for tests/test_calculator.py to reach agreement between amd64 and arm64.
* Skip doctest evaluation for arm64. While it is possible to go through and revise the precision in the docs examples to be lower so that the [`# doctest: +NUMBER` `doctest` option](https://docs.pytest.org/en/7.1.x/how-to/doctest.html#using-doctest-options) could be used, it isn't necesssarily worth it at the moment to add this.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add Apple M1 runner to tests using 'macos-14' for the 'runs-on' key.
   - c.f. https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
* Lower the tolerance for tests/test_calculator.py to reach agreement
  between amd64 and arm64.
* Skip doctest evaluation for arm64.
```