### PR TITLE
docs: Use modern sphinx-click extension syntax

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinxcontrib.bibtex',
     'sphinx.ext.napoleon',
-    'sphinx_click.ext',
+    'sphinx_click',
     'nbsphinx',
     'sphinx_issues',
     'sphinx_copybutton',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ docs = [
     "pyhf[xmlio,contrib]",
     "sphinx>=7.0.0",  # c.f. https://github.com/scikit-hep/pyhf/pull/2271
     "sphinxcontrib-bibtex>=2.1",
-    "sphinx-click",
+    "sphinx-click>=2.5.0",
     "pydata-sphinx-theme>=0.15.3",
     "nbsphinx!=0.8.8",  # c.f. https://github.com/spatialaudio/nbsphinx/issues/620
     "ipywidgets",


### PR DESCRIPTION
# Description

* Use `sphinx_click` as the form of the Sphinx extension syntax, which has been adopted since `sphinx-click` `v2.5.0`.
* Set lower bound of `v2.5.0` on `sphinx-click` requirement in `'docs'` extra.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use 'sphinx_click' as the form of the Sphinx extension syntax, which
  has been adopted since sphinx-click v2.5.0.
* Set lower bound of v2.5.0 on sphinx-click requirement in 'docs' extra.
```