### PR TITLE
fix: skip and flush garbage-collected event callbacks

### DIFF
--- a/src/pyhf/events.py
+++ b/src/pyhf/events.py
@@ -57,6 +57,8 @@ class Callables:
         """
         _callbacks = []
         for func, arg in self._callbacks:
+            if func() is None:
+                continue
             if arg is not None:
                 arg_ref = arg()
                 if arg_ref is None:
@@ -67,12 +69,15 @@ class Callables:
     def __call__(self, *args, **kwargs):
         for func, arg in self._callbacks:
             # weakref: needs to be de-ref'd first before calling
+            func_ref = func()
+            if func_ref is None:
+                continue
             if arg is not None:
                 arg_ref = arg()
                 if arg_ref is not None:
-                    func()(arg_ref, *args, **kwargs)
+                    func_ref(arg_ref, *args, **kwargs)
             else:
-                func()(*args, **kwargs)
+                func_ref(*args, **kwargs)
         # Flush after calling all the callbacks, not before, as callbacks in the
         # beginning of the iteration might cause new dead arg weakrefs in
         # callbacks that are iterated over later.

--- a/src/pyhf/tensor/manager.py
+++ b/src/pyhf/tensor/manager.py
@@ -154,18 +154,16 @@ def set_backend(
             raise AttributeError(msg)
 
     # need to determine if the tensorlib changed or the optimizer changed for events
-    tensorlib_changed = bool(
-        (new_backend.name != this.state["current"][0].name)
-        | (new_backend.precision != this.state["current"][0].precision)
+    tensorlib_changed = (new_backend.name != this.state["current"][0].name) or (
+        new_backend.precision != this.state["current"][0].precision
     )
     optimizer_changed = bool(this.state["current"][1] != new_optimizer)
     # set new backend
     this.state["current"] = (new_backend, new_optimizer)
     if default:
-        default_tensorlib_changed = bool(
-            (new_backend.name != this.state["default"][0].name)
-            | (new_backend.precision != this.state["default"][0].precision)
-        )
+        default_tensorlib_changed = (
+            new_backend.name != this.state["default"][0].name
+        ) or (new_backend.precision != this.state["default"][0].precision)
         default_optimizer_changed = bool(this.state["default"][1] != new_optimizer)
         # trigger events
         if default_tensorlib_changed:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,3 +1,4 @@
+import gc
 from unittest import mock
 
 from pyhf import events
@@ -70,6 +71,24 @@ def test_trigger_noevent():
     noop_m.assert_called_once()
 
     events.noop = noop
+
+
+def test_event_function_weakref():
+    ename = "test"
+
+    def add(a, b):
+        print(a + b)  # noqa: T201
+
+    events.subscribe(ename)(add)
+    assert len(events.trigger(ename)) == 1
+    # plain function should be weakly referenced
+    del add
+    gc.collect()
+    # triggering a dead plain-function callback must not raise
+    events.trigger(ename)()
+    # and the dead callback should be flushed
+    assert len(events.trigger(ename)) == 0
+    del events.__events[ename]
 
 
 def test_subscribe_function(capsys):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of the code review in #2706.

## Summary

`pyhf.events.Callables` stores plain (non-method) callbacks as `(weakref.ref(callback), None)`. Two latent defects are fixed:

- `__call__` invoked `func()(...)` without dereferencing the weakref first. Once a plain-function callback (or a bound method, in the method branch) was garbage-collected, `func()` returned `None`, raising `TypeError: 'NoneType' object is not callable`. It now dereferences `func()` and skips dead callbacks in both branches.
- `_flush()` only pruned entries whose `arg` weakref was dead, so dead plain-function refs (`arg is None`) were never removed. It now also drops entries whose `func()` is dead. The existing flush-after-iteration behavior is preserved.

Also a small cleanup in `src/pyhf/tensor/manager.py`: two `bool((a != b) | (c != d))` expressions used bitwise `|` between comparisons; these are now logical `or` with the redundant `bool(...)` wrapper removed.

## Test plan

- Added `test_event_function_weakref` to `tests/test_events.py`: subscribes a locally-defined function, deletes it, `gc.collect()`, then triggers the event (must not raise) and asserts the dead callback is flushed (`len` drops to 0). Verified this test fails with the old `events.py` (`TypeError`) and passes with the fix.
- `pytest tests/test_events.py tests/test_tensor.py -q` -> 108 passed.
- `pytest --doctest-modules src/pyhf/events.py -q` -> 2 passed.
- `prek -a` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event callback cleanup to properly manage weak references to deleted callback functions, preventing errors when registered event callbacks become invalid or are garbage collected during event execution and triggering.

* **Refactor**
  * Enhanced clarity and readability of backend change detection logic in tensor operations, making boolean comparisons more explicit and easier to maintain for future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->