### PR TITLE
ci: Don't test warnings on release tests

### DIFF
--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -28,6 +28,7 @@ jobs:
           # Intel runner
           - os: macos-13
             python-version: '3.12'
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v4
@@ -47,6 +48,10 @@ jobs:
 
     - name: Canary test public API
       run: |
+        # Override the ini option for filterwarnings with an empty list to disable error on filterwarnings
+        # as testing the latest release API still works, not the release is warning free.
+        # Though still show warnings by setting warning control to 'default'.
+        export PYTHONWARNINGS='default'
         pytest tests/test_public_api.py
 
       # FIXME: c.f. https://github.com/proycon/codemetapy/issues/24


### PR DESCRIPTION
# Description

This follows up on a conversation with @alexander-held on better knowing if the latest releases are actually passing on new CPython versions. That being said, all the tests will fail currently given `v0.7.6` happened before PR https://github.com/scikit-hep/pyhf/pull/2452 and so TensorFlow is breaking everything.

* Override error on filterwarnings to avoid failing on warnings.
* Set the fail-fast to False in the CI strategy to allow for identifying if things are OS specific.


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Override error on filterwarnings to avoid failing on warnings.
* Set the fail-fast to False in the CI strategy to allow for identifying
  if things are OS specific.
```
