### PR TITLE
refactor: Align with backends percentile API arguments

### DIFF
--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -687,7 +687,7 @@ class EmpiricalDistribution:
         """
         tensorlib, _ = get_backend()
         return tensorlib.percentile(
-            self.samples, tensorlib.normal_cdf(nsigma) * 100, interpolation="linear"
+            self.samples, tensorlib.normal_cdf(nsigma) * 100, method="linear"
         )
 
 

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -294,7 +294,7 @@ class jax_backend:
     def exp(self, tensor_in):
         return jnp.exp(tensor_in)
 
-    def percentile(self, tensor_in, q, axis=None, interpolation="linear"):
+    def percentile(self, tensor_in, q, axis=None, method="linear"):
         r"""
         Compute the :math:`q`-th percentile of the tensor along the specified axis.
 
@@ -313,7 +313,7 @@ class jax_backend:
             tensor_in (`tensor`): The tensor containing the data
             q (:obj:`float` or `tensor`): The :math:`q`-th percentile to compute
             axis (`number` or `tensor`): The dimensions along which to compute
-            interpolation (:obj:`str`): The interpolation method to use when the
+            method (:obj:`str`): The estimation method to use when the
              desired percentile lies between two data points ``i < j``:
 
                 - ``'linear'``: ``i + (j - i) * fraction``, where ``fraction`` is the
@@ -331,8 +331,10 @@ class jax_backend:
             JAX ndarray: The value of the :math:`q`-th percentile of the tensor along the specified axis.
 
         .. versionadded:: 0.7.0
+        .. version-changed:: 0.8.0
+           Argument renamed from *interpolation* to *method* to align with NumPy and JAX.
         """
-        return jnp.percentile(tensor_in, q, axis=axis, method=interpolation)
+        return jnp.percentile(tensor_in, q, axis=axis, method=method)
 
     def stack(self, sequence, axis=0):
         return jnp.stack(sequence, axis=axis)

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -307,9 +307,7 @@ class numpy_backend(Generic[T]):
         tensor_in: Tensor[T],
         q: float | NDArray[np.floating[T]] | NDArray[np.integer[T]],
         axis: int | Sequence[int] | None = None,
-        interpolation: Literal[
-            "linear", "lower", "higher", "midpoint", "nearest"
-        ] = "linear",
+        method: Literal["linear", "lower", "higher", "midpoint", "nearest"] = "linear",
     ) -> ArrayLike:
         r"""
         Compute the :math:`q`-th percentile of the tensor along the specified axis.
@@ -328,7 +326,7 @@ class numpy_backend(Generic[T]):
             tensor_in (`tensor`): The tensor containing the data
             q (:obj:`float` or `tensor`): The :math:`q`-th percentile to compute
             axis (`number` or `tensor`): The dimensions along which to compute
-            interpolation (:obj:`str`): The interpolation method to use when the
+            method (:obj:`str`): The estimation method to use when the
              desired percentile lies between two data points ``i < j``:
 
                 - ``'linear'``: ``i + (j - i) * fraction``, where ``fraction`` is the
@@ -346,11 +344,10 @@ class numpy_backend(Generic[T]):
             NumPy ndarray: The value of the :math:`q`-th percentile of the tensor along the specified axis.
 
         .. versionadded:: 0.7.0
+        .. version-changed:: 0.8.0
+           Argument renamed from *interpolation* to *method* to align with NumPy.
         """
-        # see https://github.com/numpy/numpy/issues/22125
-        return cast(
-            ArrayLike, np.percentile(tensor_in, q, axis=axis, method=interpolation)
-        )
+        return cast(ArrayLike, np.percentile(tensor_in, q, axis=axis, method=method))
 
     def stack(self, sequence: Sequence[Tensor[T]], axis: int = 0) -> ArrayLike:
         return np.stack(sequence, axis=axis)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -319,15 +319,15 @@ def test_percentile(backend):
     assert tb.tolist(tb.percentile(a, 50, axis=1)) == [7.0, 2.0]
 
 
-def test_percentile_interpolation(backend):
+def test_percentile_method(backend):
     tb = pyhf.tensorlib
     a = tb.astensor([[10, 7, 4], [3, 2, 1]])
 
-    assert tb.tolist(tb.percentile(a, 50, interpolation="linear")) == 3.5
-    assert tb.tolist(tb.percentile(a, 50, interpolation="nearest")) == 3.0
-    assert tb.tolist(tb.percentile(a, 50, interpolation="lower")) == 3.0
-    assert tb.tolist(tb.percentile(a, 50, interpolation="midpoint")) == 3.5
-    assert tb.tolist(tb.percentile(a, 50, interpolation="higher")) == 4.0
+    assert tb.tolist(tb.percentile(a, 50, method="linear")) == 3.5
+    assert tb.tolist(tb.percentile(a, 50, method="nearest")) == 3.0
+    assert tb.tolist(tb.percentile(a, 50, method="lower")) == 3.0
+    assert tb.tolist(tb.percentile(a, 50, method="midpoint")) == 3.5
+    assert tb.tolist(tb.percentile(a, 50, method="higher")) == 4.0
 
 
 def test_tensor_tile(backend):


### PR DESCRIPTION
# Description

Migrated from PR https://github.com/scikit-hep/pyhf/pull/2652 and so needs that to go in first.

* Change argument from `interpolation` to `method` to align with NumPy's percentile arguments from NumPy v1.22.0+.
   - c.f. https://numpy.org/doc/stable/reference/generated/numpy.percentile.html
* Change `interpolation` to `method` in tests.
* Add version-changed note in tensor backend percentile docstrings.

Relevant docs preview: https://pyhf--2655.org.readthedocs.build/en/2655/_generated/pyhf.tensor.numpy_backend.numpy_backend.html#pyhf.tensor.numpy_backend.numpy_backend.percentile

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Change argument from 'interpolation' to 'method' to align with
  NumPy's percentile arguments from NumPy v1.22.0+.
   - c.f. https://numpy.org/doc/stable/reference/generated/numpy.percentile.html
* Change 'interpolation' to 'method' in tests.
* Add version-changed note in tensor backend percentile docstrings.
```