### PR TITLE
docs: Change docs theme to PyData Sphinx theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -248,9 +248,7 @@ html_theme = 'pydata_sphinx_theme'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-html_theme_options = {
-    "header_links_before_dropdown": 6
-}
+html_theme_options = {"header_links_before_dropdown": 6}
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,6 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
     'sphinx.ext.intersphinx',
-    'sphinx_rtd_theme',
     'sphinxcontrib.bibtex',
     'sphinx.ext.napoleon',
     'sphinx_click.ext',
@@ -243,7 +242,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'pydata_sphinx_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -248,7 +248,9 @@ html_theme = 'pydata_sphinx_theme'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-html_theme_options = {}
+html_theme_options = {
+    "header_links_before_dropdown": 6
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = []

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -34,3 +34,4 @@ Contributors include:
 - Daniel Werner
 - Jonas Rembser
 - Lorenz Gaertner
+- Melissa Weber Mendonça

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,15 +8,15 @@
 
    intro
    likelihood
-   learn
    examples
-   outreach
    api
+   cli
    installation
    development
    faq
+   learn
    babel
-   cli
+   outreach
    citations
    governance/ROADMAP
    release-notes

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,11 +24,6 @@
 
 .. raw:: html
 
-   <a class="github-fork-ribbon right-top fixed" href="https://github.com/scikit-hep/pyhf/" data-ribbon="View me on GitHub" title="View me on GitHub">View me on GitHub</a>
-
-
-.. raw:: html
-
    <p id="dev-version"><strong>Warning:</strong> This is a development version. The latest stable version is at <a href="https://pyhf.readthedocs.io/">ReadTheDocs</a>.</p>
 
 ..

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,12 +11,12 @@
    learn
    examples
    outreach
+   api
    installation
    development
    faq
    babel
    cli
-   api
    citations
    governance/ROADMAP
    release-notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ docs = [
     "sphinx>=7.0.0",  # c.f. https://github.com/scikit-hep/pyhf/pull/2271
     "sphinxcontrib-bibtex>=2.1",
     "sphinx-click",
-    "sphinx-rtd-theme>=1.3.0",  # c.f. https://github.com/scikit-hep/pyhf/pull/2271
+    "pydata-sphinx-theme>=0.15.3",
     "nbsphinx!=0.8.8",  # c.f. https://github.com/spatialaudio/nbsphinx/issues/620
     "ipywidgets",
     "sphinx-issues",


### PR DESCRIPTION
# Description
This is a simple conversion of the documentation pages to the PyData Sphinx Theme using the default configurations for the theme.

From the documentation for the theme (https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/readthedocs.html#version-switcher) the version switcher from readthedocs should still work after this is done (but won't show up before the PR is merged). If you want to use the version switcher of the PyData Sphinx Theme instead, it would require having urls for all of the previous versions of the library and one json file mapping urls to versions. This would also enable using the Version warning banner from the PyData theme itself: https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/announcements.html#version-warning-banners

Closes #2512 

# Checklist Before Requesting Reviewer

- [N/A] Tests are passing
- [X] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Switch docs theme to use the PyData Sphinx theme which is used across the
  broader Scientific Python community ubiquitously.
   - Replace sphinx-rtd-theme with pydata-sphinx-theme in 'docs' extra.
* Reorder the navigation bar to keep API reference sections visible by default.
* Remove 'View me on GitHub' ribbon.
   - The ribbon will cause issues with the theme and isn't needed anymore.
* Add Melissa Weber Mendonça to contributors list.
```