### PR TITLE
fix: Add filterwarnings for jax.xla_computation DeprecationWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,6 +227,7 @@ filterwarnings = [
     "ignore:jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the:DeprecationWarning",  # Issue #2139
     "ignore:Skipping device Apple Paravirtual device that does not support Metal 2.0:UserWarning",  # Can't fix given hardware/virtualized device
     'ignore:Type google._upb._message.[A-Z]+ uses PyType_Spec with a metaclass that has custom:DeprecationWarning',  # protobuf via tensorflow
+    "ignore:jax.xla_computation is deprecated. Please use the AOT APIs:DeprecationWarning",  # jax v0.4.30
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
# Description

Add an ignore to filterwarnings to avoid a DeprecationWarning on jax.xla_computation in jax v0.4.30+.

```
DeprecationWarning: jax.xla_computation is deprecated. Please use the AOT APIs.
```

c.f. https://github.com/google/jax/pull/21923

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add an ignore to filterwarnings to avoid a DeprecationWarning
  on jax.xla_computation in jax v0.4.30+.

  > DeprecationWarning: jax.xla_computation is deprecated.
  > Please use the AOT APIs.

   - c.f. https://github.com/google/jax/pull/21923
```