### PR TITLE
test(backport): Lower tolerance for agreement between amd64 and arm64

### DIFF
--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -84,6 +84,7 @@ def test_asymptotic_calculator_has_fitted_pars(test_stat):
         assert pytest.approx([1.0, 1.0], rel=rtol) == pyhf.tensorlib.tolist(
             fitted_pars.free_fit_to_data
         )
+        # lower tolerance for amd64 and arm64 to agree
         assert pytest.approx(
-            [7.6470499e-05, 1.4997178], rel=rtol
+            [7.6470499e-05, 1.4997178], rel=1e-3
         ) == pyhf.tensorlib.tolist(fitted_pars.free_fit_to_asimov)


### PR DESCRIPTION
# Description

Backport PR https://github.com/scikit-hep/pyhf/pull/2447

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Backport PR https://github.com/scikit-hep/pyhf/pull/2447
```