### PR TITLE
Bugfix: make numpy_backend.tile() and jax_backend.tile() consistent

### DIFF
--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -157,6 +157,8 @@ class jax_backend:
         Returns:
             JAX ndarray: The tensor with repeated axes
         """
+        if not isinstance(tensor_in, jnp.ndarray):
+            tensor_in = jnp.array(tensor_in)
         return jnp.tile(tensor_in, repeats)
 
     def conditional(self, predicate, true_callable, false_callable):


### PR DESCRIPTION
This fixes a bug in the jax_backend.tile() method. Consider the following minimal example:

```
import jax.numpy as jnp
import pyhf

pyhf.set_backend("jax", default=True)  # works without this line

spec = {
    "channels": [
        {
            "name": "singlechannel",
            "samples": [
                {
                    "name": "signal",
                    "data": jnp.array([0.0, 0.0, 0.0]),
                    "modifiers": [
                        {
                            "name": "mu",
                            "type": "normfactor",
                            "data": None,
                        },
                    ],
                },
            ],
        },
    ],
}

my_model = pyhf.Model(spec, validate=False)
```

The last line fails with `TypeError: tile requires ndarray or scalar arguments, got <class 'list'> at position 0.`. However, it works fine when using the numpy backend. The problem stems from differences between `np.tile` and `jnp.tile`:

```
import numpy as np
import jax.numpy as jnp

tensor_in = [[[0, 1, 2]]]
repeats = (0, 1, 1)

np.tile(tensor_in, repeats)  # works fine
jnp.tile(tensor_in, repeats)  # fails with same error message as above
jnp.tile(jnp.array(tensor_in), repeats)  # works fine
```
Unlike `jnp.tile`, `np.tile` implicitly converts the input to the correct type.
This PR ensures `tensor_in` is a `jnp.array` to make the behaviour of `numpy_backend.tile()` and `jax_backend.tile()` consistent.