### PR TITLE
ci: Use 'macos-13' runs-on to continue using x86 based macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         include:
+          # macos-latest runners are Apple silicon
           - os: macos-13
             python-version: '3.12'
           # Apple silicon runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         include:
-          - os: macos-latest
+          - os: macos-13
             python-version: '3.12'
           # Apple silicon runner
           - os: macos-14

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
         python-version: ['3.12']
 
     steps:

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        # macos-latest runners are Apple silicon
         os: [ubuntu-latest, macos-13]
         python-version: ['3.12']
 

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         include:
-          - os: macos-latest
+          - os: macos-13
             python-version: '3.12'
 
     steps:

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -20,6 +20,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         include:
+          # macos-latest runners are Apple silicon
           - os: macos-13
             python-version: '3.12'
 


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

```
* The 'macos-latest' `runs-on` option has been changed to
  be the Apple silicon based 'macos-14' runners. To continue
  to use the x86 based macOS runners use 'macos-13' instead.
```