### PR TITLE
feat: Use Python 3.12+ tarfile data extraction filter

### DIFF
--- a/src/pyhf/contrib/utils.py
+++ b/src/pyhf/contrib/utils.py
@@ -91,7 +91,12 @@ try:
                     with tarfile.open(
                         mode="r:*", fileobj=BytesIO(response.content)
                     ) as archive:
-                        archive.extractall(output_directory)
+                        # TODO: Simplify after pyhf is Python 3.12+ only
+                        # c.f. https://docs.python.org/3.12/library/tarfile.html#extraction-filters
+                        if hasattr(tarfile, "data_filter"):
+                            archive.extractall(output_directory, filter="data")
+                        else:
+                            archive.extractall(output_directory)
                 except tarfile.ReadError:
                     if not zipfile.is_zipfile(BytesIO(response.content)):
                         raise exceptions.InvalidArchive(


### PR DESCRIPTION
# Description

Resolves #2454

In Python 3.12 extraction filters are added and will become default in Python 3.14. To start using them for when Python 3.12 support is added, and to guard against a Python 3.14 DeprecationWarning, use the data extraction filter for extracting tarfiles in `pyhf.contrib.utils.download`.
   - c.f. https://docs.python.org/3.12/library/tarfile.html#extraction-filters

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* In Python 3.12 extraction filters are added and will become default in
  Python 3.14. To start using them for when Python 3.12 support is added, and
  to guard against a Python 3.14 DeprecationWarning, use the data extraction
  filter for extracting tarfiles in pyhf.contrib.utils.download.
   - c.f. https://docs.python.org/3.12/library/tarfile.html#extraction-filters
```