### PR TITLE
fix: correct paramset requirement reduction and constraint logpdf fallback

### DIFF
--- a/src/pyhf/constraints.py
+++ b/src/pyhf/constraints.py
@@ -135,7 +135,7 @@ class gaussian_constraint_combined:
             return (
                 tensorlib.zeros(self.batch_size)
                 if self.batch_size is not None
-                else tensorlib.astensor(0.0)[0]
+                else tensorlib.astensor(0.0)
             )
         normal_data = tensorlib.gather(auxdata, self.normal_data)
         return pdf.log_prob(normal_data)
@@ -148,7 +148,6 @@ class poisson_constraint_combined:
         self.batch_size = batch_size
         # iterate over all constraints order doesn't matter....
 
-        self.par_indices = list(range(pdfconfig.npars))
         self.data_indices = list(range(len(pdfconfig.auxdata)))
         self.parsets = [pdfconfig.param_set(cname) for cname in pdfconfig.auxdata_order]
 
@@ -256,7 +255,7 @@ class poisson_constraint_combined:
             return (
                 tensorlib.zeros(self.batch_size)
                 if self.batch_size is not None
-                else tensorlib.astensor(0.0)[0]
+                else tensorlib.astensor(0.0)
             )
         poisson_data = tensorlib.gather(auxdata, self.poisson_data)
         return pdf.log_prob(poisson_data)

--- a/src/pyhf/parameters/utils.py
+++ b/src/pyhf/parameters/utils.py
@@ -46,17 +46,21 @@ def reduce_paramsets_requirements(paramsets_requirements, paramsets_user_configs
             default_v = combined_paramset[k].pop()
             # get user-defined-config if it exists or set to default config
             v = paramset_user_configs.get(k, default_v)
-            # if v is a tuple, it's not user-configured, so convert to list
-            if v == "undefined":
+            # the modifier does not support configuring attribute k
+            if default_v == "undefined":
+                # the user explicitly tried to configure an unsupported attribute
+                if k in paramset_user_configs:
+                    msg = f"{paramset_name} does not use the {k} attribute."
+                    raise exceptions.InvalidModel(msg)
+                # drop the leftover empty set placeholder for unsupported attributes
+                del combined_paramset[k]
                 continue
+            # if v is a tuple, it's not user-configured, so convert to list
             if isinstance(v, tuple):
                 v = list(v)
             # this implies user-configured, so check that it has the right number of elements
             elif isinstance(v, list) and default_v and len(v) != len(default_v):
                 msg = f"Incorrect number of values ({len(v)}) for {k} were configured by you, expected {len(default_v)}."
-                raise exceptions.InvalidModel(msg)
-            elif v and default_v == "undefined":
-                msg = f"{paramset_name} does not use the {k} attribute."
                 raise exceptions.InvalidModel(msg)
 
             combined_paramset[k] = v

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -133,6 +133,62 @@ def test_numpy_pdf_inputs():
 
 
 @pytest.mark.usefixtures("backend")
+def test_constraint_logpdf_no_constraints():
+    # only-normal parsets: the poisson constraint has no terms and must
+    # return a scalar 0.0 without raising (and vice versa for gaussian)
+    config = MockConfig(
+        par_order=["norm1"],
+        par_map={
+            "norm1": {
+                "paramset": constrained_by_normal(
+                    name="norm1",
+                    is_scalar=False,
+                    n_parameters=2,
+                    inits=[0] * 2,
+                    bounds=[[0, 10]] * 2,
+                    auxdata=[0, 0],
+                    sigmas=[1.5, 2.0],
+                    fixed=False,
+                ),
+                "slice": slice(0, 2),
+            },
+        },
+    )
+    auxdata = pyhf.tensorlib.astensor(config.auxdata)
+    pars = pyhf.tensorlib.astensor(config.suggested_init())
+    poisson = poisson_constraint_combined(config)
+    assert poisson.has_pdf() is False
+    result = poisson.logpdf(auxdata, pars)
+    assert pyhf.tensorlib.tolist(result) == 0.0
+
+    # only-poisson parsets: the gaussian constraint has no terms
+    config = MockConfig(
+        par_order=["pois1"],
+        par_map={
+            "pois1": {
+                "paramset": constrained_by_poisson(
+                    name="pois1",
+                    is_scalar=False,
+                    n_parameters=1,
+                    inits=[1.0],
+                    bounds=[[0, 10]],
+                    auxdata=[12],
+                    factors=[12],
+                    fixed=False,
+                ),
+                "slice": slice(0, 1),
+            },
+        },
+    )
+    auxdata = pyhf.tensorlib.astensor(config.auxdata)
+    pars = pyhf.tensorlib.astensor(config.suggested_init())
+    gaussian = gaussian_constraint_combined(config)
+    assert gaussian.has_pdf() is False
+    result = gaussian.logpdf(auxdata, pars)
+    assert pyhf.tensorlib.tolist(result) == 0.0
+
+
+@pytest.mark.usefixtures("backend")
 def test_batched_constraints():
     config = MockConfig(
         par_order=["pois1", "pois2", "norm1", "norm2"],

--- a/tests/test_paramsets.py
+++ b/tests/test_paramsets.py
@@ -1,6 +1,44 @@
 import pytest
 
-from pyhf.parameters import paramsets
+import pyhf
+from pyhf.parameters import paramsets, reduce_paramsets_requirements
+
+
+def _normsys_requirement():
+    return {
+        "paramset_type": "constrained_by_normal",
+        "n_parameters": 1,
+        "is_scalar": True,
+        "inits": (0.0,),
+        "bounds": ((-5.0, 5.0),),
+        "fixed": False,
+        "auxdata": (0.0,),
+    }
+
+
+def test_reduce_paramsets_requirements_no_leftover_empty_sets():
+    # a normsys parset does not support 'sigmas'/'factors'; those keys must not
+    # leak into the reduced requirements as leftover empty sets
+    reduced = reduce_paramsets_requirements(
+        {"foo": [_normsys_requirement()]}, {"foo": {"name": "foo"}}
+    )["foo"]
+    assert "sigmas" not in reduced
+    assert "factors" not in reduced
+    # no leftover empty-set values for any key
+    assert not any(isinstance(v, set) for v in reduced.values())
+    assert reduced["inits"] == [0.0]
+
+
+def test_reduce_paramsets_requirements_unsupported_attribute():
+    # configuring an attribute the modifier does not use raises a clear error
+    with pytest.raises(
+        pyhf.exceptions.InvalidModel,
+        match=r"foo does not use the sigmas attribute\.",
+    ):
+        reduce_paramsets_requirements(
+            {"foo": [_normsys_requirement()]},
+            {"foo": {"name": "foo", "sigmas": [1.0]}},
+        )
 
 
 def test_paramset_unconstrained():


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of the code review in #2706.

## Summary

- `parameters/utils.py` `reduce_paramsets_requirements`: when a parset does not support an attribute (`default_v == "undefined"`), the reduced dict retained a leftover empty `set()` placeholder for that key. It is now dropped. Additionally, configuring an unsupported attribute previously hit the list-length check first and reported a misleading `expected 9` error (the `"undefined"` sentinel is a truthy 9-character string); the unsupported-attribute case is now handled first and raises a clear `"<name> does not use the <attr> attribute."` error.
- `constraints.py`: the no-constraint fallback in `gaussian_constraint_combined.logpdf` and `poisson_constraint_combined.logpdf` indexed a 0-d tensor (`tensorlib.astensor(0.0)[0]`), which raises `IndexError` on both the NumPy and JAX backends. It now returns the scalar `tensorlib.astensor(0.0)`.
- Removed the dead `self.par_indices = list(range(pdfconfig.npars))` attribute in `poisson_constraint_combined.__init__` (no references anywhere; the gaussian class has no equivalent).

## Test plan

- `tests/test_constraints.py::test_constraint_logpdf_no_constraints`: a normal-only model returns scalar `0.0` from the poisson constraint, and a poisson-only model returns scalar `0.0` from the gaussian constraint, without raising.
- `tests/test_paramsets.py`: `reduce_paramsets_requirements` produces no leftover empty-set values for unsupported attributes, and configuring an unsupported attribute raises the `"does not use"` error.
- `pytest tests/test_constraints.py tests/test_paramsets.py tests/test_pdf.py` passes (75 passed, 6 backend-skipped); `prek -a` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)