### PR TITLE
chore: Use uv during Dockerfile build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get -qq -y update && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/* && \
     python -m venv /usr/local/venv && \
+    . /usr/local/venv/bin/activate && \
     cd /code && \
     python -m pip --no-cache-dir install --upgrade uv && \
     uv pip install --no-cache --upgrade pip setuptools wheel && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,9 +15,10 @@ RUN apt-get -qq -y update && \
     rm -rf /var/lib/apt/lists/* && \
     python -m venv /usr/local/venv && \
     cd /code && \
-    python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
-    python -m pip --no-cache-dir install '.[xmlio,contrib]' && \
-    python -m pip list
+    python -m pip --no-cache-dir install --upgrade uv && \
+    uv pip install --no-cache --upgrade pip setuptools wheel && \
+    uv pip install --no-cache '.[xmlio,contrib]' && \
+    uv pip list
 
 FROM base
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ FROM base as builder
 # Set PATH to pickup virtual environment by default
 ENV PATH=/usr/local/venv/bin:"${PATH}"
 COPY . /code
-# hadolint ignore=DL3003,SC2102
+# hadolint ignore=DL3003,SC2102,SC1091
 RUN apt-get -qq -y update && \
     apt-get -qq -y install --no-install-recommends \
         git && \


### PR DESCRIPTION
# Description

* Speed up the Dockerfile build by using uv to install all Python dependencies.
* Have hadolint ignore SC1091 in Dockerfile.
   - c.f. https://www.shellcheck.net/wiki/SC1091

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Speed up the Dockerfile build by using uv to install all Python
  dependencies.
* Have hadolint ignore SC1091 in Dockerfile.
   - c.f. https://www.shellcheck.net/wiki/SC1091
```