### PR TITLE
ci: Update permissions for GitHub attestations

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -32,7 +32,6 @@ jobs:
     permissions:
       id-token: write
       attestations: write
-      contents: read
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
# Description

* Remove explicit content read permissions as not formally required.
   - c.f. https://github.com/actions/attest-build-provenance/tree/v1.1.2?tab=readme-ov-file#usage

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove explicit content read permissions as not formally required.
   - c.f. https://github.com/actions/attest-build-provenance/tree/v1.1.2?tab=readme-ov-file#usage
```