### PR TITLE
ci: Disable PerfPowerServices process on macos-15-intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
             python-version: '3.13'
 
     steps:
+    # c.f. https://github.com/actions/runner-images/issues/13358
+    - name: Work around x86 macOS bug for multiple CPU cores
+      if: matrix.os == 'macos-15-intel'
+      run: |
+        sudo defaults -currentHost write /Library/Preferences/com.apple.powerlogd SMCMonitorCadence 0
+        sudo killall PerfPowerServices || true
+
     - uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -24,6 +24,13 @@ jobs:
         python-version: ['3.13']
 
     steps:
+    # c.f. https://github.com/actions/runner-images/issues/13358
+    - name: Work around x86 macOS bug for multiple CPU cores
+      if: matrix.os == 'macos-15-intel'
+      run: |
+        sudo defaults -currentHost write /Library/Preferences/com.apple.powerlogd SMCMonitorCadence 0
+        sudo killall PerfPowerServices || true
+
     - uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -32,6 +32,13 @@ jobs:
       fail-fast: false
 
     steps:
+    # c.f. https://github.com/actions/runner-images/issues/13358
+    - name: Work around x86 macOS bug for multiple CPU cores
+      if: matrix.os == 'macos-15-intel'
+      run: |
+        sudo defaults -currentHost write /Library/Preferences/com.apple.powerlogd SMCMonitorCadence 0
+        sudo killall PerfPowerServices || true
+
     - uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
# Description

* Disable the PerfPowerServices process on macos-15-intel runners to address known macOS 15 bug that significantly slows down the runner.
   - c.f. https://github.com/actions/runner-images/issues/13358
   - Pattern copied from https://github.com/spack/spack/pull/51647

Thanks to @ariostas for alerting us to this!

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Disable the PerfPowerServices process on macos-15-intel runners to
  address known macOS 15 bug that significantly slows down the runner.
   - c.f. https://github.com/actions/runner-images/issues/13358
```