### PR TITLE
ci: Add Python 3.14 to tests

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -199,7 +199,7 @@ jobs:
       if: success()
       uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -199,7 +199,7 @@ jobs:
       if: success()
       uses: actions/setup-python@v7
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         include:
           - os: macos-latest
-            python-version: '3.13'
+            python-version: '3.14'
           # Intel runner
           - os: macos-15-intel
             python-version: '3.13'
@@ -95,7 +95,7 @@ jobs:
         coverage xml
 
     - name: Report contrib coverage with Codecov
-      if: github.event_name != 'schedule' && matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest' && github.repository == 'scikit-hep/pyhf'
+      if: github.event_name != 'schedule' && matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest' && github.repository == 'scikit-hep/pyhf'
       uses: codecov/codecov-action@v7
       with:
         fail_ci_if_error: true
@@ -105,17 +105,17 @@ jobs:
 
     - name: Test docstring examples with doctest
       # TODO: Don't currently try to match amd64 and arm64 floating point for docs, but will in the future.
-      if: matrix.python-version == '3.13' && matrix.os != 'macos-latest'
+      if: matrix.python-version == '3.14' && matrix.os != 'macos-latest'
       run: coverage run --data-file=.coverage-doctest --module pytest src/ README.rst
 
     - name: Coverage report for doctest only
-      if: matrix.python-version == '3.13' && matrix.os != 'macos-latest'
+      if: matrix.python-version == '3.14' && matrix.os != 'macos-latest'
       run: |
         coverage report --data-file=.coverage-doctest
         coverage xml --data-file=.coverage-doctest -o doctest-coverage.xml
 
     - name: Report doctest coverage with Codecov
-      if: github.event_name != 'schedule' && matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest' && github.repository == 'scikit-hep/pyhf'
+      if: github.event_name != 'schedule' && matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest' && github.repository == 'scikit-hep/pyhf'
       uses: codecov/codecov-action@v7
       with:
         fail_ci_if_error: true
@@ -124,6 +124,6 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Run benchmarks
-      if: github.event_name == 'schedule' && matrix.python-version == '3.13'
+      if: github.event_name == 'schedule' && matrix.python-version == '3.14'
       run: |
         pytest --benchmark-sort=mean tests/benchmarks/test_benchmark.py

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-15-intel]
-        python-version: ['3.13']
+        os: [ubuntu-latest, macos-latest]
+        python-version: ['3.14']
 
     steps:
     - uses: actions/checkout@v7
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.13']
+        python-version: ['3.14']
 
     steps:
     - uses: actions/checkout@v7
@@ -82,7 +82,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.13']
+        python-version: ['3.14']
 
     steps:
     - uses: actions/checkout@v7
@@ -109,7 +109,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.13']
+        python-version: ['3.14']
 
     steps:
     - uses: actions/checkout@v7
@@ -135,7 +135,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.13']
+        python-version: ['3.14']
 
     steps:
     - uses: actions/checkout@v7
@@ -174,7 +174,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.13']
+        python-version: ['3.14']
 
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.13']
+        python-version: ['3.14']
 
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Install python-build and twine
       run: |

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Install python-build and twine
       run: |

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -22,10 +22,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         include:
           - os: macos-latest
-            python-version: '3.13'
+            python-version: '3.14'
           # Intel runner
           - os: macos-15-intel
             python-version: '3.13'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,11 +63,11 @@ repos:
         args: ["--python-version=3.10"]
 
       - id: mypy
-        name: mypy with Python 3.13
+        name: mypy with Python 3.14
         files: src
         additional_dependencies:
           ["numpy", "rich", "click", "types-jsonpatch", "types-pyyaml", "types-jsonschema", "importlib_metadata", "packaging"]
-        args: ["--python-version=3.13"]
+        args: ["--python-version=3.14"]
 
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.4.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,11 +63,11 @@ repos:
         args: ["--python-version=3.10"]
 
       - id: mypy
-        name: mypy with Python 3.13
+        name: mypy with Python 3.14
         files: src
         additional_dependencies:
           ["numpy", "rich", "click", "types-jsonpatch", "types-pyyaml", "types-jsonschema", "importlib_metadata", "packaging"]
-        args: ["--python-version=3.13"]
+        args: ["--python-version=3.14"]
 
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.4.3

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.13"
+    python: "3.14"
   apt_packages:
     - curl
     - jq

--- a/binder/runtime.txt
+++ b/binder/runtime.txt
@@ -1,1 +1,1 @@
-python-3.13
+python-3.14

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=python:3.13-slim-bookworm
+ARG BASE_IMAGE=python:3.14-slim-bookworm
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE} AS base
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -97,7 +97,7 @@ contrib module, or notebooks, and so instead to test the core codebase a develop
 
 .. code-block:: console
 
-    nox --session tests --python 3.13
+    nox --session tests --python 3.14
 
 Contrib module matplotlib image tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -107,7 +107,7 @@ To run the visualization tests for the ``contrib`` module with the ``pytest-mpl`
 
 .. code-block:: console
 
-    nox --session tests --python 3.13 -- contrib
+    nox --session tests --python 3.14 -- contrib
 
 If the image files need to be regenerated, run the tests with the
 ``--mpl-generate-path=tests/contrib/baseline`` option or just run
@@ -141,7 +141,7 @@ or pass ``coverage`` as a positional argument to the ``nox`` ``tests`` session
 
 .. code-block:: console
 
-    nox --session tests --python 3.13 -- coverage
+    nox --session tests --python 3.14 -- coverage
 
 Coverage Report
 ^^^^^^^^^^^^^^^

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 import nox
 
-ALL_PYTHONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+ALL_PYTHONS = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
 # Default sessions to run if no session handles are passed
-nox.options.sessions = ["lint", "tests-3.13"]
+nox.options.sessions = ["lint", "tests-3.14"]
 nox.options.default_venv_backend = "uv|virtualenv"
 
 
@@ -31,10 +31,10 @@ def tests(session):
 
     Examples:
 
-        $ nox --session tests --python 3.13
-        $ nox --session tests --python 3.13 -- contrib  # run the contrib module tests
-        $ nox --session tests --python 3.13 -- tests/test_tensor.py  # run specific tests
-        $ nox --session tests --python 3.13 -- coverage  # run with coverage but slower
+        $ nox --session tests --python 3.14
+        $ nox --session tests --python 3.14 -- contrib  # run the contrib module tests
+        $ nox --session tests --python 3.14 -- tests/test_tensor.py  # run specific tests
+        $ nox --session tests --python 3.14 -- coverage  # run with coverage but slower
     """
     session.install("--upgrade", "--editable", ".[all]", "--group", "test")
     session.install("--upgrade", "pytest")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Physics",
@@ -203,7 +204,7 @@ exclude_also = [
 
 [tool.mypy]
 files = "src"
-python_version = "3.13"
+python_version = "3.14"
 warn_unused_configs = true
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -643,5 +643,5 @@ class numpy_backend(Generic[T]):
 
         .. versionadded:: 0.7.0
         """
-        # TODO: Casting needed for Python 3.10 mypy but not Python 3.13?
+        # TODO: Casting needed for Python 3.10 mypy but not Python 3.13+?
         return cast("ArrayLike", tensor_in.transpose())


### PR DESCRIPTION
# Description

* Add Python 3.14 to Python versions tested.
* Default to using Python 3.14 for all CI operations.
* Update trove classifiers to add Python 3.14 metadata.
* Keep macos-15-intel runners on Python 3.13 as JAX and other libraries have dropped x86-64 macOS support for Python 3.14+.
* Remove macos-15-intel runner from HEAD of dependenices workflow.

---

* Requires PR https://github.com/scikit-hep/pyhf/pull/2725 to go in first.
* Requires PR https://github.com/scikit-hep/pyhf/pull/2730 to go in first.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add Python 3.14 to Python versions tested.
* Default to using Python 3.14 for all CI operations.
* Update trove classifiers to add Python 3.14 metadata.
* Keep macos-15-intel runners on Python 3.13 as JAX and other
  libraries have dropped x86-64 macOS support for Python 3.14+.
* Remove macos-15-intel runner from HEAD of dependenices workflow.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Python 3.14 support across supported development, testing, documentation, notebook, and release environments.
  - Updated package metadata to officially recognize Python 3.14.

- **Improvements**
  - Docker, Binder, and documentation builds now use Python 3.14.
  - Continuous integration and automated quality checks now validate Python 3.14 compatibility.
  - Updated development and testing guidance with Python 3.14 examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->