### PR TITLE
build: Update SciPy lower bound to v1.5.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "jsonschema>=4.15.0",  # for utils
     "pyyaml>=5.1",  # for parsing CLI equal-delimited options
     # c.f. https://github.com/scikit-hep/pyhf/issues/2593 for excluded v1.16.x versions
-    "scipy>=1.5.2,!=1.16.0,!=1.16.1,!=1.16.2",  # requires numpy, which is required by pyhf
+    "scipy>=1.5.4,!=1.16.0,!=1.16.1,!=1.16.2",  # requires numpy, which is required by pyhf
     "tqdm>=4.56.0",  # for readxml
     "numpy",  # compatible versions controlled through scipy
 ]

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,5 +1,5 @@
 # core
-scipy==1.5.2  # c.f. PR #2469
+scipy==1.5.4  # c.f. PR #2469
 click==8.0.0  # c.f. PR #1958, #1909
 tqdm==4.56.0
 jsonschema==4.15.0  # c.f. PR #1979


### PR DESCRIPTION
# Description

* SciPy `v1.5.4` is the first SciPy release to have Python 3.9 wheels.
   - c.f. https://pypi.org/project/scipy/1.5.4/#files
* Update `scipy` to `v1.5.4` in `tests/constraints.txt` to enforce the lower bound for the minimum supported dependencies tests.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* SciPy v1.5.4 is the first SciPy release to have Python 3.9 wheels.
   - c.f. https://pypi.org/project/scipy/1.5.4/#files
* Update scipy to v1.5.4 in tests/constraints.txt to enforce the
  lower bound for the minimum supported dependencies tests.
```