### PR TITLE
fix: jax backend tolist for tracers in logging

### DIFF
--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -2,6 +2,7 @@ from jax import config
 
 config.update('jax_enable_x64', True)
 
+import jax
 from jax import Array
 import jax.numpy as jnp
 from jax.scipy.special import gammaln, xlogy
@@ -12,6 +13,10 @@ import scipy.stats as osp_stats
 import logging
 
 log = logging.getLogger(__name__)
+
+
+def currently_jitting():
+    return isinstance(jnp.array(1) + 1, jax.core.Tracer)
 
 
 class _BasicPoisson:
@@ -184,6 +189,9 @@ class jax_backend:
         return true_callable() if predicate else false_callable()
 
     def tolist(self, tensor_in):
+        if currently_jitting():
+            # .aval is the abstract value and has a little nicer representation
+            return tensor_in.aval
         try:
             return jnp.asarray(tensor_in).tolist()
         except (TypeError, ValueError):


### PR DESCRIPTION
# Description

This PR closes https://github.com/scikit-hep/pyhf/issues/1422

This failure is encountered during tracing time. JAX can not convert a tracer during `.tolist` which is why it fails with a different error. This PR checks if we're currently in tracing time and instead returns the tracer (or rather its abstract value for a little nicer representation).

The new error looks as expected like this now:
```python
>>> import pyhf
>>> pyhf.set_backend("jax")
>>> pyhf.simplemodels.uncorrelated_background([10], [15], [5])
>>> pyhf.infer.mle.fit([12.5], m)
>>> ... InvalidPdfData: "eval failed as data has len 1 but 2 was expected"
```
The logging will print:
```python
"Eval failed for data ShapedArray(float64[1]) pars: ShapedArray(float64[2])"
```
This is the most information available during tracing time (shape and dtype), there's not much more to give to the user.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
