### PR TITLE
build: Set rich lower bound to v12.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "pyyaml>=5.1",  # for parsing CLI equal-delimited options
     # c.f. https://github.com/scikit-hep/pyhf/issues/2593 for excluded v1.16.x versions
     "scipy>=1.5.4,!=1.16.0,!=1.16.1,!=1.16.2",  # requires numpy, which is required by pyhf
-    "rich>=10.0.0",  # for progress bars
+    "rich>=12.3.0",  # for progress bars
     "numpy>=1.22.0",  # compatible versions controlled through scipy
 ]
 

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,7 +1,7 @@
 # core
 scipy==1.5.4  # c.f. PR #2469
 click==8.0.0  # c.f. PR #1958, #1909
-rich==10.0.0  # c.f. PR #2648
+rich==12.3.0  # c.f. PR #2650
 jsonschema==4.15.0  # c.f. PR #1979
 jsonpatch==1.15
 pyyaml==5.1


### PR DESCRIPTION
# Description

* `rich.progress.TaskProgressColumn` was added in rich v12.3.0.
   - c.f. https://github.com/Textualize/rich/releases/tag/v12.3.0
   - Amends PR #2648

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* rich.progress.TaskProgressColumn was added in rich v12.3.0.
   - c.f. https://github.com/Textualize/rich/releases/tag/v12.3.0
   - Amends PR https://github.com/scikit-hep/pyhf/pull/2648
```