### PR TITLE
ci: Use macos-15-intel for x86 macOS tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           - os: macos-latest
             python-version: '3.12'
           # Intel runner
-          - os: macos-13
+          - os: macos-15-intel
             python-version: '3.12'
 
     steps:


### PR DESCRIPTION
# Description

* As the `macos-13 runner` images are deprecated use the `macos-15-intel` runner images to test x86 macOS support.
   - c.f. [2025-09-15 blog "GitHub Actions: macOS 13 runner image is closing down"](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)
* This puts an EOL for x86 macOS support in GitHub Actions of Fall 2027.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* As the macos-13 runner images are deprecated use the macos-15-intel runner
  images to test x86 macOS support.
   - c.f. https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
* This puts an EOL for x86 macOS support in GitHub Actions of Fall 2027.
```