### PR TITLE
ci: Restrict content permissions to harden GitHub Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,8 @@ permissions:
 jobs:
   docker:
     name: Build, test, and publish Docker images to Docker Hub
+    permissions:
+      contents: write  # for docker to push to registry
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,8 +26,8 @@ jobs:
   docker:
     name: Build, test, and publish Docker images to Docker Hub
     permissions:
-      actions: write  # for docker to push to registry
       contents: read
+      packages: write  # for docker to push to registry
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,8 @@ jobs:
   docker:
     name: Build, test, and publish Docker images to Docker Hub
     permissions:
-      contents: write  # for docker to push to registry
+      actions: write  # for docker to push to registry
+      contents: read
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
 


### PR DESCRIPTION
# Description

* Restrict content permissions to read. At the moment there are no steps to the changed workflows that use tokens, and so this is preventative if this ever changes.
* Give packages write permissions to publish to ghcr.
   - Amends PR https://github.com/scikit-hep/pyhf/pull/2483.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Restrict content permissions to read. At the moment there are no
  steps to the changed workflows that use tokens, and so this is
  preventative if this ever changes.
* Give packages write permissions to publish to ghcr.
   - Amends PR https://github.com/scikit-hep/pyhf/pull/2483.
```