### PR TITLE
fix: jupyter book badge url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -369,7 +369,7 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
    :target: https://pyhf.readthedocs.io/
 .. |Docs from main| image:: https://img.shields.io/badge/docs-main-blue.svg
    :target: https://scikit-hep.github.io/pyhf
-.. |Jupyter Book tutorial| image:: https://jupyterbook.org/_images/badge.svg
+.. |Jupyter Book tutorial| image:: https://raw.githubusercontent.com/jupyter-book/jupyter-book/next/docs/media/images/badge.svg
    :target: https://pyhf.github.io/pyhf-tutorial/
 .. |Binder| image:: https://mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/scikit-hep/pyhf/main?labpath=docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb


### PR DESCRIPTION
# Description

Please first read [CONTRIBUTING.md](https://github.com/scikit-hep/pyhf/tree/main/CONTRIBUTING.md).

Please describe the purpose of this pull request in some detail. Reference and link to any relevant issues or pull requests.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* jupyterbook.org url broken/changed, switched to GitHub for the badge url as it is more stable
```
