### PR TITLE
fix: Use str object for jupyterlite-sphinx jupyterlite_dir config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -531,5 +531,5 @@ linkcheck_ignore = [
 linkcheck_retries = 50
 
 # JupyterLite configuration
-# Use Path as jupyterlite-sphinx expects PosixPath
-jupyterlite_dir = Path("lite")
+# jupyterlite-sphinx v0.13.0+ expects str
+jupyterlite_dir = str(Path("lite"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ docs = [
     "ipywidgets",
     "sphinx-issues",
     "sphinx-copybutton>=0.3.2,!=0.5.1",
-    "jupyterlite-sphinx>=0.13.1",
+    "jupyterlite-sphinx>=0.13.1",  # c.f. https://github.com/scikit-hep/pyhf/pull/2458
     "jupyterlite-pyodide-kernel>=0.0.7",
     "jupytext>=1.14.0",
     "ipython!=8.7.0",  # c.f. https://github.com/scikit-hep/pyhf/pull/2068

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ docs = [
     "ipywidgets",
     "sphinx-issues",
     "sphinx-copybutton>=0.3.2,!=0.5.1",
-    "jupyterlite-sphinx>=0.8.0",
+    "jupyterlite-sphinx>=0.13.1",
     "jupyterlite-pyodide-kernel>=0.0.7",
     "jupytext>=1.14.0",
     "ipython!=8.7.0",  # c.f. https://github.com/scikit-hep/pyhf/pull/2068


### PR DESCRIPTION
# Description

* To avoid warning

```
WARNING: The config value `jupyterlite_dir` has type `PosixPath`, defaults to `str`.
```

use a `str` for the `jupyterlite-sphinx` `v0.13.0+` `jupyterlite_dir` config option.
* Update `jupyterlite-sphinx` lower bound to `v0.13.1` in `'docs'` extra.
* Amends PR https://github.com/scikit-hep/pyhf/pull/2300

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* To avoid warning

WARNING: The config value `jupyterlite_dir` has type `PosixPath`, defaults to `str`.

 use a str for the jupyterlite-sphinx v0.13.0+ jupyterlite_dir config
 option.
* Update jupyterlite-sphinx lower bound to v0.13.1 in 'docs' extra.
* Amends PR https://github.com/scikit-hep/pyhf/pull/2300
```