### PR TITLE
chore: Speed up pyhf CLI API execution for Docker users

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,4 +61,8 @@ ENV LANG=C.UTF-8
 
 ENV PATH=${HOME}/.local/bin:${PATH}
 
+# The first ever run of the CLI API incurs some overhead so do that during the
+# build instead of making the user wait
+RUN pyhf --version
+
 ENTRYPOINT ["/usr/local/venv/bin/pyhf"]


### PR DESCRIPTION
# Description

The first ever run of the CLI API incurs some overhead so do that during the build instead of making the user wait.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* The first ever run of the CLI API incurs some overhead so do that during the
build instead of making the user wait.
```