### PR TITLE
ci: Remove Python 3.8 fallback to pip install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,17 +47,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      if: matrix.python-version != '3.8'
       run: |
         python -m pip install uv
         uv pip install --system --upgrade ".[all,test]"
-
-      # c.f. https://github.com/astral-sh/uv/issues/2062
-    - name: Install dependencies (Python 3.8)
-      if: matrix.python-version == '3.8'
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade ".[all,test]"
 
     - name: List installed Python packages
       run: python -m pip list


### PR DESCRIPTION
# Description

* Use `uv` for all installations in CI, as the Python 3.8 fall back to `pip install` was needed only for TensorFlow.
   - Amends PR https://github.com/scikit-hep/pyhf/pull/2609

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use uv for all installations in CI, as the Python 3.8 fall back to
  'pip install' was needed only for TensorFlow.
   - Amends PR https://github.com/scikit-hep/pyhf/pull/2609
```