### PR TITLE
ci: Use uv for install on ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,13 @@ build:
   apt_packages:
     - curl
     - jq
+  jobs:
+    post_create_environment:
+      - pip install uv
+    post_install:
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv pip install '.[docs]'
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -20,11 +27,3 @@ sphinx:
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF and ePub
 formats: all
-
-# python -m pip install '.[docs]'
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs


### PR DESCRIPTION
# Description

RTD doesn't support uv at the same level as pip, but there are ways to still use it along with most of the infrastructure. Adopt the strategy provided in ReadTheDocs's 'Build process customization' section https://docs.readthedocs.io/en/latest/build-customization.html#install-dependencies-with-uv, from https://github.com/readthedocs/readthedocs.org/pull/11152/, but continue to monitor alternative faster methods such as those described in https://github.com/readthedocs/readthedocs.org/issues/11289 .

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* RTD doesn't support uv at the same level as pip, but there are ways
  to still use it along with most of the infrastructure. Adopt the
  strategy provided in ReadTheDocs's 'Build process customization' section
  https://docs.readthedocs.io/en/latest/build-customization.html#install-dependencies-with-uv
  , from https://github.com/readthedocs/readthedocs.org/pull/11152/,
  but continue to monitor alternative faster methods such as those
  described in https://github.com/readthedocs/readthedocs.org/issues/11289 .
```