### PR TITLE
revert: Drop upstreamed PerfPowerServices macos-15-intel fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,6 @@ jobs:
             python-version: '3.13'
 
     steps:
-    # c.f. https://github.com/actions/runner-images/issues/13358
-    - name: Work around x86 macOS bug for multiple CPU cores
-      if: matrix.os == 'macos-15-intel'
-      run: |
-        sudo defaults -currentHost write /Library/Preferences/com.apple.powerlogd SMCMonitorCadence 0
-        sudo killall PerfPowerServices || true
-
     - uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -24,13 +24,6 @@ jobs:
         python-version: ['3.13']
 
     steps:
-    # c.f. https://github.com/actions/runner-images/issues/13358
-    - name: Work around x86 macOS bug for multiple CPU cores
-      if: matrix.os == 'macos-15-intel'
-      run: |
-        sudo defaults -currentHost write /Library/Preferences/com.apple.powerlogd SMCMonitorCadence 0
-        sudo killall PerfPowerServices || true
-
     - uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -32,13 +32,6 @@ jobs:
       fail-fast: false
 
     steps:
-    # c.f. https://github.com/actions/runner-images/issues/13358
-    - name: Work around x86 macOS bug for multiple CPU cores
-      if: matrix.os == 'macos-15-intel'
-      run: |
-        sudo defaults -currentHost write /Library/Preferences/com.apple.powerlogd SMCMonitorCadence 0
-        sudo killall PerfPowerServices || true
-
     - uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
# Description

* Remove macos-15-intel specific runner fixes as they have been upstreamed into GitHub Actions runners.
   - c.f. https://github.com/actions/runner-images/pull/13414
   - https://github.com/actions/runner-images/issues/13358
* Reverts PR https://github.com/scikit-hep/pyhf/pull/2641

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove macos-15-intel specific runner fixes as they have been upstreamed
  into GitHub Actions runners.
   - c.f. https://github.com/actions/runner-images/pull/13414
* Reverts PR https://github.com/scikit-hep/pyhf/pull/2641
```