### PR TITLE
chore(backport): Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     - id: rst-inline-touching-normal
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: "v0.4.3"
+  rev: "v0.5.0"
   hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]
@@ -47,13 +47,13 @@ repos:
       types_or: [python, pyi, jupyter]
 
 -   repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.16.0
+    rev: 1.18.0
     hooks:
     - id: blacken-docs
       additional_dependencies: [black==24.4.2]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.10.1
     # check the oldest and newest supported Pythons
     hooks:
       - &mypy
@@ -68,14 +68,14 @@ repos:
         args: ["--python-version=3.12"]
 
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
     - id: codespell
       files: ^.*\.(py|md|rst)$
       args: ["-w", "-L", "hist,gaus"]
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.28.4
+  rev: 0.28.6
   hooks:
     - id: check-readthedocs
       args: ["--verbose"]


### PR DESCRIPTION
# Description

* Backport PR https://github.com/scikit-hep/pyhf/pull/2527
* Update pre-commit hooks:
   - github.com/astral-sh/ruff-pre-commit: v0.4.7 → v0.5.0
   - github.com/adamchainz/blacken-docs: 1.16.0 → 1.18.0
   - github.com/pre-commit/mirrors-mypy: v1.10.0 → v1.10.1
   - github.com/python-jsonschema/check-jsonschema: 0.28.4 → 0.28.6

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Backport PR https://github.com/scikit-hep/pyhf/pull/2527
* Update pre-commit hooks:
   - github.com/astral-sh/ruff-pre-commit: v0.4.7 → v0.5.0
   - github.com/adamchainz/blacken-docs: 1.16.0 → 1.18.0
   - github.com/pre-commit/mirrors-mypy: v1.10.0 → v1.10.1
   - github.com/python-jsonschema/check-jsonschema: 0.28.4 → 0.28.6
```