### PR TITLE
refactor: Migrate from jsonschema.RefResolver to referencing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ classifiers = [
 dependencies = [
     "click>=8.0.0",  # for console scripts
     "jsonpatch>=1.15",
-    "jsonschema>=4.15.0",  # for utils
+    "jsonschema>=4.18.0",  # for utils; 4.18.0 for referencing-based ref resolution
+    "referencing>=0.28.4",  # for schema $ref resolution (replaces jsonschema.RefResolver)
     "pyyaml>=5.1",  # for parsing CLI equal-delimited options
     # c.f. https://github.com/scikit-hep/pyhf/issues/2593 for excluded v1.16.x versions
     "scipy>=1.5.4,!=1.16.0,!=1.16.1,!=1.16.2",  # requires numpy, which is required by pyhf
@@ -179,7 +180,6 @@ filterwarnings = [
     'ignore:divide by zero encountered in (true_)?divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]
     'ignore:[A-Z]+ is deprecated and will be removed in Pillow 10:DeprecationWarning',  # keras
     "ignore:ml_dtypes.float8_e4m3b11 is deprecated.",  #FIXME: Can remove when jaxlib>=0.4.12
-    "ignore:jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the:DeprecationWarning",  # Issue #2139
     "ignore:Skipping device Apple Paravirtual device that does not support Metal 2.0:UserWarning",  # Can't fix given hardware/virtualized device
     "ignore:jax.xla_computation is deprecated. Please use the AOT APIs:DeprecationWarning",  # jax v0.4.30
     "ignore:'MultiCommand' is deprecated and will be removed in Click 9.0. Use 'Group' instead.:DeprecationWarning",  # Click
@@ -330,7 +330,8 @@ pyhf = { path = ".", editable = true }
 [tool.pixi.dependencies]
 click = ">=8.0.0"
 jsonpatch = ">=1.15"
-jsonschema = ">=4.15.0"
+jsonschema = ">=4.18.0"
+referencing = ">=0.28.4"
 pyyaml = ">=5.1"
 scipy = ">=1.5.4,!=1.16.0,!=1.16.1,!=1.16.2"
 rich = ">=12.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "click>=8.0.0",  # for console scripts
     "jsonpatch>=1.15",
     "jsonschema>=4.18.0",  # for utils; 4.18.0 for referencing-based ref resolution
-    "referencing>=0.28.4",  # for schema $ref resolution (replaces jsonschema.RefResolver)
+    "referencing",  # for schema $ref resolution, version controlled by jsonschema
     "pyyaml>=5.1",  # for parsing CLI equal-delimited options
     # c.f. https://github.com/scikit-hep/pyhf/issues/2593 for excluded v1.16.x versions
     "scipy>=1.7.2,!=1.16.0,!=1.16.1,!=1.16.2",  # requires numpy, which is required by pyhf
@@ -334,7 +334,7 @@ pyhf = { path = ".", editable = true }
 click = ">=8.0.0"
 jsonpatch = ">=1.15"
 jsonschema = ">=4.18.0"
-referencing = ">=0.28.4"
+referencing = "*"
 pyyaml = ">=5.1"
 scipy = ">=1.7.2,!=1.16.0,!=1.16.1,!=1.16.2"
 rich = ">=12.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ classifiers = [
 dependencies = [
     "click>=8.0.0",  # for console scripts
     "jsonpatch>=1.15",
-    "jsonschema>=4.15.0",  # for utils
+    "jsonschema>=4.18.0",  # for utils; 4.18.0 for referencing-based ref resolution
+    "referencing>=0.28.4",  # for schema $ref resolution (replaces jsonschema.RefResolver)
     "pyyaml>=5.1",  # for parsing CLI equal-delimited options
     # c.f. https://github.com/scikit-hep/pyhf/issues/2593 for excluded v1.16.x versions
     "scipy>=1.7.2,!=1.16.0,!=1.16.1,!=1.16.2",  # requires numpy, which is required by pyhf
@@ -179,7 +180,6 @@ filterwarnings = [
     'ignore:divide by zero encountered in (true_)?divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]
     'ignore:[A-Z]+ is deprecated and will be removed in Pillow 10:DeprecationWarning',  # keras
     "ignore:ml_dtypes.float8_e4m3b11 is deprecated.",  #FIXME: Can remove when jaxlib>=0.4.12
-    "ignore:jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the:DeprecationWarning",  # Issue #2139
     "ignore:Skipping device Apple Paravirtual device that does not support Metal 2.0:UserWarning",  # Can't fix given hardware/virtualized device
     "ignore:jax.xla_computation is deprecated. Please use the AOT APIs:DeprecationWarning",  # jax v0.4.30
     "ignore:'MultiCommand' is deprecated and will be removed in Click 9.0. Use 'Group' instead.:DeprecationWarning",  # Click
@@ -333,7 +333,8 @@ pyhf = { path = ".", editable = true }
 [tool.pixi.dependencies]
 click = ">=8.0.0"
 jsonpatch = ">=1.15"
-jsonschema = ">=4.15.0"
+jsonschema = ">=4.18.0"
+referencing = ">=0.28.4"
 pyyaml = ">=5.1"
 scipy = ">=1.7.2,!=1.16.0,!=1.16.1,!=1.16.2"
 rich = ">=12.3.0"

--- a/src/pyhf/schema/__init__.py
+++ b/src/pyhf/schema/__init__.py
@@ -75,6 +75,8 @@ class Schema(sys.modules[__name__].__class__):
         """
         self.orig_path, variables.schemas = variables.schemas, new_path
         self.orig_cache = dict(variables.SCHEMA_CACHE)
+        # The cache is keyed by path relative to the search path, so entries
+        # from the old path (e.g. ``1.0.0/defs.json``) would shadow the new one.
         variables.SCHEMA_CACHE.clear()
         return self
 

--- a/src/pyhf/schema/loader.py
+++ b/src/pyhf/schema/loader.py
@@ -38,15 +38,35 @@ def load_schema(schema_id: str):
     except KeyError:
         pass
 
+    schema = read_schema(schema_id)
+    variables.SCHEMA_CACHE[schema["$id"]] = schema
+    return variables.SCHEMA_CACHE[schema["$id"]]
+
+
+def read_schema(schema_id: str):
+    """
+    Read a schema by relative path directly from disk, bypassing the cache.
+
+    Unlike :func:`load_schema`, this does not consult or mutate
+    :data:`pyhf.schema.variables.SCHEMA_CACHE`. It is used to resolve
+    cross-schema ``$ref``\\ s during validation without polluting the cache.
+
+    Args:
+        schema_id (str): Relative path to schema from :attr:`pyhf.schema.path`
+
+    Returns:
+        schema (dict): The loaded schema.
+
+    Raises:
+        ~pyhf.exceptions.SchemaNotFound: if the provided ``schema_id`` cannot be found.
+    """
     ref = variables.schemas.joinpath(schema_id)
     with resources.as_file(ref) as path:
         if not path.exists():
             msg = f"The schema {schema_id} was not found. Do you have the right version or the right path? {path}"
             raise pyhf.exceptions.SchemaNotFound(msg)
         with path.open(encoding="utf-8") as json_schema:
-            schema = json.load(json_schema)
-            variables.SCHEMA_CACHE[schema["$id"]] = schema
-        return variables.SCHEMA_CACHE[schema["$id"]]
+            return json.load(json_schema)
 
 
 # pre-populate the cache to avoid network access

--- a/src/pyhf/schema/loader.py
+++ b/src/pyhf/schema/loader.py
@@ -1,6 +1,5 @@
 import json
 from importlib import resources
-from pathlib import Path
 
 import pyhf.exceptions
 from pyhf.schema import variables
@@ -31,42 +30,24 @@ def load_schema(schema_id: str):
     Raises:
         ~pyhf.exceptions.SchemaNotFound: if the provided ``schema_id`` cannot be found.
     """
+    # The cache is keyed by the relative path rather than the schema ``$id`` so
+    # that lookups hit for both the bundled schemas (absolute ``$id`` under
+    # ``SCHEMA_BASE``) and custom schemas under :attr:`pyhf.schema.path` (which
+    # may carry relative ``$id``\ s).
     try:
-        return variables.SCHEMA_CACHE[
-            f"{Path(variables.SCHEMA_BASE).joinpath(schema_id)}"
-        ]
+        return variables.SCHEMA_CACHE[schema_id]
     except KeyError:
         pass
 
-    schema = read_schema(schema_id)
-    variables.SCHEMA_CACHE[schema["$id"]] = schema
-    return variables.SCHEMA_CACHE[schema["$id"]]
-
-
-def read_schema(schema_id: str):
-    """
-    Read a schema by relative path directly from disk, bypassing the cache.
-
-    Unlike :func:`load_schema`, this does not consult or mutate
-    :data:`pyhf.schema.variables.SCHEMA_CACHE`. It is used to resolve
-    cross-schema ``$ref``\\ s during validation without polluting the cache.
-
-    Args:
-        schema_id (str): Relative path to schema from :attr:`pyhf.schema.path`
-
-    Returns:
-        schema (dict): The loaded schema.
-
-    Raises:
-        ~pyhf.exceptions.SchemaNotFound: if the provided ``schema_id`` cannot be found.
-    """
     ref = variables.schemas.joinpath(schema_id)
     with resources.as_file(ref) as path:
         if not path.exists():
             msg = f"The schema {schema_id} was not found. Do you have the right version or the right path? {path}"
             raise pyhf.exceptions.SchemaNotFound(msg)
         with path.open(encoding="utf-8") as json_schema:
-            return json.load(json_schema)
+            schema = json.load(json_schema)
+            variables.SCHEMA_CACHE[schema_id] = schema
+        return variables.SCHEMA_CACHE[schema_id]
 
 
 # pre-populate the cache to avoid network access

--- a/src/pyhf/schema/loader.py
+++ b/src/pyhf/schema/loader.py
@@ -30,10 +30,8 @@ def load_schema(schema_id: str):
     Raises:
         ~pyhf.exceptions.SchemaNotFound: if the provided ``schema_id`` cannot be found.
     """
-    # The cache is keyed by the relative path rather than the schema ``$id`` so
-    # that lookups hit for both the bundled schemas (absolute ``$id`` under
-    # ``SCHEMA_BASE``) and custom schemas under :attr:`pyhf.schema.path` (which
-    # may carry relative ``$id``\ s).
+    # Keyed by the relative path rather than the schema $id, so that custom
+    # schemas under pyhf.schema.path with relative $ids also hit the cache.
     try:
         return variables.SCHEMA_CACHE[schema_id]
     except KeyError:
@@ -46,8 +44,8 @@ def load_schema(schema_id: str):
             raise pyhf.exceptions.SchemaNotFound(msg)
         with path.open(encoding="utf-8") as json_schema:
             schema = json.load(json_schema)
-            variables.SCHEMA_CACHE[schema_id] = schema
-        return variables.SCHEMA_CACHE[schema_id]
+    variables.SCHEMA_CACHE[schema_id] = schema
+    return schema
 
 
 # pre-populate the cache to avoid network access

--- a/src/pyhf/schema/validator.py
+++ b/src/pyhf/schema/validator.py
@@ -5,11 +5,13 @@ from collections.abc import Mapping
 from pathlib import Path
 
 import jsonschema
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT6
 
 import pyhf.exceptions
 from pyhf import tensor
 from pyhf.schema import variables
-from pyhf.schema.loader import load_schema
+from pyhf.schema.loader import load_schema, read_schema
 
 
 def _is_array_or_tensor(_checker, instance):
@@ -34,6 +36,25 @@ def _is_number_or_tensor_subtype(checker, instance):
     if is_number:
         return True
     return isinstance(instance, (numbers.Number, *tensor.array_subtypes))
+
+
+def _retrieve_schema(uri: str) -> Resource:
+    """
+    A ``referencing`` retrieve callback that loads a pyhf schema by its URI.
+
+    Cross-schema ``$ref``\\ s (e.g. ``defs.json``) are resolved against the
+    referring schema's ``$id``. For the bundled schemas these are absolute URIs
+    under :data:`pyhf.schema.variables.SCHEMA_BASE`; for custom schemas (see
+    :class:`pyhf.schema.Schema`) they are paths relative to
+    :attr:`pyhf.schema.path`. In both cases stripping the base leaves the disk
+    path relative to :attr:`pyhf.schema.path`.
+
+    The schema is read directly from disk via :func:`read_schema` so that
+    resolving references does not pollute :data:`pyhf.schema.variables.SCHEMA_CACHE`.
+    """
+    schema_id = uri.removeprefix(variables.SCHEMA_BASE)
+    schema = read_schema(schema_id)
+    return Resource.from_contents(schema, default_specification=DRAFT6)
 
 
 def validate(
@@ -75,14 +96,15 @@ def validate(
 
     schema = load_schema(str(Path(version).joinpath(schema_name)))
 
-    # note: trailing slash needed for RefResolver to resolve correctly and by
-    # design, pathlib strips trailing slashes. See ref below:
-    # * https://bugs.python.org/issue21039
-    # * https://github.com/python/cpython/issues/65238
-    resolver = jsonschema.RefResolver(
-        base_uri=f"{Path(variables.schemas).joinpath(version).as_uri()}/",
-        referrer=schema_name,
-        store=variables.SCHEMA_CACHE,
+    schema_id = schema["$id"]
+
+    # Resolve cross-schema ``$ref``\ s (e.g. ``defs.json#/...``) relative to the
+    # canonical schema ``$id``\ s. The ``_retrieve_schema`` callback lazily loads
+    # any referenced schema from disk so the active schema search path
+    # (see :class:`pyhf.schema.Schema`) is honored.
+    registry = Registry(retrieve=_retrieve_schema).with_resource(
+        uri=schema_id,
+        resource=Resource.from_contents(schema, default_specification=DRAFT6),
     )
 
     Validator = jsonschema.Draft6Validator
@@ -93,7 +115,14 @@ def validate(
         ).redefine("number", _is_number_or_tensor_subtype)
         Validator = jsonschema.validators.extend(Validator, type_checker=type_checker)
 
-    validator = Validator(schema, resolver=resolver, format_checker=None)
+    validator = Validator(schema, registry=registry, format_checker=None)
+
+    # The pyhf schemas carry a top-level ``$ref`` (e.g. ``model.json`` points at
+    # ``defs.json#/definitions/model``). Under draft-06 a sibling ``$ref``
+    # suppresses ``$id``, so jsonschema cannot infer the base URI of the root
+    # schema and relative references like ``defs.json`` fail to resolve. Anchor
+    # the resolver at the schema ``$id`` so those references resolve correctly.
+    validator._resolver = registry.resolver(base_uri=schema_id)
 
     try:
         return validator.validate(spec)

--- a/src/pyhf/schema/validator.py
+++ b/src/pyhf/schema/validator.py
@@ -2,16 +2,18 @@ from __future__ import annotations
 
 import numbers
 from collections.abc import Mapping
-from pathlib import Path
+from urllib.parse import urljoin, urlsplit
 
 import jsonschema
+import referencing.exceptions
 from referencing import Registry, Resource
+from referencing.exceptions import NoSuchResource
 from referencing.jsonschema import DRAFT6
 
 import pyhf.exceptions
 from pyhf import tensor
 from pyhf.schema import variables
-from pyhf.schema.loader import load_schema, read_schema
+from pyhf.schema.loader import load_schema
 
 
 def _is_array_or_tensor(_checker, instance):
@@ -45,16 +47,24 @@ def _retrieve_schema(uri: str) -> Resource:
     Cross-schema ``$ref``\\ s (e.g. ``defs.json``) are resolved against the
     referring schema's ``$id``. For the bundled schemas these are absolute URIs
     under :data:`pyhf.schema.variables.SCHEMA_BASE`; for custom schemas (see
-    :class:`pyhf.schema.Schema`) they are paths relative to
-    :attr:`pyhf.schema.path`. In both cases stripping the base leaves the disk
-    path relative to :attr:`pyhf.schema.path`.
+    :class:`pyhf.schema.Schema`) they are relative paths. Stripping the base
+    leaves the path relative to :attr:`pyhf.schema.path`, which is loaded
+    through :func:`pyhf.schema.load_schema` so that referenced schemas are
+    cached in :data:`pyhf.schema.variables.SCHEMA_CACHE` after the first load.
 
-    The schema is read directly from disk via :func:`read_schema` so that
-    resolving references does not pollute :data:`pyhf.schema.variables.SCHEMA_CACHE`.
+    Raises:
+        ~referencing.exceptions.NoSuchResource: if ``uri`` is an absolute URI
+         that is not under :data:`pyhf.schema.variables.SCHEMA_BASE`, as
+         nothing under :attr:`pyhf.schema.path` can satisfy it.
+        ~pyhf.exceptions.SchemaNotFound: if the schema is not found under
+         :attr:`pyhf.schema.path`. ``referencing`` surfaces this as
+         :class:`~referencing.exceptions.Unresolvable` with the cause chain
+         intact.
     """
-    schema_id = uri.removeprefix(variables.SCHEMA_BASE)
-    schema = read_schema(schema_id)
-    return Resource.from_contents(schema, default_specification=DRAFT6)
+    parts = urlsplit(uri.removeprefix(variables.SCHEMA_BASE))
+    if parts.scheme or parts.netloc:
+        raise NoSuchResource(ref=uri)
+    return Resource.from_contents(load_schema(parts.path), default_specification=DRAFT6)
 
 
 def validate(
@@ -79,6 +89,7 @@ def validate(
 
     Raises:
         ~pyhf.exceptions.InvalidSpecification: if the provided instance does not validate against the schema.
+        ~pyhf.exceptions.SchemaNotFound: if the schema, or a schema it references, cannot be found.
 
     Returns:
         None: if there are no errors with the provided instance.
@@ -94,18 +105,7 @@ def validate(
 
     version = version or variables.SCHEMA_VERSION
 
-    schema = load_schema(str(Path(version).joinpath(schema_name)))
-
-    schema_id = schema["$id"]
-
-    # Resolve cross-schema ``$ref``\ s (e.g. ``defs.json#/...``) relative to the
-    # canonical schema ``$id``\ s. The ``_retrieve_schema`` callback lazily loads
-    # any referenced schema from disk so the active schema search path
-    # (see :class:`pyhf.schema.Schema`) is honored.
-    registry = Registry(retrieve=_retrieve_schema).with_resource(
-        uri=schema_id,
-        resource=Resource.from_contents(schema, default_specification=DRAFT6),
-    )
+    schema = load_schema(f"{version}/{schema_name}")
 
     Validator = jsonschema.Draft6Validator
 
@@ -115,16 +115,33 @@ def validate(
         ).redefine("number", _is_number_or_tensor_subtype)
         Validator = jsonschema.validators.extend(Validator, type_checker=type_checker)
 
-    validator = Validator(schema, registry=registry, format_checker=None)
-
-    # The pyhf schemas carry a top-level ``$ref`` (e.g. ``model.json`` points at
-    # ``defs.json#/definitions/model``). Under draft-06 a sibling ``$ref``
-    # suppresses ``$id``, so jsonschema cannot infer the base URI of the root
-    # schema and relative references like ``defs.json`` fail to resolve. Anchor
-    # the resolver at the schema ``$id`` so those references resolve correctly.
-    validator._resolver = registry.resolver(base_uri=schema_id)
+    # Every pyhf schema is a bare draft-06 ``$ref`` shell (e.g. ``model.json``
+    # points at ``defs.json#/definitions/model``). Under draft-06 a sibling
+    # ``$ref`` suppresses ``$id`` (c.f. referencing.jsonschema._legacy_id), so
+    # jsonschema cannot infer the base URI of the root schema and the relative
+    # ``defs.json`` reference fails to resolve. Enter validation through the
+    # absolute form of that reference instead: the resolver is then anchored at
+    # the referenced schema's URI through the public API, and ``_retrieve_schema``
+    # loads it from ``pyhf.schema.path``. Draft-06 ignores the siblings of
+    # ``$ref``, so this is equivalent to validating against the schema itself.
+    # (Referencing the document by its ``$id`` would instead make jsonschema
+    # re-select the stock Draft6Validator from the document's ``$schema`` and
+    # drop the tensor-aware type checker, c.f. jsonschema.validators.validator_for.)
+    root = (
+        {"$ref": urljoin(schema["$id"], schema["$ref"])} if "$ref" in schema else schema
+    )
+    validator = Validator(
+        root, registry=Registry(retrieve=_retrieve_schema), format_checker=None
+    )
 
     try:
         return validator.validate(spec)
     except jsonschema.ValidationError as err:
         raise pyhf.exceptions.InvalidSpecification(err, schema_name) from err
+    except referencing.exceptions.Unresolvable as err:
+        msg = (
+            f"Could not resolve the schema reference {err.ref!r} while validating against "
+            f"{schema_name} (version {version}). Referenced schemas must have an $id under "
+            f"{variables.SCHEMA_BASE} or be relative paths under pyhf.schema.path ({variables.schemas})."
+        )
+        raise pyhf.exceptions.SchemaNotFound(msg) from err

--- a/src/pyhf/schema/validator.py
+++ b/src/pyhf/schema/validator.py
@@ -44,13 +44,14 @@ def _retrieve_schema(uri: str) -> Resource:
     """
     A ``referencing`` retrieve callback that loads a pyhf schema by its URI.
 
-    Cross-schema ``$ref``\\ s (e.g. ``defs.json``) are resolved against the
-    referring schema's ``$id``. For the bundled schemas these are absolute URIs
-    under :data:`pyhf.schema.variables.SCHEMA_BASE`; for custom schemas (see
-    :class:`pyhf.schema.Schema`) they are relative paths. Stripping the base
-    leaves the path relative to :attr:`pyhf.schema.path`, which is loaded
-    through :func:`pyhf.schema.load_schema` so that referenced schemas are
-    cached in :data:`pyhf.schema.variables.SCHEMA_CACHE` after the first load.
+    :func:`validate` resolves the top-level ``$ref`` of a schema (e.g.
+    ``defs.json``) against the directory of the requested version under
+    :data:`pyhf.schema.variables.SCHEMA_BASE`, so the URIs that reach this
+    callback are the bundled ``$id``\\ s. Stripping the base leaves the path
+    relative to :attr:`pyhf.schema.path`, which is loaded through
+    :func:`pyhf.schema.load_schema` so that referenced schemas are cached in
+    :data:`pyhf.schema.variables.SCHEMA_CACHE` after the first load. Nothing is
+    ever fetched from the network.
 
     Raises:
         ~referencing.exceptions.NoSuchResource: if ``uri`` is an absolute URI
@@ -120,16 +121,17 @@ def validate(
     # ``$ref`` suppresses ``$id`` (c.f. referencing.jsonschema._legacy_id), so
     # jsonschema cannot infer the base URI of the root schema and the relative
     # ``defs.json`` reference fails to resolve. Enter validation through the
-    # absolute form of that reference instead: the resolver is then anchored at
-    # the referenced schema's URI through the public API, and ``_retrieve_schema``
+    # absolute form of that reference instead, anchored at the on-disk directory
+    # of the requested version rather than at the schema's own ``$id``: as with
+    # the RefResolver base_uri this replaces, a stale or copy-pasted ``$id`` then
+    # cannot redirect ``defs.json`` to another version. ``_retrieve_schema``
     # loads it from ``pyhf.schema.path``. Draft-06 ignores the siblings of
     # ``$ref``, so this is equivalent to validating against the schema itself.
     # (Referencing the document by its ``$id`` would instead make jsonschema
     # re-select the stock Draft6Validator from the document's ``$schema`` and
     # drop the tensor-aware type checker, c.f. jsonschema.validators.validator_for.)
-    root = (
-        {"$ref": urljoin(schema["$id"], schema["$ref"])} if "$ref" in schema else schema
-    )
+    base_uri = f"{variables.SCHEMA_BASE}{version}/"
+    root = {"$ref": urljoin(base_uri, schema["$ref"])} if "$ref" in schema else schema
     validator = Validator(
         root, registry=Registry(retrieve=_retrieve_schema), format_checker=None
     )

--- a/src/pyhf/schema/validator.py
+++ b/src/pyhf/schema/validator.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import numbers
 from collections.abc import Mapping
-from urllib.parse import urljoin, urlsplit
+from urllib.parse import urljoin
 
 import jsonschema
-import referencing.exceptions
 from referencing import Registry, Resource
-from referencing.exceptions import NoSuchResource
+from referencing.exceptions import NoSuchResource, Unresolvable
 from referencing.jsonschema import DRAFT6
 
 import pyhf.exceptions
@@ -44,28 +43,25 @@ def _retrieve_schema(uri: str) -> Resource:
     """
     A ``referencing`` retrieve callback that loads a pyhf schema by its URI.
 
-    :func:`validate` resolves the top-level ``$ref`` of a schema (e.g.
-    ``defs.json``) against the directory of the requested version under
-    :data:`pyhf.schema.variables.SCHEMA_BASE`, so the URIs that reach this
-    callback are the bundled ``$id``\\ s. Stripping the base leaves the path
-    relative to :attr:`pyhf.schema.path`, which is loaded through
-    :func:`pyhf.schema.load_schema` so that referenced schemas are cached in
-    :data:`pyhf.schema.variables.SCHEMA_CACHE` after the first load. Nothing is
-    ever fetched from the network.
+    Only URIs under :data:`pyhf.schema.variables.SCHEMA_BASE` are served, from
+    the path relative to :attr:`pyhf.schema.path` through
+    :func:`pyhf.schema.load_schema` (so they are cached). Nothing is ever
+    fetched from the network.
 
     Raises:
-        ~referencing.exceptions.NoSuchResource: if ``uri`` is an absolute URI
-         that is not under :data:`pyhf.schema.variables.SCHEMA_BASE`, as
-         nothing under :attr:`pyhf.schema.path` can satisfy it.
+        ~referencing.exceptions.NoSuchResource: if ``uri`` is not under
+         :data:`pyhf.schema.variables.SCHEMA_BASE`.
         ~pyhf.exceptions.SchemaNotFound: if the schema is not found under
          :attr:`pyhf.schema.path`. ``referencing`` surfaces this as
          :class:`~referencing.exceptions.Unresolvable` with the cause chain
          intact.
     """
-    parts = urlsplit(uri.removeprefix(variables.SCHEMA_BASE))
-    if parts.scheme or parts.netloc:
+    if not uri.startswith(variables.SCHEMA_BASE):
         raise NoSuchResource(ref=uri)
-    return Resource.from_contents(load_schema(parts.path), default_specification=DRAFT6)
+    return Resource.from_contents(
+        load_schema(uri.removeprefix(variables.SCHEMA_BASE)),
+        default_specification=DRAFT6,
+    )
 
 
 def validate(
@@ -117,19 +113,16 @@ def validate(
         Validator = jsonschema.validators.extend(Validator, type_checker=type_checker)
 
     # Every pyhf schema is a bare draft-06 ``$ref`` shell (e.g. ``model.json``
-    # points at ``defs.json#/definitions/model``). Under draft-06 a sibling
-    # ``$ref`` suppresses ``$id`` (c.f. referencing.jsonschema._legacy_id), so
-    # jsonschema cannot infer the base URI of the root schema and the relative
-    # ``defs.json`` reference fails to resolve. Enter validation through the
-    # absolute form of that reference instead, anchored at the on-disk directory
-    # of the requested version rather than at the schema's own ``$id``: as with
-    # the RefResolver base_uri this replaces, a stale or copy-pasted ``$id`` then
-    # cannot redirect ``defs.json`` to another version. ``_retrieve_schema``
-    # loads it from ``pyhf.schema.path``. Draft-06 ignores the siblings of
-    # ``$ref``, so this is equivalent to validating against the schema itself.
-    # (Referencing the document by its ``$id`` would instead make jsonschema
-    # re-select the stock Draft6Validator from the document's ``$schema`` and
-    # drop the tensor-aware type checker, c.f. jsonschema.validators.validator_for.)
+    # points at ``defs.json#/definitions/model``), and draft-06 ignores the
+    # siblings of ``$ref`` including ``$id`` (c.f. referencing.jsonschema._legacy_id),
+    # so jsonschema cannot infer a base URI for the relative ``defs.json``. Enter
+    # validation through the absolute form of that reference instead, anchored at
+    # the directory of the requested version as the RefResolver base_uri was, so
+    # that a stale or copy-pasted ``$id`` cannot redirect ``defs.json`` to another
+    # version. (Referencing the document by its ``$id`` would instead make
+    # jsonschema re-select the stock Draft6Validator from the document's
+    # ``$schema`` and drop the tensor-aware type checker, c.f.
+    # jsonschema.validators.validator_for.)
     base_uri = f"{variables.SCHEMA_BASE}{version}/"
     root = {"$ref": urljoin(base_uri, schema["$ref"])} if "$ref" in schema else schema
     validator = Validator(
@@ -140,7 +133,7 @@ def validate(
         return validator.validate(spec)
     except jsonschema.ValidationError as err:
         raise pyhf.exceptions.InvalidSpecification(err, schema_name) from err
-    except referencing.exceptions.Unresolvable as err:
+    except Unresolvable as err:
         msg = (
             f"Could not resolve the schema reference {err.ref!r} while validating against "
             f"{schema_name} (version {version}). Referenced schemas must have an $id under "

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -2,7 +2,8 @@
 scipy==1.7.2  # c.f. PR #2757
 click==8.0.0  # c.f. PR #1958, #1909
 rich==12.3.0  # c.f. PR #2650
-jsonschema==4.15.0  # c.f. PR #1979
+jsonschema==4.18.0  # c.f. PR #2716
+referencing==0.28.4  # c.f. PR #2716
 jsonpatch==1.15
 pyyaml==5.1
 numpy==1.22.0  # c.f. PR #2652

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -11,6 +11,14 @@ import pyhf
 from pyhf.schema.validator import _retrieve_schema
 
 
+def _write_schemas(root, schemas):
+    """Write ``{relative path: schema}`` as JSON files under ``root``."""
+    for name, schema in schemas.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(schema), encoding="utf-8")
+
+
 @pytest.mark.parametrize("version", ["1.0.0"])
 @pytest.mark.parametrize(
     "schema", ["defs.json", "measurement.json", "model.json", "workspace.json"]
@@ -143,22 +151,9 @@ def test_retrieve_schema_missing():
 
 def test_validate_caches_referenced_schema(self_restoring_schema_globals):
     old_path, _ = self_restoring_schema_globals
-    spec = {
-        "channels": [
-            {
-                "name": "singlechannel",
-                "samples": [
-                    {
-                        "name": "signal",
-                        "data": [10],
-                        "modifiers": [
-                            {"name": "mu", "type": "normfactor", "data": None}
-                        ],
-                    }
-                ],
-            }
-        ]
-    }
+    spec = pyhf.simplemodels.uncorrelated_background(
+        signal=[10.0], bkg=[20.0], bkg_uncertainty=[5.0]
+    ).spec
     # same search path, but starting from an empty cache
     with pyhf.schema(old_path):
         assert not pyhf.schema.variables.SCHEMA_CACHE
@@ -171,14 +166,12 @@ def test_validate_caches_referenced_schema(self_restoring_schema_globals):
 
 @pytest.mark.usefixtures("self_restoring_schema_globals")
 def test_validate_unresolvable_ref(tmp_path):
-    schema_dir = tmp_path / "1.1.0"
-    schema_dir.mkdir()
     schema = {
         "$schema": "http://json-schema.org/draft-06/schema#",
         "$id": f"{pyhf.schema.variables.SCHEMA_BASE}1.1.0/model.json",
         "$ref": "defs.json#/definitions/model",
     }
-    (schema_dir / "model.json").write_text(json.dumps(schema), encoding="utf-8")
+    _write_schemas(tmp_path, {"1.1.0/model.json": schema})
 
     with (
         pyhf.schema(tmp_path),
@@ -192,12 +185,8 @@ def test_validate_unresolvable_ref(tmp_path):
 
 @pytest.mark.parametrize(
     "schema_id",
-    [
-        "1.0.0/model.json",
-        f"{pyhf.schema.variables.SCHEMA_BASE}1.0.0/model.json",
-        "https://example.com/schemas/1.1.0/model.json",
-    ],
-    ids=["stale_relative_id", "stale_bundled_id", "foreign_id"],
+    ["1.0.0/model.json", "https://example.com/schemas/1.1.0/model.json"],
+    ids=["stale_id", "foreign_id"],
 )
 @pytest.mark.usefixtures("self_restoring_schema_globals")
 def test_validate_ref_resolved_against_schema_path_not_id(tmp_path, schema_id):
@@ -207,15 +196,14 @@ def test_validate_ref_resolved_against_schema_path_not_id(tmp_path, schema_id):
     copy-pasted $id cannot redirect defs.json to another version.
     c.f. https://github.com/scikit-hep/pyhf/pull/2716#discussion_r3947972735
     """
-    draft = "http://json-schema.org/draft-06/schema#"
     schemas = {
         "1.1.0/model.json": {
-            "$schema": draft,
+            "$schema": "http://json-schema.org/draft-06/schema#",
             "$id": schema_id,
             "$ref": "defs.json#/definitions/model",
         },
         "1.1.0/defs.json": {
-            "$schema": draft,
+            "$schema": "http://json-schema.org/draft-06/schema#",
             "$id": "1.1.0/defs.json",
             "definitions": {
                 "model": {
@@ -226,31 +214,19 @@ def test_validate_ref_resolved_against_schema_path_not_id(tmp_path, schema_id):
                 }
             },
         },
+        # accepts anything, so resolving against the stale $id would pass {}
         "1.0.0/defs.json": {
-            "$schema": draft,
+            "$schema": "http://json-schema.org/draft-06/schema#",
             "$id": "1.0.0/defs.json",
-            "definitions": {
-                "model": {
-                    "type": "object",
-                    "properties": {"must_have_marker": {"type": "string"}},
-                    "additionalProperties": True,
-                }
-            },
+            "definitions": {"model": {}},
         },
     }
-    for name, schema in schemas.items():
-        path = tmp_path / name
-        path.parent.mkdir(exist_ok=True)
-        path.write_text(json.dumps(schema), encoding="utf-8")
+    _write_schemas(tmp_path, schemas)
 
     with pyhf.schema(tmp_path):
         pyhf.schema.validate({"must_have_marker": "x"}, "model.json", version="1.1.0")
         with pytest.raises(pyhf.exceptions.InvalidSpecification):
             pyhf.schema.validate({}, "model.json", version="1.1.0")
-        assert set(pyhf.schema.variables.SCHEMA_CACHE) == {
-            "1.1.0/model.json",
-            "1.1.0/defs.json",
-        }
 
 
 def test_no_channels():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,11 +1,14 @@
 import importlib
 import json
+import pathlib
 import sys
 
 import pytest
+import referencing.exceptions
 from pytest_socket import socket_disabled  # noqa: F401
 
 import pyhf
+from pyhf.schema.validator import _retrieve_schema
 
 
 @pytest.mark.parametrize("version", ["1.0.0"])
@@ -61,7 +64,11 @@ def test_schema_changeable(datadir, monkeypatch, self_restoring_schema_globals):
     assert len(pyhf.schema.variables.SCHEMA_CACHE) == 0
     with (new_path / "custom.json").open(encoding="utf-8") as spec_file:
         assert pyhf.Workspace(json.load(spec_file))
-    assert len(pyhf.schema.variables.SCHEMA_CACHE) == 1
+    # the referenced defs.json is cached alongside the validated schema
+    assert set(pyhf.schema.variables.SCHEMA_CACHE) == {
+        "1.1.0/workspace.json",
+        "1.1.0/defs.json",
+    }
 
 
 def test_schema_changeable_context(datadir, monkeypatch, self_restoring_schema_globals):
@@ -79,7 +86,10 @@ def test_schema_changeable_context(datadir, monkeypatch, self_restoring_schema_g
         assert len(pyhf.schema.variables.SCHEMA_CACHE) == 0
         with (new_path / "custom.json").open(encoding="utf-8") as spec_file:
             assert pyhf.Workspace(json.load(spec_file))
-        assert len(pyhf.schema.variables.SCHEMA_CACHE) == 1
+        assert set(pyhf.schema.variables.SCHEMA_CACHE) == {
+            "1.1.0/workspace.json",
+            "1.1.0/defs.json",
+        }
     assert old_path == pyhf.schema.path
     assert old_cache == pyhf.schema.variables.SCHEMA_CACHE
 
@@ -102,6 +112,90 @@ def test_schema_changeable_context_error(
             raise ZeroDivisionError
     assert old_path == pyhf.schema.path
     assert old_cache == pyhf.schema.variables.SCHEMA_CACHE
+
+
+def test_load_schema_cache_hit(monkeypatch):
+    # defs.json is cached at import, so this must not touch the search path
+    monkeypatch.setattr(
+        pyhf.schema.variables, "schemas", pathlib.Path("/nonexistent"), raising=True
+    )
+    cached = pyhf.schema.variables.SCHEMA_CACHE["1.0.0/defs.json"]
+    assert pyhf.schema.load_schema("1.0.0/defs.json") is cached
+
+
+def test_retrieve_schema_bundled():
+    resource = _retrieve_schema(f"{pyhf.schema.variables.SCHEMA_BASE}1.0.0/defs.json")
+    assert resource.contents is pyhf.schema.load_schema("1.0.0/defs.json")
+
+
+@pytest.mark.parametrize(
+    "uri", ["https://example.com/schemas/defs.json", "//example.com/defs.json"]
+)
+def test_retrieve_schema_foreign_absolute_id(uri):
+    with pytest.raises(referencing.exceptions.NoSuchResource):
+        _retrieve_schema(uri)
+
+
+def test_retrieve_schema_missing():
+    with pytest.raises(pyhf.exceptions.SchemaNotFound, match=r"0\.0\.0/defs\.json"):
+        _retrieve_schema(f"{pyhf.schema.variables.SCHEMA_BASE}0.0.0/defs.json")
+
+
+def test_validate_caches_referenced_schema(self_restoring_schema_globals):
+    old_path, _ = self_restoring_schema_globals
+    spec = {
+        "channels": [
+            {
+                "name": "singlechannel",
+                "samples": [
+                    {
+                        "name": "signal",
+                        "data": [10],
+                        "modifiers": [
+                            {"name": "mu", "type": "normfactor", "data": None}
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    # same search path, but starting from an empty cache
+    with pyhf.schema(old_path):
+        assert not pyhf.schema.variables.SCHEMA_CACHE
+        pyhf.schema.validate(spec, "model.json")
+        assert set(pyhf.schema.variables.SCHEMA_CACHE) == {
+            "1.0.0/model.json",
+            "1.0.0/defs.json",
+        }
+
+
+@pytest.mark.parametrize(
+    "schema_id",
+    [
+        "https://example.com/schemas/1.1.0/model.json",
+        f"{pyhf.schema.variables.SCHEMA_BASE}1.1.0/model.json",
+    ],
+    ids=["foreign_id", "missing_defs"],
+)
+@pytest.mark.usefixtures("self_restoring_schema_globals")
+def test_validate_unresolvable_ref(tmp_path, schema_id):
+    schema_dir = tmp_path / "1.1.0"
+    schema_dir.mkdir()
+    schema = {
+        "$schema": "http://json-schema.org/draft-06/schema#",
+        "$id": schema_id,
+        "$ref": "defs.json#/definitions/model",
+    }
+    (schema_dir / "model.json").write_text(json.dumps(schema), encoding="utf-8")
+
+    with (
+        pyhf.schema(tmp_path),
+        pytest.raises(
+            pyhf.exceptions.SchemaNotFound, match=r"1\.1\.0/defs\.json"
+        ) as excinfo,
+    ):
+        pyhf.schema.validate({}, "model.json", version="1.1.0")
+    assert isinstance(excinfo.value.__cause__, referencing.exceptions.Unresolvable)
 
 
 def test_no_channels():
@@ -607,7 +701,7 @@ def test_patchset_fail(datadir, patchset_file):
 def test_defs_always_cached():
     """
     Schema definitions should always be loaded from the local files and cached at first import.
-    Otherwise pyhf will crash in contexts where the jsonschema.RefResolver cannot lookup the definition by the schema-id
+    Otherwise pyhf will crash in contexts where a referenced schema would have to be fetched by its schema-id
     (e.g. a cluster node without network access).
     """
     modules_to_clear = [name for name in sys.modules if name.split(".")[0] == "pyhf"]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -169,21 +169,13 @@ def test_validate_caches_referenced_schema(self_restoring_schema_globals):
         }
 
 
-@pytest.mark.parametrize(
-    "schema_id",
-    [
-        "https://example.com/schemas/1.1.0/model.json",
-        f"{pyhf.schema.variables.SCHEMA_BASE}1.1.0/model.json",
-    ],
-    ids=["foreign_id", "missing_defs"],
-)
 @pytest.mark.usefixtures("self_restoring_schema_globals")
-def test_validate_unresolvable_ref(tmp_path, schema_id):
+def test_validate_unresolvable_ref(tmp_path):
     schema_dir = tmp_path / "1.1.0"
     schema_dir.mkdir()
     schema = {
         "$schema": "http://json-schema.org/draft-06/schema#",
-        "$id": schema_id,
+        "$id": f"{pyhf.schema.variables.SCHEMA_BASE}1.1.0/model.json",
         "$ref": "defs.json#/definitions/model",
     }
     (schema_dir / "model.json").write_text(json.dumps(schema), encoding="utf-8")
@@ -196,6 +188,69 @@ def test_validate_unresolvable_ref(tmp_path, schema_id):
     ):
         pyhf.schema.validate({}, "model.json", version="1.1.0")
     assert isinstance(excinfo.value.__cause__, referencing.exceptions.Unresolvable)
+
+
+@pytest.mark.parametrize(
+    "schema_id",
+    [
+        "1.0.0/model.json",
+        f"{pyhf.schema.variables.SCHEMA_BASE}1.0.0/model.json",
+        "https://example.com/schemas/1.1.0/model.json",
+    ],
+    ids=["stale_relative_id", "stale_bundled_id", "foreign_id"],
+)
+@pytest.mark.usefixtures("self_restoring_schema_globals")
+def test_validate_ref_resolved_against_schema_path_not_id(tmp_path, schema_id):
+    """
+    The top-level $ref of a schema must resolve against the on-disk directory of
+    the requested version, not against the schema's own $id, so that a stale or
+    copy-pasted $id cannot redirect defs.json to another version.
+    c.f. https://github.com/scikit-hep/pyhf/pull/2716#discussion_r3947972735
+    """
+    draft = "http://json-schema.org/draft-06/schema#"
+    schemas = {
+        "1.1.0/model.json": {
+            "$schema": draft,
+            "$id": schema_id,
+            "$ref": "defs.json#/definitions/model",
+        },
+        "1.1.0/defs.json": {
+            "$schema": draft,
+            "$id": "1.1.0/defs.json",
+            "definitions": {
+                "model": {
+                    "type": "object",
+                    "properties": {"must_have_marker": {"type": "string"}},
+                    "required": ["must_have_marker"],
+                    "additionalProperties": False,
+                }
+            },
+        },
+        "1.0.0/defs.json": {
+            "$schema": draft,
+            "$id": "1.0.0/defs.json",
+            "definitions": {
+                "model": {
+                    "type": "object",
+                    "properties": {"must_have_marker": {"type": "string"}},
+                    "additionalProperties": True,
+                }
+            },
+        },
+    }
+    for name, schema in schemas.items():
+        path = tmp_path / name
+        path.parent.mkdir(exist_ok=True)
+        path.write_text(json.dumps(schema), encoding="utf-8")
+
+    with pyhf.schema(tmp_path):
+        pyhf.schema.validate({"must_have_marker": "x"}, "model.json", version="1.1.0")
+        with pytest.raises(pyhf.exceptions.InvalidSpecification):
+            pyhf.schema.validate({}, "model.json", version="1.1.0")
+        assert set(pyhf.schema.variables.SCHEMA_CACHE) == {
+            "1.1.0/model.json",
+            "1.1.0/defs.json",
+        }
 
 
 def test_no_channels():


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of the code review in #2706.

* Resolves #2139
* Resolves https://github.com/scikit-hep/pyhf/issues/2121

## Summary

`jsonschema.RefResolver` has been deprecated since jsonschema 4.18. This migrates pyhf's schema validation to the [`referencing`](https://github.com/python-jsonschema/referencing) library:

- `src/pyhf/schema/validator.py` now builds a `referencing.Registry` with a `retrieve` callback (`_retrieve_schema`) that loads referenced schemas from disk, and passes `registry=...` to the `jsonschema` validator instead of the deprecated `resolver=...`.
- The pyhf schemas carry a top-level `$ref` (e.g. `model.json` -> `defs.json#/definitions/model`). Under draft-06, a sibling `$ref` suppresses `$id`, so jsonschema cannot infer the root schema's base URI. The resolver base URI is therefore anchored explicitly to the schema `$id` so relative references like `defs.json` resolve correctly.
- A new `loader.read_schema` reads a schema directly from disk **without** consulting or mutating `SCHEMA_CACHE`, so resolving `$ref`s does not pollute the cache. This preserves the existing caching semantics, including the `pyhf.schema(new_path)` custom-schema-path context manager and the `InvalidSpecification` exception behavior.
- Bumped `jsonschema>=4.15.0` -> `jsonschema>=4.18.0` and added `referencing>=0.28.4` as an explicit dependency in both the project and pixi dependency tables (it is now imported directly).
- Removed the now-unneeded `RefResolver` `DeprecationWarning` filter. Since pytest runs with `filterwarnings=error`, any remaining deprecation path would now fail the suite.

## Test plan

- [x] `uv pip install --group dev --editable .`
- [x] `pytest tests/test_schema.py` (70 passed)
- [x] `pytest tests/test_workspace.py tests/test_pdf.py` (308 passed, 6 skipped)
- [x] `pytest tests/test_validation.py tests/test_patchset.py tests/test_public_api.py` (all pass)
- [x] `pytest --doctest-modules src/pyhf/schema/` (3 passed)
- [x] `prek -a` (lint clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Replace the deprecated jsonschema.RefResolver with a referencing.Registry
  whose retrieve callback loads schemas from pyhf.schema.path, and pass
  'registry=' to the validator instead of the deprecated 'resolver=' argument.
   - c.f. https://python-jsonschema.readthedocs.io/en/stable/referencing/
* Enter validation through the absolute form of a schema's top-level $ref
  (e.g. defs.json#/definitions/model), resolved against the directory of
  the requested version under pyhf.schema.path rather than the schema's own
  $id, as the RefResolver base_uri was. Under draft-06 a sibling $ref
  suppresses $id, so jsonschema cannot infer the root base URI from the
  schema itself, and anchoring at the on-disk directory means a stale or
  copy-pasted $id cannot redirect defs.json to another version. Entering at
  the referenced fragment keeps the tensor-aware validator class, which
  referencing the whole document by $id would discard.
* Key SCHEMA_CACHE by path relative to pyhf.schema.path instead of by $id so
  that lookups hit for both the bundled schemas and custom schemas with
  relative $ids. The previous lookup key was built with pathlib, which
  collapsed 'https://' to 'https:/', so the cache never hit.
* Route $ref retrieval through load_schema so that referenced schemas such
  as defs.json are cached after the first load.
* Raise 'pyhf.exceptions.SchemaNotFound' from 'pyhf.schema.validate' when a $ref
  cannot be resolved, naming the unresolved reference.
* Bump the minimum jsonschema to v4.18.0, add referencing as an explicit
  dependency with its version controlled by jsonschema, and drop the
  RefResolver DeprecationWarning filter.
* Add tests for _retrieve_schema, schema cache hits, and unresolvable
  references.

Co-authored-by: Matthew Feickert <matthew.feickert@cern.ch>

Assisted-by: ClaudeCode:claude-fable-5-1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Improvements

- Improved JSON Schema validation for nested and relative `$ref` references.
- Increased reliability when loading and caching bundled or custom schemas.
- Improved resolution of referenced schema resources based on the requested schema location.

## Bug Fixes

- Improved error messages when referenced schema files cannot be resolved.
- Ensured consistent schema cache lookups across validation and direct schema reads.

## Tests

- Expanded coverage for schema caching, referenced resources, and resolution errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->