### PR TITLE
fix: Add tolerance to mpl_image_compare tests

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -38,3 +38,4 @@ Contributors include:
 - Matthias Bussonnier
 - Peter Fackeldey
 - Alok Kumar
+- Julian Kuhlmann

--- a/tests/contrib/test_viz.py
+++ b/tests/contrib/test_viz.py
@@ -52,7 +52,7 @@ def test_brazil_band_collection(datadir):
     assert brazil_band_collection.axes == ax
 
 
-@pytest.mark.mpl_image_compare
+@pytest.mark.mpl_image_compare(tolerance=25)
 def test_plot_results(datadir):
     data = json.load(datadir.joinpath("hypotest_results.json").open(encoding="utf-8"))
 
@@ -66,7 +66,7 @@ def test_plot_results(datadir):
     return fig
 
 
-@pytest.mark.mpl_image_compare
+@pytest.mark.mpl_image_compare(tolerance=25)
 def test_plot_results_no_axis(datadir):
     data = json.load(datadir.joinpath("hypotest_results.json").open(encoding="utf-8"))
 
@@ -78,7 +78,7 @@ def test_plot_results_no_axis(datadir):
     return fig
 
 
-@pytest.mark.mpl_image_compare
+@pytest.mark.mpl_image_compare(tolerance=25)
 def test_plot_results_components(datadir):
     data = json.load(
         datadir.joinpath("tail_probs_hypotest_results.json").open(encoding="utf-8")
@@ -92,7 +92,7 @@ def test_plot_results_components(datadir):
     return fig
 
 
-@pytest.mark.mpl_image_compare
+@pytest.mark.mpl_image_compare(tolerance=25)
 def test_plot_results_components_no_clb(datadir):
     data = json.load(
         datadir.joinpath("tail_probs_hypotest_results.json").open(encoding="utf-8")
@@ -114,7 +114,7 @@ def test_plot_results_components_no_clb(datadir):
     return fig
 
 
-@pytest.mark.mpl_image_compare
+@pytest.mark.mpl_image_compare(tolerance=25)
 def test_plot_results_components_no_clsb(datadir):
     data = json.load(
         datadir.joinpath("tail_probs_hypotest_results.json").open(encoding="utf-8")
@@ -136,7 +136,7 @@ def test_plot_results_components_no_clsb(datadir):
     return fig
 
 
-@pytest.mark.mpl_image_compare
+@pytest.mark.mpl_image_compare(tolerance=25)
 def test_plot_results_components_no_cls(datadir):
     data = json.load(
         datadir.joinpath("tail_probs_hypotest_results.json").open(encoding="utf-8")


### PR DESCRIPTION
# Description

Resolves https://github.com/scikit-hep/pyhf/issues/2718

Fixes the failing tests of `tests/contrib/test_viz.py` as described in #2718 with matplotlib 3.11.0.

Tests complain about the images being too different, encoded in the RMS, the calculation can be found [here](https://github.com/matplotlib/matplotlib/blob/91f9a9d166b4454b16877fde6246deeee44e6a31/src/_image_wrapper.cpp#L209). It amounts to a sum over the pixel-wise squared differences of RGB(A) values between both images, which is then averaged over the image size and number of color channels.


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add a tolerance to tests in tests/contrib/test_viz.py marked with pytest.mark.mpl_image_compare,
  to be compatible across multiple Matplotlib minor versions
  (matplotlib v3.10.x differs from v3.11.0).
  The tolerance is the maximum RMS difference between the result image
  and the baseline image before the test fails.
   - c.f. https://pytest-mpl.readthedocs.io/en/stable/configuration.html#rms-tolerance
* Add Julian Kuhlmann to contributors list.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated visualization image-comparison checks to use explicit tolerance settings, improving consistency across Brazil-related rendering scenarios.
* **Documentation**
  * Added a new contributor to the contributors list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->