### PR TITLE
fix: Test xml.etree.ElementTree.Element truth value by 'is not None'

### DIFF
--- a/src/pyhf/writexml.py
+++ b/src/pyhf/writexml.py
@@ -56,7 +56,7 @@ def _export_root_histogram(hist_name, data):
 # https://stackoverflow.com/a/4590052
 def indent(elem, level=0):
     i = "\n" + level * "  "
-    if elem:
+    if elem is not None:
         if not elem.text or not elem.text.strip():
             elem.text = i + "  "
         if not elem.tail or not elem.tail.strip():

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -447,7 +447,7 @@ def test_integer_data(datadir, mocker):
     mocker.patch("pyhf.writexml._ROOT_DATA_FILE")
 
     channel = pyhf.writexml.build_channel(spec, channel_spec, {})
-    assert channel
+    assert channel is not None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Resolves #2453

In Python 3.14 testing the truth value of an [`xml.etree.ElementTree.Element`](https://docs.python.org/3.12/library/xml.etree.elementtree.html#element-objects) is deprecated and will raise an exception. As of Python 3.12 this behavior will raise a `DeprecationWarning`:

```
DeprecationWarning: Testing an element's truth value will raise an exception in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
```

To avoid this, determine the truth element by using the `elem is not None` method.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

~~~
* In Python 3.14 testing the truth value of an xml.etree.ElementTree.Element is
  deprecated and will raise an exception. As of Python 3.12 this behavior will
  raise a DeprecationWarning:

  ```
  DeprecationWarning: Testing an element's truth value will raise an exception
  in future versions.  Use specific 'len(elem)' or 'elem is not None' test
  instead.
  ```

  To avoid this, determine the truth element by using the 'elem is not None'
  method.
   - c.f. https://docs.python.org/3.12/library/xml.etree.elementtree.html#element-objects
~~~