### PR TITLE
build(backport): Determine tensorflow-probability requirements from python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,10 +68,18 @@ Homepage = "https://github.com/scikit-hep/pyhf"
 
 [project.optional-dependencies]
 shellcomplete = ["click_completion"]
+# TODO: 'tensorflow' supports all platform_machine for tensorflow v2.16.1+
+# but TensorFlow only supports python_version 3.8 up through tensorflow v2.13.1.
+# So until Python 3.8 support is dropped, split requirments on python_version
+# before and after 3.9.
+# NOTE: macos x86 support is deprecated from tensorflow v2.17.0 onwards.
 tensorflow = [
-    "tensorflow>=2.7.0; platform_machine != 'arm64'",  # c.f. PR #1962
-    "tensorflow-macos>=2.7.0; platform_machine == 'arm64' and platform_system == 'Darwin'",  # c.f. PR #2119
-    "tensorflow-probability>=0.11.0,!=0.20.0",  # c.f. PR #1657, PR #2203
+    # python == 3.8
+    "tensorflow>=2.7.0; python_version < '3.9' and platform_machine != 'arm64'",  # c.f. PR #1962, #2452
+    "tensorflow-macos>=2.7.0; python_version < '3.9' and platform_machine == 'arm64' and platform_system == 'Darwin'",  # c.f. PR #2119, #2452
+    "tensorflow-probability>=0.11.0; python_version < '3.9'",  # c.f. PR #1657, #2452
+    # python >= 3.9
+    "tensorflow-probability[tf]>=0.24.0; python_version >= '3.9'"  # c.f. PR #2452
 ]
 torch = ["torch>=1.10.0"]  # c.f. PR #1657
 jax = [


### PR DESCRIPTION
# Description

Backport PR https://github.com/scikit-hep/pyhf/pull/2452

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Backport PR https://github.com/scikit-hep/pyhf/pull/2452
* Split the requirements for the 'tensorflow' extra into two different
  conditional groups by python_version.
   - Starting with tensorflow v2.16.1, multiple changes were made that simplifies
   the installation of tensorflow across platform_machine and Keras v3.0 was adopted.
   - tensorflow-probability did _not_ adopt Keras v3.0, but instead requires
   tf-keras. Starting in tensorflow-probability v0.24.0 the
   'tensorflow-probability[tf]' extra was added which includes all the required
   dependencies to be able to use tensorflow-probability with tensorflow v2.15+.
   - tensorflow v2.16.1 and tensorflow-probability v0.24.0 support Python 3.9+,
   so for Python 3.8 support the 'tensorflow' requirements need to use the
   previous more verbose conditionals.
```