### PR TITLE
chore: Add .git-blame-ignore-revs to ignore style in blame view

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,14 @@
+# style: Move formatting from Black to Ruff
+dc3a6cfdb66036e318b2317fde0e4ef17f135925
+
+# style: Add extended Ruff rules from Scientific Python repo review
+ebf841e656a9eb9a6114f95971d890be1bde8c3e
+
+# style: Apply Ruff rules to most notebooks
+7ec8a2161befb71264a5d6d50f841aa3f89b40f6
+
+# style: fix up tests
+018c823cc6800f7ffabaf726de8ef0e504444710
+
+# style: Fix unused-function-argument (ARG001) in tests
+52dfcb3719c6c93aaab0b4ae6c61359fbe3dad5b


### PR DESCRIPTION
# Description

Follow up to PR https://github.com/scikit-hep/pyhf/pull/2686, https://github.com/scikit-hep/pyhf/pull/2688, https://github.com/scikit-hep/pyhf/pull/2690, https://github.com/scikit-hep/pyhf/pull/2691, https://github.com/scikit-hep/pyhf/pull/2695.

* Add a git blame ignore-revs file to automatically ignore commits listed in it from the blame view on GitHub. Include in it style changes added by pre-commit hooks which touch multiple files.

To ignore the commits in the .git-blame-ignore-revs when running `git blame` locally run: `git blame --ignore-revs-file .git-blame-ignore-revs`.

c.f.:
- https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt
- https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

* Ignore 'style: Move formatting from Black to Ruff' (PR https://github.com/scikit-hep/pyhf/pull/2686).
* Ignore 'style: Add extended Ruff rules from Scientific Python repo review' (PR https://github.com/scikit-hep/pyhf/pull/2688).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add a git blame ignore-revs file to automatically ignore commits listed
in it from the blame view on GitHub. Include in it style changes added by
pre-commit hooks which touch multiple files.

To ignore the commits in the .git-blame-ignore-revs when running `git blame`
locally run: `git blame --ignore-revs-file .git-blame-ignore-revs`.

c.f.:
- https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt
- https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

* Ignore 'style: Move formatting from Black to Ruff' (PR 2686).
* Ignore 'style: Add extended Ruff rules from Scientific Python repo review' (PR 2688).
* Ignore 'style: Apply Ruff rules to most notebooks' (PR 2690).
* Ignore 'style: fix up tests' (PR 2691).
* Ignore 'style: Fix unused-function-argument (ARG001) in tests' (PR 2695).
```