### PR TITLE
fix: assorted small fixes (patchset lookup, logpdf error logging, typos)

### DIFF
--- a/src/pyhf/infer/test_statistics.py
+++ b/src/pyhf/infer/test_statistics.py
@@ -18,7 +18,7 @@ def _qmu_like(
 ):
     """
     Clipped version of _tmu_like where the returned test statistic
-    is 0 if muhat > 0 else tmu_like_stat.
+    is 0 if muhat > mu else tmu_like_stat.
 
     If the lower bound of the POI is 0 this automatically implements
     qmu_tilde. Otherwise this is qmu (no tilde).

--- a/src/pyhf/patchset.py
+++ b/src/pyhf/patchset.py
@@ -176,7 +176,7 @@ class PatchSet:
         # list of all patch objects
         self._patches = []
         # look-up table for retrieving patch by name or values
-        self._patches_by_key = {"name": {}, "values": {}}
+        self._patches_by_key = {}
 
         # inflate all patches
         for patchspec in spec["patches"]:

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -148,9 +148,9 @@ def _nominal_and_modifiers_from_spec(modifier_set, config, spec, batch_size):
 
     # 4. finalize nominal & modifier builders
     nominal_rates = nominal.finalize()
-    finalizd_builder_data = {}
+    finalized_builder_data = {}
     for k, (builder, applier) in modifier_set.items():  # noqa: B007
-        finalizd_builder_data[k] = modifiers_builders[k].finalize()
+        finalized_builder_data[k] = modifiers_builders[k].finalize()
 
     # 5. collect parameters from spec and from user.
     # At this point we know all constraints and so forth
@@ -166,7 +166,7 @@ def _nominal_and_modifiers_from_spec(modifier_set, config, spec, batch_size):
         user_parameters,
         _required_paramsets,
     )
-    _prameter_objects, _auxdata, _auxdata_order = _create_parameters_from_spec(
+    _parameter_objects, _auxdata, _auxdata_order = _create_parameters_from_spec(
         _required_paramsets
     )
 
@@ -174,7 +174,7 @@ def _nominal_and_modifiers_from_spec(modifier_set, config, spec, batch_size):
         msg = "No parameters specified for the Model."
         raise exceptions.InvalidModel(msg)
 
-    config.set_parameters(_prameter_objects)
+    config.set_parameters(_parameter_objects)
     config.set_auxinfo(_auxdata, _auxdata_order)
 
     # 6. use finalized modifier data to build reparametrization function for main likelihood part
@@ -185,7 +185,7 @@ def _nominal_and_modifiers_from_spec(modifier_set, config, spec, batch_size):
                 x for x in config.modifiers if x[1] == k
             ],  # filter modifier names for that mtype (x[1])
             pdfconfig=config,
-            builder_data=finalizd_builder_data.get(k),
+            builder_data=finalized_builder_data.get(k),
             batch_size=batch_size,
             **config.modifier_settings.get(k, {}),
         )
@@ -988,11 +988,7 @@ class Model:
                 return tensorlib.reshape(result, (1,))
             return result
         except Exception:
-            log.exception(
-                "Eval failed for data %s pars: %s",
-                tensorlib.tolist(data),
-                tensorlib.tolist(pars),
-            )
+            log.exception("Eval failed for data %r pars: %r", data, pars)
             raise
 
     def pdf(self, pars, data):

--- a/tests/test_patchset.py
+++ b/tests/test_patchset.py
@@ -83,6 +83,14 @@ def test_patchset_get_nonexisting_patch(patchset):
     assert "nonexisting_patch" in str(exc_info.value)
 
 
+@pytest.mark.parametrize("key", ["name", "values"])
+def test_patchset_sentinel_keys_raise(patchset, key):
+    # Regression: previously "name" and "values" were pre-seeded in _patches_by_key
+    # causing lookups to return {} instead of raising InvalidPatchLookup.
+    with pytest.raises(pyhf.exceptions.InvalidPatchLookup):
+        patchset[key]
+
+
 def test_patchset_iterable(patchset):
     assert iter(patchset)
     assert list(iter(patchset))


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of the code review in #2706.

## Summary

- **patchset.py**: Remove vestigial `{"name": {}, "values": {}}` sentinel keys from `_patches_by_key`, which caused two bugs: a patch named `"name"` or `"values"` falsely triggered the duplicate-patch error, and `patchset["name"]` returned `{}` instead of raising `InvalidPatchLookup`. Now initialized to `{}`.
- **pdf.py** (`Model.logpdf`): Fix the except handler to use `%r` directly on `data`/`pars` instead of calling `tensorlib.tolist()`, which can itself raise (e.g. on ragged input) and mask the original exception.
- **pdf.py**: Rename two typo local variables: `finalizd_builder_data` → `finalized_builder_data` and `_prameter_objects` → `_parameter_objects`.
- **infer/test_statistics.py**: Fix `_qmu_like` docstring: condition is `muhat > mu`, not `muhat > 0`.

## Test plan

- [ ] `pytest tests/test_patchset.py tests/test_pdf.py tests/test_teststats.py -q` — 105 passed, 6 skipped (backend-skip markers)
- [ ] New parametrized test `test_patchset_sentinel_keys_raise` verifies that `patchset["name"]` and `patchset["values"]` raise `InvalidPatchLookup`
- [ ] `prek -a --quiet` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)