### PR TITLE
build: Disallow TensorFlow v2.16.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,9 +67,11 @@ Homepage = "https://github.com/scikit-hep/pyhf"
 
 [project.optional-dependencies]
 shellcomplete = ["click_completion"]
+# TODO: Use 'tensorflow' for all platform_machine for tensorflow v2.16.x+
+# NOTE: macos x86 support is deprecated from tensorflow v2.17.0 onwards.
 tensorflow = [
-    "tensorflow>=2.7.0; platform_machine != 'arm64'",  # c.f. PR #1962
-    "tensorflow-macos>=2.7.0; platform_machine == 'arm64' and platform_system == 'Darwin'",  # c.f. PR #2119
+    "tensorflow>=2.7.0,!=2.16.1; platform_machine != 'arm64'",  # c.f. PR #1962
+    "tensorflow-macos>=2.7.0,!=2.16.1; platform_machine == 'arm64' and platform_system == 'Darwin'",  # c.f. PR #2119
     "tensorflow-probability>=0.11.0",  # c.f. PR #1657
 ]
 torch = ["torch>=1.10.0"]  # c.f. PR #1657

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,8 @@ shellcomplete = ["click_completion"]
 # TODO: Use 'tensorflow' for all platform_machine for tensorflow v2.16.x+
 # NOTE: macos x86 support is deprecated from tensorflow v2.17.0 onwards.
 tensorflow = [
-    "tensorflow>=2.7.0,!=2.16.1; platform_machine != 'arm64'",  # c.f. PR #1962
-    "tensorflow-macos>=2.7.0,!=2.16.1; platform_machine == 'arm64' and platform_system == 'Darwin'",  # c.f. PR #2119
+    "tensorflow>=2.7.0,!=2.16.1; platform_machine != 'arm64'",  # c.f. PR #1962, #2448
+    "tensorflow-macos>=2.7.0,!=2.16.1; platform_machine == 'arm64' and platform_system == 'Darwin'",  # c.f. PR #2119, #2448
     "tensorflow-probability>=0.11.0",  # c.f. PR #1657
 ]
 torch = ["torch>=1.10.0"]  # c.f. PR #1657


### PR DESCRIPTION
# Description

* [`tensorflow` `v2.16.1`](https://github.com/tensorflow/tensorflow/releases/tag/v2.16.1) breaks `tensorflow-probability` at import time with the Keras `v3.0` API breaking change. Until Keras `v3.0` is adopted in `tensorflow-probability`, `tensorflow` `v2.16.1+` can't be used.
   - c.f. https://github.com/tensorflow/probability/issues/1795
* Note that Apple silicon machines should revert to installing 'tensorflow' instead of 'tensorflow-macos' for `tensorflow v2.16.1+`.
* Note that macos x86 builds of tensorflow will be deprecated and no longer released from `tensorflow v2.17.0+`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* tensorflow v2.16.1 breaks tensorflow-probability at import time with
  the Keras v3.0 API breaking change. Until Keras v3.0 is adopted in
  tensorflow-probability, tensorflow v2.16.1+ can't be used.
   - c.f. https://github.com/tensorflow/probability/issues/1795
* Note that Apple silicon machines should revert to installing
  'tensorflow' instead of 'tensorflow-macos' for tensorflow v2.16.1+.
* Note that macos x86 builds of tensorflow will be deprecated and no
  longer released from tensorflow v2.17.0+.
```