### PR TITLE
fix: Correct mask in code2 fast interpolation for alpha < -1

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -37,3 +37,4 @@ Contributors include:
 - Melissa Weber Mendonça
 - Matthias Bussonnier
 - Peter Fackeldey
+- Alok Kumar

--- a/src/pyhf/interpolators/code2.py
+++ b/src/pyhf/interpolators/code2.py
@@ -95,7 +95,7 @@ class code2:
             "sa,sa,shb->shab", alphasets, alphasets, self.a
         ) + tensorlib.einsum("sa,shb->shab", alphasets, self.b)
         value_lt1 = tensorlib.einsum(
-            "sa,shb->shab", alphasets + self.mask_off, self.b_minus_2a
+            'sa,shb->shab', alphasets + self.mask_on, self.b_minus_2a
         )
 
         masks_gt1 = tensorlib.astensor(

--- a/src/pyhf/interpolators/code2.py
+++ b/src/pyhf/interpolators/code2.py
@@ -95,7 +95,7 @@ class code2:
             "sa,sa,shb->shab", alphasets, alphasets, self.a
         ) + tensorlib.einsum("sa,shb->shab", alphasets, self.b)
         value_lt1 = tensorlib.einsum(
-            'sa,shb->shab', alphasets + self.mask_on, self.b_minus_2a
+            "sa,shb->shab", alphasets + self.mask_on, self.b_minus_2a
         )
 
         masks_gt1 = tensorlib.astensor(

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -195,7 +195,7 @@ def test_code1_validation(backend, do_tensorized_calc):
     )
 
 
-@pytest.mark.parametrize("do_tensorized_calc", [False, True], ids=['slow', 'fast'])
+@pytest.mark.parametrize("do_tensorized_calc", [False, True], ids=["slow", "fast"])
 def test_code2_validation(backend, do_tensorized_calc):
     histogramssets = [[[[0.5], [1.0], [2.0]]]]
     # Test across all three regions : alpha > 1, alpha < -1 and |alpha| <= 1
@@ -210,7 +210,7 @@ def test_code2_validation(backend, do_tensorized_calc):
     # Calculate the actual interpolate values: nom + delta
     histogramssets_tensor = pyhf.tensorlib.astensor(histogramssets)
     allsets_allhistos_noms_repeated = pyhf.tensorlib.einsum(
-        'sa,shb->shab',
+        "sa,shb->shab",
         pyhf.tensorlib.ones(pyhf.tensorlib.shape(alphasets)),
         histogramssets_tensor[:, :, 1],
     )
@@ -222,7 +222,7 @@ def test_code2_validation(backend, do_tensorized_calc):
     )
 
 
-@pytest.mark.parametrize("do_tensorized_calc", [False, True], ids=['slow', 'fast'])
+@pytest.mark.parametrize("do_tensorized_calc", [False, True], ids=["slow", "fast"])
 def test_code2_fast_slow_consistency_extrapolation(backend, do_tensorized_calc):
     histogramssets = [[[[0.5], [1.0], [2.0]]]]
     # Only test the region alpha < -1

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -195,6 +195,52 @@ def test_code1_validation(backend, do_tensorized_calc):
     )
 
 
+@pytest.mark.parametrize("do_tensorized_calc", [False, True], ids=['slow', 'fast'])
+def test_code2_validation(backend, do_tensorized_calc):
+    histogramssets = [[[[0.5], [1.0], [2.0]]]]
+    # Test across all three regions : alpha > 1, alpha < -1 and |alpha| <= 1
+    alphasets = pyhf.tensorlib.astensor([[-2, -1, 0, 1, 2]])
+    expected = pyhf.tensorlib.astensor([[[[0.75], [0.5], [1.0], [2.0], [2.25]]]])
+
+    interpolator = pyhf.interpolators.get(2, do_tensorized_calc=do_tensorized_calc)(
+        histogramssets, subscribe=False
+    )
+    result_deltas = pyhf.tensorlib.astensor(interpolator(alphasets))
+
+    # Calculate the actual interpolate values: nom + delta
+    histogramssets_tensor = pyhf.tensorlib.astensor(histogramssets)
+    allsets_allhistos_noms_repeated = pyhf.tensorlib.einsum(
+        'sa,shb->shab',
+        pyhf.tensorlib.ones(pyhf.tensorlib.shape(alphasets)),
+        histogramssets_tensor[:, :, 1],
+    )
+    results = allsets_allhistos_noms_repeated + result_deltas
+
+    assert (
+        pytest.approx(np.asarray(pyhf.tensorlib.tolist(results)).ravel().tolist())
+        == np.asarray(pyhf.tensorlib.tolist(expected)).ravel().tolist()
+    )
+
+
+@pytest.mark.parametrize("do_tensorized_calc", [False, True], ids=['slow', 'fast'])
+def test_code2_fast_slow_consistency_extrapolation(backend, do_tensorized_calc):
+    histogramssets = [[[[0.5], [1.0], [2.0]]]]
+    # Only test the region alpha < -1
+    alphasets = pyhf.tensorlib.astensor([[-2.0]])
+
+    slow_interpolator = pyhf.interpolators.get(2, do_tensorized_calc=False)(
+        histogramssets, subscribe=False
+    )
+    fast_interpolator = pyhf.interpolators.get(2, do_tensorized_calc=True)(
+        histogramssets, subscribe=False
+    )
+
+    slow_result = np.asarray(pyhf.tensorlib.tolist(slow_interpolator(alphasets)))
+    fast_result = np.asarray(pyhf.tensorlib.tolist(fast_interpolator(alphasets)))
+    
+    assert pytest.approx(slow_result.ravel().tolist()) == fast_result.ravel().tolist()
+
+
 def test_invalid_interpcode():
     with pytest.raises(pyhf.exceptions.InvalidInterpCode):
         pyhf.interpolators.get("fake")

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -237,7 +237,7 @@ def test_code2_fast_slow_consistency_extrapolation(backend, do_tensorized_calc):
 
     slow_result = np.asarray(pyhf.tensorlib.tolist(slow_interpolator(alphasets)))
     fast_result = np.asarray(pyhf.tensorlib.tolist(fast_interpolator(alphasets)))
-    
+
     assert pytest.approx(slow_result.ravel().tolist()) == fast_result.ravel().tolist()
 
 


### PR DESCRIPTION
# Description

This PR fixes an inconsistency between the slow and fast implementations
of the `code2` interpolator for the extrapolation region where alpha < -1.

Previously, the fast (tensorized) implementation incorrectly used
`mask_off` instead of `mask_on` when computing the extrapolation term.
This resulted in the expression

    (b - 2a) * alpha

being used instead of the correct

    (b - 2a) * (alpha + 1)

and caused a mismatch with the slow implementation.

This PR corrects the mask usage in:

    src/pyhf/interpolators/code2.py 

so that the fast implementation now matches the slow implementation
for alpha < -1.

Additionally, regression tests were added in:

    tests/test_interpolate.py

to:

- Validate interpolation across all regions (alpha > 1, |alpha| <= 1, alpha < -1)
- Ensure consistency between slow and fast implementations in the alpha < -1 region
- Prevent future regressions

Fixes #2610


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

```
* For code2's fast interpolation, use mask_on to properly use (b - 2a) * (alpha + 1)
  for the alpha < -1 case.
* Add regression tests to tests/test_interpolate.py.
* Add Alok Kumar to contributors list.
```