### PR TITLE
ci: Use 2i2c endpoint for triggering Binder build

### DIFF
--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -18,4 +18,4 @@ jobs:
     - name: Trigger Binder build
       run: |
         # Use Binder build API to trigger repo2docker to build image on Google Cloud and Turing Institute Binder Federation clusters
-        bash binder/trigger_binder.sh https://turing.mybinder.org/build/gh/scikit-hep/pyhf/main
+        bash binder/trigger_binder.sh https://2i2c.mybinder.org/build/gh/scikit-hep/pyhf/main


### PR DESCRIPTION
# Description

* Use 2i2c as the endpoint to trigger the Binder build given it is the primary endpoint for the Binder federation.
   - The Turing Institute no longer contributes to the [Binder federation](https://mybinder.readthedocs.io/en/latest/about/federation.html) through compute resources.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use 2i2c as the endpoint to trigger the Binder build given it is
  the primary endpoint for the Binder federation.
   - The Turing Institute no longer contributes to the Binder federation
   through compute resources.
   - c.f. https://mybinder.readthedocs.io/en/latest/about/federation.html
```