### PR TITLE
fix: Convert itertools.permutations to list for pytest v9.1 compatibility

### DIFF
--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -94,7 +94,7 @@ def test_optimizer_mixin_extra_kwargs(optimizer):
 
 @pytest.mark.parametrize(
     'backend,backend_new',
-    itertools.permutations([('numpy', False), ('jax', True)], 2),
+    list(itertools.permutations([('numpy', False), ('jax', True)], 2)),
     ids=lambda pair: f'{pair[0]}',
 )
 def test_minimize_do_grad_autoconfig(mocker, backend, backend_new):


### PR DESCRIPTION
# Pull Request Description

pytest v9.1.0 deprecates passing non-Collection iterables to `pytest.mark.parametrize` (will become an error in pytest v10). This fix wraps the `itertools.permutations(...)` call in `test_minimize_do_grad_autoconfig` in `list()` to resolve the `PytestRemovedIn10Warning`.

Closes #2680

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Wrap itertools.permutation() in list() call before being passed into
  pytest.mark.parametrize for compatibility in pytest v9.1+.
   - pytest v9.1.0 deprecates passing non-Collection iterables to
     pytest.mark.parametrize (PytestRemovedIn10Warning).
```