### PR TITLE
ci: Add GitHub artifact attestations to package distribution

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,10 +1,10 @@
 name: publish distributions
 on:
   push:
-    # branches:
-    # - main
-    # tags:
-    # - v*
+    branches:
+    - main
+    tags:
+    - v*
   pull_request:
     branches:
     - main
@@ -104,11 +104,11 @@ jobs:
       run: python -m zipfile --list dist/pyhf-*.whl
 
     - name: Generate artifact attestation for sdist and wheel
-      # # If publishing to TestPyPI or PyPI
-      # if: >-
-      #   (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
-      #   || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
-      #   || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf')
+      # If publishing to TestPyPI or PyPI
+      if: >-
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
+        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
+        || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf')
       uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
       with:
         subject-path: "dist/pyhf-*"
@@ -144,20 +144,20 @@ jobs:
 
     - name: Verify sdist artifact attestation
       # If publishing to TestPyPI or PyPI
-      # if: >-
-      #   (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
-      #   || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
-      #   || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf')
+      if: >-
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
+        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
+        || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf')
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: gh attestation verify dist/pyhf-*.tar.gz --repo ${{ github.repository }}
 
     - name: Verify wheel artifact attestation
       # If publishing to TestPyPI or PyPI
-      # if: >-
-      #   (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
-      #   || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
-      #   || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf')
+      if: >-
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
+        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
+        || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf')
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: gh attestation verify dist/pyhf-*.whl --repo ${{ github.repository }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -31,6 +31,11 @@ jobs:
   build:
     name: Build Python distribution
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -98,6 +103,16 @@ jobs:
     - name: List contents of wheel
       run: python -m zipfile --list dist/pyhf-*.whl
 
+    - name: Generate artifact attestation for sdist and wheel
+      # If publishing to TestPyPI or PyPI
+      if: >-
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
+        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
+        || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf')
+      uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
+      with:
+        subject-path: "dist/pyhf-*"
+
     - name: Upload distribution artifact
       uses: actions/upload-artifact@v4
       with:
@@ -126,6 +141,26 @@ jobs:
 
     - name: List all files
       run: ls -lh dist
+
+    - name: Verify sdist artifact attestation
+      # If publishing to TestPyPI or PyPI
+      if: >-
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
+        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
+        || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf')
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh attestation verify dist/pyhf-*.tar.gz --repo ${{ github.repository }}
+
+    - name: Verify wheel artifact attestation
+      # If publishing to TestPyPI or PyPI
+      if: >-
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
+        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
+        || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf')
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh attestation verify dist/pyhf-*.whl --repo ${{ github.repository }}
 
     - name: Publish distribution 📦 to Test PyPI
       # Publish to TestPyPI on tag events of if manually triggered

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -113,20 +113,6 @@ jobs:
       with:
         subject-path: "dist/pyhf-*"
 
-    # DEBUG
-    - name: Verify sdist artifact attestation
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        gh --version
-        gh attestation verify dist/pyhf-*.tar.gz --repo ${{ github.repository }}
-
-    - name: Verify wheel artifact attestation
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        gh attestation verify dist/pyhf-*.whl --repo ${{ github.repository }}
-
     - name: Upload distribution artifact
       uses: actions/upload-artifact@v4
       with:
@@ -158,20 +144,20 @@ jobs:
 
     - name: Verify sdist artifact attestation
       # If publishing to TestPyPI or PyPI
-      if: >-
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
-        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
-        || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf')
+      # if: >-
+      #   (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
+      #   || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
+      #   || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf')
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: gh attestation verify dist/pyhf-*.tar.gz --repo ${{ github.repository }}
 
     - name: Verify wheel artifact attestation
       # If publishing to TestPyPI or PyPI
-      if: >-
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
-        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
-        || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf')
+      # if: >-
+      #   (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
+      #   || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
+      #   || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf')
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: gh attestation verify dist/pyhf-*.whl --repo ${{ github.repository }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,10 +1,10 @@
 name: publish distributions
 on:
   push:
-    branches:
-    - main
-    tags:
-    - v*
+    # branches:
+    # - main
+    # tags:
+    # - v*
   pull_request:
     branches:
     - main
@@ -104,14 +104,28 @@ jobs:
       run: python -m zipfile --list dist/pyhf-*.whl
 
     - name: Generate artifact attestation for sdist and wheel
-      # If publishing to TestPyPI or PyPI
-      if: >-
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
-        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
-        || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf')
+      # # If publishing to TestPyPI or PyPI
+      # if: >-
+      #   (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
+      #   || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
+      #   || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf')
       uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
       with:
         subject-path: "dist/pyhf-*"
+
+    # DEBUG
+    - name: Verify sdist artifact attestation
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh --version
+        gh attestation verify dist/pyhf-*.tar.gz --repo ${{ github.repository }}
+
+    - name: Verify wheel artifact attestation
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh attestation verify dist/pyhf-*.whl --repo ${{ github.repository }}
 
     - name: Upload distribution artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Description

* Add generation of GitHub artifact attestations to built sdist and wheel before upload.
  c.f.:
   - https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/
   - https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
* Add verification of artifact attestation before publishing to PyPI using the `gh attestation verify` CLI API, added in `v2.49.0`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add generation of GitHub artifact attestations to built sdist and wheel
  before upload.
  c.f.:
   - https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/
   - https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
* Add verification of artifact attestation before publishing to PyPI
  using the 'gh attestation verify' CLI API, added in v2.49.0.
   - c.f. https://github.com/cli/cli/releases/tag/v2.49.0
```