### PR TITLE
feat: Support return_tail_probs=True in upper_limit scan functions

### DIFF
--- a/src/pyhf/infer/intervals/upper_limits.py
+++ b/src/pyhf/infer/intervals/upper_limits.py
@@ -75,6 +75,10 @@ def toms748_scan(
 
     .. versionadded:: 0.7.0
     """
+    # When return_tail_probs=True, hypotest inserts (CLsb, CLb) at index 1,
+    # shifting the expected band from index 1 to index 2.
+    _exp_idx = 2 if hypotest_kwargs.get("return_tail_probs", False) else 1
+
     cache = {}
 
     def f_cached(poi):
@@ -95,7 +99,7 @@ def toms748_scan(
         return (
             f_cached(poi)[0] - level
             if limit == 0
-            else f_cached(poi)[1][limit - 1] - level
+            else f_cached(poi)[_exp_idx][limit - 1] - level
         )
 
     def best_bracket(limit):
@@ -103,7 +107,7 @@ def toms748_scan(
         ks = np.asarray(list(cache))
         vals = np.asarray(
             [
-                value[0] - level if limit == 0 else value[1][limit - 1] - level
+                value[0] - level if limit == 0 else value[_exp_idx][limit - 1] - level
                 for value in cache.values()
             ]
         )
@@ -115,14 +119,14 @@ def toms748_scan(
 
     # extend bounds_low and bounds_up if they don't bracket CLs level
     lower_results = f_cached(bounds_low)
-    # {lower,upper}_results[0] is an array and {lower,upper}_results[1] is a
+    # {lower,upper}_results[0] is an array and {lower,upper}_results[_exp_idx] is a
     # list of arrays so need to turn {lower,upper}_results[0] into list to
     # concatenate them
-    while np.any(np.asarray([lower_results[0]] + lower_results[1]) < level):
+    while np.any(np.asarray([lower_results[0]] + lower_results[_exp_idx]) < level):
         bounds_low /= 2
         lower_results = f_cached(bounds_low)
     upper_results = f_cached(bounds_up)
-    while np.any(np.asarray([upper_results[0]] + upper_results[1]) > level):
+    while np.any(np.asarray([upper_results[0]] + upper_results[_exp_idx]) > level):
         bounds_up *= 2
         upper_results = f_cached(bounds_up)
 
@@ -186,13 +190,17 @@ def linear_grid_scan(
 
     .. versionadded:: 0.7.0
     """
+    # When return_tail_probs=True, hypotest inserts (CLsb, CLb) at index 1,
+    # shifting the expected band from index 1 to index 2.
+    _exp_idx = 2 if hypotest_kwargs.get("return_tail_probs", False) else 1
+
     tb, _ = get_backend()
     results = [
         hypotest(mu, data, model, return_expected_set=True, **hypotest_kwargs)
         for mu in scan
     ]
     obs = tb.astensor([[r[0]] for r in results])
-    exp = tb.astensor([[r[1][idx] for idx in range(5)] for r in results])
+    exp = tb.astensor([[r[_exp_idx][idx] for idx in range(5)] for r in results])
 
     result_array = tb.concatenate([obs, exp], axis=1).T
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -166,6 +166,46 @@ def test_upper_limit_with_kwargs(hypotest_args):
     )
 
 
+def test_upper_limit_return_tail_probs(hypotest_args):
+    """
+    Regression test for https://github.com/scikit-hep/pyhf/issues/2669.
+    upper_limit should support return_tail_probs=True without raising IndexError.
+    The tail probability information should be accessible in the per-point results.
+    """
+    _, data, model = hypotest_args
+    scan = np.linspace(0, 5, 11)
+
+    # linear_grid_scan: return_tail_probs=True alone
+    results = pyhf.infer.intervals.upper_limits.upper_limit(
+        data, model, scan=scan, return_tail_probs=True
+    )
+    assert len(results) == 2
+    observed_limit, expected_limits = results
+    assert observed_limit == pytest.approx(1.0262704738584554)
+    assert expected_limits == pytest.approx(
+        [0.65765653, 0.87999725, 1.12453992, 1.50243428, 2.09232927]
+    )
+
+    # linear_grid_scan: return_tail_probs=True with return_results=True
+    results = pyhf.infer.intervals.upper_limits.upper_limit(
+        data, model, scan=scan, return_results=True, return_tail_probs=True
+    )
+    assert len(results) == 3
+    observed_limit, expected_limits, (_scan, point_results) = results
+    assert observed_limit == pytest.approx(1.0262704738584554)
+    assert len(_scan) == len(point_results)
+    # Each per-point result has 3 elements: (CLs, [CLsb, CLb], exp_band)
+    assert len(point_results[0]) == 3
+
+    # toms748_scan: return_tail_probs=True
+    results = pyhf.infer.intervals.upper_limits.upper_limit(
+        data, model, return_tail_probs=True, rtol=1e-4
+    )
+    assert len(results) == 2
+    observed_limit, expected_limits = results
+    assert observed_limit == pytest.approx(1.01156939, abs=0.1)
+
+
 def test_mle_fit_default(tmp_path, hypotest_args):
     """
     Check that the default return structure of pyhf.infer.mle.fit is as expected


### PR DESCRIPTION
# Pull Request Description

The agreed fix (per the issue discussion between @lorenzennio and @matthewfeickert) is to support `return_tail_probs=True` and include the tail probability information in the per-point results.

**Root cause:** When `hypotest` is called with both `return_tail_probs=True` and `return_expected_set=True`, it inserts `(CLsb, CLb)` at index 1, shifting the expected band to index 2. Both `linear_grid_scan` and `toms748_scan` hardcoded `r[1]` for the expected band, causing an `IndexError`.

**Fix:** Compute `_exp_idx` (1 or 2) based on whether `return_tail_probs` is set in `hypotest_kwargs`, and use that index throughout both scan functions. The tail probability information is now accessible in per-point results when `return_results=True`.

Resolves #2669
Closes #2670

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

## Commit Summary

```
* Based on the value of return_tail_probs shift the index of the expected
  return values for 'toms748_scan' and 'linear_grid_scan'. The tail probability
  information is now accessible in per-point results when return_results=True
  is also passed.
* Add test_upper_limit_return_tail_probs regression test covering linear scan,
  linear scan + return_results, and toms748 scan paths.
```