### PR TITLE
feat: add optimistix optimizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,18 @@ htmlcov
 
 # text editors
 .vscode/
+.ropeproject/
 
 # pixi environments
 .pixi/*
 !.pixi/config.toml
 pixi.lock
+
+# venv's (uv)
+.venv/
+
+# ruff
+.ruff_cache/
+
+# mypy
+.mypy_cache/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,6 +92,10 @@ intersphinx_mapping = get_intersphinx_mapping(
         "jsonpatch",
     }
 )
+intersphinx_mapping["optimistix"] = (
+    "https://docs.kidger.site/optimistix/",
+    "https://docs.kidger.site/optimistix/objects.inv",
+)
 
 # GitHub repo
 issues_github_path = "scikit-hep/pyhf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -361,7 +361,7 @@ requests = ">=2.22.0"
 iminuit = ">=2.7.0"
 
 [tool.pixi.feature.optimistix.dependencies]
-python = ">=3.11.*"
+python = ">=3.11"
 optimistix = ">=0.1.0"
 
 [tool.pixi.feature.test.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,11 +70,12 @@ jax = [
 ]
 xmlio = ["uproot>=4.1.1"]  # c.f. PR #1567
 minuit = ["iminuit>=2.7.0"]  # c.f. PR #1895
+optimistix = ["optimistix>=0.1.0"]
 contrib = [
     "matplotlib>=3.0.0",
     "requests>=2.22.0",
 ]
-backends = ["pyhf[jax,minuit]"]
+backends = ["pyhf[jax,minuit,optimistix]"]
 all = ["pyhf[backends,xmlio,contrib]"]
 
 # Developer extras
@@ -359,6 +360,9 @@ requests = ">=2.22.0"
 [tool.pixi.feature.minuit.dependencies]
 iminuit = ">=2.7.0"
 
+[tool.pixi.feature.optimistix.dependencies]
+optimistix = ">=0.1.0"
+
 [tool.pixi.feature.test.dependencies]
 pytest = ">=6.0"
 scikit-hep-testdata = ">=0.4.11"
@@ -464,10 +468,11 @@ jax-cpu = { features = ["jax-cpu"], solve-group = "default" }
 jax-gpu = { features = ["jax-gpu"], solve-group = "gpu" }
 xmlio = { features = ["xmlio"], solve-group = "default" }
 minuit = { features = ["minuit"], solve-group = "default" }
+optimistix = { features = ["optimistix"], solve-group = "default" }
 contrib = { features = ["contrib"], solve-group = "default" }
-backends = { features = ["jax", "minuit"], solve-group = "default" }
-all = { features = ["jax", "minuit", "xmlio", "contrib"], solve-group = "default" }
+backends = { features = ["jax", "minuit", "optimistix"], solve-group = "default" }
+all = { features = ["jax", "minuit", "optimistix", "xmlio", "contrib"], solve-group = "default" }
 
-test = { features = ["jax", "minuit", "xmlio", "contrib", "test"], solve-group = "default" }
+test = { features = ["jax", "minuit", "optimistix", "xmlio", "contrib", "test"], solve-group = "default" }
 docs = { features = ["xmlio", "contrib", "docs"], solve-group = "default" }
 dev = { features = ["all", "test", "docs", "dev"], solve-group = "default" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,7 @@ log_level = "INFO"
 testpaths = "tests"
 markers = [
     "fail_jax",
+    "fail_jax_optimistix",
     "fail_numpy",
     "fail_numpy_minuit",
     "only_jax",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ jax = [
 ]
 xmlio = ["uproot>=4.1.1"]  # c.f. PR #1567
 minuit = ["iminuit>=2.7.0"]  # c.f. PR #1895
-optimistix = ["optimistix>=0.1.0"]
+optimistix = ["optimistix>=0.1.0;python_version>='3.11'"]
 contrib = [
     "matplotlib>=3.0.0",
     "requests>=2.22.0",
@@ -361,7 +361,7 @@ requests = ">=2.22.0"
 iminuit = ">=2.7.0"
 
 [tool.pixi.feature.optimistix.dependencies]
-optimistix = ">=0.1.0"
+optimistix = ">=0.1.0;python_version>='3.11'"
 
 [tool.pixi.feature.test.dependencies]
 pytest = ">=6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -361,7 +361,8 @@ requests = ">=2.22.0"
 iminuit = ">=2.7.0"
 
 [tool.pixi.feature.optimistix.dependencies]
-optimistix = ">=0.1.0;python_version>='3.11'"
+python = ">=3.11.*"
+optimistix = ">=0.1.0"
 
 [tool.pixi.feature.test.dependencies]
 pytest = ">=6.0"

--- a/src/pyhf/optimize/__init__.py
+++ b/src/pyhf/optimize/__init__.py
@@ -32,6 +32,20 @@ class _OptimizerRetriever:
                     msg,
                     exc,
                 ) from exc
+        elif name == "optimistix_optimizer":
+            try:
+                from pyhf.optimize.opt_optimistix import optimistix_optimizer
+
+                assert optimistix_optimizer
+                # hide away one level of the module name
+                # pyhf.optimize.optimistix_optimizer.optimistix_optimizer->pyhf.optimize.optimistix_optimizer
+                optimistix_optimizer.__module__ = __name__
+                # for autocomplete and dir() calls
+                self.optimistix_optimizer = optimistix_optimizer
+                return optimistix_optimizer
+            except ImportError as exc:
+                msg = "There was a problem importing optimistix. The optimistix optimizer cannot be used."
+                raise exceptions.ImportBackendError(msg) from exc
         elif name == "__wrapped__":  # doctest
             pass
         return None

--- a/src/pyhf/optimize/opt_optimistix.py
+++ b/src/pyhf/optimize/opt_optimistix.py
@@ -1,0 +1,138 @@
+"""Optimistix Optimizer Class."""
+
+import optimistix as optx
+import scipy
+
+import pyhf
+from pyhf.optimize.mixins import OptimizerMixin
+
+
+class optimistix_optimizer(OptimizerMixin):
+    """
+    Optimizer that uses :func:`scipy.optimize.minimize`.
+    """
+
+    __slots__ = ["name", "options", "solver", "throw"]
+
+    def __init__(self, *args, **kwargs):
+        """
+        Initialize the optimistix_optimizer.
+
+        See :class:`pyhf.optimize.mixins.OptimizerMixin` for other configuration options.
+
+        Args:
+            solver: optimistix.Solver instance.
+            options: Runtime args for the solver.
+            throw (:obj:`bool`): How to deal with errors. If True, raises exceptions.
+        """
+        self.name = "optimistix"
+        self.solver = kwargs.pop("solver", optx.DFP(rtol=1e-6, atol=1e-6))
+        if self.solver is None:
+            msg = f"{type(self).__name__} needs a solver"
+            raise ValueError(msg)
+        self.options = kwargs.pop("options", None)
+        self.throw = kwargs.pop("throw", True)
+
+        # the default for maxiter is too high for optimistix, so we'll lower it here:
+        self.maxiter = kwargs.pop("maxiter", 1000)
+        super().__init__(*args, **kwargs)
+
+    def _get_minimizer(
+        self,
+        objective_and_grad,  # noqa: ARG002
+        init_pars,  # noqa: ARG002
+        init_bounds,  # noqa: ARG002
+        fixed_vals=None,  # noqa: ARG002
+        do_grad=False,  # noqa: ARG002
+        par_names=None,  # noqa: ARG002
+    ):
+        return optx.minimise
+
+    def _minimize(
+        self,
+        minimizer,
+        func,
+        x0,
+        do_grad=False,  # noqa: ARG002
+        bounds=None,  # noqa: ARG002
+        fixed_vals=None,
+        options=None,
+    ):
+        """
+        Similar signature as :func:`optimistix.minimise`.
+
+        Minimizer Options:
+          * maxiter (:obj:`int`): Maximum number of iterations. Default is ``1000``.
+          * verbose (:obj:`bool`): Print verbose output during minimization. Unused.
+          * solver: optimistix.Solver instance.
+          * options: Runtime args for the solver.
+          * throw (:obj:`bool`): How to deal with errors. If True, raises exceptions.
+
+        Returns:
+            fitresult (scipy.optimize.OptimizeResult): the fit result
+        """
+        # first make sure we're working with the JAX backend,
+        # otherwise we can't minimise with optimistix
+        if pyhf.tensorlib.name != "jax":
+            msg = (
+                "The optimistix optimizer can only be used with the JAX backend. "
+                "Use `pyhf.set_backend('jax', pyhf.optimize.optimistix_optimizer(...)) "
+                "at the top level of your python code to change your backend to JAX."
+            )
+            raise ValueError(msg)
+
+        options = options or {}
+        max_steps = options.pop("maxiter", self.maxiter)
+        solver = options.pop("solver", self.solver)
+        throw = options.pop("throw", self.throw)
+        options = options.pop("options", self.options)
+
+        fixed_vals = fixed_vals or []
+        # for optimistix we re-express the func such that the x0 only contains
+        # floating point values for params (x0) that the optimizer should minimise.
+        # Fixed parameters are set to None (static pytree leaf-type) and thus won't receive
+        # a gradient update by the minimizer. We patch/set back their fixed values
+        # in the `wrapped_func` before forwarding them to the original `func`.
+        x0_floating = list(x0)
+        for idx, _ in fixed_vals:
+            x0_floating[idx] = None
+
+        def wrapped_func(x0, args):
+            (fixed_vals,) = args
+            for idx, val in fixed_vals:
+                x0[idx] = val
+            return func(x0)
+
+        res = minimizer(
+            fn=wrapped_func,
+            solver=solver,
+            y0=x0_floating,
+            args=(fixed_vals,),
+            max_steps=max_steps,
+            throw=throw,
+            has_aux=True,
+            options=options,
+        )
+
+        # patch fixed values back in:
+        x = list(res.value)
+        for idx, val in fixed_vals:
+            x[idx] = val
+
+        converged = res.result == optx.RESULTS.successful
+        message = "Optimization terminated successfully."
+        if not converged:
+            message = "Optimization failed."
+
+        return scipy.optimize.OptimizeResult(
+            x=x,
+            unc=None,
+            corr=None,
+            success=converged,
+            fun=res.state.f_info.f,
+            hess_inv=None,
+            message=message,
+            nfev=None,
+            nit=res.stats["num_steps"],
+            optx_state=res.state,
+        )

--- a/src/pyhf/optimize/opt_optimistix.py
+++ b/src/pyhf/optimize/opt_optimistix.py
@@ -9,7 +9,7 @@ from pyhf.optimize.mixins import OptimizerMixin
 
 class optimistix_optimizer(OptimizerMixin):
     """
-    Optimizer that uses :func:`scipy.optimize.minimize`.
+    Optimizer that uses :func:`optimistix.minimise`.
     """
 
     __slots__ = ["name", "options", "solver", "throw"]

--- a/src/pyhf/optimize/opt_optimistix.py
+++ b/src/pyhf/optimize/opt_optimistix.py
@@ -31,7 +31,7 @@ class optimistix_optimizer(OptimizerMixin):
             msg = f"{type(self).__name__} needs a solver"
             raise ValueError(msg)
         self.options = kwargs.pop("options", None)
-        self.throw = kwargs.pop("throw", True)
+        self.throw = kwargs.pop("throw", False)
 
         # the default for maxiter is too high for optimistix, so we'll lower it here:
         self.maxiter = kwargs.pop("maxiter", 1000)

--- a/src/pyhf/optimize/opt_optimistix.py
+++ b/src/pyhf/optimize/opt_optimistix.py
@@ -88,36 +88,52 @@ class optimistix_optimizer(OptimizerMixin):
         options = options.pop("options", self.options)
 
         fixed_vals = fixed_vals or []
-        # for optimistix we re-express the func such that the x0 only contains
-        # floating point values for params (x0) that the optimizer should minimise.
-        # Fixed parameters are set to None (static pytree leaf-type) and thus won't receive
-        # a gradient update by the minimizer. We patch/set back their fixed values
-        # in the `wrapped_func` before forwarding them to the original `func`.
-        x0_floating = list(x0)
-        for idx, _ in fixed_vals:
-            x0_floating[idx] = None
+        # for optimistix we re-express the func such that the fixed values will be
+        # 'patched' into the correct indices again. This trick essentially zeros the
+        # gradients of fixed values because the optimizer never sees them.
+        # We also only pass the free params to the optimizer (without the fixed ones!)
+        # that way the hessian is only as big as it has to be. This is much more efficient
+        # as we only calculate gradients for the free parameters and not just zero the
+        # gradients for the fixed ones manually.
+        x0_full = pyhf.tensorlib.astensor(x0, dtype="float")
 
-        def wrapped_func(x0, args):
-            (fixed_vals,) = args
-            for idx, val in fixed_vals:
-                x0[idx] = val
-            return func(x0)
+        fixed_idxs, fixed_vals_arr = zip(*fixed_vals) if fixed_vals else ((), ())
+        fixed_idxs = pyhf.tensorlib.astensor(fixed_idxs, dtype="int")
+        fixed_vals_arr = pyhf.tensorlib.astensor(fixed_vals_arr, dtype="float")
+
+        npars = x0_full.shape[0]
+        all_idxs = pyhf.tensorlib.arange(npars)
+        free_mask = pyhf.tensorlib.ones(npars, dtype="bool").at[fixed_idxs].set(False)
+        free_idxs = all_idxs[free_mask]
+
+        x0_free = x0_full[free_idxs]
+
+        def wrapped_func(x0_free, args):
+            free_idxs, fixed_idxs, fixed_vals_arr, npars = args
+
+            x_full = pyhf.tensorlib.empty((npars,), dtype="float")
+            x_full = x_full.at[free_idxs].set(x0_free)
+            x_full = x_full.at[fixed_idxs].set(fixed_vals_arr)
+
+            return func(x_full)
+
+        args = (free_idxs, fixed_idxs, fixed_vals_arr, npars)
 
         res = minimizer(
             fn=wrapped_func,
             solver=solver,
-            y0=x0_floating,
-            args=(fixed_vals,),
+            y0=x0_free,
+            args=args,
             max_steps=max_steps,
             throw=throw,
             has_aux=True,
             options=options,
         )
 
-        # patch fixed values back in:
-        x = list(res.value)
-        for idx, val in fixed_vals:
-            x[idx] = val
+        # reconstruct output params vector
+        x_res = pyhf.tensorlib.empty((npars,), dtype="float")
+        x_res = x_res.at[free_idxs].set(res.value)
+        x_res = x_res.at[fixed_idxs].set(fixed_vals_arr)
 
         converged = res.result == optx.RESULTS.successful
         message = "Optimization terminated successfully."
@@ -125,7 +141,7 @@ class optimistix_optimizer(OptimizerMixin):
             message = "Optimization failed."
 
         return scipy.optimize.OptimizeResult(
-            x=x,
+            x=x_res.tolist(),
             unc=None,
             corr=None,
             success=converged,

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -276,6 +276,20 @@ class jax_backend:
 
         return jnp.zeros(shape, dtype=dtype)
 
+    def empty(self, shape, dtype="float"):
+        try:
+            dtype = self.dtypemap[dtype]
+        except KeyError:
+            log.exception(
+                "Invalid dtype: dtype must be one of %s.", list(self.dtypemap)
+            )
+            raise
+
+        return jnp.empty(shape, dtype=dtype)
+
+    def arange(self, start, stop=None, step=None):
+        return jnp.arange(start, stop, step, dtype=self.dtypemap["int"])
+
     def power(self, tensor_in_1, tensor_in_2):
         return jnp.power(tensor_in_1, tensor_in_2)
 

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -281,6 +281,25 @@ class numpy_backend(Generic[T]):
 
         return np.zeros(shape, dtype=dtype_obj)
 
+    def empty(self, shape: Shape, dtype: FloatIntOrBool = "float") -> ArrayLike:
+        try:
+            dtype_obj = self.dtypemap[dtype]
+        except KeyError:
+            log.exception(
+                "Invalid dtype: dtype must be one of %s.", list(self.dtypemap)
+            )
+            raise
+
+        return np.empty(shape, dtype=dtype_obj)
+
+    def arange(
+        self,
+        start: int,
+        stop: int | None = None,
+        step: int | None = None,
+    ) -> ArrayLike:
+        return np.arange(start, stop, step, dtype=self.dtypemap["int"])
+
     def power(self, tensor_in_1: Tensor[T], tensor_in_2: Tensor[T]) -> ArrayLike:
         return np.power(tensor_in_1, tensor_in_2)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,17 +74,29 @@ def reset_backend():
     pyhf.set_backend("numpy", default=True)
 
 
+_backend_params = [
+    (("numpy_backend", {}), ("scipy_optimizer", {})),
+    (("jax_backend", {}), ("scipy_optimizer", {})),
+    (
+        ("numpy_backend", {"poisson_from_normal": True}),
+        ("minuit_optimizer", {}),
+    ),
+    (("jax_backend", {}), ("optimistix_optimizer", {})),
+]
+_backend_ids = ["numpy", "jax", "numpy_minuit"]
+
+try:
+    import optimistix  # noqa: F401
+
+    _backend_params.append((("jax_backend", {}), ("optimistix_optimizer", {})))
+    _backend_ids.append("jax_optimistix")
+except ImportError:
+    pass
+
+
 @pytest.fixture(
-    params=[
-        (("numpy_backend", {}), ("scipy_optimizer", {})),
-        (("jax_backend", {}), ("scipy_optimizer", {})),
-        (
-            ("numpy_backend", {"poisson_from_normal": True}),
-            ("minuit_optimizer", {}),
-        ),
-        (("jax_backend", {}), ("optimistix_optimizer", {})),
-    ],
-    ids=["numpy", "jax", "numpy_minuit", "jax_optimistix"],
+    params=_backend_params,
+    ids=_backend_ids,
 )
 def backend(request):
     # a better way to get the id? all the backends we have so far for testing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,8 +82,9 @@ def reset_backend():
             ("numpy_backend", {"poisson_from_normal": True}),
             ("minuit_optimizer", {}),
         ),
+        (("jax_backend", {}), ("optimistix_optimizer", {})),
     ],
-    ids=["numpy", "jax", "numpy_minuit"],
+    ids=["numpy", "jax", "numpy_minuit", "jax_optimistix"],
 )
 def backend(request):
     # a better way to get the id? all the backends we have so far for testing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,6 @@ _backend_params = [
         ("numpy_backend", {"poisson_from_normal": True}),
         ("minuit_optimizer", {}),
     ),
-    (("jax_backend", {}), ("optimistix_optimizer", {})),
 ]
 _backend_ids = ["numpy", "jax", "numpy_minuit"]
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -68,8 +68,9 @@ def test_missing_backends(param):
 def test_missing_optimizer(param):
     backend_name, module_name, import_name, expectation = param
 
-    # hide
-    CACHE_BACKEND, sys.modules[backend_name] = sys.modules[backend_name], None
+    # hide - use .get() since the package may not be installed (e.g. optimistix on py<3.11)
+    CACHE_BACKEND = sys.modules.get(backend_name)
+    sys.modules[backend_name] = None
     sys.modules.setdefault(f"pyhf.optimize.{import_name}", None)
     CACHE_MODULE, sys.modules[f"pyhf.optimize.{import_name}"] = (
         sys.modules[f"pyhf.optimize.{import_name}"],
@@ -82,7 +83,10 @@ def test_missing_optimizer(param):
         getattr(pyhf.optimize, module_name)
 
     # put back
-    CACHE_BACKEND, sys.modules[backend_name] = None, CACHE_BACKEND
+    if CACHE_BACKEND is None:
+        sys.modules.pop(backend_name, None)
+    else:
+        sys.modules[backend_name] = CACHE_BACKEND
     CACHE_MODULE, sys.modules[f"pyhf.optimize.{import_name}"] = (
         None,
         CACHE_MODULE,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -55,8 +55,14 @@ def test_missing_backends(param):
             "opt_minuit",
             pytest.raises(pyhf.exceptions.ImportBackendError),
         ],
+        [
+            "optimistix",
+            "optimistix_optimizer",
+            "opt_optimistix",
+            pytest.raises(pyhf.exceptions.ImportBackendError),
+        ],
     ],
-    ids=["scipy", "minuit"],
+    ids=["scipy", "minuit", "optimistix"],
 )
 @pytest.mark.usefixtures("isolate_modules")
 def test_missing_optimizer(param):

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -599,3 +599,50 @@ def test_minuit_all_fixed_params():
     data = [80] + model.config.auxdata
     result = pyhf.infer.mle.fit(data, model, fixed_params=[True, True])
     assert result is not None
+
+
+def test_optimistix_no_solver():
+    pytest.importorskip("optimistix")
+    with pytest.raises(ValueError, match="needs a solver"):
+        pyhf.optimize.optimistix_optimizer(solver=None)
+
+
+def test_optimistix_wrong_backend():
+    pytest.importorskip("optimistix")
+    pyhf.set_backend("numpy", pyhf.optimize.optimistix_optimizer())
+    model = pyhf.simplemodels.uncorrelated_background([5.0], [10.0], [3.5])
+    data = pyhf.tensorlib.astensor([10.0] + model.config.auxdata)
+    with pytest.raises(ValueError, match="JAX backend"):
+        pyhf.infer.mle.fit(data, model)
+
+
+def test_optimistix_minimize():
+    pytest.importorskip("optimistix")
+    pyhf.set_backend("jax", pyhf.optimize.optimistix_optimizer())
+    model = pyhf.simplemodels.uncorrelated_background([5.0], [10.0], [3.5])
+    data = pyhf.tensorlib.astensor([10.0] + model.config.auxdata)
+    result = pyhf.infer.mle.fit(data, model)
+    assert result is not None
+    assert len(result) == 2
+
+
+def test_optimistix_minimize_fixed_params():
+    pytest.importorskip("optimistix")
+    pyhf.set_backend("jax", pyhf.optimize.optimistix_optimizer())
+    model = pyhf.simplemodels.uncorrelated_background([5.0], [10.0], [3.5])
+    data = pyhf.tensorlib.astensor([10.0] + model.config.auxdata)
+    # fix mu=1.0 and float nuisance parameter only
+    result = pyhf.infer.mle.fit(data, model, fixed_params=[True, False])
+    assert result is not None
+    assert pytest.approx(1.0) == float(result[0])
+
+
+def test_optimistix_return_result_obj():
+    pytest.importorskip("optimistix")
+    pyhf.set_backend("jax", pyhf.optimize.optimistix_optimizer())
+    model = pyhf.simplemodels.uncorrelated_background([5.0], [10.0], [3.5])
+    data = pyhf.tensorlib.astensor([10.0] + model.config.auxdata)
+    _fitted_pars, result = pyhf.infer.mle.fit(data, model, return_result_obj=True)
+    assert isinstance(result, OptimizeResult)
+    assert result.success
+    assert "optx_state" in result

--- a/tests/test_simplemodels.py
+++ b/tests/test_simplemodels.py
@@ -42,6 +42,7 @@ def test_uncorrelated_background():
 
 # See https://github.com/scikit-hep/pyhf/issues/1654
 @pytest.mark.fail_jax
+@pytest.mark.fail_jax_optimistix
 @pytest.mark.usefixtures("default_backend")
 def test_correlated_background_default_backend():
     model = pyhf.simplemodels.correlated_background(
@@ -59,6 +60,7 @@ def test_correlated_background_default_backend():
 
 # See https://github.com/scikit-hep/pyhf/issues/1654
 @pytest.mark.fail_jax
+@pytest.mark.fail_jax_optimistix
 @pytest.mark.usefixtures("default_backend")
 def test_uncorrelated_background_default_backend():
     model = pyhf.simplemodels.uncorrelated_background(


### PR DESCRIPTION
# Description

This PR adds `optimistix` as a new optimizer backend. Optimistix implements JAX-native solvers and supports differentiation through minimization via the implicit function theorem, moving pyhf a step closer to being fully differentiable out of the box.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

---

```
* Add new `optimistix_optimizer` class wrapping `optx.minimise` 
  with DFP solver by default (maxiter=1000); fixed parameters are 
  represented as `None` pytree leaves so the minimizer skips
  gradient updates for them; returns a `scipy.optimize.OptimizeResult`
  including `optx_state`
* Add `optimistix` optional dependency in `pyproject.toml` constrained
  to `python_version >= '3.11'`; wire into `backends`, `all`, and `test`
  pixi environments
* Extend `tests/conftest.py` `backend` fixture to conditionally include
  a `jax_optimistix` parametrize entry when `optimistix` is importable, so 
  all existing parametrized tests exercise the new optimizer automatically
* Add targeted tests:`ValueError` on `solver=None`, `ValueError` when
  used with non-JAX backend, basic fit, fit with a fixed parameter, 
  and `return_result_obj` round-trip checking `optx_state` is present

Co-Authored-By: Giordon Stark <kratsg@gmail.com>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Optimistix-based optimizer backend (Python 3.11+), including fixed-parameter handling and richer result metadata.
  * Added `empty` and `arange` array-creation utilities to tensor backends.
* **Bug Fixes**
  * Improved optional backend import errors when Optimistix is unavailable.
* **Documentation**
  * Expanded Sphinx cross-references to include Optimistix docs.
* **Tests**
  * Added/updated coverage and a new test marker related to the JAX+Optimistix combination.
* **Chores**
  * Updated optional dependency groups and tool configuration; improved local artifact ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->