### PR TITLE
fix: Add q0 test statistic as valid option to CLI infer interface

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -36,3 +36,4 @@ Contributors include:
 - Lorenz Gaertner
 - Melissa Weber Mendonça
 - Matthias Bussonnier
+- Ben Rosser

--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -144,7 +144,7 @@ def fit(
 @click.option('--measurement', default=None)
 @click.option('-p', '--patch', multiple=True)
 @click.option('--test-poi', default=1.0)
-@click.option('--test-stat', type=click.Choice(['q', 'qtilde']), default='qtilde')
+@click.option('--test-stat', type=click.Choice(['q', 'qtilde', 'q0']), default='qtilde')
 @click.option(
     '--calctype', type=click.Choice(['asymptotics', 'toybased']), default='asymptotics'
 )


### PR DESCRIPTION
# Description

The CLI API (e.g. `pyhf cls`) allows the test statistic to be set, but it limits the options to `q` and `qtilde`. However, the discovery test statistic `q0` is also a valid option here (as described in [the documentation](https://scikit-hep.org/pyhf/_generated/pyhf.infer.calculators.AsymptoticCalculator.html#pyhf.infer.calculators.AsymptoticCalculator)), but it can't currently be set on the command line. This commit is a simple fix; it adds `q0` to the list of allowed arguments to `pyhf cls --test-stat`. With this change one can do something like this to quickly test a workspace on the command line:

```
cat workspace.json | | pyhf cls --test-stat q0 --test-poi 0
```

Since this is a one-line fix, I didn't open an issue first; hopefully that's okay!

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [ ] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR