### PR TITLE
docs: Use importlib.metadata to get version info

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,11 +15,11 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use Path('../relative_path_to_dir').resolve() to make it absolute, like shown here.
 
+import importlib.metadata
 import sys
 from pathlib import Path
 
 import jupytext
-from pkg_resources import get_distribution
 
 sys.path.insert(0, str(Path('./exts').resolve()))
 
@@ -123,7 +123,7 @@ author = 'Lukas Heinrich, Matthew Feickert, Giordon Stark'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 # The full version, including alpha/beta/rc tags.
-release = get_distribution('pyhf').version
+release = importlib.metadata.version("pyhf")
 # for example take major/minor/patch
 version = '.'.join(release.split('.')[:3])
 


### PR DESCRIPTION
# Description

* `pkg_resources` is deprecated as an API, so stop using it.
   - c.f. https://setuptools.pypa.io/en/latest/pkg_resources.html
* `importlib.metadata.version` is the recommended way to get package version information.
   - c.f. https://docs.python.org/3/library/importlib.metadata.html

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* pkg_resources is deprecated as an API, so stop using it.
   - c.f. https://setuptools.pypa.io/en/latest/pkg_resources.html
* importlib.metadata.version is the recommended way to get package
  version information.
   - c.f. https://docs.python.org/3/library/importlib.metadata.html
```