### PR TITLE
style: Fix unused-function-argument (ARG001) in tests

### DIFF
--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1371,7 +1371,8 @@ def test_multi_component_poi():
         pyhf.Workspace(spec).model()
 
 
-def test_pdf_invalid_parameter_shapes(backend):
+@pytest.mark.usefixtures("backend")
+def test_pdf_invalid_parameter_shapes():
     nbins = np.random.randint(2, 10)
 
     signal = np.random.random(nbins).tolist()


### PR DESCRIPTION
# Description

* Use '@pytest.mark.usefixtures("backend")' to avoid 'unused-function-argument (ARG001)' in tests.
   - c.f. https://docs.astral.sh/ruff/rules/unused-function-argument/
   - Amends PR https://github.com/scikit-hep/pyhf/pull/2691

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use '@pytest.mark.usefixtures("backend")' to avoid 'unused-function-argument (ARG001)' in tests.
   - c.f. https://docs.astral.sh/ruff/rules/unused-function-argument/
   - Amends PR https://github.com/scikit-hep/pyhf/pull/2691
```