### PR TITLE
ci: Use Apple silicon for the default macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,10 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         include:
-          # macos-latest runners are Apple silicon
-          - os: macos-13
+          - os: macos-latest
             python-version: '3.12'
-          # Apple silicon runner
-          - os: macos-14
+          # Intel runner
+          - os: macos-13
             python-version: '3.12'
 
     steps:
@@ -97,11 +96,11 @@ jobs:
 
     - name: Test docstring examples with doctest
       # TODO: Don't currently try to match amd64 and arm64 floating point for docs, but will in the future.
-      if: matrix.python-version == '3.12' && matrix.os != 'macos-14'
+      if: matrix.python-version == '3.12' && matrix.os != 'macos-latest'
       run: coverage run --data-file=.coverage-doctest --module pytest src/ README.rst
 
     - name: Coverage report for doctest only
-      if: matrix.python-version == '3.12' && matrix.os != 'macos-14'
+      if: matrix.python-version == '3.12' && matrix.os != 'macos-latest'
       run: |
         coverage report --data-file=.coverage-doctest
         coverage xml --data-file=.coverage-doctest -o doctest-coverage.xml

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -16,8 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-latest runners are Apple silicon
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-latest, macos-13]
         python-version: ['3.12']
 
     steps:

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -20,7 +20,9 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         include:
-          # macos-latest runners are Apple silicon
+          - os: macos-latest
+            python-version: '3.12'
+          # Intel runner
           - os: macos-13
             python-version: '3.12'
 
@@ -35,7 +37,7 @@ jobs:
     - name: Install from PyPI
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --pre pyhf[backends,xmlio]
+        python -m pip install --pre 'pyhf[backends,xmlio]'
         python -m pip install pytest
         python -m pip list
 


### PR DESCRIPTION
# Description

* Use the 'macos-latest' runs-on option which now defaults to 'macos-14' which are Apple silicon runners.
   - c.f. https://github.com/actions/runner-images/blob/e63a194563cb0bb3bc1493144fe0ef6804249b43/images/macos/macos-14-arm64-Readme.md
* Keep a 'macos-13' runners to continue to test Intel based macOS for the latest Python version.
   - c.f. https://github.com/actions/runner-images/blob/e63a194563cb0bb3bc1493144fe0ef6804249b43/images/macos/macos-13-Readme.md

Updates PR #2468 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use the 'macos-latest' runs-on option which now defaults to 'macos-14' which are
  Apple silicon runners.
   - c.f. https://github.com/actions/runner-images/blob/e63a194563cb0bb3bc1493144fe0ef6804249b43/images/macos/macos-14-arm64-Readme.md
* Keep a 'macos-13' runners to continue to test Intel based macOS for the
  latest Python version.
   - c.f. https://github.com/actions/runner-images/blob/e63a194563cb0bb3bc1493144fe0ef6804249b43/images/macos/macos-13-Readme.md
* Updates PR https://github.com/scikit-hep/pyhf/pull/2468
```