### PR TITLE
feat: Log warning when fitted parameter is at the bounds

### DIFF
--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -88,6 +88,8 @@ class OptimizerMixin:
         tensorlib, _ = get_backend()
 
         # TODO: check how to handle this for batching
+        # TODO: handle skipping fixed parameters
+        # TODO: handle various backends
         for par_index, (fitted_par, bound) in enumerate(zip(fitresult.x, par_bounds)):
             if fitted_par in bound:
                 log.warning(f'parameter at index {par_index} is at the bounds')

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -90,9 +90,17 @@ class OptimizerMixin:
         # TODO: check how to handle this for batching
         # TODO: handle skipping fixed parameters
         # TODO: handle various backends
-        for par_index, (fitted_par, bound) in enumerate(zip(fitresult.x, par_bounds)):
-            if fitted_par in bound:
-                log.warning(f"parameter at index {par_index} is at the bounds")
+        for par_index, (fitted_par, (lower, upper)) in enumerate(
+            zip(fitresult.x, par_bounds)
+        ):
+            if fitted_par in (lower, upper):
+                log.warning(
+                    "fit result for parameter at index %d is at a bound: value=%g, bounds=(%g, %g)",
+                    par_index,
+                    fitted_par,
+                    lower,
+                    upper,
+                )
 
         # stitch in missing parameters (e.g. fixed parameters)
         fitted_pars = stitch_pars(tensorlib.astensor(fitresult.x))

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -223,7 +223,7 @@ class OptimizerMixin:
         result = self._internal_postprocess(
             result,
             stitch_pars,
-            par_bounds=minimizer_kwargs["bounds"],
+            par_bounds=par_bounds,
             return_uncertainties=return_uncertainties,
         )
 

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -68,14 +68,29 @@ class OptimizerMixin:
             raise exceptions.FailedMinimization(result) from exc
         return result
 
-    def _internal_postprocess(self, fitresult, stitch_pars, return_uncertainties=False):
+    def _internal_postprocess(
+        self, fitresult, stitch_pars, /, par_bounds, *, return_uncertainties=False
+    ):
         """
         Post-process the fit result.
+
+        Args:
+            fitresult (scipy.optimize.OptimizeResult): Fit result from :func:`_internal_minimize`
+            stitch_pars (:obj:`func`): callable that stitches fixed parameters into the unfixed parameters
+            par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
+                are allowed to reach in the fit.
+                The shape should be ``(n, 2)`` for ``n`` model parameters.
+            return_uncertainties (:obj:`bool`): Return uncertainties on the fitted parameters. Default is off (``False``).
 
         Returns:
             fitresult (scipy.optimize.OptimizeResult): A modified version of the fit result.
         """
         tensorlib, _ = get_backend()
+
+        # TODO: check how to handle this for batching
+        for par_index, (fitted_par, bound) in enumerate(zip(fitresult.x, par_bounds)):
+            if fitted_par in bound:
+                log.warning(f'parameter at index {par_index} is at the bounds')
 
         # stitch in missing parameters (e.g. fixed parameters)
         fitted_pars = stitch_pars(tensorlib.astensor(fitresult.x))
@@ -196,7 +211,10 @@ class OptimizerMixin:
             **minimizer_kwargs, options=kwargs, par_names=par_names
         )
         result = self._internal_postprocess(
-            result, stitch_pars, return_uncertainties=return_uncertainties
+            result,
+            stitch_pars,
+            par_bounds=minimizer_kwargs['bounds'],
+            return_uncertainties=return_uncertainties,
         )
 
         _returns = [result.x]

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -92,7 +92,7 @@ class OptimizerMixin:
         # TODO: handle various backends
         for par_index, (fitted_par, bound) in enumerate(zip(fitresult.x, par_bounds)):
             if fitted_par in bound:
-                log.warning(f'parameter at index {par_index} is at the bounds')
+                log.warning(f"parameter at index {par_index} is at the bounds")
 
         # stitch in missing parameters (e.g. fixed parameters)
         fitted_pars = stitch_pars(tensorlib.astensor(fitresult.x))
@@ -215,7 +215,7 @@ class OptimizerMixin:
         result = self._internal_postprocess(
             result,
             stitch_pars,
-            par_bounds=minimizer_kwargs['bounds'],
+            par_bounds=minimizer_kwargs["bounds"],
             return_uncertainties=return_uncertainties,
         )
 

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -87,9 +87,9 @@ class OptimizerMixin:
         """
         tensorlib, _ = get_backend()
 
-        # TODO: check how to handle this for batching
-        # TODO: handle skipping fixed parameters
-        # TODO: handle various backends
+        # fitresult.x and par_bounds both cover only the free parameters
+        # (fixed params are stripped by shim() before optimization and
+        # stitched back in below), so they always align correctly.
         for par_index, (fitted_par, (lower, upper)) in enumerate(
             zip(fitresult.x, par_bounds)
         ):

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -88,8 +88,12 @@ def _at_bound_warning_messages(
             ``max(1, |bound|)`` if only one side is bounded), so that it stays meaningful
             for both wide bounds and bounds whose endpoints are small --- pyhf's own
             ``shapesys`` and ``staterror`` gammas default to ``(1e-10, 10)``. Optimizers
-            stop near but not exactly at bounds (scipy's SLSQP rails within O(1e-14)),
-            so exact comparison would miss them. Default is ``1e-8``.
+            stop near but not exactly at bounds, so exact comparison would miss them:
+            scipy's SLSQP rails within O(1e-14) on the unconstrained path, but with
+            ``do_stitch=False`` and fixed parameters it minimizes under an equality
+            constraint and can stop O(1e-7) away, which this tolerance may miss (cf. the
+            discussion on https://github.com/scikit-hep/pyhf/pull/2526). Default is
+            ``1e-8``.
 
     Returns:
         :obj:`list` of :obj:`str`: one message per parameter at a bound

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -8,6 +8,7 @@ from collections.abc import Sequence
 from typing import Any
 
 import numpy as np
+import scipy.optimize
 
 from pyhf import exceptions
 from pyhf.optimize.common import shim
@@ -48,12 +49,11 @@ def _minuit_at_limit_flags(
         return minimizer_flags
     # do_stitch=True: minuit saw only the free parameters, so map the flags
     # back to model parameter indices
-    variable_idx = [index for index in range(npars) if index not in set(fixed_idx)]
-    if len(minimizer_flags) != len(variable_idx):
-        return [False] * npars
+    fixed = set(fixed_idx)
+    variable_idx = [index for index in range(npars) if index not in fixed]
     flags = [False] * npars
-    for minimizer_index, model_index in enumerate(variable_idx):
-        flags[model_index] = minimizer_flags[minimizer_index]
+    for model_index, minimizer_flag in zip(variable_idx, minimizer_flags):
+        flags[model_index] = minimizer_flag
     return flags
 
 
@@ -63,7 +63,7 @@ def _at_bound_warning_messages(
     fixed_idx: Sequence[int],
     par_names: Sequence[str] | None,
     at_limit: Sequence[bool] | None = None,
-    rtol: float = 1e-8,
+    rtol: float = 1e-4,
 ) -> list[str]:
     """
     Build warning messages for free fitted parameters that are at a bound.
@@ -80,29 +80,34 @@ def _at_bound_warning_messages(
             identified by index only.
         at_limit (:obj:`list` of :obj:`bool` or :obj:`None`): optional per-parameter
             at-limit flags from the optimizer's own determination (see
-            :func:`_minuit_at_limit_flags`), combined with the tolerance check.
+            :func:`_minuit_at_limit_flags`). Parameters flagged here but not caught
+            by the tolerance check are reported with the optimizer's criterion
+            spelled out, as they need not be numerically at a bound.
         rtol (:obj:`float`): relative tolerance for deciding that a fitted parameter is
             at a bound: within ``rtol * max(1, |bound|)`` of the bound, or beyond it.
-            Optimizers stop near but not exactly at bounds --- scipy's SLSQP rails
-            within O(1e-14) of a bound --- so exact comparison would miss them.
-            Default is ``1e-8``.
+            Optimizers stop near but not exactly at bounds --- measured rail distances
+            are O(1e-14) for scipy's SLSQP and up to O(1e-5) for minuit --- so exact
+            comparison would miss them. Default is ``1e-4``.
 
     Returns:
         :obj:`list` of :obj:`str`: one message per parameter at a bound
     """
+
+    def _par_label(par_index: int) -> str:
+        return (
+            f"'{par_names[par_index]}' (index {par_index})"
+            if par_names is not None and par_index < len(par_names)
+            else f"at index {par_index}"
+        )
+
     messages: list[str] = []
     fixed = set(fixed_idx)
     for par_index, (fitted_par, bounds) in enumerate(zip(fitted_pars, par_bounds)):
         if par_index in fixed:
             continue
-        par_label = (
-            f"'{par_names[par_index]}' (index {par_index})"
-            if par_names is not None and par_index < len(par_names)
-            else f"at index {par_index}"
-        )
         if not math.isfinite(fitted_par):
             messages.append(
-                f"fit result for parameter {par_label} is not finite: value={fitted_par:g}"
+                f"fit result for parameter {_par_label(par_index)} is not finite: value={fitted_par!r}"
             )
             continue
         # a None or non-finite bound is unbounded on that side
@@ -113,9 +118,14 @@ def _at_bound_warning_messages(
         upper = (
             raw_upper if raw_upper is not None and math.isfinite(raw_upper) else None
         )
-        if lower is not None and lower == upper:
+        if (
+            lower is not None
+            and lower == upper
+            and abs(fitted_par - lower) <= rtol * max(1.0, abs(lower))
+        ):
             # bounds that pin the parameter to a single value are deliberate,
-            # like the fixed parameters skipped above
+            # like the fixed parameters skipped above, but only exonerate
+            # the parameter if it actually sits at the pinned value
             continue
         # one-sided comparisons also catch values beyond the bounds
         at_lower = lower is not None and fitted_par <= lower + rtol * max(
@@ -124,11 +134,25 @@ def _at_bound_warning_messages(
         at_upper = upper is not None and fitted_par >= upper - rtol * max(
             1.0, abs(upper)
         )
-        if at_lower or at_upper or (at_limit is not None and at_limit[par_index]):
-            lower_str = "None" if lower is None else f"{lower:g}"
-            upper_str = "None" if upper is None else f"{upper:g}"
+        optimizer_at_limit = (
+            at_limit is not None
+            and par_index < len(at_limit)
+            and bool(at_limit[par_index])
+        )
+        if not (at_lower or at_upper or optimizer_at_limit):
+            continue
+        # display the bounds as provided (e.g. inf), not as normalized
+        lower_str = "None" if raw_lower is None else f"{raw_lower:g}"
+        upper_str = "None" if raw_upper is None else f"{raw_upper:g}"
+        if at_lower or at_upper:
             messages.append(
-                f"fit result for parameter {par_label} is at a bound: value={fitted_par:g}, bounds=({lower_str}, {upper_str})"
+                f"fit result for parameter {_par_label(par_index)} is at a bound: value={fitted_par!r}, bounds=({lower_str}, {upper_str})"
+            )
+        else:
+            # flagged only by the optimizer's own statistical criterion, so
+            # the value need not be numerically at a bound
+            messages.append(
+                f"fit result for parameter {_par_label(par_index)} is within half its uncertainty of a bound (iminuit at-limit criterion): value={fitted_par!r}, bounds=({lower_str}, {upper_str})"
             )
     return messages
 
@@ -209,7 +233,6 @@ class OptimizerMixin:
             par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the full set of
                 model parameters are allowed to reach in the fit.
                 The shape should be ``(n, 2)`` for ``n`` model parameters.
-                A :class:`scipy.optimize.Bounds` instance is also accepted.
                 If ``None`` (the default), the check warning about fitted parameters at their
                 bounds is skipped.
             fixed_idx (:obj:`sequence` of :obj:`int`): The indices of the model parameters held
@@ -233,16 +256,7 @@ class OptimizerMixin:
             # fitresult.x for the minimization (do_stitch)
             fitted_pars_list = tensorlib.tolist(fitted_pars)
             npars = len(fitted_pars_list)
-            if hasattr(par_bounds, "lb"):
-                # scipy.optimize.Bounds instance (lb/ub broadcast to npars)
-                par_bounds = list(
-                    zip(
-                        np.broadcast_to(par_bounds.lb, npars),
-                        np.broadcast_to(par_bounds.ub, npars),
-                    )
-                )
-            else:
-                par_bounds = list(par_bounds)
+            par_bounds = list(par_bounds)
             if len(par_bounds) != npars:
                 log.warning(
                     "length of par_bounds (%d) does not match the number of model parameters (%d), skipping check for parameters at bounds",
@@ -251,9 +265,10 @@ class OptimizerMixin:
                 )
             else:
                 minuit = getattr(fitresult, "minuit", None)
+                # the O(1) aggregate gates the per-parameter walk
                 at_limit = (
                     _minuit_at_limit_flags(minuit, npars, fixed_idx)
-                    if minuit is not None
+                    if minuit is not None and minuit.fmin.has_parameters_at_limit
                     else None
                 )
                 at_bound_messages = _at_bound_warning_messages(
@@ -340,6 +355,7 @@ class OptimizerMixin:
             par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
                 are allowed to reach in the fit.
                 The shape should be ``(n, 2)`` for ``n`` model parameters.
+                A :class:`scipy.optimize.Bounds` instance is also accepted.
             fixed_vals (:obj:`list` of :obj:`list`/:obj:`tuple`): The pairs of index and constant value for a constant
                 model parameter during minimization. Set to ``None`` to allow all parameters to float.
             return_fitted_val (:obj:`bool`): Return bestfit value of the objective. Default is off (``False``).
@@ -360,6 +376,16 @@ class OptimizerMixin:
         # Configure do_grad based on backend "automagically" if not set by user
         tensorlib, _ = get_backend()
         do_grad = tensorlib.default_do_grad if do_grad is None else do_grad
+
+        if isinstance(par_bounds, scipy.optimize.Bounds):
+            # normalize to pairs (lb/ub broadcast to the number of parameters)
+            # so that all optimizer and do_stitch code paths handle the bounds
+            par_bounds = list(
+                zip(
+                    np.broadcast_to(par_bounds.lb, len(init_pars)),
+                    np.broadcast_to(par_bounds.ub, len(init_pars)),
+                )
+            )
 
         minimizer_kwargs, stitch_pars = shim(
             objective,

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -20,10 +20,16 @@ def _minuit_at_limit_flags(
     minuit: Any, npars: int, fixed_idx: Sequence[int]
 ) -> list[bool]:
     """
-    Replicate iminuit's per-parameter at-limit determination: a free bounded
-    parameter is at a limit when it is within half its uncertainty of a bound
-    (cf. :class:`iminuit.util.FMin`, which aggregates the same criterion into
-    ``has_parameters_at_limit`` but does not expose it per parameter).
+    Apply iminuit's at-limit criterion to each parameter: a free bounded
+    parameter is at a limit when it is within half its uncertainty of a bound.
+
+    iminuit computes this internally but does not currently expose it per
+    parameter --- only the OR-aggregated result is public, as
+    :attr:`iminuit.util.FMin.has_parameters_at_limit` (as of iminuit v2.32.0,
+    cf. ``iminuit/util.py`` in :class:`iminuit.util.FMin`) --- so the same
+    criterion is re-evaluated here from the public per-parameter data in
+    ``minuit.params``. If iminuit gains a per-parameter API for this (e.g.
+    ``Param.at_limit``), this function can be replaced by it.
 
     Returns:
         :obj:`list` of :obj:`bool`: flags aligned with the full set of model parameters

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -1,6 +1,9 @@
 """Helper Classes for use of automatic differentiation."""
 
+from __future__ import annotations
+
 import logging
+from collections.abc import Sequence
 
 import numpy as np
 
@@ -10,14 +13,14 @@ from pyhf.tensor.manager import get_backend
 
 log = logging.getLogger(__name__)
 
-# Relative tolerance (w.r.t. the bound range) for deciding that a fitted
-# parameter is at a bound. Optimizers stop near but not exactly at bounds:
-# iminuit's sin-transformed limits land within O(1e-7) of the bound range and
-# scipy's SLSQP rails within O(1e-14), so exact comparison would miss them.
-_AT_BOUND_RTOL = 1e-6
 
-
-def _at_bound_warning_messages(fitted_pars, par_bounds, fixed_idx, par_names):
+def _at_bound_warning_messages(
+    fitted_pars: Sequence[float],
+    par_bounds: Sequence[Sequence[float | None]],
+    fixed_idx: Sequence[int],
+    par_names: Sequence[str] | None,
+    rtol: float = 1e-6,
+) -> list[str]:
     """
     Build warning messages for free fitted parameters that are at a bound.
 
@@ -30,21 +33,30 @@ def _at_bound_warning_messages(fitted_pars, par_bounds, fixed_idx, par_names):
         par_names (:obj:`list` of :obj:`str` or :obj:`None`): names of the full set of
             model parameters, used to identify parameters. If ``None``, parameters are
             identified by index only.
+        rtol (:obj:`float`): relative tolerance (w.r.t. the bound range) for deciding
+            that a fitted parameter is at a bound. Optimizers stop near but not exactly
+            at bounds --- iminuit's sin-transformed limits land within O(1e-7) of the
+            bound range and scipy's SLSQP rails within O(1e-14) --- so exact comparison
+            would miss them. Default is ``1e-6``.
 
     Returns:
         :obj:`list` of :obj:`str`: one message per parameter at a bound
     """
-    messages = []
+    messages: list[str] = []
     for par_index, (fitted_par, (lower, upper)) in enumerate(
         zip(fitted_pars, par_bounds)
     ):
-        if par_index in fixed_idx or (lower is None and upper is None):
+        if par_index in fixed_idx:
             continue
         if lower is not None and upper is not None:
-            tolerance = _AT_BOUND_RTOL * (upper - lower)
+            tolerance = rtol * (upper - lower)
+        elif lower is not None:
+            tolerance = rtol * max(1.0, abs(lower))
+        elif upper is not None:
+            tolerance = rtol * max(1.0, abs(upper))
         else:
-            one_sided_bound = lower if lower is not None else upper
-            tolerance = _AT_BOUND_RTOL * max(1.0, abs(one_sided_bound))
+            # unbounded on both sides — nothing to be at
+            continue
         if any(
             bound is not None and abs(fitted_par - bound) <= tolerance
             for bound in (lower, upper)

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Sequence
+from typing import Any
 
 import numpy as np
 
@@ -14,12 +16,48 @@ from pyhf.tensor.manager import get_backend
 log = logging.getLogger(__name__)
 
 
+def _minuit_at_limit_flags(
+    minuit: Any, npars: int, fixed_idx: Sequence[int]
+) -> list[bool]:
+    """
+    Replicate iminuit's per-parameter at-limit determination: a free bounded
+    parameter is at a limit when it is within half its uncertainty of a bound
+    (cf. :class:`iminuit.util.FMin`, which aggregates the same criterion into
+    ``has_parameters_at_limit`` but does not expose it per parameter).
+
+    Returns:
+        :obj:`list` of :obj:`bool`: flags aligned with the full set of model parameters
+    """
+    minimizer_flags = []
+    for param in minuit.params:
+        if param.is_fixed or not param.has_limits:
+            minimizer_flags.append(False)
+            continue
+        lower = param.lower_limit if param.has_lower_limit else -np.inf
+        upper = param.upper_limit if param.has_upper_limit else np.inf
+        minimizer_flags.append(
+            min(param.value - lower, upper - param.value) < 0.5 * param.error
+        )
+    if len(minimizer_flags) == npars:
+        return minimizer_flags
+    # do_stitch=True: minuit saw only the free parameters, so map the flags
+    # back to model parameter indices
+    variable_idx = [index for index in range(npars) if index not in set(fixed_idx)]
+    if len(minimizer_flags) != len(variable_idx):
+        return [False] * npars
+    flags = [False] * npars
+    for minimizer_index, model_index in enumerate(variable_idx):
+        flags[model_index] = minimizer_flags[minimizer_index]
+    return flags
+
+
 def _at_bound_warning_messages(
     fitted_pars: Sequence[float],
     par_bounds: Sequence[Sequence[float | None]],
     fixed_idx: Sequence[int],
     par_names: Sequence[str] | None,
-    rtol: float = 1e-6,
+    at_limit: Sequence[bool] | None = None,
+    rtol: float = 1e-8,
 ) -> list[str]:
     """
     Build warning messages for free fitted parameters that are at a bound.
@@ -27,45 +65,60 @@ def _at_bound_warning_messages(
     Args:
         fitted_pars (:obj:`list` of :obj:`float`): the full set of fitted model parameters
         par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): bounds for the full set of
-            model parameters. A bound of ``None`` is treated as unbounded on that side.
+            model parameters. A bound that is ``None`` or non-finite (e.g. ``inf``) is
+            treated as unbounded on that side.
         fixed_idx (:obj:`sequence` of :obj:`int`): indices of parameters held constant in
             the fit, which are skipped (a parameter fixed at a bound is deliberate)
         par_names (:obj:`list` of :obj:`str` or :obj:`None`): names of the full set of
             model parameters, used to identify parameters. If ``None``, parameters are
             identified by index only.
-        rtol (:obj:`float`): relative tolerance (w.r.t. the bound range) for deciding
-            that a fitted parameter is at a bound. Optimizers stop near but not exactly
-            at bounds --- iminuit's sin-transformed limits land within O(1e-7) of the
-            bound range and scipy's SLSQP rails within O(1e-14) --- so exact comparison
-            would miss them. Default is ``1e-6``.
+        at_limit (:obj:`list` of :obj:`bool` or :obj:`None`): optional per-parameter
+            at-limit flags from the optimizer's own determination (see
+            :func:`_minuit_at_limit_flags`), combined with the tolerance check.
+        rtol (:obj:`float`): relative tolerance for deciding that a fitted parameter is
+            at a bound: within ``rtol * max(1, |bound|)`` of the bound, or beyond it.
+            Optimizers stop near but not exactly at bounds --- scipy's SLSQP rails
+            within O(1e-14) of a bound --- so exact comparison would miss them.
+            Default is ``1e-8``.
 
     Returns:
         :obj:`list` of :obj:`str`: one message per parameter at a bound
     """
     messages: list[str] = []
-    for par_index, (fitted_par, (lower, upper)) in enumerate(
-        zip(fitted_pars, par_bounds)
-    ):
-        if par_index in fixed_idx:
+    fixed = set(fixed_idx)
+    for par_index, (fitted_par, bounds) in enumerate(zip(fitted_pars, par_bounds)):
+        if par_index in fixed:
             continue
-        if lower is not None and upper is not None:
-            tolerance = rtol * (upper - lower)
-        elif lower is not None:
-            tolerance = rtol * max(1.0, abs(lower))
-        elif upper is not None:
-            tolerance = rtol * max(1.0, abs(upper))
-        else:
-            # unbounded on both sides — nothing to be at
-            continue
-        if any(
-            bound is not None and abs(fitted_par - bound) <= tolerance
-            for bound in (lower, upper)
-        ):
-            par_label = (
-                f"'{par_names[par_index]}' (index {par_index})"
-                if par_names is not None
-                else f"at index {par_index}"
+        par_label = (
+            f"'{par_names[par_index]}' (index {par_index})"
+            if par_names is not None and par_index < len(par_names)
+            else f"at index {par_index}"
+        )
+        if not math.isfinite(fitted_par):
+            messages.append(
+                f"fit result for parameter {par_label} is not finite: value={fitted_par:g}"
             )
+            continue
+        # a None or non-finite bound is unbounded on that side
+        raw_lower, raw_upper = bounds
+        lower = (
+            raw_lower if raw_lower is not None and math.isfinite(raw_lower) else None
+        )
+        upper = (
+            raw_upper if raw_upper is not None and math.isfinite(raw_upper) else None
+        )
+        if lower is not None and lower == upper:
+            # bounds that pin the parameter to a single value are deliberate,
+            # like the fixed parameters skipped above
+            continue
+        # one-sided comparisons also catch values beyond the bounds
+        at_lower = lower is not None and fitted_par <= lower + rtol * max(
+            1.0, abs(lower)
+        )
+        at_upper = upper is not None and fitted_par >= upper - rtol * max(
+            1.0, abs(upper)
+        )
+        if at_lower or at_upper or (at_limit is not None and at_limit[par_index]):
             lower_str = "None" if lower is None else f"{lower:g}"
             upper_str = "None" if upper is None else f"{upper:g}"
             messages.append(
@@ -150,6 +203,7 @@ class OptimizerMixin:
             par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the full set of
                 model parameters are allowed to reach in the fit.
                 The shape should be ``(n, 2)`` for ``n`` model parameters.
+                A :class:`scipy.optimize.Bounds` instance is also accepted.
                 If ``None`` (the default), the check warning about fitted parameters at their
                 bounds is skipped.
             fixed_idx (:obj:`sequence` of :obj:`int`): The indices of the model parameters held
@@ -167,17 +221,46 @@ class OptimizerMixin:
         # stitch in missing parameters (e.g. fixed parameters)
         fitted_pars = stitch_pars(tensorlib.astensor(fitresult.x))
 
-        if par_bounds is not None:
+        if par_bounds is not None and log.isEnabledFor(logging.WARNING):
             # fitted_pars covers the full set of model parameters, so it aligns
             # with par_bounds whether or not fixed parameters were stripped from
             # fitresult.x for the minimization (do_stitch)
-            at_bound_messages = _at_bound_warning_messages(
-                tensorlib.tolist(fitted_pars), par_bounds, fixed_idx, par_names
-            )
-            if at_bound_messages:
-                # a single warning per fit to avoid excessively logging in
-                # pseudoexperiment studies
-                log.warning("\n".join(at_bound_messages))
+            fitted_pars_list = tensorlib.tolist(fitted_pars)
+            npars = len(fitted_pars_list)
+            if hasattr(par_bounds, "lb"):
+                # scipy.optimize.Bounds instance (lb/ub broadcast to npars)
+                par_bounds = list(
+                    zip(
+                        np.broadcast_to(par_bounds.lb, npars),
+                        np.broadcast_to(par_bounds.ub, npars),
+                    )
+                )
+            else:
+                par_bounds = list(par_bounds)
+            if len(par_bounds) != npars:
+                log.warning(
+                    "length of par_bounds (%d) does not match the number of model parameters (%d), skipping check for parameters at bounds",
+                    len(par_bounds),
+                    npars,
+                )
+            else:
+                minuit = getattr(fitresult, "minuit", None)
+                at_limit = (
+                    _minuit_at_limit_flags(minuit, npars, fixed_idx)
+                    if minuit is not None
+                    else None
+                )
+                at_bound_messages = _at_bound_warning_messages(
+                    fitted_pars_list,
+                    par_bounds,
+                    fixed_idx,
+                    par_names,
+                    at_limit=at_limit,
+                )
+                if at_bound_messages:
+                    # a single warning per fit to avoid excessively logging in
+                    # pseudoexperiment studies
+                    log.warning("\n".join(at_bound_messages))
 
         # check if uncertainties were provided (and stitch just in case)
         uncertainties = getattr(fitresult, "unc", None)
@@ -239,6 +322,10 @@ class OptimizerMixin:
         """
         Find parameters that minimize the objective.
 
+        When ``par_bounds`` is provided, a ``WARNING`` log message is emitted
+        for any free fitted parameter at (or beyond) a bound, as such
+        parameters can indicate problems with the fit.
+
         Args:
             objective (:obj:`func`): objective function
             data (:obj:`list`): observed data
@@ -285,25 +372,25 @@ class OptimizerMixin:
         except AttributeError:
             par_names = None
 
-        # keep the full set of parameter names for the at-bound check in
-        # postprocessing, before fixed parameters are stripped below
-        all_par_names = list(par_names) if par_names else None
-
-        # need to remove parameters that are fixed in the fit
+        # the minimizer only sees the free parameters when stitching, so
+        # remove the names of parameters that are fixed in the fit (without
+        # mutating par_names, which is needed in full in postprocessing)
+        minimizer_par_names = par_names
         if par_names and do_stitch and fixed_vals:
-            for index, _ in fixed_vals:
-                par_names[index] = None
-            par_names = [name for name in par_names if name]
+            fixed = {index for index, _ in fixed_vals}
+            minimizer_par_names = [
+                name for index, name in enumerate(par_names) if index not in fixed
+            ]
 
         result = self._internal_minimize(
-            **minimizer_kwargs, options=kwargs, par_names=par_names
+            **minimizer_kwargs, options=kwargs, par_names=minimizer_par_names
         )
         result = self._internal_postprocess(
             result,
             stitch_pars,
             par_bounds=par_bounds,
             fixed_idx=[index for index, _ in fixed_vals or []],
-            par_names=all_par_names,
+            par_names=par_names,
             return_uncertainties=return_uncertainties,
         )
 

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -10,6 +10,57 @@ from pyhf.tensor.manager import get_backend
 
 log = logging.getLogger(__name__)
 
+# Relative tolerance (w.r.t. the bound range) for deciding that a fitted
+# parameter is at a bound. Optimizers stop near but not exactly at bounds:
+# iminuit's sin-transformed limits land within O(1e-7) of the bound range and
+# scipy's SLSQP rails within O(1e-14), so exact comparison would miss them.
+_AT_BOUND_RTOL = 1e-6
+
+
+def _at_bound_warning_messages(fitted_pars, par_bounds, fixed_idx, par_names):
+    """
+    Build warning messages for free fitted parameters that are at a bound.
+
+    Args:
+        fitted_pars (:obj:`list` of :obj:`float`): the full set of fitted model parameters
+        par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): bounds for the full set of
+            model parameters. A bound of ``None`` is treated as unbounded on that side.
+        fixed_idx (:obj:`sequence` of :obj:`int`): indices of parameters held constant in
+            the fit, which are skipped (a parameter fixed at a bound is deliberate)
+        par_names (:obj:`list` of :obj:`str` or :obj:`None`): names of the full set of
+            model parameters, used to identify parameters. If ``None``, parameters are
+            identified by index only.
+
+    Returns:
+        :obj:`list` of :obj:`str`: one message per parameter at a bound
+    """
+    messages = []
+    for par_index, (fitted_par, (lower, upper)) in enumerate(
+        zip(fitted_pars, par_bounds)
+    ):
+        if par_index in fixed_idx or (lower is None and upper is None):
+            continue
+        if lower is not None and upper is not None:
+            tolerance = _AT_BOUND_RTOL * (upper - lower)
+        else:
+            one_sided_bound = lower if lower is not None else upper
+            tolerance = _AT_BOUND_RTOL * max(1.0, abs(one_sided_bound))
+        if any(
+            bound is not None and abs(fitted_par - bound) <= tolerance
+            for bound in (lower, upper)
+        ):
+            par_label = (
+                f"'{par_names[par_index]}' (index {par_index})"
+                if par_names is not None
+                else f"at index {par_index}"
+            )
+            lower_str = "None" if lower is None else f"{lower:g}"
+            upper_str = "None" if upper is None else f"{upper:g}"
+            messages.append(
+                f"fit result for parameter {par_label} is at a bound: value={fitted_par:g}, bounds=({lower_str}, {upper_str})"
+            )
+    return messages
+
 
 class OptimizerMixin:
     """Mixin Class to build optimizers."""
@@ -69,7 +120,14 @@ class OptimizerMixin:
         return result
 
     def _internal_postprocess(
-        self, fitresult, stitch_pars, /, par_bounds, *, return_uncertainties=False
+        self,
+        fitresult,
+        stitch_pars,
+        *,
+        par_bounds=None,
+        fixed_idx=(),
+        par_names=None,
+        return_uncertainties=False,
     ):
         """
         Post-process the fit result.
@@ -77,9 +135,16 @@ class OptimizerMixin:
         Args:
             fitresult (scipy.optimize.OptimizeResult): Fit result from :func:`_internal_minimize`
             stitch_pars (:obj:`func`): callable that stitches fixed parameters into the unfixed parameters
-            par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
-                are allowed to reach in the fit.
+            par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the full set of
+                model parameters are allowed to reach in the fit.
                 The shape should be ``(n, 2)`` for ``n`` model parameters.
+                If ``None`` (the default), the check warning about fitted parameters at their
+                bounds is skipped.
+            fixed_idx (:obj:`sequence` of :obj:`int`): The indices of the model parameters held
+                constant in the fit, which are excluded from the at-bound check.
+            par_names (:obj:`list` of :obj:`str`): The names of the full set of model parameters,
+                used to identify parameters in the at-bound warning. If ``None``, parameters are
+                identified by index only.
             return_uncertainties (:obj:`bool`): Return uncertainties on the fitted parameters. Default is off (``False``).
 
         Returns:
@@ -87,23 +152,20 @@ class OptimizerMixin:
         """
         tensorlib, _ = get_backend()
 
-        # fitresult.x and par_bounds both cover only the free parameters
-        # (fixed params are stripped by shim() before optimization and
-        # stitched back in below), so they always align correctly.
-        for par_index, (fitted_par, (lower, upper)) in enumerate(
-            zip(fitresult.x, par_bounds)
-        ):
-            if fitted_par in (lower, upper):
-                log.warning(
-                    "fit result for parameter at index %d is at a bound: value=%g, bounds=(%g, %g)",
-                    par_index,
-                    fitted_par,
-                    lower,
-                    upper,
-                )
-
         # stitch in missing parameters (e.g. fixed parameters)
         fitted_pars = stitch_pars(tensorlib.astensor(fitresult.x))
+
+        if par_bounds is not None:
+            # fitted_pars covers the full set of model parameters, so it aligns
+            # with par_bounds whether or not fixed parameters were stripped from
+            # fitresult.x for the minimization (do_stitch)
+            at_bound_messages = _at_bound_warning_messages(
+                tensorlib.tolist(fitted_pars), par_bounds, fixed_idx, par_names
+            )
+            if at_bound_messages:
+                # a single warning per fit to avoid excessively logging in
+                # pseudoexperiment studies
+                log.warning("\n".join(at_bound_messages))
 
         # check if uncertainties were provided (and stitch just in case)
         uncertainties = getattr(fitresult, "unc", None)
@@ -211,6 +273,10 @@ class OptimizerMixin:
         except AttributeError:
             par_names = None
 
+        # keep the full set of parameter names for the at-bound check in
+        # postprocessing, before fixed parameters are stripped below
+        all_par_names = list(par_names) if par_names else None
+
         # need to remove parameters that are fixed in the fit
         if par_names and do_stitch and fixed_vals:
             for index, _ in fixed_vals:
@@ -224,6 +290,8 @@ class OptimizerMixin:
             result,
             stitch_pars,
             par_bounds=par_bounds,
+            fixed_idx=[index for index, _ in fixed_vals or []],
+            par_names=all_par_names,
             return_uncertainties=return_uncertainties,
         )
 

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -273,7 +273,6 @@ class OptimizerMixin:
             # fitresult.x for the minimization (do_stitch)
             fitted_pars_list = tensorlib.tolist(fitted_pars)
             npars = len(fitted_pars_list)
-            par_bounds = list(par_bounds)
             if len(par_bounds) != npars:
                 log.warning(
                     "length of par_bounds (%d) does not match the number of model parameters (%d), skipping check for parameters at bounds",
@@ -407,6 +406,11 @@ class OptimizerMixin:
                     np.broadcast_to(par_bounds.ub, len(init_pars)),
                 )
             )
+        elif par_bounds is not None:
+            # materialize before shim() and the minimizer consume it, as a one-shot
+            # iterable (generator, zip, map) would otherwise be exhausted by the time
+            # the at-bound check in _internal_postprocess indexes it
+            par_bounds = list(par_bounds)
 
         minimizer_kwargs, stitch_pars = shim(
             objective,

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -281,10 +281,13 @@ class OptimizerMixin:
                 )
             else:
                 minuit = getattr(fitresult, "minuit", None)
+                # fmin is None until migrad has run, and a non-iminuit result may
+                # carry no fmin at all, so guard it as defensively as minuit itself
+                fmin = getattr(minuit, "fmin", None)
                 # the O(1) aggregate gates the per-parameter walk
                 at_limit = (
                     _minuit_at_limit_flags(minuit, npars, fixed_idx)
-                    if minuit is not None and minuit.fmin.has_parameters_at_limit
+                    if fmin is not None and fmin.has_parameters_at_limit
                     else None
                 )
                 at_bound_messages = _at_bound_warning_messages(

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -109,8 +109,6 @@ def _at_bound_warning_messages(
     messages: list[str] = []
     fixed = set(fixed_idx)
     for par_index, (fitted_par, bounds) in enumerate(zip(fitted_pars, par_bounds)):
-        if par_index in fixed:
-            continue
         # a None or non-finite bound is unbounded on that side
         raw_lower, raw_upper = bounds
         lower = (
@@ -124,10 +122,16 @@ def _at_bound_warning_messages(
         upper_str = "None" if raw_upper is None else f"{raw_upper:g}"
         bounds_str = f"bounds=({lower_str}, {upper_str})"
 
+        # checked before the fixed-parameter skip below: a parameter held
+        # constant *at* a bound is deliberate, but one holding a non-finite
+        # value is a symptom (a corrupted fixed_vals, or a non-finite init_pars
+        # entry stitched back in) and must not be swallowed
         if not math.isfinite(fitted_par):
             messages.append(
                 f"fit result for parameter {_par_label(par_index)} is not finite: value={fitted_par!r}, {bounds_str}"
             )
+            continue
+        if par_index in fixed:
             continue
         # scale the tolerance with the bound range so that it stays meaningful
         # for both wide bounds and bounds with small endpoints

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -63,7 +63,7 @@ def _at_bound_warning_messages(
     fixed_idx: Sequence[int],
     par_names: Sequence[str] | None,
     at_limit: Sequence[bool] | None = None,
-    rtol: float = 1e-4,
+    rtol: float = 1e-8,
 ) -> list[str]:
     """
     Build warning messages for free fitted parameters that are at a bound.
@@ -84,10 +84,12 @@ def _at_bound_warning_messages(
             by the tolerance check are reported with the optimizer's criterion
             spelled out, as they need not be numerically at a bound.
         rtol (:obj:`float`): relative tolerance for deciding that a fitted parameter is
-            at a bound: within ``rtol * max(1, |bound|)`` of the bound, or beyond it.
-            Optimizers stop near but not exactly at bounds --- measured rail distances
-            are O(1e-14) for scipy's SLSQP and up to O(1e-5) for minuit --- so exact
-            comparison would miss them. Default is ``1e-4``.
+            at a bound. The tolerance scales with the bound range (or with
+            ``max(1, |bound|)`` if only one side is bounded), so that it stays meaningful
+            for both wide bounds and bounds whose endpoints are small --- pyhf's own
+            ``shapesys`` and ``staterror`` gammas default to ``(1e-10, 10)``. Optimizers
+            stop near but not exactly at bounds (scipy's SLSQP rails within O(1e-14)),
+            so exact comparison would miss them. Default is ``1e-8``.
 
     Returns:
         :obj:`list` of :obj:`str`: one message per parameter at a bound
@@ -105,11 +107,6 @@ def _at_bound_warning_messages(
     for par_index, (fitted_par, bounds) in enumerate(zip(fitted_pars, par_bounds)):
         if par_index in fixed:
             continue
-        if not math.isfinite(fitted_par):
-            messages.append(
-                f"fit result for parameter {_par_label(par_index)} is not finite: value={fitted_par!r}"
-            )
-            continue
         # a None or non-finite bound is unbounded on that side
         raw_lower, raw_upper = bounds
         lower = (
@@ -118,22 +115,36 @@ def _at_bound_warning_messages(
         upper = (
             raw_upper if raw_upper is not None and math.isfinite(raw_upper) else None
         )
+        # display the bounds as provided, not as normalized
+        lower_str = "None" if raw_lower is None else f"{raw_lower:g}"
+        upper_str = "None" if raw_upper is None else f"{raw_upper:g}"
+        bounds_str = f"bounds=({lower_str}, {upper_str})"
+
+        if not math.isfinite(fitted_par):
+            messages.append(
+                f"fit result for parameter {_par_label(par_index)} is not finite: value={fitted_par!r}, {bounds_str}"
+            )
+            continue
+        # scale the tolerance with the bound range so that it stays meaningful
+        # for both wide bounds and bounds with small endpoints
+        if lower is not None and upper is not None:
+            tolerance = rtol * abs(upper - lower)
+        else:
+            one_sided = lower if lower is not None else upper
+            tolerance = (
+                rtol * max(1.0, abs(one_sided)) if one_sided is not None else None
+            )
         if (
             lower is not None
             and lower == upper
-            and abs(fitted_par - lower) <= rtol * max(1.0, abs(lower))
+            and abs(fitted_par - lower) <= tolerance
         ):
             # bounds that pin the parameter to a single value are deliberate,
             # like the fixed parameters skipped above, but only exonerate
             # the parameter if it actually sits at the pinned value
             continue
-        # one-sided comparisons also catch values beyond the bounds
-        at_lower = lower is not None and fitted_par <= lower + rtol * max(
-            1.0, abs(lower)
-        )
-        at_upper = upper is not None and fitted_par >= upper - rtol * max(
-            1.0, abs(upper)
-        )
+        at_lower = lower is not None and fitted_par <= lower + tolerance
+        at_upper = upper is not None and fitted_par >= upper - tolerance
         optimizer_at_limit = (
             at_limit is not None
             and par_index < len(at_limit)
@@ -141,18 +152,24 @@ def _at_bound_warning_messages(
         )
         if not (at_lower or at_upper or optimizer_at_limit):
             continue
-        # display the bounds as provided (e.g. inf), not as normalized
-        lower_str = "None" if raw_lower is None else f"{raw_lower:g}"
-        upper_str = "None" if raw_upper is None else f"{raw_upper:g}"
-        if at_lower or at_upper:
+
+        if (lower is not None and fitted_par < lower) or (
+            upper is not None and fitted_par > upper
+        ):
+            # Being strictly outside the bounds is worse than being at one.
+            # The minimization returned a point the bounds should have excluded.
             messages.append(
-                f"fit result for parameter {_par_label(par_index)} is at a bound: value={fitted_par!r}, bounds=({lower_str}, {upper_str})"
+                f"fit result for parameter {_par_label(par_index)} is outside its bounds: value={fitted_par!r}, {bounds_str}"
+            )
+        elif at_lower or at_upper:
+            messages.append(
+                f"fit result for parameter {_par_label(par_index)} is at a bound: value={fitted_par!r}, {bounds_str}"
             )
         else:
             # flagged only by the optimizer's own statistical criterion, so
             # the value need not be numerically at a bound
             messages.append(
-                f"fit result for parameter {_par_label(par_index)} is within half its uncertainty of a bound (iminuit at-limit criterion): value={fitted_par!r}, bounds=({lower_str}, {upper_str})"
+                f"fit result for parameter {_par_label(par_index)} is within half its uncertainty of a bound (iminuit at-limit criterion): value={fitted_par!r}, {bounds_str}"
             )
     return messages
 
@@ -343,9 +360,12 @@ class OptimizerMixin:
         """
         Find parameters that minimize the objective.
 
-        When ``par_bounds`` is provided, a ``WARNING`` log message is emitted
-        for any free fitted parameter at (or beyond) a bound, as such
-        parameters can indicate problems with the fit.
+        When ``par_bounds`` is provided, a ``WARNING`` log message is emitted for
+        any free fitted parameter that is at (or outside) a bound, as such
+        parameters can indicate problems with the fit. With the minuit optimizer
+        parameters that iminuit reports as being at a limit --- within half their
+        uncertainty of a bound, which need not be numerically at it --- are
+        reported as well, under distinct wording.
 
         Args:
             objective (:obj:`func`): objective function
@@ -355,7 +375,6 @@ class OptimizerMixin:
             par_bounds (:obj:`list` of :obj:`list`/:obj:`tuple`): The extrema of values the model parameters
                 are allowed to reach in the fit.
                 The shape should be ``(n, 2)`` for ``n`` model parameters.
-                A :class:`scipy.optimize.Bounds` instance is also accepted.
             fixed_vals (:obj:`list` of :obj:`list`/:obj:`tuple`): The pairs of index and constant value for a constant
                 model parameter during minimization. Set to ``None`` to allow all parameters to float.
             return_fitted_val (:obj:`bool`): Return bestfit value of the objective. Default is off (``False``).
@@ -378,8 +397,10 @@ class OptimizerMixin:
         do_grad = tensorlib.default_do_grad if do_grad is None else do_grad
 
         if isinstance(par_bounds, scipy.optimize.Bounds):
-            # normalize to pairs (lb/ub broadcast to the number of parameters)
-            # so that all optimizer and do_stitch code paths handle the bounds
+            # scipy accepts a Bounds instance, so can use the optimizer
+            # API. Normalize to pairs (lb/ub broadcast to the number of
+            # parameters) so the stitching and postprocessing paths, which
+            # index bounds per parameter, do not choke on it
             par_bounds = list(
                 zip(
                     np.broadcast_to(par_bounds.lb, len(init_pars)),

--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -157,11 +157,14 @@ def _at_bound_warning_messages(
         if not (at_lower or at_upper or optimizer_at_limit):
             continue
 
-        if (lower is not None and fitted_par < lower) or (
-            upper is not None and fitted_par > upper
+        if (lower is not None and fitted_par < lower - tolerance) or (
+            upper is not None and fitted_par > upper + tolerance
         ):
-            # Being strictly outside the bounds is worse than being at one.
-            # The minimization returned a point the bounds should have excluded.
+            # Being outside the bounds is worse than being at one: the
+            # minimization returned a point the bounds should have excluded.
+            # Judged against the same tolerance as the at-bound check, so that
+            # the float slop optimizers leave behind is not reported as a
+            # constraint violation.
             messages.append(
                 f"fit result for parameter {_par_label(par_index)} is outside its bounds: value={fitted_par!r}, {bounds_str}"
             )

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -599,3 +599,42 @@ def test_minuit_all_fixed_params():
     data = [80] + model.config.auxdata
     result = pyhf.infer.mle.fit(data, model, fixed_params=[True, True])
     assert result is not None
+
+
+@pytest.mark.parametrize(
+    ("fitted_x", "par_bounds", "expect_warning"),
+    [
+        # exactly at lower bound
+        ([3.0], [(3.0, 10.0)], True),
+        # exactly at upper bound
+        ([10.0], [(3.0, 10.0)], True),
+        # interior — no warning
+        ([5.0], [(3.0, 10.0)], False),
+    ],
+    ids=["lower_bound", "upper_bound", "no_bound"],
+)
+def test_parameter_at_bounds_warning(caplog, fitted_x, par_bounds, expect_warning):
+    # Regression test for https://github.com/scikit-hep/pyhf/issues/2525
+    # Test _internal_postprocess directly with controlled fit results so the
+    # check is independent of optimizer-specific floating-point behaviour.
+    import logging
+
+    from scipy.optimize import OptimizeResult
+
+    from pyhf.optimize.mixins import OptimizerMixin
+
+    def stitch_pars(x, _stitch_with=None):
+        return x
+
+    mixin = OptimizerMixin()
+    result = OptimizeResult(x=np.array(fitted_x), fun=0.0, success=True)
+
+    with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
+        mixin._internal_postprocess(result, stitch_pars, par_bounds=par_bounds)
+
+    warning_records = [r for r in caplog.records if "is at a bound" in r.message]
+    if expect_warning:
+        assert len(warning_records) == 1
+        assert "bounds" in warning_records[0].message
+    else:
+        assert len(warning_records) == 0

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -639,6 +639,12 @@ NOT_FINITE = "is not finite"
         ([5e-5], [(1e-10, 10.0)], None),
         # outside the lower bound (constraint violation)
         ([2.5], [(3.0, 10.0)], OUTSIDE_BOUNDS),
+        # ... but float slop below a bound is being *at* it, not violating it:
+        # the escalation is judged against the same tolerance as the detection
+        ([-1e-17], [(0.0, 10.0)], AT_BOUND),
+        ([-1e-6], [(0.0, 10.0)], OUTSIDE_BOUNDS),
+        ([10.0 + 1e-8], [(0.0, 10.0)], AT_BOUND),
+        ([10.0 + 1e-6], [(0.0, 10.0)], OUTSIDE_BOUNDS),
         # interior — no warning
         ([5.0], [(3.0, 10.0)], None),
         # near lower bound but outside tolerance — no warning
@@ -677,6 +683,10 @@ NOT_FINITE = "is not finite"
         "near_bound_within_tolerance",
         "small_bound_value_interior",
         "outside_lower_bound",
+        "below_bound_within_tolerance",
+        "below_bound_outside_tolerance",
+        "above_bound_within_tolerance",
+        "above_bound_outside_tolerance",
         "interior",
         "near_bound_outside_tolerance",
         "wide_bounds_interior",

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -618,38 +618,58 @@ def _at_bound_warning_lines(caplog):
     return _warning_lines(caplog, "is at a bound")
 
 
+# the three kinds of message the check can emit; expected_kind is the substring
+# that identifies one, or None when the parameter must not be reported at all
+AT_BOUND = "is at a bound"
+OUTSIDE_BOUNDS = "is outside its bounds"
+NOT_FINITE = "is not finite"
+
+
 @pytest.mark.parametrize(
-    ("fitted_x", "par_bounds", "expect_warning"),
+    ("fitted_x", "par_bounds", "expected_kind"),
     [
         # exactly at lower bound
-        ([3.0], [(3.0, 10.0)], True),
+        ([3.0], [(3.0, 10.0)], AT_BOUND),
         # exactly at upper bound
-        ([10.0], [(3.0, 10.0)], True),
+        ([10.0], [(3.0, 10.0)], AT_BOUND),
         # near lower bound, within tolerance (optimizers stop near, not at, bounds)
-        ([3.0 + 1e-9], [(3.0, 10.0)], True),
+        ([3.0 + 1e-9], [(3.0, 10.0)], AT_BOUND),
         # a gamma well above the (1e-10, 10) lower bound pyhf itself uses must
         # not be flagged just because the bound value is small
-        ([5e-5], [(1e-10, 10.0)], False),
+        ([5e-5], [(1e-10, 10.0)], None),
         # outside the lower bound (constraint violation)
-        ([2.5], [(3.0, 10.0)], True),
+        ([2.5], [(3.0, 10.0)], OUTSIDE_BOUNDS),
         # interior — no warning
-        ([5.0], [(3.0, 10.0)], False),
+        ([5.0], [(3.0, 10.0)], None),
         # near lower bound but outside tolerance — no warning
-        ([3.01], [(3.0, 10.0)], False),
+        ([3.01], [(3.0, 10.0)], None),
         # interior with wide bounds — the scaled tolerance stays far away
-        ([0.4], [(0.0, 1e6)], False),
+        ([0.4], [(0.0, 1e6)], None),
         # a narrow bound range must not be swallowed by the tolerance
-        ([0.5], [(0.49995, 0.50005)], False),
+        ([0.5], [(0.49995, 0.50005)], None),
+        # the tolerance scales with the *range*, not with either endpoint alone:
+        # 1e-7 is inside a (0, 10) window but outside a (0, 1) one
+        ([1e-7], [(0.0, 10.0)], AT_BOUND),
+        ([1e-7], [(0.0, 1.0)], None),
+        # ... and the range is what matters even when the near endpoint is small
+        ([1.0 - 5e-8], [(-10.0, 1.0)], AT_BOUND),
+        # ... and it is not floored at 1, or this narrow window would swallow 1e-10
+        ([0.49995 + 1e-10], [(0.49995, 0.50005)], None),
         # non-finite bounds are unbounded — nothing to be at
-        ([0.4], [(-np.inf, np.inf)], False),
+        ([0.4], [(-np.inf, np.inf)], None),
         # at lower bound with an infinite upper bound
-        ([0.0], [(0.0, np.inf)], True),
+        ([0.0], [(0.0, np.inf)], AT_BOUND),
+        # an infinite bound must be unbounded rather than an infinite tolerance
+        # window that swallows every interior value
+        ([5.0], [(0.0, np.inf)], None),
         # bounds that pin the parameter are deliberate — no warning
-        ([1.0], [(1.0, 1.0)], False),
+        ([1.0], [(1.0, 1.0)], None),
         # but pinning bounds do not exonerate a value away from the pin
-        ([5.0], [(1.0, 1.0)], True),
+        ([5.0], [(1.0, 1.0)], OUTSIDE_BOUNDS),
         # inverted bounds are malformed and surfaced rather than silenced
-        ([5.0], [(10.0, 3.0)], True),
+        ([5.0], [(10.0, 3.0)], OUTSIDE_BOUNDS),
+        # a non-finite fit result is surfaced as such, not compared to the bounds
+        ([np.inf], [(3.0, 10.0)], NOT_FINITE),
     ],
     ids=[
         "lower_bound",
@@ -661,14 +681,20 @@ def _at_bound_warning_lines(caplog):
         "near_bound_outside_tolerance",
         "wide_bounds_interior",
         "narrow_bounds_interior",
+        "tolerance_scales_with_range_wide",
+        "tolerance_scales_with_range_narrow",
+        "tolerance_scales_with_range_small_endpoint",
+        "tolerance_not_floored_at_unity",
         "unbounded",
         "lower_bound_infinite_upper",
+        "infinite_upper_interior",
         "degenerate_bounds_at_pin",
         "degenerate_bounds_violated",
         "inverted_bounds",
+        "infinite_value",
     ],
 )
-def test_parameter_at_bounds_warning(caplog, fitted_x, par_bounds, expect_warning):
+def test_parameter_at_bounds_warning(caplog, fitted_x, par_bounds, expected_kind):
     # Regression test for https://github.com/scikit-hep/pyhf/issues/2525
     # Test _internal_postprocess directly with controlled fit results so the
     # check is independent of optimizer-specific floating-point behaviour.
@@ -681,13 +707,16 @@ def test_parameter_at_bounds_warning(caplog, fitted_x, par_bounds, expect_warnin
         )
 
     warning_lines = _warning_lines(caplog)
-    if expect_warning:
+    if expected_kind is None:
+        assert len(warning_lines) == 0
+    else:
         assert len(warning_lines) == 1
+        # assert the message *kind*, not just that something was logged: being
+        # outside a bound is a stronger claim than sitting on one
+        assert expected_kind in warning_lines[0]
         assert "'mu' (index 0)" in warning_lines[0]
         # full-precision repr so a near-bound value is distinguishable from the bound
         assert f"value={fitted_x[0]!r}" in warning_lines[0]
-    else:
-        assert len(warning_lines) == 0
 
 
 def test_parameter_at_bounds_warning_fixed_parameter(caplog):
@@ -847,10 +876,15 @@ def test_no_parameter_at_bounds_warning_infinite_bounds(caplog):
 
 
 @pytest.mark.parametrize("optimizer_name", ["scipy", "minuit"])
-def test_parameter_at_bounds_warning_scipy_bounds_object(caplog, optimizer_name):
+@pytest.mark.parametrize("do_stitch", [False, True])
+def test_parameter_at_bounds_warning_scipy_bounds_object(
+    caplog, optimizer_name, do_stitch
+):
     # A scipy.optimize.Bounds instance is a valid bounds specification through
     # the direct optimizer API: it is normalized to pairs in minimize() so all
-    # optimizer and do_stitch code paths (and postprocessing) handle it.
+    # optimizer and do_stitch code paths (and postprocessing) handle it. shim()
+    # slices par_bounds per parameter under do_stitch, which a Bounds instance
+    # does not support, so the fixed_vals + do_stitch combination is covered too.
     pyhf.set_backend("numpy", optimizer_name)
     model = pyhf.simplemodels.uncorrelated_background(
         signal=[5.0], bkg=[10.0], bkg_uncertainty=[3.5]
@@ -865,6 +899,8 @@ def test_parameter_at_bounds_warning_scipy_bounds_object(caplog, optimizer_name)
             model,
             model.config.suggested_init(),
             Bounds([0.0, 1e-10], [10.0, 10.0]),
+            fixed_vals=[(1, 1.0)],
+            do_stitch=do_stitch,
         )
 
     assert result is not None
@@ -872,6 +908,26 @@ def test_parameter_at_bounds_warning_scipy_bounds_object(caplog, optimizer_name)
     assert len(warning_lines) == 1
     assert "'mu' (index 0)" in warning_lines[0]
     assert "uncorr_bkguncrt" not in warning_lines[0]
+
+
+@pytest.mark.parametrize(
+    "par_bounds", [[(0.0, None)], [(0.0, np.inf)]], ids=["none", "inf"]
+)
+def test_parameter_at_bounds_warning_reports_bounds_as_given(caplog, par_bounds):
+    # An unbounded side is normalized to None for the comparison, but the message
+    # must echo the bound the user supplied so they can match it to their input.
+    mixin = OptimizerMixin()
+    result = OptimizeResult(x=np.array([0.0]), fun=0.0, success=True)
+
+    with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
+        mixin._internal_postprocess(
+            result, _make_stitch_pars(), par_bounds=par_bounds, par_names=["mu"]
+        )
+
+    warning_lines = _at_bound_warning_lines(caplog)
+    assert len(warning_lines) == 1
+    expected = "None" if par_bounds[0][1] is None else "inf"
+    assert f"bounds=(0, {expected})" in warning_lines[0]
 
 
 def test_parameter_at_bounds_warning_nan_value(caplog):
@@ -986,32 +1042,116 @@ def test_minuit_at_limit_flags_real_minuit():
     assert any(flags) == minuit.fmin.has_parameters_at_limit
 
 
-def test_minuit_at_limit_flags_skips_fixed_and_unbounded():
-    # fixed and unbounded parameters cannot be at a limit and must be skipped,
-    # matching iminuit's own aggregation (cf. iminuit.util.FMin)
+def _minuit_param_stub(value, error, lower=None, upper=None, is_fixed=False):
+    # stands in for iminuit.util.Param, which cannot be constructed with
+    # arbitrary limits without running a fit
+    return SimpleNamespace(
+        is_fixed=is_fixed,
+        has_limits=not (lower is None and upper is None),
+        has_lower_limit=lower is not None,
+        lower_limit=lower,
+        has_upper_limit=upper is not None,
+        upper_limit=upper,
+        value=value,
+        error=error,
+    )
+
+
+@pytest.mark.parametrize(
+    ("param", "expected"),
+    [
+        # iminuit's criterion is min(value - lower, upper - value) < 0.5 * error,
+        # so with error=1.0 the threshold sits at a distance of 0.5 from a bound
+        (_minuit_param_stub(0.4, 1.0, lower=0.0, upper=10.0), True),
+        (_minuit_param_stub(0.6, 1.0, lower=0.0, upper=10.0), False),
+        # the criterion applies to whichever bound is nearer, not just the lower
+        (_minuit_param_stub(9.7, 1.0, lower=0.0, upper=10.0), True),
+        # a one-sided limit is unbounded on the other side, so a value far from
+        # the limit it does have is not at a limit
+        (_minuit_param_stub(5.0, 1.0, upper=10.0), False),
+        (_minuit_param_stub(5.0, 1.0, lower=0.0), False),
+        # fixed and unbounded parameters cannot be at a limit at all
+        (_minuit_param_stub(0.4, 1.0, lower=0.0, upper=10.0, is_fixed=True), False),
+        (_minuit_param_stub(0.4, 1.0), False),
+    ],
+    ids=[
+        "inside_half_uncertainty",
+        "outside_half_uncertainty",
+        "near_upper_limit",
+        "one_sided_upper_far_away",
+        "one_sided_lower_far_away",
+        "fixed",
+        "unbounded",
+    ],
+)
+def test_minuit_at_limit_flags_criterion(param, expected):
+    # pin iminuit's criterion itself (cf. iminuit.util.FMin), which the message
+    # wording quotes verbatim
+    from pyhf.optimize.mixins import _minuit_at_limit_flags
+
+    minuit_stub = SimpleNamespace(params=[param])
+    assert _minuit_at_limit_flags(minuit_stub, npars=1, fixed_idx=()) == [expected]
+
+
+def test_minuit_at_limit_flags_full_parameter_set_is_not_remapped():
+    # do_stitch=False: minuit sees every model parameter, fixed ones included,
+    # so the flags already align and must not be run through the free-parameter
+    # remap, which would shift them onto the wrong model indices
     from pyhf.optimize.mixins import _minuit_at_limit_flags
 
     minuit_stub = SimpleNamespace(
         params=[
-            SimpleNamespace(is_fixed=True, has_limits=True),
-            SimpleNamespace(is_fixed=False, has_limits=False),
-            SimpleNamespace(
-                is_fixed=False,
-                has_limits=True,
-                has_lower_limit=True,
-                lower_limit=0.0,
-                has_upper_limit=True,
-                upper_limit=10.0,
-                value=0.5,
-                error=1.5,
-            ),
+            _minuit_param_stub(5.0, 1.0, lower=0.0, upper=10.0, is_fixed=True),
+            _minuit_param_stub(5.0, 1.0, lower=0.0, upper=10.0),
+            _minuit_param_stub(0.4, 1.0, lower=0.0, upper=10.0),
         ]
     )
-    assert _minuit_at_limit_flags(minuit_stub, npars=3, fixed_idx=()) == [
+    assert _minuit_at_limit_flags(minuit_stub, npars=3, fixed_idx=[0]) == [
         False,
         False,
         True,
     ]
+
+
+def test_minuit_at_limit_flags_remap_preserves_unflagged_parameters():
+    # do_stitch=True: minuit saw only the free parameters, so flags map back to
+    # model indices --- and a free parameter that is not at a limit must stay
+    # False through the mapping rather than inheriting its neighbour's flag
+    from pyhf.optimize.mixins import _minuit_at_limit_flags
+
+    minuit_stub = SimpleNamespace(
+        params=[
+            _minuit_param_stub(0.4, 1.0, lower=0.0, upper=10.0),  # model index 0
+            _minuit_param_stub(5.0, 1.0, lower=0.0, upper=10.0),  # model index 2
+            _minuit_param_stub(5.0, 1.0, lower=0.0, upper=10.0),  # model index 3
+        ]
+    )
+    assert _minuit_at_limit_flags(minuit_stub, npars=4, fixed_idx=[1]) == [
+        True,
+        False,
+        False,
+        False,
+    ]
+
+
+def test_no_parameter_at_bounds_warning_when_minuit_reports_no_limits(caplog):
+    # the O(1) aggregate gates the per-parameter walk: when iminuit reports no
+    # parameter at a limit, its criterion must not be re-evaluated per parameter
+    minuit_stub = SimpleNamespace(
+        fmin=SimpleNamespace(has_parameters_at_limit=False),
+        params=[_minuit_param_stub(0.4, 1.0, lower=0.0, upper=10.0)],
+    )
+    mixin = OptimizerMixin()
+    result = OptimizeResult(
+        x=np.array([0.4]), fun=0.0, success=True, minuit=minuit_stub
+    )
+
+    with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
+        mixin._internal_postprocess(
+            result, _make_stitch_pars(), par_bounds=[(0.0, 10.0)], par_names=["mu"]
+        )
+
+    assert not _warning_lines(caplog)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -1,11 +1,12 @@
 import itertools
 import logging
+from types import SimpleNamespace
 from unittest.mock import PropertyMock, patch
 
 import iminuit
 import numpy as np
 import pytest
-from scipy.optimize import OptimizeResult, OptimizeWarning, minimize
+from scipy.optimize import Bounds, OptimizeResult, OptimizeWarning, minimize
 
 import pyhf
 from pyhf.optimize.common import _get_tensor_shim, _make_stitch_pars
@@ -602,6 +603,16 @@ def test_minuit_all_fixed_params():
     assert result is not None
 
 
+def _at_bound_warning_lines(caplog):
+    # the check emits a single aggregated record per fit with one line per parameter
+    return [
+        line
+        for record in caplog.records
+        if "is at a bound" in record.message
+        for line in record.message.splitlines()
+    ]
+
+
 @pytest.mark.parametrize(
     ("fitted_x", "par_bounds", "expect_warning"),
     [
@@ -609,19 +620,37 @@ def test_minuit_all_fixed_params():
         ([3.0], [(3.0, 10.0)], True),
         # exactly at upper bound
         ([10.0], [(3.0, 10.0)], True),
-        # near lower bound, within tolerance (minuit stops near, not at, bounds)
-        ([3.0 + 1e-7 * 7.0], [(3.0, 10.0)], True),
+        # near lower bound, within tolerance (optimizers stop near, not at, bounds)
+        ([3.0 + 1e-9], [(3.0, 10.0)], True),
+        # beyond the lower bound (constraint violation)
+        ([2.5], [(3.0, 10.0)], True),
         # interior — no warning
         ([5.0], [(3.0, 10.0)], False),
         # near lower bound but outside tolerance — no warning
         ([3.01], [(3.0, 10.0)], False),
+        # interior with wide bounds — tolerance must not scale with the range
+        ([0.4], [(0.0, 1e6)], False),
+        # non-finite bounds are unbounded — nothing to be at
+        ([0.4], [(-np.inf, np.inf)], False),
+        # at lower bound with an infinite upper bound
+        ([0.0], [(0.0, np.inf)], True),
+        # bounds that pin the parameter are deliberate — no warning
+        ([1.0], [(1.0, 1.0)], False),
+        # inverted bounds are malformed and surfaced rather than silenced
+        ([5.0], [(10.0, 3.0)], True),
     ],
     ids=[
         "lower_bound",
         "upper_bound",
         "near_bound_within_tolerance",
+        "below_lower_bound",
         "interior",
         "near_bound_outside_tolerance",
+        "wide_bounds_interior",
+        "unbounded",
+        "lower_bound_infinite_upper",
+        "degenerate_bounds",
+        "inverted_bounds",
     ],
 )
 def test_parameter_at_bounds_warning(caplog, fitted_x, par_bounds, expect_warning):
@@ -636,17 +665,13 @@ def test_parameter_at_bounds_warning(caplog, fitted_x, par_bounds, expect_warnin
             result, _make_stitch_pars(), par_bounds=par_bounds, par_names=["mu"]
         )
 
-    warning_records = [
-        record for record in caplog.records if "is at a bound" in record.message
-    ]
+    warning_lines = _at_bound_warning_lines(caplog)
     if expect_warning:
-        assert len(warning_records) == 1
-        message = warning_records[0].message
-        assert "'mu' (index 0)" in message
-        assert f"value={fitted_x[0]:g}" in message
-        assert "bounds=(3, 10)" in message
+        assert len(warning_lines) == 1
+        assert "'mu' (index 0)" in warning_lines[0]
+        assert f"value={fitted_x[0]:g}" in warning_lines[0]
     else:
-        assert len(warning_records) == 0
+        assert len(warning_lines) == 0
 
 
 def test_parameter_at_bounds_warning_fixed_parameter(caplog):
@@ -663,9 +688,7 @@ def test_parameter_at_bounds_warning_fixed_parameter(caplog):
             fixed_idx=[0],
         )
 
-    assert not [
-        record for record in caplog.records if "is at a bound" in record.message
-    ]
+    assert not _at_bound_warning_lines(caplog)
 
 
 def test_parameter_at_bounds_warning_nonterminal_fixed_parameter(caplog):
@@ -688,15 +711,12 @@ def test_parameter_at_bounds_warning_nonterminal_fixed_parameter(caplog):
             par_names=["fixed_par", "free_par"],
         )
 
-    warning_records = [
-        record for record in caplog.records if "is at a bound" in record.message
-    ]
-    assert len(warning_records) == 1
-    message = warning_records[0].message
+    warning_lines = _at_bound_warning_lines(caplog)
+    assert len(warning_lines) == 1
     # the fixed parameter (model index 0, held at its lower bound) is skipped
-    assert "'free_par' (index 1)" in message
-    assert "fixed_par" not in message
-    assert "bounds=(3, 10)" in message
+    assert "'free_par' (index 1)" in warning_lines[0]
+    assert "fixed_par" not in warning_lines[0]
+    assert "bounds=(3, 10)" in warning_lines[0]
 
 
 @pytest.mark.parametrize("optimizer", ["scipy", "minuit"])
@@ -728,13 +748,10 @@ def test_parameter_at_bounds_warning_end_to_end(caplog, optimizer):
     with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
         pyhf.infer.mle.fit(data, model, init_pars=[5.0], par_bounds=[(3.0, 10.0)])
 
-    warning_records = [
-        record for record in caplog.records if "is at a bound" in record.message
-    ]
-    assert len(warning_records) == 1
-    message = warning_records[0].message
-    assert "'mu' (index 0)" in message
-    assert "bounds=(3, 10)" in message
+    warning_lines = _at_bound_warning_lines(caplog)
+    assert len(warning_lines) == 1
+    assert "'mu' (index 0)" in warning_lines[0]
+    assert "bounds=(3, 10)" in warning_lines[0]
 
 
 def test_no_parameter_at_bounds_warning_fixed_poi(caplog):
@@ -748,9 +765,7 @@ def test_no_parameter_at_bounds_warning_fixed_poi(caplog):
     with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
         pyhf.infer.mle.fixed_poi_fit(0.0, data, model)
 
-    assert not [
-        record for record in caplog.records if "is at a bound" in record.message
-    ]
+    assert not _at_bound_warning_lines(caplog)
 
 
 def test_minimize_par_bounds_none(caplog):
@@ -772,9 +787,7 @@ def test_minimize_par_bounds_none(caplog):
         )
 
     assert result is not None
-    assert not [
-        record for record in caplog.records if "is at a bound" in record.message
-    ]
+    assert not _at_bound_warning_lines(caplog)
 
 
 def test_parameter_at_bounds_warning_open_bound(caplog):
@@ -796,10 +809,127 @@ def test_parameter_at_bounds_warning_open_bound(caplog):
             [(0.0, None), (1e-10, 10.0)],
         )
 
+    warning_lines = _at_bound_warning_lines(caplog)
+    assert len(warning_lines) == 1
+    assert "'mu' (index 0)" in warning_lines[0]
+    assert "uncorr_bkguncrt" not in warning_lines[0]
+    assert "bounds=(0, None)" in warning_lines[0]
+
+
+def test_no_parameter_at_bounds_warning_infinite_bounds(caplog):
+    # Non-finite bounds mean unbounded on that side: an interior fit must not
+    # warn just because the tolerance window would be infinite.
+    model = pyhf.simplemodels.uncorrelated_background(
+        signal=[5.0], bkg=[10.0], bkg_uncertainty=[3.5]
+    )
+    data = [12.0] + model.config.auxdata
+
+    with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
+        pyhf.infer.mle.fit(data, model, par_bounds=[(-np.inf, np.inf), (1e-10, 10.0)])
+
+    assert not _at_bound_warning_lines(caplog)
+
+
+def test_parameter_at_bounds_warning_scipy_bounds_object(caplog):
+    # A scipy.optimize.Bounds instance is a valid bounds specification for the
+    # scipy optimizer through the direct API and must not break postprocessing.
+    model = pyhf.simplemodels.uncorrelated_background(
+        signal=[5.0], bkg=[10.0], bkg_uncertainty=[3.5]
+    )
+    # best-fit mu is negative, so the fit rails at the lower bound of 0
+    data = [7.0] + model.config.auxdata
+
+    optimizer = pyhf.optimize.scipy_optimizer()
+    with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
+        result = optimizer.minimize(
+            pyhf.infer.mle.twice_nll,
+            data,
+            model,
+            model.config.suggested_init(),
+            Bounds([0.0, 1e-10], [10.0, 10.0]),
+        )
+
+    assert result is not None
+    warning_lines = _at_bound_warning_lines(caplog)
+    assert len(warning_lines) == 1
+    assert "'mu' (index 0)" in warning_lines[0]
+    assert "uncorr_bkguncrt" not in warning_lines[0]
+
+
+def test_parameter_at_bounds_warning_nan_value(caplog):
+    # A non-finite fit result must be surfaced, not silently swallowed.
+    mixin = OptimizerMixin()
+    result = OptimizeResult(x=np.array([np.nan]), fun=0.0, success=True)
+
+    with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
+        mixin._internal_postprocess(
+            result, _make_stitch_pars(), par_bounds=[(3.0, 10.0)], par_names=["mu"]
+        )
+
     warning_records = [
-        record for record in caplog.records if "is at a bound" in record.message
+        record for record in caplog.records if "is not finite" in record.message
     ]
     assert len(warning_records) == 1
-    message = warning_records[0].message
-    assert "'mu' (index 0)" in message
-    assert "bounds=(0, None)" in message
+    assert "'mu' (index 0)" in warning_records[0].message
+
+
+def test_parameter_at_bounds_warning_short_par_names(caplog):
+    # par_names shorter than the parameter vector (possible for non-pyhf model
+    # configs) must fall back to index labels instead of raising IndexError.
+    mixin = OptimizerMixin()
+    result = OptimizeResult(x=np.array([3.0, 4.0]), fun=0.0, success=True)
+
+    with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
+        mixin._internal_postprocess(
+            result,
+            _make_stitch_pars(),
+            par_bounds=[(3.0, 10.0), (4.0, 10.0)],
+            par_names=["mu"],
+        )
+
+    warning_lines = _at_bound_warning_lines(caplog)
+    assert len(warning_lines) == 2
+    assert "'mu' (index 0)" in warning_lines[0]
+    assert "at index 1" in warning_lines[1]
+
+
+def test_parameter_at_bounds_warning_minuit_at_limit(caplog):
+    # minuit's own at-limit determination (within half an uncertainty of a
+    # bound, cf. iminuit.util.FMin) must warn even when the fitted value is
+    # outside any numerical tolerance, including under do_stitch=True where
+    # the minuit parameters cover only the free parameters.
+    tv = _TensorViewer([[0], [1]])
+    stitch_pars = _make_stitch_pars(tv, fixed_values=[2.0])
+
+    minuit_stub = SimpleNamespace(
+        params=[
+            SimpleNamespace(
+                is_fixed=False,
+                has_limits=True,
+                has_lower_limit=True,
+                lower_limit=0.0,
+                has_upper_limit=True,
+                upper_limit=10.0,
+                value=0.5,
+                error=1.5,
+            )
+        ]
+    )
+    mixin = OptimizerMixin()
+    result = OptimizeResult(
+        x=np.array([0.5]), fun=0.0, success=True, minuit=minuit_stub
+    )
+
+    with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
+        mixin._internal_postprocess(
+            result,
+            stitch_pars,
+            par_bounds=[(0.0, 10.0), (0.0, 10.0)],
+            fixed_idx=[0],
+            par_names=["fixed_par", "free_par"],
+        )
+
+    warning_lines = _at_bound_warning_lines(caplog)
+    assert len(warning_lines) == 1
+    assert "'free_par' (index 1)" in warning_lines[0]
+    assert "value=0.5" in warning_lines[0]

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -603,15 +603,19 @@ def test_minuit_all_fixed_params():
     assert result is not None
 
 
-def _at_bound_warning_lines(caplog):
+def _warning_lines(caplog, match="fit result for parameter"):
     # the check emits a single aggregated record per fit with one line per
     # parameter, so filter per line (records can mix message types)
     return [
         line
         for record in caplog.records
         for line in record.message.splitlines()
-        if "is at a bound" in line
+        if match in line
     ]
+
+
+def _at_bound_warning_lines(caplog):
+    return _warning_lines(caplog, "is at a bound")
 
 
 @pytest.mark.parametrize(
@@ -623,16 +627,19 @@ def _at_bound_warning_lines(caplog):
         ([10.0], [(3.0, 10.0)], True),
         # near lower bound, within tolerance (optimizers stop near, not at, bounds)
         ([3.0 + 1e-9], [(3.0, 10.0)], True),
-        # at minuit's measured rail distance from the bound (up to O(1e-5))
-        ([1.7e-5], [(0.0, 10.0)], True),
-        # beyond the lower bound (constraint violation)
+        # a gamma well above the (1e-10, 10) lower bound pyhf itself uses must
+        # not be flagged just because the bound value is small
+        ([5e-5], [(1e-10, 10.0)], False),
+        # outside the lower bound (constraint violation)
         ([2.5], [(3.0, 10.0)], True),
         # interior — no warning
         ([5.0], [(3.0, 10.0)], False),
         # near lower bound but outside tolerance — no warning
         ([3.01], [(3.0, 10.0)], False),
-        # interior with wide bounds — tolerance must not scale with the range
+        # interior with wide bounds — the scaled tolerance stays far away
         ([0.4], [(0.0, 1e6)], False),
+        # a narrow bound range must not be swallowed by the tolerance
+        ([0.5], [(0.49995, 0.50005)], False),
         # non-finite bounds are unbounded — nothing to be at
         ([0.4], [(-np.inf, np.inf)], False),
         # at lower bound with an infinite upper bound
@@ -648,11 +655,12 @@ def _at_bound_warning_lines(caplog):
         "lower_bound",
         "upper_bound",
         "near_bound_within_tolerance",
-        "minuit_rail_distance",
-        "below_lower_bound",
+        "small_bound_value_interior",
+        "outside_lower_bound",
         "interior",
         "near_bound_outside_tolerance",
         "wide_bounds_interior",
+        "narrow_bounds_interior",
         "unbounded",
         "lower_bound_infinite_upper",
         "degenerate_bounds_at_pin",
@@ -672,7 +680,7 @@ def test_parameter_at_bounds_warning(caplog, fitted_x, par_bounds, expect_warnin
             result, _make_stitch_pars(), par_bounds=par_bounds, par_names=["mu"]
         )
 
-    warning_lines = _at_bound_warning_lines(caplog)
+    warning_lines = _warning_lines(caplog)
     if expect_warning:
         assert len(warning_lines) == 1
         assert "'mu' (index 0)" in warning_lines[0]
@@ -876,11 +884,11 @@ def test_parameter_at_bounds_warning_nan_value(caplog):
             result, _make_stitch_pars(), par_bounds=[(3.0, 10.0)], par_names=["mu"]
         )
 
-    warning_records = [
-        record for record in caplog.records if "is not finite" in record.message
-    ]
-    assert len(warning_records) == 1
-    assert "'mu' (index 0)" in warning_records[0].message
+    warning_lines = _warning_lines(caplog, "is not finite")
+    assert len(warning_lines) == 1
+    assert "'mu' (index 0)" in warning_lines[0]
+    # the bounds give the reader context for how the value diverged
+    assert "bounds=(3, 10)" in warning_lines[0]
 
 
 def test_parameter_at_bounds_warning_short_par_names(caplog):
@@ -957,6 +965,25 @@ def test_parameter_at_bounds_warning_minuit_at_limit(caplog):
     assert "value=0.5" in warning_lines[0]
     # the value is not numerically at a bound, so no at-bound claim is made
     assert not _at_bound_warning_lines(caplog)
+
+
+def test_minuit_at_limit_flags_real_minuit():
+    # Drive a real iminuit.Minuit so a change to the Param API this function
+    # depends on is caught here rather than inside every minuit fit. The
+    # aggregate is iminuit's own OR over the same criterion, so the per
+    # parameter flags must agree with it.
+    from pyhf.optimize.mixins import _minuit_at_limit_flags
+
+    minuit = iminuit.Minuit(lambda x, y: (x + 1.0) ** 2 + (y - 5.0) ** 2, 0.5, 5.0)
+    minuit.limits = [(0.0, 10.0), (0.0, 10.0)]
+    minuit.errordef = 1.0
+    minuit.migrad()
+
+    flags = _minuit_at_limit_flags(minuit, npars=2, fixed_idx=())
+    # x is pulled to its lower bound, y sits in the interior
+    assert flags[0]
+    assert not flags[1]
+    assert any(flags) == minuit.fmin.has_parameters_at_limit
 
 
 def test_minuit_at_limit_flags_skips_fixed_and_unbounded():

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -1014,6 +1014,43 @@ def test_minuit_at_limit_flags_skips_fixed_and_unbounded():
     ]
 
 
+@pytest.mark.parametrize(
+    "make_par_bounds",
+    [
+        lambda: [(0.0, 10.0), (1e-10, 10.0)],
+        lambda: zip([0.0, 1e-10], [10.0, 10.0]),
+        lambda: iter([(0.0, 10.0), (1e-10, 10.0)]),
+    ],
+    ids=["list", "zip", "iterator"],
+)
+def test_parameter_at_bounds_warning_one_shot_par_bounds(caplog, make_par_bounds):
+    # par_bounds is consumed by shim() and the minimizer before postprocessing
+    # sees it, so a one-shot iterable must be materialized in minimize() or the
+    # check silently degrades to the length-mismatch path
+    model = pyhf.simplemodels.uncorrelated_background(
+        signal=[5.0], bkg=[10.0], bkg_uncertainty=[3.5]
+    )
+    # best-fit mu is negative, so the fit rails at the lower bound of 0
+    data = [7.0] + model.config.auxdata
+
+    optimizer = pyhf.optimize.scipy_optimizer()
+    with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
+        optimizer.minimize(
+            pyhf.infer.mle.twice_nll,
+            data,
+            model,
+            model.config.suggested_init(),
+            make_par_bounds(),
+        )
+
+    warning_lines = _at_bound_warning_lines(caplog)
+    assert len(warning_lines) == 1
+    assert "'mu' (index 0)" in warning_lines[0]
+    assert not [
+        record for record in caplog.records if "does not match" in record.message
+    ]
+
+
 def test_parameter_at_bounds_warning_par_bounds_length_mismatch(caplog):
     # A par_bounds that does not cover all model parameters cannot be checked
     # meaningfully; the check is skipped with a warning saying so.

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -604,12 +604,13 @@ def test_minuit_all_fixed_params():
 
 
 def _at_bound_warning_lines(caplog):
-    # the check emits a single aggregated record per fit with one line per parameter
+    # the check emits a single aggregated record per fit with one line per
+    # parameter, so filter per line (records can mix message types)
     return [
         line
         for record in caplog.records
-        if "is at a bound" in record.message
         for line in record.message.splitlines()
+        if "is at a bound" in line
     ]
 
 
@@ -622,6 +623,8 @@ def _at_bound_warning_lines(caplog):
         ([10.0], [(3.0, 10.0)], True),
         # near lower bound, within tolerance (optimizers stop near, not at, bounds)
         ([3.0 + 1e-9], [(3.0, 10.0)], True),
+        # at minuit's measured rail distance from the bound (up to O(1e-5))
+        ([1.7e-5], [(0.0, 10.0)], True),
         # beyond the lower bound (constraint violation)
         ([2.5], [(3.0, 10.0)], True),
         # interior — no warning
@@ -636,6 +639,8 @@ def _at_bound_warning_lines(caplog):
         ([0.0], [(0.0, np.inf)], True),
         # bounds that pin the parameter are deliberate — no warning
         ([1.0], [(1.0, 1.0)], False),
+        # but pinning bounds do not exonerate a value away from the pin
+        ([5.0], [(1.0, 1.0)], True),
         # inverted bounds are malformed and surfaced rather than silenced
         ([5.0], [(10.0, 3.0)], True),
     ],
@@ -643,13 +648,15 @@ def _at_bound_warning_lines(caplog):
         "lower_bound",
         "upper_bound",
         "near_bound_within_tolerance",
+        "minuit_rail_distance",
         "below_lower_bound",
         "interior",
         "near_bound_outside_tolerance",
         "wide_bounds_interior",
         "unbounded",
         "lower_bound_infinite_upper",
-        "degenerate_bounds",
+        "degenerate_bounds_at_pin",
+        "degenerate_bounds_violated",
         "inverted_bounds",
     ],
 )
@@ -669,7 +676,8 @@ def test_parameter_at_bounds_warning(caplog, fitted_x, par_bounds, expect_warnin
     if expect_warning:
         assert len(warning_lines) == 1
         assert "'mu' (index 0)" in warning_lines[0]
-        assert f"value={fitted_x[0]:g}" in warning_lines[0]
+        # full-precision repr so a near-bound value is distinguishable from the bound
+        assert f"value={fitted_x[0]!r}" in warning_lines[0]
     else:
         assert len(warning_lines) == 0
 
@@ -830,18 +838,20 @@ def test_no_parameter_at_bounds_warning_infinite_bounds(caplog):
     assert not _at_bound_warning_lines(caplog)
 
 
-def test_parameter_at_bounds_warning_scipy_bounds_object(caplog):
-    # A scipy.optimize.Bounds instance is a valid bounds specification for the
-    # scipy optimizer through the direct API and must not break postprocessing.
+@pytest.mark.parametrize("optimizer_name", ["scipy", "minuit"])
+def test_parameter_at_bounds_warning_scipy_bounds_object(caplog, optimizer_name):
+    # A scipy.optimize.Bounds instance is a valid bounds specification through
+    # the direct optimizer API: it is normalized to pairs in minimize() so all
+    # optimizer and do_stitch code paths (and postprocessing) handle it.
+    pyhf.set_backend("numpy", optimizer_name)
     model = pyhf.simplemodels.uncorrelated_background(
         signal=[5.0], bkg=[10.0], bkg_uncertainty=[3.5]
     )
     # best-fit mu is negative, so the fit rails at the lower bound of 0
     data = [7.0] + model.config.auxdata
 
-    optimizer = pyhf.optimize.scipy_optimizer()
     with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
-        result = optimizer.minimize(
+        result = pyhf.optimizer.minimize(
             pyhf.infer.mle.twice_nll,
             data,
             model,
@@ -887,6 +897,11 @@ def test_parameter_at_bounds_warning_short_par_names(caplog):
             par_names=["mu"],
         )
 
+    # both parameters warn as individual lines of a single aggregated record
+    assert (
+        len([record for record in caplog.records if "is at a bound" in record.message])
+        == 1
+    )
     warning_lines = _at_bound_warning_lines(caplog)
     assert len(warning_lines) == 2
     assert "'mu' (index 0)" in warning_lines[0]
@@ -897,11 +912,13 @@ def test_parameter_at_bounds_warning_minuit_at_limit(caplog):
     # minuit's own at-limit determination (within half an uncertainty of a
     # bound, cf. iminuit.util.FMin) must warn even when the fitted value is
     # outside any numerical tolerance, including under do_stitch=True where
-    # the minuit parameters cover only the free parameters.
+    # the minuit parameters cover only the free parameters. As the value is
+    # not numerically at a bound, the message must say which criterion fired.
     tv = _TensorViewer([[0], [1]])
     stitch_pars = _make_stitch_pars(tv, fixed_values=[2.0])
 
     minuit_stub = SimpleNamespace(
+        fmin=SimpleNamespace(has_parameters_at_limit=True),
         params=[
             SimpleNamespace(
                 is_fixed=False,
@@ -913,7 +930,7 @@ def test_parameter_at_bounds_warning_minuit_at_limit(caplog):
                 value=0.5,
                 error=1.5,
             )
-        ]
+        ],
     )
     mixin = OptimizerMixin()
     result = OptimizeResult(
@@ -929,7 +946,60 @@ def test_parameter_at_bounds_warning_minuit_at_limit(caplog):
             par_names=["fixed_par", "free_par"],
         )
 
-    warning_lines = _at_bound_warning_lines(caplog)
+    warning_lines = [
+        line
+        for record in caplog.records
+        for line in record.message.splitlines()
+        if "within half its uncertainty of a bound" in line
+    ]
     assert len(warning_lines) == 1
     assert "'free_par' (index 1)" in warning_lines[0]
     assert "value=0.5" in warning_lines[0]
+    # the value is not numerically at a bound, so no at-bound claim is made
+    assert not _at_bound_warning_lines(caplog)
+
+
+def test_minuit_at_limit_flags_skips_fixed_and_unbounded():
+    # fixed and unbounded parameters cannot be at a limit and must be skipped,
+    # matching iminuit's own aggregation (cf. iminuit.util.FMin)
+    from pyhf.optimize.mixins import _minuit_at_limit_flags
+
+    minuit_stub = SimpleNamespace(
+        params=[
+            SimpleNamespace(is_fixed=True, has_limits=True),
+            SimpleNamespace(is_fixed=False, has_limits=False),
+            SimpleNamespace(
+                is_fixed=False,
+                has_limits=True,
+                has_lower_limit=True,
+                lower_limit=0.0,
+                has_upper_limit=True,
+                upper_limit=10.0,
+                value=0.5,
+                error=1.5,
+            ),
+        ]
+    )
+    assert _minuit_at_limit_flags(minuit_stub, npars=3, fixed_idx=()) == [
+        False,
+        False,
+        True,
+    ]
+
+
+def test_parameter_at_bounds_warning_par_bounds_length_mismatch(caplog):
+    # A par_bounds that does not cover all model parameters cannot be checked
+    # meaningfully; the check is skipped with a warning saying so.
+    mixin = OptimizerMixin()
+    result = OptimizeResult(x=np.array([3.0, 4.0]), fun=0.0, success=True)
+
+    with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
+        mixin._internal_postprocess(
+            result, _make_stitch_pars(), par_bounds=[(3.0, 10.0)]
+        )
+
+    assert not _at_bound_warning_lines(caplog)
+    mismatch_records = [
+        record for record in caplog.records if "does not match" in record.message
+    ]
+    assert len(mismatch_records) == 1

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 from unittest.mock import PropertyMock, patch
 
 import iminuit
@@ -608,33 +609,197 @@ def test_minuit_all_fixed_params():
         ([3.0], [(3.0, 10.0)], True),
         # exactly at upper bound
         ([10.0], [(3.0, 10.0)], True),
+        # near lower bound, within tolerance (minuit stops near, not at, bounds)
+        ([3.0 + 1e-7 * 7.0], [(3.0, 10.0)], True),
         # interior — no warning
         ([5.0], [(3.0, 10.0)], False),
+        # near lower bound but outside tolerance — no warning
+        ([3.01], [(3.0, 10.0)], False),
     ],
-    ids=["lower_bound", "upper_bound", "no_bound"],
+    ids=[
+        "lower_bound",
+        "upper_bound",
+        "near_bound_within_tolerance",
+        "interior",
+        "near_bound_outside_tolerance",
+    ],
 )
 def test_parameter_at_bounds_warning(caplog, fitted_x, par_bounds, expect_warning):
     # Regression test for https://github.com/scikit-hep/pyhf/issues/2525
     # Test _internal_postprocess directly with controlled fit results so the
     # check is independent of optimizer-specific floating-point behaviour.
-    import logging
-
-    from scipy.optimize import OptimizeResult
-
-    from pyhf.optimize.mixins import OptimizerMixin
-
-    def stitch_pars(x, _stitch_with=None):
-        return x
-
     mixin = OptimizerMixin()
     result = OptimizeResult(x=np.array(fitted_x), fun=0.0, success=True)
 
     with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
-        mixin._internal_postprocess(result, stitch_pars, par_bounds=par_bounds)
+        mixin._internal_postprocess(
+            result, _make_stitch_pars(), par_bounds=par_bounds, par_names=["mu"]
+        )
 
-    warning_records = [r for r in caplog.records if "is at a bound" in r.message]
+    warning_records = [
+        record for record in caplog.records if "is at a bound" in record.message
+    ]
     if expect_warning:
         assert len(warning_records) == 1
-        assert "bounds" in warning_records[0].message
+        message = warning_records[0].message
+        assert "'mu' (index 0)" in message
+        assert f"value={fitted_x[0]:g}" in message
+        assert "bounds=(3, 10)" in message
     else:
         assert len(warning_records) == 0
+
+
+def test_parameter_at_bounds_warning_fixed_parameter(caplog):
+    # A parameter held constant at a bound is deliberate (e.g. a POI fixed at
+    # zero for a discovery fit) and must not warn.
+    mixin = OptimizerMixin()
+    result = OptimizeResult(x=np.array([0.0, 5.0]), fun=0.0, success=True)
+
+    with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
+        mixin._internal_postprocess(
+            result,
+            _make_stitch_pars(),
+            par_bounds=[(0.0, 10.0), (3.0, 10.0)],
+            fixed_idx=[0],
+        )
+
+    assert not [
+        record for record in caplog.records if "is at a bound" in record.message
+    ]
+
+
+def test_parameter_at_bounds_warning_nonterminal_fixed_parameter(caplog):
+    # With do_stitch=True fitresult.x holds only the free parameters; the
+    # warning must still compare against the correct full-model bounds and
+    # report the model index, not the free-vector index.
+    tv = _TensorViewer([[0], [1]])
+    stitch_pars = _make_stitch_pars(tv, fixed_values=[2.0])
+
+    mixin = OptimizerMixin()
+    # the free parameter (model index 1) is exactly at its lower bound
+    result = OptimizeResult(x=np.array([3.0]), fun=0.0, success=True)
+
+    with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
+        mixin._internal_postprocess(
+            result,
+            stitch_pars,
+            par_bounds=[(2.0, 10.0), (3.0, 10.0)],
+            fixed_idx=[0],
+            par_names=["fixed_par", "free_par"],
+        )
+
+    warning_records = [
+        record for record in caplog.records if "is at a bound" in record.message
+    ]
+    assert len(warning_records) == 1
+    message = warning_records[0].message
+    # the fixed parameter (model index 0, held at its lower bound) is skipped
+    assert "'free_par' (index 1)" in message
+    assert "fixed_par" not in message
+    assert "bounds=(3, 10)" in message
+
+
+@pytest.mark.parametrize("optimizer", ["scipy", "minuit"])
+def test_parameter_at_bounds_warning_end_to_end(caplog, optimizer):
+    # Model from https://github.com/scikit-hep/pyhf/issues/2525: the best-fit
+    # mu is below the lower bound, so the fit rails at the bound. minuit stops
+    # near but not exactly at the bound, which the tolerance must catch.
+    pyhf.set_backend("numpy", optimizer)
+    spec = {
+        "channels": [
+            {
+                "name": "singlechannel",
+                "samples": [
+                    {
+                        "name": "signal",
+                        "data": [3.0],
+                        "modifiers": [
+                            {"name": "mu", "type": "normfactor", "data": None}
+                        ],
+                    },
+                    {"name": "background", "data": [5.0], "modifiers": []},
+                ],
+            }
+        ]
+    }
+    model = pyhf.Model(spec)
+    data = [5.0] + model.config.auxdata
+
+    with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
+        pyhf.infer.mle.fit(data, model, init_pars=[5.0], par_bounds=[(3.0, 10.0)])
+
+    warning_records = [
+        record for record in caplog.records if "is at a bound" in record.message
+    ]
+    assert len(warning_records) == 1
+    message = warning_records[0].message
+    assert "'mu' (index 0)" in message
+    assert "bounds=(3, 10)" in message
+
+
+def test_no_parameter_at_bounds_warning_fixed_poi(caplog):
+    # A POI deliberately fixed at its lower bound (as in discovery fits, where
+    # generate_asimov_data runs fixed_poi_fit(0.0, ...)) must not warn.
+    model = pyhf.simplemodels.uncorrelated_background(
+        signal=[5.0], bkg=[10.0], bkg_uncertainty=[3.5]
+    )
+    data = [10.0] + model.config.auxdata
+
+    with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
+        pyhf.infer.mle.fixed_poi_fit(0.0, data, model)
+
+    assert not [
+        record for record in caplog.records if "is at a bound" in record.message
+    ]
+
+
+def test_minimize_par_bounds_none(caplog):
+    # Direct optimizer API use with unbounded parameters worked before the
+    # at-bound check was added and must keep working.
+    model = pyhf.simplemodels.uncorrelated_background(
+        signal=[5.0], bkg=[10.0], bkg_uncertainty=[3.5]
+    )
+    data = [12.0] + model.config.auxdata
+
+    optimizer = pyhf.optimize.scipy_optimizer()
+    with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
+        result = optimizer.minimize(
+            pyhf.infer.mle.twice_nll,
+            data,
+            model,
+            model.config.suggested_init(),
+            None,
+        )
+
+    assert result is not None
+    assert not [
+        record for record in caplog.records if "is at a bound" in record.message
+    ]
+
+
+def test_parameter_at_bounds_warning_open_bound(caplog):
+    # scipy accepts one-sided (None) bounds through the direct optimizer API;
+    # the warning must handle and report them without breaking log formatting.
+    model = pyhf.simplemodels.uncorrelated_background(
+        signal=[5.0], bkg=[10.0], bkg_uncertainty=[3.5]
+    )
+    # best-fit mu is negative, so the fit rails at the lower bound of 0
+    data = [7.0] + model.config.auxdata
+
+    optimizer = pyhf.optimize.scipy_optimizer()
+    with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
+        optimizer.minimize(
+            pyhf.infer.mle.twice_nll,
+            data,
+            model,
+            model.config.suggested_init(),
+            [(0.0, None), (1e-10, 10.0)],
+        )
+
+    warning_records = [
+        record for record in caplog.records if "is at a bound" in record.message
+    ]
+    assert len(warning_records) == 1
+    message = warning_records[0].message
+    assert "'mu' (index 0)" in message
+    assert "bounds=(0, None)" in message

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -1192,14 +1192,21 @@ def test_no_parameter_at_bounds_warning_when_minuit_reports_no_limits(caplog):
 
 
 @pytest.mark.parametrize(
-    "minuit",
-    [None, SimpleNamespace(), iminuit.Minuit(lambda x: x**2, 0.0)],
+    "make_minuit",
+    [
+        lambda: None,
+        SimpleNamespace,
+        lambda: iminuit.Minuit(lambda x: x**2, 0.0),
+    ],
     ids=["no_fmin_attribute", "empty_namespace", "minuit_before_migrad"],
 )
-def test_parameter_at_bounds_warning_without_minuit_fmin(caplog, minuit):
+def test_parameter_at_bounds_warning_without_minuit_fmin(caplog, make_minuit):
     # the at-limit lookup is a diagnostic, so a result carrying no usable minuit
-    # (iminuit.Minuit.fmin is None until migrad has run) must not raise
+    # (iminuit.Minuit.fmin is None until migrad has run) must not raise.
+    # Built inside the test: constructing a Minuit in the parametrize list makes
+    # it a shared import-time object whose fmin-is-None premise is not guaranteed
     mixin = OptimizerMixin()
+    minuit = make_minuit()
     kwargs = {} if minuit is None else {"minuit": minuit}
     result = OptimizeResult(x=np.array([0.0]), fun=0.0, success=True, **kwargs)
 

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -1015,6 +1015,27 @@ def test_minuit_at_limit_flags_skips_fixed_and_unbounded():
 
 
 @pytest.mark.parametrize(
+    "minuit",
+    [None, SimpleNamespace(), iminuit.Minuit(lambda x: x**2, 0.0)],
+    ids=["no_fmin_attribute", "empty_namespace", "minuit_before_migrad"],
+)
+def test_parameter_at_bounds_warning_without_minuit_fmin(caplog, minuit):
+    # the at-limit lookup is a diagnostic, so a result carrying no usable minuit
+    # (iminuit.Minuit.fmin is None until migrad has run) must not raise
+    mixin = OptimizerMixin()
+    kwargs = {} if minuit is None else {"minuit": minuit}
+    result = OptimizeResult(x=np.array([0.0]), fun=0.0, success=True, **kwargs)
+
+    with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
+        mixin._internal_postprocess(
+            result, _make_stitch_pars(), par_bounds=[(0.0, 10.0)], par_names=["mu"]
+        )
+
+    # the numeric check still runs and still reports the railed parameter
+    assert len(_at_bound_warning_lines(caplog)) == 1
+
+
+@pytest.mark.parametrize(
     "make_par_bounds",
     [
         lambda: [(0.0, 10.0), (1e-10, 10.0)],

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -743,7 +743,9 @@ def test_parameter_at_bounds_warning_fixed_parameter(caplog):
             fixed_idx=[0],
         )
 
-    assert not _at_bound_warning_lines(caplog)
+    # no message of any kind: the fixed parameter is skipped and the free one
+    # sits in the interior
+    assert not _warning_lines(caplog)
 
 
 def test_parameter_at_bounds_warning_nonterminal_fixed_parameter(caplog):
@@ -955,6 +957,31 @@ def test_parameter_at_bounds_warning_nan_value(caplog):
     assert "'mu' (index 0)" in warning_lines[0]
     # the bounds give the reader context for how the value diverged
     assert "bounds=(3, 10)" in warning_lines[0]
+
+
+@pytest.mark.parametrize("value", [np.nan, np.inf, -np.inf], ids=["nan", "inf", "-inf"])
+def test_parameter_at_bounds_warning_non_finite_fixed_parameter(caplog, value):
+    # A parameter held constant *at* a bound is deliberate and stays silent,
+    # but one holding a non-finite value is a symptom and must be surfaced --
+    # the fixed-parameter skip must not swallow it.
+    mixin = OptimizerMixin()
+    result = OptimizeResult(x=np.array([value, 5.0]), fun=0.0, success=True)
+
+    with caplog.at_level(logging.WARNING, logger="pyhf.optimize.mixins"):
+        mixin._internal_postprocess(
+            result,
+            _make_stitch_pars(),
+            par_bounds=[(0.0, 10.0), (0.0, 10.0)],
+            fixed_idx=[0],
+            par_names=["fixed_par", "free_par"],
+        )
+
+    warning_lines = _warning_lines(caplog, NOT_FINITE)
+    assert len(warning_lines) == 1
+    assert "'fixed_par' (index 0)" in warning_lines[0]
+    assert f"value={value!r}" in warning_lines[0]
+    # the free parameter sits in the interior, so nothing else is reported
+    assert not _at_bound_warning_lines(caplog)
 
 
 def test_parameter_at_bounds_warning_short_par_names(caplog):


### PR DESCRIPTION
# Pull Request Description

Resolves #2525.

When nuisance parameters hit their bounds during fitting (e.g. in a large-model toy run), there was previously no indication that this had happened, making it difficult to diagnose suspect fit results. This PR adds a `WARNING` log message from `_internal_postprocess` whenever a fitted parameter lands exactly on a bound, reporting the parameter index, the fitted value, and the bound range.

The implementation iterates over the free parameters in `fitresult.x` alongside their bounds (both already stripped of fixed parameters by `shim()` before optimization). Three architectural concerns (batching, fixed-parameter skipping, and backend compatibility) were investigated (using CLAUDE) and confirmed to be non-issues given the current design; a clarifying comment documents why the alignment is guaranteed.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add a WARNING log message in _internal_postprocess when a fitted
  parameter lands exactly on a bound. Reports the parameter index, 
  fitted value, and bound range.
* Add regression tests for lower bound, upper bound, and interior
  cases via _internal_postprocess directly with a synthetic
  OptimizeResult, making the check independent of optimizer
  floating-point behaviour.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added clear warnings when fitted parameters reach, approach, exceed, or produce non-finite values relative to configured bounds.
  * Warnings identify affected parameters by name or index and include their values and limits.
  * Improved handling of fixed, stitched, unbounded, and one-sided-bound parameters.
  * Added support for optimizer bounds provided through SciPy’s standard bounds format.
  * Consolidated bound warnings so each fit reports them once.

* **Tests**
  * Added comprehensive coverage for boundary conditions across supported optimization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->