### PR TITLE
fix: Handle None covariance from iminuit when all parameters are fixed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,7 @@ filterwarnings = [
     "ignore:Skipping device Apple Paravirtual device that does not support Metal 2.0:UserWarning",  # Can't fix given hardware/virtualized device
     "ignore:jax.xla_computation is deprecated. Please use the AOT APIs:DeprecationWarning",  # jax v0.4.30
     "ignore:'MultiCommand' is deprecated and will be removed in Click 9.0. Use 'Group' instead.:DeprecationWarning",  # Click
+    "ignore:Hesse called with all parameters fixed:iminuit.warnings.IMinuitWarning",  # Issue #2637
     "ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",  # papermill
     "ignore:datetime.datetime.utcnow\\(\\) is deprecated:DeprecationWarning",  # papermill
 ]

--- a/src/pyhf/optimize/opt_minuit.py
+++ b/src/pyhf/optimize/opt_minuit.py
@@ -138,7 +138,7 @@ class minuit_optimizer(OptimizerMixin):
             # Extra call to hesse() after migrad() is always needed for good error estimates. If you pass a user-provided gradient to MINUIT, convergence is faster.
             minimizer.hesse()
             hess_inv = minimizer.covariance
-            corr = hess_inv.correlation()
+            corr = hess_inv.correlation() if hess_inv is not None else None
             unc = minimizer.errors
 
         return scipy.optimize.OptimizeResult(

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -577,3 +577,16 @@ def test_minuit_param_names(mocker):
         _, result = pyhf.infer.mle.fit(data, pdf, return_result_obj=True)
         assert "minuit" in result
         assert result.minuit.parameters == ("x0", "x1")
+
+
+def test_minuit_all_fixed_params():
+    # Regression test for https://github.com/scikit-hep/pyhf/issues/2637
+    # iminuit v2.32.0+ returns None for covariance when all parameters are fixed
+    # instead of a zero matrix, so .correlation() must be guarded against None.
+    pyhf.set_backend('numpy', 'minuit')
+    model = pyhf.simplemodels.uncorrelated_background(
+        signal=[10.0], bkg=[70.0], bkg_uncertainty=[10.0]
+    )
+    data = [80] + model.config.auxdata
+    result = pyhf.infer.mle.fit(data, model, fixed_params=[True, True])
+    assert result is not None


### PR DESCRIPTION
# Pull Request Description

`iminuit` v2.32.0+ changed behavior when fitting with all parameters fixed: instead of returning a zero covariance matrix, it now returns `None`. This caused `hess_inv.correlation()` to crash with `AttributeError: 'NoneType' object has no attribute 'correlation'`.

**Changes:**
- Guard `.correlation()` call in `opt_minuit.py` against `None` covariance
- Add `IMinuitWarning: Hesse called with all parameters fixed` to pytest `filterwarnings` ignore list (the warning is expected and informational)
- Add regression test using the exact reproducer from the issue

Closes #2637

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

## Commit Summary

```
* Guard iminuit's hess_inv.correlation() against 'None' covariance when all
  parameters are fixed. Relevant for iminuit v2.32.0+.
* Add 'IMinuitWarning' to pytest filterwarnings ignore list in pyproject.toml.
* Add test_minuit_all_fixed_params regression test.
```