### PR TITLE
feat: Use 'method' arg for jax.numpy.percentile

### DIFF
--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -321,7 +321,7 @@ class jax_backend:
 
         .. versionadded:: 0.7.0
         """
-        return jnp.percentile(tensor_in, q, axis=axis, interpolation=interpolation)
+        return jnp.percentile(tensor_in, q, axis=axis, method=interpolation)
 
     def stack(self, sequence, axis=0):
         return jnp.stack(sequence, axis=axis)


### PR DESCRIPTION
# Description

* Change the argument name in `jax.numpy.percentile` from `'interpolation'` to `'method'`. No change to the lower bounds on `jax` and `jaxlib` is required as `'method'` already existed as an argument in `jax` `v0.4.1`. This just deprecates the use of `'interpolation'`.
   - Avoids the following DeprecationWarning in `jax` `v0.4.29+`:

```
DeprecationWarning: The interpolation= argument to 'percentile' is deprecated. Use 'method=' instead.
```
   - c.f. https://github.com/google/jax/pull/21267

The CI is failing given another `DeprecationWarning` fixed in PR https://github.com/scikit-hep/pyhf/pull/2523.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Change the argument name in jax.numpy.percentile from 'interpolation' to 'method'.
  No change to the lower bounds on jax and jaxlib is required as 'method' already
  existed as an argument in jax v0.4.1. This just deprecates the use of 'interpolation'.
   - Avoids the following DeprecationWarning in jax v0.4.29+:

     > DeprecationWarning: The interpolation= argument to 'percentile' is deprecated.
     > Use 'method=' instead.
   - c.f. https://github.com/google/jax/pull/21267
```