### PR TITLE
fix: make optimizer post-processing robust to correlations without uncertainties

### DIFF
--- a/src/pyhf/optimize/mixins.py
+++ b/src/pyhf/optimize/mixins.py
@@ -80,12 +80,12 @@ class OptimizerMixin:
         # stitch in missing parameters (e.g. fixed parameters)
         fitted_pars = stitch_pars(tensorlib.astensor(fitresult.x))
 
+        # extract number of fixed parameters
+        num_fixed_pars = len(fitted_pars) - len(fitresult.x)
+
         # check if uncertainties were provided (and stitch just in case)
         uncertainties = getattr(fitresult, "unc", None)
         if uncertainties is not None:
-            # extract number of fixed parameters
-            num_fixed_pars = len(fitted_pars) - len(fitresult.x)
-
             # FIXME: Set uncertainties for fixed parameters to 0 manually
             # https://github.com/scikit-hep/iminuit/issues/762
             # https://github.com/scikit-hep/pyhf/issues/1918
@@ -185,6 +185,11 @@ class OptimizerMixin:
             par_names = pdf.config.par_names
         except AttributeError:
             par_names = None
+
+        # defensive copy: par_names is mutated in place below, and duck-typed
+        # configs may return a stored list rather than a fresh one
+        if par_names is not None:
+            par_names = list(par_names)
 
         # need to remove parameters that are fixed in the fit
         if par_names and do_stitch and fixed_vals:

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -599,3 +599,25 @@ def test_minuit_all_fixed_params():
     data = [80] + model.config.auxdata
     result = pyhf.infer.mle.fit(data, model, fixed_params=[True, True])
     assert result is not None
+
+
+def test_postprocess_correlations_without_uncertainties():
+    # Regression test: _internal_postprocess must not raise when a fit result
+    # carries correlations but no uncertainties (num_fixed_pars was previously
+    # only defined inside the uncertainties branch).
+    pyhf.set_backend("numpy")
+
+    fitresult = OptimizeResult(
+        x=np.asarray([1.0, 2.0]),
+        fun=0.0,
+        corr=np.asarray([[1.0, 0.5], [0.5, 1.0]]),
+    )
+
+    def stitch_pars(pars, stitch_with=None):  # noqa: ARG001
+        return pars
+
+    optimizer = OptimizerMixin()
+    result = optimizer._internal_postprocess(fitresult, stitch_pars)
+
+    assert result.unc is None
+    assert np.allclose(pyhf.tensorlib.tolist(result.corr), [[1.0, 0.5], [0.5, 1.0]])


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of the code review in #2706.

## Summary

Two correctness fixes in `src/pyhf/optimize/mixins.py`:

- **`_internal_postprocess`**: `num_fixed_pars` was only defined inside the `if uncertainties is not None:` branch but used unconditionally in the `if correlations is not None:` branch. A fit result carrying `corr` without `unc` therefore raised an `UnboundLocalError`. The assignment is now hoisted to right after `fitted_pars` is computed so both branches can use it.
- **`minimize`**: `par_names = pdf.config.par_names` was mutated in place (`par_names[index] = None`). pyhf's own property returns a fresh list, but duck-typed configs returning a stored list would be corrupted. A defensive copy (`list(...)`) is now made when `par_names` is not `None`.

## Test plan

- Added `test_postprocess_correlations_without_uncertainties` in `tests/test_optim.py`, which exercises `_internal_postprocess` with an `OptimizeResult` that has `corr` but no `unc`. It fails with `UnboundLocalError` on `main` and passes with this change.
- `pytest tests/test_optim.py -q`: 73 passed, 5 skipped.
- `prek -a` (ruff lint/format): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Fixed parameter name handling in optimization to prevent unintended side effects from downstream processing.
  * Improved robustness of optimization result postprocessing.

* **Tests**
  * Added regression test for edge case with correlation data but no uncertainties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->