### PR TITLE
test: Lower tolerance for iminuit v2.26.0+ on Apple silicon

### DIFF
--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -385,7 +385,9 @@ def test_optim_uncerts(backend, source, spec, mu):
         return_uncertainties=True,
     )
     assert result.shape == (2, 2)
-    assert pytest.approx([0.26418431, 0.0]) == pyhf.tensorlib.tolist(result[:, 1])
+    assert pytest.approx([0.26418431, 0.0], rel=1e-5) == pyhf.tensorlib.tolist(
+        result[:, 1]
+    )
 
 
 @pytest.mark.parametrize('mu', [1.0], ids=['mu=1'])


### PR DESCRIPTION
# Description

Lower the tolerance for the `tests/test_optim.py` `test_optim_uncerts` test to reach agreement for `iminuit` `v2.26.0+` on Apple silicon.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Lower the tolerance for the tests/test_optim.py test_optim_uncerts test
  to reach agreement for iminuit v2.26.0+ on Apple silicon.
```