### PR TITLE
fix: Ensure that setting upper limit works for toms748 scan

### DIFF
--- a/src/pyhf/infer/intervals/upper_limits.py
+++ b/src/pyhf/infer/intervals/upper_limits.py
@@ -270,6 +270,7 @@ def upper_limit(
         model,
         bounds[0],
         bounds[1],
+        level=level,
         from_upper_limit_fn=True,
         **hypotest_kwargs,
     )

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -702,12 +702,12 @@ def test_issue2563_toms748_scan_set_level(hypotest_args):
         data, model, rtol=1e-8, level=0.10, scan=None
     )
 
-    assert obs_limit_95 != pytest.approx(
-        obs_limit_90
-    ), "Observed limit at 95% is the same as the observed limit at 90%"
+    assert obs_limit_95 != pytest.approx(obs_limit_90), (
+        "Observed limit at 95% is the same as the observed limit at 90%"
+    )
     for index, (exp_limit_95, exp_limit_90) in enumerate(
         zip(exp_limits_95, exp_limits_90), 1
     ):
-        assert exp_limit_95 != pytest.approx(
-            exp_limit_90
-        ), f"Expected limit for 95% is the same as the expected limit at 90% for position {index}"
+        assert exp_limit_95 != pytest.approx(exp_limit_90), (
+            f"Expected limit for 95% is the same as the expected limit at 90% for position {index}"
+        )

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -690,7 +690,7 @@ def test_deprecated_upperlimit(hypotest_args):
 
 def test_issue2563_toms748_scan_setLevel(tmp_path, hypotest_args):
     """
-    Test that setting the level actually gives us what we expect.
+    Test that setting the level actually gives us what we expect for scan=None (using the toms748 algorithm)
     """
     _, data, model = hypotest_args
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -686,3 +686,28 @@ def test_deprecated_upperlimit(hypotest_args):
             "pyhf.infer.intervals.upperlimit is deprecated in favor of pyhf.infer.intervals.upper_limits.upper_limit"
             in str(_warning[-1].message)
         )
+
+
+def test_issue2563_toms748_scan_setLevel(tmp_path, hypotest_args):
+    """
+    Test that setting the level actually gives us what we expect.
+    """
+    _, data, model = hypotest_args
+
+    obs_limit_95, exp_limits_95 = pyhf.infer.intervals.upper_limits.upper_limit(
+        data, model, rtol=1e-8, level=0.05, scan=None
+    )
+
+    obs_limit_90, exp_limits_90 = pyhf.infer.intervals.upper_limits.upper_limit(
+        data, model, rtol=1e-8, level=0.10, scan=None
+    )
+
+    assert obs_limit_95 != pytest.approx(
+        obs_limit_90
+    ), "Observed limit at 95% is the same as the observed limit at 90%"
+    for index, (exp_limit_95, exp_limit_90) in enumerate(
+        zip(exp_limits_95, exp_limits_90), 1
+    ):
+        assert exp_limit_95 != pytest.approx(
+            exp_limit_90
+        ), f"Expected limit for 95% is the same as the expected limit at 90% for position {index}"

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -688,7 +688,7 @@ def test_deprecated_upperlimit(hypotest_args):
         )
 
 
-def test_issue2563_toms748_scan_setLevel(tmp_path, hypotest_args):
+def test_issue2563_toms748_scan_set_level(hypotest_args):
     """
     Test that setting the level actually gives us what we expect for scan=None (using the toms748 algorithm)
     """


### PR DESCRIPTION
# Pull Request Description

- resolves #2563


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Pass 'level' kwarg from the upper_limits.upper_limit through to toms748 scan.
* Add test to ensure that a different level being set is actually providing
  different limits.
```
