### PR TITLE
build: Update scipy lower bound to v1.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "jsonpatch>=1.15",
     "jsonschema>=4.15.0",  # for utils
     "pyyaml>=5.1",  # for parsing CLI equal-delimited options
-    "scipy>=1.5.1",  # requires numpy, which is required by pyhf and tensorflow
+    "scipy>=1.5.2",  # requires numpy, which is required by pyhf and tensorflow
     "tqdm>=4.56.0",  # for readxml
     "numpy",  # compatible versions controlled through scipy
 ]

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,5 +1,5 @@
 # core
-scipy==1.5.1  # c.f. PR #2081
+scipy==1.5.2  # c.f. PR #2469
 click==8.0.0  # c.f. PR #1958, #1909
 tqdm==4.56.0
 jsonschema==4.15.0  # c.f. PR #1979


### PR DESCRIPTION
# Description

* Update the lower bounds on `scipy` to `v1.5.2` to ensure that the minimum supported dependencies workflow passes as it has started to fail consistently for `scipy` `v1.5.1`.
* Update `scipy` to `v1.5.2` in `tests/constraints.txt` to enforce the lower bound for the minimum supported dependencies tests.

Amends PR [#2081](https://github.com/scikit-hep/pyhf/pull/2081)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update the lower bounds on scipy to v1.5.2 to ensure that the minimum
  supported dependencies workflow passes as it has started to fail
  consistently for scipy v1.5.1.
* Update scipy to v1.5.2 in tests/constraints.txt to enforce the lower
  bound for the minimum supported dependencies tests.
```