### PR TITLE
chore: pytest log_level is better than log_cli_level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,7 @@ addopts = [
     "--doctest-modules",
     "--doctest-glob='*.rst'",
 ]
-log_cli_level = "INFO"
+log_level = "INFO"
 testpaths = "tests"
 markers = [
     "fail_jax",


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

See https://github.com/scientific-python/cookie/issues/679