### PR TITLE
build: Use lower bounds for all dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,8 +107,8 @@ test = [
     "pytest-mpl",
     "ipympl>=0.3.0",
     "pydocstyle",
-    "papermill~=2.5.0",
-    "scrapbook~=0.5.0",
+    "papermill>=2.5.0",
+    "scrapbook>=0.5.0",
     "jupyter",
     "graphviz",
     "pytest-socket>=0.2.0",  # c.f. PR #1917
@@ -116,7 +116,7 @@ test = [
 docs = [
     "pyhf[xmlio,contrib]",
     "sphinx>=7.0.0",  # c.f. https://github.com/scikit-hep/pyhf/pull/2271
-    "sphinxcontrib-bibtex~=2.1",
+    "sphinxcontrib-bibtex>=2.1",
     "sphinx-click",
     "sphinx-rtd-theme>=1.3.0",  # c.f. https://github.com/scikit-hep/pyhf/pull/2271
     "nbsphinx!=0.8.8",  # c.f. https://github.com/spatialaudio/nbsphinx/issues/620


### PR DESCRIPTION
# Description

* Loosen the install requirements for papermill, scrapbook, and sphinxcontrib-bibtex to use lower bounds instead of compatible release constraints.
* Required for PR https://github.com/scikit-hep/pyhf/pull/2444

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Loosen the install requirements for papermill, scrapbook, and
  sphinxcontrib-bibtex to use lower bounds instead of
  compatible release constraints.
* Required for PR https://github.com/scikit-hep/pyhf/pull/2444
```