### PR TITLE
docs: Add automatic release notes config file

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci


### PR DESCRIPTION
# Description

* Add a `.github/release.yml` file to configure the automatic release notes that GitHub can generate on a release.
   - https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
* Ignore contributions from Dependabot and pre-commit-ci from the release notes.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add a .github/release.yml file to configure the automatic release notes that GitHub can generate on a release.
   - https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
* Ignore contributions from Dependabot and pre-commit-ci from the release notes.
```