### PR TITLE
fix: more linkcheck ignore for docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,11 +146,9 @@ language = "en"
 # today_fmt = '%B %d, %Y'
 
 autodoc_mock_imports = [
-    'tensorflow',
     'torch',
     'jax',
     'iminuit',
-    'tensorflow_probability',
 ]
 
 
@@ -529,6 +527,20 @@ linkcheck_ignore = [
     # and ReadTheDocs need to reference them
     r'https://github.com/scikit-hep/pyhf/releases/tag/.*',
     r'https://pyhf.readthedocs.io/en/.*',
+    # the following are 403s as they map to journals.aps.org or academic.oup.com
+    r'https://doi.org/10.1093/ptep/ptad144',
+    r'https://doi.org/10.1103/PhysRevD.104.055017',
+    r'https://doi.org/10.1103/PhysRevD.107.095021',
+    r'https://doi.org/10.1103/PhysRevD.108.016002',
+    r'https://doi.org/10.1103/PhysRevD.106.032005',
+    r'https://doi.org/10.1103/PhysRevLett.127.181802',
+    r'https://doi.org/10.1103/PhysRevLett.130.231801',
+    r'https://doi.org/10.1103/PhysRevLett.131.211802',
+    # FNAL blocks GitHub Actions?
+    r'https://indico.fnal.gov/event/17566/contributions/44103/',
+    r'https://indico.fnal.gov/event/17566/session/0/contribution/99',
+    # GitHub anchor links don't work
+    r'https://github.com/scikit-hep/pyhf/issues/850#issuecomment-1239975121',
 ]
 linkcheck_retries = 50
 


### PR DESCRIPTION
# Pull Request Description

Pulled out of #2566. Docs are not building due to various linkcheck errors. Just need to add these to the ignore list.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* add more linkcheck ignores to the docs
  - doi.org routes to journals.aps.org or academic.oup.com
  - fnal.gov blocks GitHub Actions
  - GitHub anchor links do not work
```
