### PR TITLE
ci: Add Python 3.13 to tests

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -195,11 +195,11 @@ jobs:
         echo "steps.script.outputs.old_tag=v${current_tag}"
         echo "old_tag=v${current_tag}" >> $GITHUB_OUTPUT
 
-    - name: Set up Python 3.12
+    - name: Set up Python
       if: success()
       uses: actions/setup-python@v6
       with:
-        python-version: '3.12'
+        python-version: '3.13'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         include:
           - os: macos-latest
-            python-version: '3.12'
+            python-version: '3.13'
           # Intel runner
           - os: macos-15-intel
-            python-version: '3.12'
+            python-version: '3.13'
 
     steps:
     - uses: actions/checkout@v5
@@ -89,7 +89,7 @@ jobs:
         coverage xml
 
     - name: Report contrib coverage with Codecov
-      if: github.event_name != 'schedule' && matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
+      if: github.event_name != 'schedule' && matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true
@@ -99,17 +99,17 @@ jobs:
 
     - name: Test docstring examples with doctest
       # TODO: Don't currently try to match amd64 and arm64 floating point for docs, but will in the future.
-      if: matrix.python-version == '3.12' && matrix.os != 'macos-latest'
+      if: matrix.python-version == '3.13' && matrix.os != 'macos-latest'
       run: coverage run --data-file=.coverage-doctest --module pytest src/ README.rst
 
     - name: Coverage report for doctest only
-      if: matrix.python-version == '3.12' && matrix.os != 'macos-latest'
+      if: matrix.python-version == '3.13' && matrix.os != 'macos-latest'
       run: |
         coverage report --data-file=.coverage-doctest
         coverage xml --data-file=.coverage-doctest -o doctest-coverage.xml
 
     - name: Report doctest coverage with Codecov
-      if: github.event_name != 'schedule' && matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
+      if: github.event_name != 'schedule' && matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true
@@ -118,6 +118,6 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Run benchmarks
-      if: github.event_name == 'schedule' && matrix.python-version == '3.12'
+      if: github.event_name == 'schedule' && matrix.python-version == '3.13'
       run: |
         pytest --benchmark-sort=mean tests/benchmarks/test_benchmark.py

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13]
-        python-version: ['3.12']
+        os: [ubuntu-latest, macos-latest, macos-15-intel]
+        python-version: ['3.13']
 
     steps:
     - uses: actions/checkout@v5
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.12']
+        python-version: ['3.13']
 
     steps:
     - uses: actions/checkout@v5
@@ -79,7 +79,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.12']
+        python-version: ['3.13']
 
     steps:
     - uses: actions/checkout@v5
@@ -105,7 +105,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.12']
+        python-version: ['3.13']
 
     steps:
     - uses: actions/checkout@v5
@@ -130,7 +130,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.12']
+        python-version: ['3.13']
 
     steps:
     - uses: actions/checkout@v5
@@ -168,7 +168,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.12']
+        python-version: ['3.13']
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.12'
+        python-version: '3.13'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.13']
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -41,10 +41,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python 3.12
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.12'
+        python-version: '3.13'
 
     - name: Install python-build and twine
       run: |

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -21,13 +21,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         include:
           - os: macos-latest
-            python-version: '3.12'
+            python-version: '3.13'
           # Intel runner
-          - os: macos-13
-            python-version: '3.12'
+          - os: macos-15-intel
+            python-version: '3.13'
       fail-fast: false
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,8 +64,8 @@ repos:
           ['numpy', 'types-tqdm', 'click', 'types-jsonpatch', 'types-pyyaml', 'types-jsonschema', 'importlib_metadata', 'packaging']
         args: ["--python-version=3.8"]
       - <<: *mypy
-        name: mypy with Python 3.12
-        args: ["--python-version=3.12"]
+        name: mypy with Python 3.13
+        args: ["--python-version=3.13"]
 
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.3.0

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.13"
   apt_packages:
     - curl
     - jq

--- a/binder/runtime.txt
+++ b/binder/runtime.txt
@@ -1,1 +1,1 @@
-python-3.12
+python-3.13

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=python:3.12-slim-bullseye
+ARG BASE_IMAGE=python:3.13-slim-bookworm
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE} AS base
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -97,7 +97,7 @@ contrib module, or notebooks, and so instead to test the core codebase a develop
 
 .. code-block:: console
 
-    nox --session tests --python 3.12
+    nox --session tests --python 3.13
 
 Contrib module matplotlib image tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -107,7 +107,7 @@ To run the visualization tests for the ``contrib`` module with the ``pytest-mpl`
 
 .. code-block:: console
 
-    nox --session tests --python 3.12 -- contrib
+    nox --session tests --python 3.13 -- contrib
 
 If the image files need to be regenerated, run the tests with the
 ``--mpl-generate-path=tests/contrib/baseline`` option or just run
@@ -141,7 +141,7 @@ or pass ``coverage`` as a positional argument to the ``nox`` ``tests`` session
 
 .. code-block:: console
 
-    nox --session tests --python 3.12 -- coverage
+    nox --session tests --python 3.13 -- coverage
 
 Coverage Report
 ^^^^^^^^^^^^^^^

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 import nox
 
-ALL_PYTHONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+ALL_PYTHONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
 # Default sessions to run if no session handles are passed
-nox.options.sessions = ["lint", "tests-3.12"]
+nox.options.sessions = ["lint", "tests-3.13"]
 
 
 DIR = Path(__file__).parent.resolve()
@@ -30,10 +30,10 @@ def tests(session):
 
     Examples:
 
-        $ nox --session tests --python 3.12
-        $ nox --session tests --python 3.12 -- contrib  # run the contrib module tests
-        $ nox --session tests --python 3.12 -- tests/test_tensor.py  # run specific tests
-        $ nox --session tests --python 3.12 -- coverage  # run with coverage but slower
+        $ nox --session tests --python 3.13
+        $ nox --session tests --python 3.13 -- contrib  # run the contrib module tests
+        $ nox --session tests --python 3.13 -- tests/test_tensor.py  # run specific tests
+        $ nox --session tests --python 3.13 -- coverage  # run with coverage but slower
     """
     session.install("--upgrade", "--editable", ".[all,test]")
     session.install("--upgrade", "pytest")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Physics",
@@ -217,7 +218,7 @@ exclude_also = [
 
 [tool.mypy]
 files = "src"
-python_version = "3.12"
+python_version = "3.13"
 warn_unused_configs = true
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]


### PR DESCRIPTION
# Description

* Add Python 3.13 to Python versions tested.
* Default to using Python 3.13 for all CI operations.
* Update trove classifiers to add Python 3.13 metadata.
* Update Dockerfile base image OS to Bookworm.
* Use macos-15-intel over macos-13 runner image in all workflows.
   - Amends PR https://github.com/scikit-hep/pyhf/pull/2620.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add Python 3.13 to Python versions tested.
* Default to using Python 3.13 for all CI operations.
* Update trove classifiers to add Python 3.13 metadata.
* Update Dockerfile base image OS to Bookworm.
* Use macos-15-intel over macos-13 runner image in all workflows.
   - Amends PR https://github.com/scikit-hep/pyhf/pull/2620.
```