### PR TITLE
fix: raise typed exceptions instead of asserts in modifier validation

### DIFF
--- a/src/pyhf/modifiers/histosys.py
+++ b/src/pyhf/modifiers/histosys.py
@@ -2,7 +2,7 @@ import logging
 
 import pyhf
 from pyhf import events, interpolators
-from pyhf.exceptions import InvalidModifier
+from pyhf.exceptions import InvalidInterpCode, InvalidModifier
 from pyhf.parameters import ParamViewer
 from pyhf.tensor.manager import get_backend
 
@@ -104,7 +104,12 @@ class histosys_combined:
     ):
         self.batch_size = batch_size
         self.interpcode = interpcode
-        assert self.interpcode in ["code0", "code2", "code4p"]
+        if self.interpcode not in ["code0", "code2", "code4p"]:
+            msg = (
+                f"interpcode '{self.interpcode}' is not implemented for histosys."
+                " Choose from: 'code0', 'code2', 'code4p'."
+            )
+            raise InvalidInterpCode(msg)
 
         keys = [f"{mtype}/{m}" for m, mtype in modifiers]
         histosys_mods = [m for m, _ in modifiers]

--- a/src/pyhf/modifiers/normsys.py
+++ b/src/pyhf/modifiers/normsys.py
@@ -1,6 +1,7 @@
 import logging
 
 from pyhf import events, get_backend, interpolators
+from pyhf.exceptions import InvalidInterpCode
 from pyhf.parameters import ParamViewer
 
 log = logging.getLogger(__name__)
@@ -72,7 +73,12 @@ class normsys_combined:
         self, modifiers, pdfconfig, builder_data, interpcode="code1", batch_size=None
     ):
         self.interpcode = interpcode
-        assert self.interpcode in ["code1", "code4"]
+        if self.interpcode not in ["code1", "code4"]:
+            msg = (
+                f"interpcode '{self.interpcode}' is not implemented for normsys."
+                " Choose from: 'code1', 'code4'."
+            )
+            raise InvalidInterpCode(msg)
 
         keys = [f"{mtype}/{m}" for m, mtype in modifiers]
         normsys_mods = [m for m, _ in modifiers]

--- a/src/pyhf/modifiers/staterror.py
+++ b/src/pyhf/modifiers/staterror.py
@@ -2,7 +2,7 @@ import logging
 
 import pyhf
 from pyhf import events
-from pyhf.exceptions import InvalidModifier
+from pyhf.exceptions import InvalidModel, InvalidModifier
 from pyhf.parameters import ParamViewer
 from pyhf.tensor.manager import get_backend
 
@@ -118,8 +118,14 @@ class staterror_builder:
                 if mask_this_sample.any():
                     if modname not in masks:
                         masks[modname] = mask_this_sample
-                    else:
-                        assert (mask_this_sample == masks[modname]).all()
+                    elif not (mask_this_sample == masks[modname]).all():
+                        _modifier_name = modname.split("/")[1]
+                        msg = (
+                            f"staterror modifier '{_modifier_name}' has inconsistent"
+                            " masks across samples: all samples sharing a staterror"
+                            " modifier must have identical bin masks."
+                        )
+                        raise InvalidModel(msg)
 
             # extract sigmas using this modifiers mask
             sigmas = relerrs[masks[modname]]

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -247,3 +247,86 @@ def test_issue1720_greedy_staterror(datadir, inits):
     expected_staterror = model_staterror.expected_actualdata(inits)
 
     assert expected_staterror == expected_shapesys
+
+
+def _minimal_spec_with_histosys():
+    return {
+        "channels": [
+            {
+                "name": "singlechannel",
+                "samples": [
+                    {
+                        "name": "signal",
+                        "data": [5.0, 10.0],
+                        "modifiers": [
+                            {"name": "mu", "type": "normfactor", "data": None}
+                        ],
+                    },
+                    {
+                        "name": "background",
+                        "data": [50.0, 60.0],
+                        "modifiers": [
+                            {
+                                "name": "bkg_norm",
+                                "type": "histosys",
+                                "data": {
+                                    "lo_data": [45.0, 55.0],
+                                    "hi_data": [55.0, 65.0],
+                                },
+                            }
+                        ],
+                    },
+                ],
+            }
+        ]
+    }
+
+
+def _minimal_spec_with_normsys():
+    return {
+        "channels": [
+            {
+                "name": "singlechannel",
+                "samples": [
+                    {
+                        "name": "signal",
+                        "data": [5.0, 10.0],
+                        "modifiers": [
+                            {"name": "mu", "type": "normfactor", "data": None}
+                        ],
+                    },
+                    {
+                        "name": "background",
+                        "data": [50.0, 60.0],
+                        "modifiers": [
+                            {
+                                "name": "bkg_norm",
+                                "type": "normsys",
+                                "data": {"lo": 0.9, "hi": 1.1},
+                            }
+                        ],
+                    },
+                ],
+            }
+        ]
+    }
+
+
+@pytest.mark.parametrize("bad_code", ["code1", "code4", "code3", "bad"])
+def test_histosys_invalid_interpcode(bad_code):
+    spec = _minimal_spec_with_histosys()
+    with pytest.raises(pyhf.exceptions.InvalidInterpCode):
+        pyhf.Model(
+            spec,
+            modifier_settings={"histosys": {"interpcode": bad_code}},
+        )
+
+
+@pytest.mark.parametrize("bad_code", ["code0", "code2", "code4p", "bad"])
+def test_normsys_invalid_interpcode(bad_code):
+    spec = _minimal_spec_with_normsys()
+    with pytest.raises(pyhf.exceptions.InvalidInterpCode):
+        pyhf.Model(
+            spec,
+            modifier_settings={"normsys": {"interpcode": bad_code}},
+        )


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of the code review in #2706.

## Summary

- Replace `assert self.interpcode in [...]` in `histosys_combined.__init__` and `normsys_combined.__init__` with `raise InvalidInterpCode(msg)` so the check is never silently dropped under `python -O`
- Replace `assert (mask_this_sample == masks[modname]).all()` in `staterror_builder.finalize` with `raise InvalidModel(msg)` naming the offending modifier, guarding the real invariant that shared staterror parameters must have identical bin masks across samples
- Add 8 new parametrized tests in `tests/test_modifiers.py` covering invalid interpcode values for both `histosys` and `normsys`

## Test plan

- [x] `pytest tests/test_modifiers.py tests/test_pdf.py tests/test_interpolate.py` — 144 passed, 6 skipped
- [x] `prek -a --quiet` (ruff + pre-commit) — clean
- [x] `test_histosys_invalid_interpcode` parametrized over `["code1", "code4", "code3", "bad"]` all raise `InvalidInterpCode`
- [x] `test_normsys_invalid_interpcode` parametrized over `["code0", "code2", "code4p", "bad"]` all raise `InvalidInterpCode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)