### PR TITLE
ci: Use lychee for linkchecking

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -63,12 +63,9 @@ jobs:
         jsonschema <(curl -sL "https://citation-file-format.github.io/1.2.0/schema.json") --instance <(cat CITATION.cff | yq)
 
     - name: Check for broken links
-      run: |
-        pushd docs
-        make linkcheck
-        # Don't ship the linkcheck
-        rm -r _build/linkcheck
-        popd
+      uses: lycheeverse/lychee-action@v2
+      with:
+        args: docs/
 
     - name: Test and build docs
       run: |


### PR DESCRIPTION
# Pull Request Description

As requested in #2675 - trying out lychee instead for linkchecking.

* Use `lychee` for more robust linkchecking than Sphinx's `linkcheck`

https://github.com/scikit-hep/pyhf/blob/26962f599979309af0e61b89980cc478a13762b9/docs/Makefile#L197-L202

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use lychee for more robust linkchecking than Sphnix's linkcheck.
   - Use https://github.com/lycheeverse/lychee-action over local install.
```
