### PR TITLE
chore: Update Sphinx lower bound to v9.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ test = [
 ]
 docs = [
     "pyhf[xmlio,contrib]",
-    "sphinx>=7.0.0",  # c.f. https://github.com/scikit-hep/pyhf/pull/2271
+    "sphinx>=9.0.3",  # c.f. https://github.com/scikit-hep/pyhf/pull/2642
     "sphinxcontrib-bibtex>=2.1",
     "sphinx-click>=2.5.0",
     "pydata-sphinx-theme>=0.15.3",


### PR DESCRIPTION
# Description

* Update Sphinx to v9.0.3 to use modern v9+ Sphinx while skipping v9.0.0 to v9.0.2 which had bugs that affected pyhf's docs.
   - c.f. https://github.com/scikit-hep/pyhf/pull/2642#issuecomment-3598870553

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update Sphinx to v9.0.3 to use modern v9+ Sphinx while skipping
  v9.0.0 to v9.0.2 which had bugs that affected pyhf's docs.
```