### PR TITLE
fix: Use shutil.copytree over setuptools._distutils

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,6 +164,6 @@ def datadir(tmp_path, request):
     test_dir = pathlib.Path(request.module.__file__).with_suffix('')
 
     if test_dir.is_dir():
-        shutil.copytree(test_dir, tmp_path)
+        shutil.copytree(test_dir, tmp_path, dirs_exist_ok=True)
 
     return tmp_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,10 @@
 import json
 import pathlib
+import shutil
 import sys
 import tarfile
 
 import pytest
-from setuptools._distutils import dir_util
 
 import pyhf
 
@@ -164,9 +164,6 @@ def datadir(tmp_path, request):
     test_dir = pathlib.Path(request.module.__file__).with_suffix('')
 
     if test_dir.is_dir():
-        dir_util.copy_tree(test_dir, str(tmp_path))
-        # shutil is nicer, but doesn't work: https://bugs.python.org/issue20849
-        # Once pyhf is Python 3.8+ only then the below can be used.
-        # shutil.copytree(test_dir, tmp_path)
+        shutil.copytree(test_dir, tmp_path)
 
     return tmp_path


### PR DESCRIPTION
# Description

As `setuptools` is not the build backend there should be no reliance on `setuptools` or `distutils` for use. This exchanges `setuptools._distutils.dir_util.copy_tree` for `shutil.copytree` with `dirs_exist_ok=True` as pyhf supports Python 3.8+.

Follows up on an idea brought forward in PR https://github.com/scikit-hep/pyhf/pull/1711.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* As setuptools is not the build backend there should be no reliance on
  setuptools or distutils for use. This exchanges
  setuptools._distutils.dir_util.copy_tree for shutil.copytree with
  dirs_exist_ok=True as pyhf supports Python 3.8+.
```