### PR TITLE
fix: strip return_tail_probs from hypotest_kwargs in upper_limit scan functions

### DIFF
--- a/src/pyhf/infer/intervals/upper_limits.py
+++ b/src/pyhf/infer/intervals/upper_limits.py
@@ -75,6 +75,10 @@ def toms748_scan(
 
     .. versionadded:: 0.7.0
     """
+    # return_tail_probs shifts the hypotest result tuple indices, which would
+    # break the index assumptions below. Strip it out before calling hypotest.
+    hypotest_kwargs.pop("return_tail_probs", None)
+
     cache = {}
 
     def f_cached(poi):
@@ -186,6 +190,8 @@ def linear_grid_scan(
 
     .. versionadded:: 0.7.0
     """
+    hypotest_kwargs.pop("return_tail_probs", None)
+
     tb, _ = get_backend()
     results = [
         hypotest(mu, data, model, return_expected_set=True, **hypotest_kwargs)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -125,6 +125,42 @@ def test_upper_limit(hypotest_args):
     )
 
 
+def test_upper_limit_with_return_tail_probs(hypotest_args):
+    """
+    upper_limit should not raise IndexError when return_tail_probs=True 
+    """
+    _, data, model = hypotest_args
+    scan = np.linspace(0, 5, 11)
+
+    # linear_grid_scan path: passing return_tail_probs=True must not raise
+    results = pyhf.infer.intervals.upper_limits.upper_limit(
+        data, model, scan=scan, return_tail_probs=True
+    )
+    assert len(results) == 2
+    observed_limit, expected_limits = results
+    assert observed_limit == pytest.approx(1.0262704738584554)
+    assert expected_limits == pytest.approx(
+        [0.65765653, 0.87999725, 1.12453992, 1.50243428, 2.09232927]
+    )
+
+    # linear_grid_scan path: with return_results=True as well
+    results = pyhf.infer.intervals.upper_limits.upper_limit(
+        data, model, scan=scan, return_results=True, return_tail_probs=True
+    )
+    assert len(results) == 3
+    observed_limit, expected_limits, (_scan, point_results) = results
+    assert observed_limit == pytest.approx(1.0262704738584554)
+    assert len(_scan) == len(point_results)
+
+    # toms748_scan path: passing return_tail_probs=True must not raise
+    results = pyhf.infer.intervals.upper_limits.upper_limit(
+        data, model, return_tail_probs=True, rtol=1e-4
+    )
+    assert len(results) == 2
+    observed_limit, expected_limits = results
+    assert observed_limit == pytest.approx(1.01156939, abs=0.1)
+
+
 def test_upper_limit_with_kwargs(hypotest_args):
     """
     Check that the default return structure of pyhf.infer.hypotest is as expected

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -127,7 +127,7 @@ def test_upper_limit(hypotest_args):
 
 def test_upper_limit_with_return_tail_probs(hypotest_args):
     """
-    upper_limit should not raise IndexError when return_tail_probs=True 
+    upper_limit should not raise IndexError when return_tail_probs=True
     """
     _, data, model = hypotest_args
     scan = np.linspace(0, 5, 11)


### PR DESCRIPTION
# Description

Fixes #2669

This PR fixes an `IndexError` raised by `pyhf.infer.intervals.upper_limits.upper_limit`
when `return_tail_probs=True` is used during a POI scan.

## Problem

Both `linear_grid_scan` and `toms748_scan` call `hypotest` with
`return_expected_set=True` and expect the expected band at index `[1]`
of the returned tuple.

When `return_tail_probs=True` is also passed through `**hypotest_kwargs`,
the returned tuple structure changes:
- Tail probabilities are inserted at index `[1]`
- The expected band shifts to index `[2]`

This breaks the index assumption and results in:

```
IndexError: list index out of range
```

## Fix

`return_tail_probs` is removed from `hypotest_kwargs` inside both scan
functions before calling `hypotest`.

This preserves the expected return structure and prevents index misalignment.

## Tests

- Added a regression test in `tests/test_infer.py`
- Covers both `linear_grid_scan` and `toms748_scan`
- Verifies that `upper_limit(..., return_tail_probs=True)` runs without error
- All tests pass with the full `pytest` suite

---

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title
- [ ] Selected an Assignee for the PR log summary

---

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR