### PR TITLE
perf: Remove dead work and vectorize loops in modifier construction

### DIFF
--- a/src/pyhf/modifiers/normfactor.py
+++ b/src/pyhf/modifiers/normfactor.py
@@ -99,13 +99,12 @@ class normfactor_combined:
         if not self.param_viewer.index_selection:
             return None
         tensorlib, _ = get_backend()
+        normfactors = self.param_viewer.get(pars)
         if self.batch_size is None:
-            normfactors = self.param_viewer.get(pars)
             results_normfactor = tensorlib.einsum(
                 "msab,m->msab", self.normfactor_mask, normfactors
             )
         else:
-            normfactors = self.param_viewer.get(pars)
             results_normfactor = tensorlib.einsum(
                 "msab,ma->msab", self.normfactor_mask, normfactors
             )

--- a/src/pyhf/modifiers/shapefactor.py
+++ b/src/pyhf/modifiers/shapefactor.py
@@ -173,11 +173,18 @@ class shapefactor_combined:
         # access field is shape (sys, batch, globalbin)
         for s, syst_access in enumerate(self._access_field):
             for t, batch_access in enumerate(syst_access):
-                selection = self.param_viewer.index_selection[s][t]
-                for b, bin_access in enumerate(batch_access):
-                    self._access_field[s, t, b] = (
-                        selection[bin_access] if bin_access < len(selection) else 0
-                    )
+                selection = default_backend.astensor(
+                    self.param_viewer.index_selection[s][t], dtype="int"
+                )
+                in_range = batch_access < len(selection)
+                # clip out-of-range indices so the gather is safe; their
+                # contribution is overwritten with the ``0`` fallback below
+                clipped = default_backend.clip(batch_access, 0, len(selection) - 1)
+                self._access_field[s, t] = default_backend.where(
+                    in_range,
+                    default_backend.gather(selection, clipped),
+                    default_backend.zeros(batch_access.shape, dtype="int"),
+                )
 
         self._precompute()
         events.subscribe("tensorlib_changed")(self._precompute)

--- a/src/pyhf/modifiers/shapefactor.py
+++ b/src/pyhf/modifiers/shapefactor.py
@@ -176,15 +176,11 @@ class shapefactor_combined:
                 selection = default_backend.astensor(
                     self.param_viewer.index_selection[s][t], dtype="int"
                 )
-                in_range = batch_access < len(selection)
-                # clip out-of-range indices so the gather is safe; their
-                # contribution is overwritten with the ``0`` fallback below
-                clipped = default_backend.clip(batch_access, 0, len(selection) - 1)
-                self._access_field[s, t] = default_backend.where(
-                    in_range,
-                    default_backend.gather(selection, clipped),
-                    default_backend.zeros(batch_access.shape, dtype="int"),
-                )
+                # trailing 0 is the dummy index that out-of-range bins clip onto
+                padded = default_backend.concatenate([selection, [0]])
+                self._access_field[s, t] = padded[
+                    default_backend.clip(batch_access, 0, len(selection))
+                ]
 
         self._precompute()
         events.subscribe("tensorlib_changed")(self._precompute)

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -117,19 +117,6 @@ class shapesys_combined:
             [[builder_data[m][s]["data"]["mask"]] for s in pdfconfig.samples]
             for m in keys
         ]
-        self.__shapesys_info = default_backend.astensor(
-            [
-                [
-                    [
-                        builder_data[m][s]["data"]["mask"],
-                        builder_data[m][s]["data"]["nom_data"],
-                        builder_data[m][s]["data"]["uncrt"],
-                    ]
-                    for s in pdfconfig.samples
-                ]
-                for m in keys
-            ]
-        )
         global_concatenated_bin_indices = [
             [[j for c in pdfconfig.channels for j in range(pdfconfig.channel_nbins[c])]]
         ]
@@ -149,12 +136,11 @@ class shapesys_combined:
     def _reindex_access_field(self, _pdfconfig):
         default_backend = pyhf.default_backend
 
+        shapesys_mask = default_backend.astensor(self._shapesys_mask)
         for syst_index, syst_access in enumerate(self._access_field):
             singular_sample_index = [
                 idx
-                for idx, syst in enumerate(
-                    default_backend.astensor(self._shapesys_mask)[syst_index, :, 0]
-                )
+                for idx, syst in enumerate(shapesys_mask[syst_index, :, 0])
                 if any(syst)
             ][-1]
 
@@ -190,7 +176,6 @@ class shapesys_combined:
         tensorlib, _ = get_backend()
         if not self.param_viewer.index_selection:
             return None
-        tensorlib, _ = get_backend()
         flat_pars = pars if self.batch_size is None else tensorlib.reshape(pars, (-1,))
         shapefactors = tensorlib.gather(flat_pars, self.access_field)
         results_shapesys = tensorlib.einsum(

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -136,12 +136,12 @@ class shapesys_combined:
     def _reindex_access_field(self, _pdfconfig):
         default_backend = pyhf.default_backend
 
-        shapesys_mask = default_backend.astensor(self._shapesys_mask)
+        shapesys_mask = default_backend.astensor(self._shapesys_mask, dtype="bool")
         for syst_index, syst_access in enumerate(self._access_field):
             singular_sample_index = [
                 idx
                 for idx, syst in enumerate(shapesys_mask[syst_index, :, 0])
-                if any(syst)
+                if syst.any()
             ][-1]
 
             for batch_index, batch_access in enumerate(syst_access):
@@ -173,9 +173,9 @@ class shapesys_combined:
         Returns:
             modification tensor: Shape (n_modifiers, n_global_samples, n_alphas, n_global_bin)
         """
-        tensorlib, _ = get_backend()
         if not self.param_viewer.index_selection:
             return None
+        tensorlib, _ = get_backend()
         flat_pars = pars if self.batch_size is None else tensorlib.reshape(pars, (-1,))
         shapefactors = tensorlib.gather(flat_pars, self.access_field)
         results_shapesys = tensorlib.einsum(

--- a/src/pyhf/modifiers/staterror.py
+++ b/src/pyhf/modifiers/staterror.py
@@ -89,21 +89,25 @@ class staterror_builder:
                 ],
                 axis=0,
             )
-            relerrs = default_backend.sum(
+            uncrts = default_backend.astensor(
                 [
-                    [
-                        (
-                            (modifier_data["data"]["uncrt"][binnr] / nomsall[binnr])
-                            ** 2
-                            if nomsall[binnr] > 0
-                            else 0.0
-                        )
-                        for binnr in range(len(modifier_data["data"]["nom_data"]))
-                    ]
+                    modifier_data["data"]["uncrt"]
                     for modifier_data in self.builder_data[modname].values()
-                ],
-                axis=0,
+                ]
             )
+            valid_bins = nomsall > 0
+            # guard the denominator so empty bins do not emit a divide-by-zero
+            # warning (pytest runs with filterwarnings=error); these bins are
+            # zeroed out below anyway
+            safe_nomsall = default_backend.where(
+                valid_bins, nomsall, default_backend.ones(nomsall.shape)
+            )
+            per_sample_relerrs = default_backend.where(
+                valid_bins,
+                default_backend.divide(uncrts, safe_nomsall) ** 2,
+                default_backend.zeros(uncrts.shape),
+            )
+            relerrs = default_backend.sum(per_sample_relerrs, axis=0)
             # here relerrs still has all the bins, while the staterror are usually per-channel
             # so we need to pick out the masks for this modifier to extract the
             # modifier configuration (sigmas, etc..)
@@ -170,12 +174,11 @@ class staterror_combined:
 
     def _reindex_access_field(self, _pdfconfig):
         default_backend = pyhf.default_backend
+        staterror_mask = default_backend.astensor(self._staterror_mask)
         for syst_index, syst_access in enumerate(self._access_field):
             singular_sample_index = [
                 idx
-                for idx, syst in enumerate(
-                    default_backend.astensor(self._staterror_mask)[syst_index, :, 0]
-                )
+                for idx, syst in enumerate(staterror_mask[syst_index, :, 0])
                 if any(syst)
             ][-1]
 

--- a/src/pyhf/modifiers/staterror.py
+++ b/src/pyhf/modifiers/staterror.py
@@ -96,18 +96,13 @@ class staterror_builder:
                 ]
             )
             valid_bins = nomsall > 0
-            # guard the denominator so empty bins do not emit a divide-by-zero
-            # warning (pytest runs with filterwarnings=error); these bins are
-            # zeroed out below anyway
-            safe_nomsall = default_backend.where(
-                valid_bins, nomsall, default_backend.ones(nomsall.shape)
+            # bins with no nominal yield have no relative error; guard the
+            # denominator so the division stays finite before zeroing them
+            safe_nomsall = default_backend.where(valid_bins, nomsall, 1.0)
+            relerrs = default_backend.sum(
+                default_backend.where(valid_bins, uncrts / safe_nomsall, 0.0) ** 2,
+                axis=0,
             )
-            per_sample_relerrs = default_backend.where(
-                valid_bins,
-                default_backend.divide(uncrts, safe_nomsall) ** 2,
-                default_backend.zeros(uncrts.shape),
-            )
-            relerrs = default_backend.sum(per_sample_relerrs, axis=0)
             # here relerrs still has all the bins, while the staterror are usually per-channel
             # so we need to pick out the masks for this modifier to extract the
             # modifier configuration (sigmas, etc..)
@@ -174,12 +169,12 @@ class staterror_combined:
 
     def _reindex_access_field(self, _pdfconfig):
         default_backend = pyhf.default_backend
-        staterror_mask = default_backend.astensor(self._staterror_mask)
+        staterror_mask = default_backend.astensor(self._staterror_mask, dtype="bool")
         for syst_index, syst_access in enumerate(self._access_field):
             singular_sample_index = [
                 idx
                 for idx, syst in enumerate(staterror_mask[syst_index, :, 0])
-                if any(syst)
+                if syst.any()
             ][-1]
 
             for batch_index, batch_access in enumerate(syst_access):

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -87,7 +87,7 @@ class ParamViewer:
     def _precompute(self):
         tensorlib, _ = get_backend()
 
-        self.all_indices = tensorlib.astensor(self._all_indices)
+        self.all_indices = tensorlib.astensor(self._all_indices, dtype="int")
         (
             self.index_selection,
             self.stitched,

--- a/src/pyhf/parameters/paramview.py
+++ b/src/pyhf/parameters/paramview.py
@@ -87,7 +87,7 @@ class ParamViewer:
     def _precompute(self):
         tensorlib, _ = get_backend()
 
-        self.all_indices = tensorlib.astensor(self._all_indices, dtype="int")
+        self.all_indices = tensorlib.astensor(self._all_indices)
         (
             self.index_selection,
             self.stitched,


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of the code review in #2706.

## Summary

Performance and dead-code cleanups in the modifier construction layer. These touch numerical code, so the focus is correctness-preserving refactors rather than the (small) speedups.

- **shapesys**: delete the never-read `self.__shapesys_info` tensor (a large `(mods, samples, 3, bins)` array built and immediately discarded; confirmed unused across `src/` and `tests/`, including the name-mangled `_shapesys_combined__shapesys_info`).
- **shapesys / staterror**: hoist `default_backend.astensor(self._shapesys_mask)` (resp. `self._staterror_mask`) out of the per-systematic `_reindex_access_field` loop so the full mask is tensorized once instead of once per systematic. The mask is built as a `bool` tensor and tested with tensor `.any()` rather than the Python builtin `any()` iterating over a float array, which was the dominant cost of that loop at analysis scale.
- **staterror.finalize**: vectorize `relerrs`. The previous per-`(sample, bin)` Python comprehension with scalar indexing is replaced by a single `where`-guarded division. Bins with `nomsall <= 0` stay at `0.0`; the guarded denominator keeps the division finite so those bins can be zeroed without producing `inf`/`nan`. Verified numerically equivalent to the old scalar logic (to one ulp, with zeros exact), including the `nomsall <= 0` edge case.
- **shapefactor**: vectorize the access-field population. The element-wise triple loop is replaced, per `(s, t)`, by a selection padded with a trailing dummy index `0` that out-of-range bins clip onto. This preserves the exact `else 0` fallback semantics of the old loop.
- **normfactor.apply**: hoist `normfactors = self.param_viewer.get(pars)` above the `batch_size` if/else (it was identical in both branches).
- **shapesys.apply**: remove a duplicated back-to-back `tensorlib, _ = get_backend()`, and move the remaining call below the `index_selection` early return to match the sibling modifiers.

## Test plan

Ran with both numpy and jax backends:

- `pytest --ignore=tests/test_notebooks.py --ignore=tests/contrib --ignore=tests/benchmarks --ignore=tests/test_regression.py` — 1138 passed, 13 skipped, 2 xfailed.
- `tests/test_regression.py::test_sbottom_regionA_1400_950_60` fails locally with identical `CLs_exp` values on clean `main`, so it is a local environment difference unrelated to this PR.
- Direct numerical equivalence checks of the `staterror` `relerrs` vectorization and the `shapefactor` access-field construction against the original scalar loops over 500 randomized cases each, including `nomsall <= 0` bins and the out-of-range `else 0` path.
- A model with a shapefactor shared across channels of unequal bin count (which exercises the out-of-range fallback) builds identically on numpy and jax, batched and unbatched.
- `prek` (lint/format/mypy) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved computational efficiency for model calculations, particularly when processing batched data and large collections of bins.
  * Replaced several iterative calculations with optimized tensor operations, reducing processing overhead.
  * Streamlined internal data preparation and indexing for modifier and parameter calculations.
  * Improved handling of zero-valued inputs and boundary conditions during uncertainty and shape-related calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
