### PR TITLE
ci: Restrict deployment workflows to not run on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,8 @@ jobs:
     - name: Report core project coverage with Codecov
       if: >-
         github.event_name != 'schedule' &&
-        matrix.os == 'ubuntu-latest'
+        matrix.os == 'ubuntu-latest' &&
+        github.repository == 'scikit-hep/pyhf'
       uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true
@@ -89,7 +90,7 @@ jobs:
         coverage xml
 
     - name: Report contrib coverage with Codecov
-      if: github.event_name != 'schedule' && matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'
+      if: github.event_name != 'schedule' && matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest' && github.repository == 'scikit-hep/pyhf'
       uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true
@@ -109,7 +110,7 @@ jobs:
         coverage xml --data-file=.coverage-doctest -o doctest-coverage.xml
 
     - name: Report doctest coverage with Codecov
-      if: github.event_name != 'schedule' && matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'
+      if: github.event_name != 'schedule' && matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest' && github.repository == 'scikit-hep/pyhf'
       uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   release-candidates:
 
+    if: github.repository == 'scikit-hep/pyhf'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -46,6 +47,7 @@ jobs:
 
   scipy:
 
+    if: github.repository == 'scikit-hep/pyhf'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -75,6 +77,7 @@ jobs:
 
   iminuit:
 
+    if: github.repository == 'scikit-hep/pyhf'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -101,6 +104,7 @@ jobs:
 
   uproot5:
 
+    if: github.repository == 'scikit-hep/pyhf'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -126,6 +130,7 @@ jobs:
 
   matplotlib:
 
+    if: github.repository == 'scikit-hep/pyhf'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -164,6 +169,7 @@ jobs:
 
   pytest:
 
+    if: github.repository == 'scikit-hep/pyhf'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,14 +65,14 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.repository == 'scikit-hep/pyhf'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.repository == 'scikit-hep/pyhf'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -100,7 +100,7 @@ jobs:
 
   deploy:
     name: Deploy docs to GitHub Pages
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'scikit-hep/pyhf'
     needs: build
     # Set permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
     permissions:

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -17,6 +17,7 @@ jobs:
 
   pypi_release:
 
+    if: github.repository == 'scikit-hep/pyhf'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
# Description

* Restrict workflows involving deployment or repository specific secrets to to only run on the https://github.com/scikit-hep/pyhf/ repository and not forks.
* Also restrict workflows that run on nightly schedules so if there are failures it doesn't create noise on forks.

The motivation of this is to improve the developer experience of working on forks (which I'd like the devs to try to do too, not just contributors).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Restrict workflows involving deployment or repository specific secrets to
  to only run on the scikit-hep/pyhf repository and not forks.
* Also restrict workflows that run on nightly schedules so if there are
  failures it doesn't create noise on forks.
```