### PR TITLE
perf: Linear-time key lookups in workspace joins

### DIFF
--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -51,15 +51,18 @@ def _join_items(join, left_items, right_items, key="name", deep_merge_key=None):
     else:
         primary_items, secondary_items = left_items, right_items
     joined_items = copy.deepcopy(primary_items)
-    keys = [item[key] for item in joined_items]
+    # Build a dict from key value to index for O(1) lookups.
+    # NB: this dict is intentionally NOT updated when items are appended below,
+    # preserving the original behaviour that secondary items with duplicate
+    # key values are each appended rather than merged.
+    key_to_index = {item[key]: idx for idx, item in enumerate(joined_items)}
     for secondary_item in secondary_items:
         # first, check for deep merging
-        if secondary_item[key] in keys and deep_merge_key is not None:
-            _deep_left_items = joined_items[keys.index(secondary_item[key])][
-                deep_merge_key
-            ]
+        if secondary_item[key] in key_to_index and deep_merge_key is not None:
+            idx = key_to_index[secondary_item[key]]
+            _deep_left_items = joined_items[idx][deep_merge_key]
             _deep_right_items = secondary_item[deep_merge_key]
-            joined_items[keys.index(secondary_item[key])][deep_merge_key] = _join_items(
+            joined_items[idx][deep_merge_key] = _join_items(
                 "left outer", _deep_left_items, _deep_right_items
             )
         # next, move over whole items where possible:
@@ -67,13 +70,12 @@ def _join_items(join, left_items, right_items, key="name", deep_merge_key=None):
         #   - if outer join and item on right is not in left
         #   - if left outer join and item (by name) is on right and not in left
         #   - if right outer join and item (by name) is on left and not in right
-        # NB: this will be slow for large numbers of items
         elif (
             join == "none"
             or (join == "outer" and secondary_item not in primary_items)
             or (
                 join in ["left outer", "right outer"]
-                and secondary_item[key] not in keys
+                and secondary_item[key] not in key_to_index
             )
         ):
             joined_items.append(copy.deepcopy(secondary_item))

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -52,21 +52,20 @@ def _join_items(join, left_items, right_items, key="name", deep_merge_key=None):
     else:
         primary_items, secondary_items = left_items, right_items
     joined_items = copy.deepcopy(primary_items)
-    # Group the primary items by key value so each lookup below is O(1). Items
-    # sharing a key value keep their order, so ``[0]`` is the item that
-    # ``list.index`` used to find. The groups are deliberately not updated as
-    # secondary items are appended: a secondary item whose key value matches
-    # only an earlier appended secondary item is appended again.
-    key_to_items = collections.defaultdict(list)
+    # Snapshot of the primary items grouped by key value, holding the live
+    # objects in joined_items so the deep merge below updates them in place.
+    # Appended secondary items are not added, matching the pre-existing join
+    # semantics: a secondary item is only ever matched against primary items.
+    key_to_items = {}
     for item in joined_items:
-        key_to_items[item[key]].append(item)
+        key_to_items.setdefault(item[key], []).append(item)
     for secondary_item in secondary_items:
         # items with different key values can never compare equal, so this
-        # group is all the ``outer`` equality check below has to scan
-        matching_items = key_to_items.get(secondary_item[key], [])
+        # bounds the ``outer`` equality scan below
+        same_key_items = key_to_items.get(secondary_item[key], [])
         # first, check for deep merging
-        if matching_items and deep_merge_key is not None:
-            primary_item = matching_items[0]
+        if same_key_items and deep_merge_key is not None:
+            primary_item = same_key_items[0]
             primary_item[deep_merge_key] = _join_items(
                 "left outer",
                 primary_item[deep_merge_key],
@@ -79,8 +78,8 @@ def _join_items(join, left_items, right_items, key="name", deep_merge_key=None):
         #   - if right outer join and item (by name) is on left and not in right
         elif (
             join == "none"
-            or (join == "outer" and secondary_item not in matching_items)
-            or (join in ["left outer", "right outer"] and not matching_items)
+            or (join == "outer" and secondary_item not in same_key_items)
+            or (join in ["left outer", "right outer"] and not same_key_items)
         ):
             joined_items.append(copy.deepcopy(secondary_item))
     return joined_items

--- a/src/pyhf/workspace.py
+++ b/src/pyhf/workspace.py
@@ -40,6 +40,7 @@ def _join_items(join, left_items, right_items, key="name", deep_merge_key=None):
         join (:obj:`str`): The join operation to apply. See ~pyhf.workspace.Workspace for valid join operations.
         left_items (:obj:`list`): A list of dictionaries to join on the left
         right_items (:obj:`list`): A list of dictionaries to join on the right
+        key (:obj:`str`): The dictionary key to join on. Its values must be hashable.
         deep_merge_key (:obj:`str`): A key on which to deeply merge items if set.
 
     Returns:
@@ -51,19 +52,25 @@ def _join_items(join, left_items, right_items, key="name", deep_merge_key=None):
     else:
         primary_items, secondary_items = left_items, right_items
     joined_items = copy.deepcopy(primary_items)
-    # Build a dict from key value to index for O(1) lookups.
-    # NB: this dict is intentionally NOT updated when items are appended below,
-    # preserving the original behaviour that secondary items with duplicate
-    # key values are each appended rather than merged.
-    key_to_index = {item[key]: idx for idx, item in enumerate(joined_items)}
+    # Group the primary items by key value so each lookup below is O(1). Items
+    # sharing a key value keep their order, so ``[0]`` is the item that
+    # ``list.index`` used to find. The groups are deliberately not updated as
+    # secondary items are appended: a secondary item whose key value matches
+    # only an earlier appended secondary item is appended again.
+    key_to_items = collections.defaultdict(list)
+    for item in joined_items:
+        key_to_items[item[key]].append(item)
     for secondary_item in secondary_items:
+        # items with different key values can never compare equal, so this
+        # group is all the ``outer`` equality check below has to scan
+        matching_items = key_to_items.get(secondary_item[key], [])
         # first, check for deep merging
-        if secondary_item[key] in key_to_index and deep_merge_key is not None:
-            idx = key_to_index[secondary_item[key]]
-            _deep_left_items = joined_items[idx][deep_merge_key]
-            _deep_right_items = secondary_item[deep_merge_key]
-            joined_items[idx][deep_merge_key] = _join_items(
-                "left outer", _deep_left_items, _deep_right_items
+        if matching_items and deep_merge_key is not None:
+            primary_item = matching_items[0]
+            primary_item[deep_merge_key] = _join_items(
+                "left outer",
+                primary_item[deep_merge_key],
+                secondary_item[deep_merge_key],
             )
         # next, move over whole items where possible:
         #   - if no join logic
@@ -72,11 +79,8 @@ def _join_items(join, left_items, right_items, key="name", deep_merge_key=None):
         #   - if right outer join and item (by name) is on left and not in right
         elif (
             join == "none"
-            or (join == "outer" and secondary_item not in primary_items)
-            or (
-                join in ["left outer", "right outer"]
-                and secondary_item[key] not in key_to_index
-            )
+            or (join == "outer" and secondary_item not in matching_items)
+            or (join in ["left outer", "right outer"] and not matching_items)
         ):
             joined_items.append(copy.deepcopy(secondary_item))
     return joined_items

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -408,6 +408,40 @@ def test_join_items_right_outer_deep(join_items):
     ]
 
 
+def test_join_items_duplicate_secondary_keys_appended():
+    # secondary items are only matched against the primary items, so a
+    # secondary item whose key value repeats an earlier appended secondary
+    # item is appended again rather than merged
+    left_items = [{"name": "A"}]
+    right_items = [{"name": "B"}, {"name": "B"}]
+    joined = pyhf.workspace._join_items("left outer", left_items, right_items)
+    assert joined == [{"name": "A"}, {"name": "B"}, {"name": "B"}]
+
+
+def test_join_items_duplicate_primary_keys_first_match_deep():
+    # deep merging targets the first primary item with a matching key value
+    left_items = [
+        {"name": "SR", "samples": [{"name": "s1"}]},
+        {"name": "SR", "samples": [{"name": "s2"}]},
+    ]
+    right_items = [{"name": "SR", "samples": [{"name": "s3"}]}]
+    joined = pyhf.workspace._join_items(
+        "left outer", left_items, right_items, deep_merge_key="samples"
+    )
+    assert joined == [
+        {"name": "SR", "samples": [{"name": "s1"}, {"name": "s3"}]},
+        {"name": "SR", "samples": [{"name": "s2"}]},
+    ]
+
+
+def test_join_items_outer_equal_items_not_duplicated():
+    # an outer join appends a secondary item only if no primary item equals it
+    left_items = [{"name": "A", "x": 1}]
+    right_items = [{"name": "A", "x": 1}, {"name": "A", "x": 2}]
+    joined = pyhf.workspace._join_items("outer", left_items, right_items)
+    assert joined == [{"name": "A", "x": 1}, {"name": "A", "x": 2}]
+
+
 @pytest.mark.parametrize("join", ["none", "outer"])
 def test_combine_workspace_same_channels_incompatible_structure(
     workspace_factory, join

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -409,36 +409,37 @@ def test_join_items_right_outer_deep(join_items):
 
 
 def test_join_items_duplicate_secondary_keys_appended():
-    # secondary items are only matched against the primary items, so a
-    # secondary item whose key value repeats an earlier appended secondary
-    # item is appended again rather than merged
+    # secondary items are only ever matched against primary items
     left_items = [{"name": "A"}]
     right_items = [{"name": "B"}, {"name": "B"}]
-    joined = pyhf.workspace._join_items("left outer", left_items, right_items)
+    joined = pyhf.workspace._join_items(
+        "left outer", left_items, right_items, key="name"
+    )
     assert joined == [{"name": "A"}, {"name": "B"}, {"name": "B"}]
 
 
 def test_join_items_duplicate_primary_keys_first_match_deep():
-    # deep merging targets the first primary item with a matching key value
+    # Workspace rejects duplicate channel names, but _join_items is generic.
+    # As in the join_items fixture, "deep" holds the nested list of items that
+    # deep_merge_key merges (the "samples" of a channel in a real workspace).
     left_items = [
-        {"name": "SR", "samples": [{"name": "s1"}]},
-        {"name": "SR", "samples": [{"name": "s2"}]},
+        {"name": "A", "deep": [{"name": "d1"}]},
+        {"name": "A", "deep": [{"name": "d2"}]},
     ]
-    right_items = [{"name": "SR", "samples": [{"name": "s3"}]}]
+    right_items = [{"name": "A", "deep": [{"name": "d3"}]}]
     joined = pyhf.workspace._join_items(
-        "left outer", left_items, right_items, deep_merge_key="samples"
+        "left outer", left_items, right_items, key="name", deep_merge_key="deep"
     )
     assert joined == [
-        {"name": "SR", "samples": [{"name": "s1"}, {"name": "s3"}]},
-        {"name": "SR", "samples": [{"name": "s2"}]},
+        {"name": "A", "deep": [{"name": "d1"}, {"name": "d3"}]},
+        {"name": "A", "deep": [{"name": "d2"}]},
     ]
 
 
 def test_join_items_outer_equal_items_not_duplicated():
-    # an outer join appends a secondary item only if no primary item equals it
     left_items = [{"name": "A", "x": 1}]
     right_items = [{"name": "A", "x": 1}, {"name": "A", "x": 2}]
-    joined = pyhf.workspace._join_items("outer", left_items, right_items)
+    joined = pyhf.workspace._join_items("outer", left_items, right_items, key="name")
     assert joined == [{"name": "A", "x": 1}, {"name": "A", "x": 2}]
 
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of the code review in #2706.

## Summary

- Replace `keys = [item[key] for item in joined_items]` + `keys.index(...)` with a `key_to_index` dict built once from the primary items, giving O(1) membership tests and index lookups instead of O(n) per secondary item.
- The dict is intentionally **not** updated when secondary items are appended, preserving the existing behaviour that duplicate-keyed secondary items are each appended rather than merged.
- The full-dict `secondary_item not in primary_items` comparison in the `outer` join branch is left as-is (different semantics — full equality check, not keyed).
- Removes the stale `# NB: this will be slow for large numbers of items` comment since it no longer applies to the keyed lookups.

## Test plan

- [x] `pytest tests/test_workspace.py -q` — 253 tests, all passing, no warnings
- [x] `prek -a --quiet` — all pre-commit hooks pass with no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Replace the O(n) list membership and index searches in _join_items with
  lookups in a dict of the primary items grouped by key value, built once
  per join, so that Workspace.combine scales linearly rather than
  quadratically in the number of channels, samples, observations, and
  measurements being joined.
* Use the same grouping for the "outer" join equality check. Items with
  different key values can never compare equal, so scanning only the group
  with a matching key value is equivalent to scanning all primary items.
* Preserve the existing join semantics: deep merging targets the first
  primary item with a matching key value, and the grouping is not updated
  as secondary items are appended, so a secondary item whose key value
  matches only an earlier appended secondary item is still appended.
   - Verified with a 60000 case differential fuzz against main over all
     join operations, with and without deep merging.
* Document that join key values must be hashable, which the dict lookup
  requires and the schema guarantees for names.
* Add regression tests for first-match deep merging with duplicated
  primary keys, duplicated secondary keys being appended rather than
  merged, and outer join equality.

Assisted-by: ClaudeCode:claude-fable-5
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved the efficiency of workspace item merging, especially for larger workspaces.
  * Preserved existing behavior when duplicate key values are encountered.

* **Bug Fixes**
  * Corrected workspace join handling for duplicate keys, including deep merges and outer joins.
  * Improved consistency when matching items across join types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->