### PR TITLE
fix: skip excluded backends before test backend setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,6 +136,13 @@ def backend(request):
         request.node.add_marker(
             pytest.mark.xfail(reason=f"expect {func_name} to fail as specified")
         )
+    
+    # If this backend is not selected by only_* markers, do not even attempt setup
+    if only_backends and param_id not in only_backends:
+        pytest.skip(
+            f"skipping {func_name} as specified to only look at: {', '.join(only_backends)}"
+        )
+
 
     tensor_config, optimizer_config = request.param
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,13 +136,12 @@ def backend(request):
         request.node.add_marker(
             pytest.mark.xfail(reason=f"expect {func_name} to fail as specified")
         )
-    
+
     # If this backend is not selected by only_* markers, do not even attempt setup
     if only_backends and param_id not in only_backends:
         pytest.skip(
             f"skipping {func_name} as specified to only look at: {', '.join(only_backends)}"
         )
-
 
     tensor_config, optimizer_config = request.param
 


### PR DESCRIPTION
This PR updates the backend test fixture to respect only_* markers
before creating backend objects.

This avoids importing optional backends (e.g. JAX, PyTorch) when running
marker-restricted test suites such as `pytest -m only_numpy`, improving
test behavior in minimal environments.

Fixes #2654
