### PR TITLE
docs: Use intersphinx_registry to keep intersphinx urls up to date

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,7 @@ import sys
 from pathlib import Path
 
 import jupytext
+from intersphinx_registry import get_intersphinx_mapping
 
 sys.path.insert(0, str(Path('./exts').resolve()))
 
@@ -80,15 +81,17 @@ bibtex_default_style = "unsrt"
 # external links
 xref_links = {"arXiv:1007.1727": ("[1007.1727]", "https://arxiv.org/abs/1007.1727")}
 
-intersphinx_mapping = {
-    'python': ('https://docs.python.org/3', None),
-    'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
-    'matplotlib': ('https://matplotlib.org/stable/', None),
-    'iminuit': ('https://iminuit.readthedocs.io/en/stable/', None),
-    'uproot': ('https://uproot.readthedocs.io/en/latest/', None),
-    'jsonpatch': ('https://python-json-patch.readthedocs.io/en/latest/', None),
-}
+intersphinx_mapping = get_intersphinx_mapping(
+    packages={
+        'python',
+        'numpy',
+        'scipy',
+        'matplotlib',
+        'iminuit',
+        'uproot',
+        'jsonpatch',
+    }
+)
 
 # GitHub repo
 issues_github_path = 'scikit-hep/pyhf'

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -35,3 +35,4 @@ Contributors include:
 - Jonas Rembser
 - Lorenz Gaertner
 - Melissa Weber Mendonça
+- Matthias Bussonnier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ docs = [
     "pydata-sphinx-theme>=0.15.3",
     "nbsphinx!=0.8.8",  # c.f. https://github.com/spatialaudio/nbsphinx/issues/620
     "ipywidgets",
+    "intersphinx_registry",
     "sphinx-issues",
     "sphinx-copybutton>=0.3.2,!=0.5.1",
     "jupyterlite-sphinx>=0.13.1",  # c.f. https://github.com/scikit-hep/pyhf/pull/2458

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ docs = [
     "pydata-sphinx-theme>=0.15.3",
     "nbsphinx!=0.8.8",  # c.f. https://github.com/spatialaudio/nbsphinx/issues/620
     "ipywidgets",
-    "intersphinx_registry",
+    "intersphinx_registry>=0.2411.17",
     "sphinx-issues",
     "sphinx-copybutton>=0.3.2,!=0.5.1",
     "jupyterlite-sphinx>=0.13.1",  # c.f. https://github.com/scikit-hep/pyhf/pull/2458


### PR DESCRIPTION
I think one of the difference is it will point toward uproot stable instead of latest (which is the dev version).

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
   - No, but expected.
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add intersphinx_registry to 'docs' extra.
* Use intersphinx_registry to provide automated inter Sphinx mapping.
   - c.f. https://github.com/Quansight-labs/intersphinx_registry
* Add Matthias Bussonnier to contributors list.
```