### PR TITLE
cast to list, as the default backend numpy casts the bools to np.bool…

### DIFF
--- a/src/pyhf/modifiers/histosys.py
+++ b/src/pyhf/modifiers/histosys.py
@@ -67,6 +67,7 @@ class histosys_builder:
                 sample["data"]["mask"] = default_backend.concatenate(
                     sample["data"]["mask"]
                 )
+                sample["data"]["mask"] = sample["data"]["mask"].tolist()
                 sample["data"]["lo_data"] = default_backend.concatenate(
                     sample["data"]["lo_data"]
                 )


### PR DESCRIPTION
fix: we are casting the numpy array to a list. that way the booleans get cast from np.bool to python's native bool. i am doing
this because my torch backend has problems casting np.bool to torch.bool:

>In[0]: torch.as_tensor ( [False,np.bool_(True)], dtype=torch.bool )
> ---------------------------------------------------------------------------
> TypeError                                 Traceback (most recent call last)
> Cell In[6], line 1
> ----> 1 torch.as_tensor ( [False,np.bool_(True)], dtype=torch.bool )>
>
> TypeError: 'numpy.bool' object cannot be interpreted as an integer

Which happens for me at 

 File "/home/walten/.venvs/default/lib/python3.13/site-packages/pyhf/tensor/pytorch_backend.py", line 207, in astensor
    return torch.as_tensor(tensor_in, dtype=dtype)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'numpy.bool' object cannot be interpreted as an integer

Feel free though to solve this weird casting issue differently. Why it seems to be a problem for me but not for you, eludes me.

Wolfgang
