### PR TITLE
ci: Place upper bound on min supported setuptools

### DIFF
--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies and force lowest bound
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip 'setuptools<70.0.0' wheel
         uv pip --no-cache install --system --constraint tests/constraints.txt ".[all,test]"
 
     - name: List installed Python packages


### PR DESCRIPTION
# Description

* Place an upper bound on setuptools of <70.0.0 for the 'minimum supported dependencies' workflow as setuptools v70.0.0 reduces pkg_resources useage.
   - Avoids a "cannot import name 'packaging' from 'pkg_resources'" ImportError caused by PyTorch.
   - c.f. https://setuptools.pypa.io/en/latest/pkg_resources.html

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Place an upper bound on setuptools of <70.0.0 for the 'minimum supported
  dependencies' workflow as setuptools v70.0.0 reduces pkg_resources
  useage.
   - Avoids a "cannot import name 'packaging' from 'pkg_resources'" ImportError
     caused by PyTorch.
   - c.f. https://setuptools.pypa.io/en/latest/pkg_resources.html
```