### PR TITLE
ci: Remove setuptools uprgrade as no longer backend

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -204,7 +204,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip wheel
         uv pip install --system tbump
         python -m pip list
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip wheel
         uv pip install --system --upgrade '.[all,test]'
 
     - name: List installed Python packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,14 @@ jobs:
       if: matrix.python-version != '3.8'
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip wheel
         uv pip install --system --upgrade ".[all,test]"
 
       # c.f. https://github.com/astral-sh/uv/issues/2062
     - name: Install dependencies (Python 3.8)
       if: matrix.python-version == '3.8'
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip wheel
         python -m pip install --upgrade ".[all,test]"
 
     - name: List installed Python packages

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip wheel
         uv pip --no-cache --quiet install --system --upgrade --pre ".[all,test]"
         python -m pip list
 
@@ -64,7 +64,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip wheel
         uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
         uv pip uninstall --system scipy
         # uv wants to upgrade dependencies (numpy) to a dev release too, so don't --upgrade
@@ -92,7 +92,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip wheel
         uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
         uv pip uninstall --system iminuit
         uv pip install --system --upgrade cython
@@ -119,7 +119,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip wheel
         uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
         uv pip uninstall --system uproot
         uv pip install --system --upgrade git+https://github.com/scikit-hep/uproot5.git
@@ -147,7 +147,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip wheel
         uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
         uv pip uninstall --system matplotlib
         # Need to use --extra-index-url as all dependencies aren't on scientific-python-nightly-wheels package index.
@@ -184,7 +184,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip wheel
         uv pip --no-cache --quiet install --system --upgrade ".[all,test]"
         uv pip uninstall --system pytest
         uv pip install --system --upgrade git+https://github.com/pytest-dev/pytest.git

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip wheel
         uv pip --quiet install --system --upgrade ".[docs,test]"
         uv pip install --system yq
         python -m pip list

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip wheel
         # FIXME: c.f. https://github.com/scikit-hep/pyhf/issues/2104
         uv pip install --system --upgrade ".[all,test]" 'jupyter-client<8.0.0'
 

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Install from PyPI
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip wheel
         uv pip install --system --pre 'pyhf[backends,xmlio]'
         uv pip install --system pytest
         python -m pip list

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get -qq -y update && \
     . /usr/local/venv/bin/activate && \
     cd /code && \
     python -m pip --no-cache-dir install --upgrade uv && \
-    uv pip install --no-cache --upgrade pip setuptools wheel && \
+    uv pip install --no-cache --upgrade pip wheel && \
     uv pip install --no-cache '.[xmlio,contrib]' && \
     uv pip list
 

--- a/docker/gpu/Dockerfile
+++ b/docker/gpu/Dockerfile
@@ -14,7 +14,7 @@ COPY . /code
 COPY ./docker/gpu/install_backend.sh /code/install_backend.sh
 WORKDIR /code
 ARG BACKEND=tensorflow
-RUN python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
+RUN python3 -m pip --no-cache-dir install --upgrade pip wheel && \
     /bin/bash install_backend.sh ${BACKEND} && \
     python3 -m pip list
 


### PR DESCRIPTION
# Description

Remove `setuptools` installs and upgrades from CI workflows and the Dockerfile build as it should not be required by any component of `pyhf`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove setuptools installs and upgrades from CI workflows and the
  Dockerfile build as it should not be required by any component of pyhf.
```