### PR TITLE
chore: Update services and docs to Python 3.12 as default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,8 +64,8 @@ repos:
           ['numpy', 'types-tqdm', 'click', 'types-jsonpatch', 'types-pyyaml', 'types-jsonschema', 'importlib_metadata', 'packaging']
         args: ["--python-version=3.8"]
       - <<: *mypy
-        name: mypy with Python 3.11
-        args: ["--python-version=3.11"]
+        name: mypy with Python 3.12
+        args: ["--python-version=3.12"]
 
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.2.6

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
   apt_packages:
     - curl
     - jq

--- a/binder/runtime.txt
+++ b/binder/runtime.txt
@@ -1,1 +1,1 @@
-python-3.11
+python-3.12

--- a/codemeta.json
+++ b/codemeta.json
@@ -50,6 +50,7 @@
     "runtimePlatform": [
         "Python 3",
         "Python 3 Only",
+        "Python 3.12",
         "Python 3.11",
         "Python 3.10",
         "Python 3.8",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=python:3.11-slim-bullseye
+ARG BASE_IMAGE=python:3.12-slim-bullseye
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE} as base
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -97,7 +97,7 @@ contrib module, or notebooks, and so instead to test the core codebase a develop
 
 .. code-block:: console
 
-    nox --session tests --python 3.11
+    nox --session tests --python 3.12
 
 Contrib module matplotlib image tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -107,7 +107,7 @@ To run the visualization tests for the ``contrib`` module with the ``pytest-mpl`
 
 .. code-block:: console
 
-    nox --session tests --python 3.11 -- contrib
+    nox --session tests --python 3.12 -- contrib
 
 If the image files need to be regenerated, run the tests with the
 ``--mpl-generate-path=tests/contrib/baseline`` option or just run
@@ -141,7 +141,7 @@ or pass ``coverage`` as a positional argument to the ``nox`` ``tests`` session
 
 .. code-block:: console
 
-    nox --session tests --python 3.11 -- coverage
+    nox --session tests --python 3.12 -- coverage
 
 Coverage Report
 ^^^^^^^^^^^^^^^

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 import nox
 
-ALL_PYTHONS = ["3.8", "3.9", "3.10", "3.11"]
+ALL_PYTHONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
 # Default sessions to run if no session handles are passed
-nox.options.sessions = ["lint", "tests-3.11"]
+nox.options.sessions = ["lint", "tests-3.12"]
 
 
 DIR = Path(__file__).parent.resolve()
@@ -30,10 +30,10 @@ def tests(session):
 
     Examples:
 
-        $ nox --session tests --python 3.11
-        $ nox --session tests --python 3.11 -- contrib  # run the contrib module tests
-        $ nox --session tests --python 3.11 -- tests/test_tensor.py  # run specific tests
-        $ nox --session tests --python 3.11 -- coverage  # run with coverage but slower
+        $ nox --session tests --python 3.12
+        $ nox --session tests --python 3.12 -- contrib  # run the contrib module tests
+        $ nox --session tests --python 3.12 -- tests/test_tensor.py  # run specific tests
+        $ nox --session tests --python 3.12 -- coverage  # run with coverage but slower
     """
     session.install("--upgrade", "--editable", ".[all,test]")
     session.install("--upgrade", "pytest")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,7 +244,7 @@ exclude_also = [
 
 [tool.mypy]
 files = "src"
-python_version = "3.11"
+python_version = "3.12"
 warn_unused_configs = true
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]


### PR DESCRIPTION
# Description

* Update to using Python 3.12 in linting and validation tools.
* Update Binder runtime Python to Python 3.12.
* Update Dockerfile base image to python:3.12-slim-bullseye.
* Update the docs to advocate using Python 3.12 for development.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update to using Python 3.12 in linting and validation tools.
* Update Binder runtime Python to Python 3.12.
* Update Dockerfile base image to python:3.12-slim-bullseye.
* Update the docs to advocate using Python 3.12 for development.
```