### PR TITLE
ci: Constrain pyparsing for Python 3.9 on Windows CI

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -33,7 +33,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade '.[all]' --group test
+        uv pip install --system --upgrade ".[all]" --group test
+
+    # c.f. https://github.com/scikit-hep/pyhf/issues/2653
+    - name: Guard against Python 3.9 pyparsing
+      if: matrix.python-version == '3.9'
+      run: uv pip install --system "pyparsing<3.3.0"
 
     - name: List installed Python packages
       run: python -m pip list


### PR DESCRIPTION
# Description

* Constraint pyparsing to versions older than v3.3.0 for Python 3.9 in CI.
   - c.f. Issue https://github.com/scikit-hep/pyhf/issues/2653
   - Amends PR https://github.com/scikit-hep/pyhf/issues/2652

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Constrain pyparsing to versions older than v3.3.0 for Python 3.9 in CI.
   - c.f. Issue https://github.com/scikit-hep/pyhf/issues/2653
   - Amends PR https://github.com/scikit-hep/pyhf/issues/2652
```