### PR TITLE
fix: Add filterwarnings ignore for NumPy 'scalar divide' by zero RuntimeWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,7 @@ filterwarnings = [
     'ignore: Exception ignored in:pytest.PytestUnraisableExceptionWarning',  #FIXME: Exception ignored in: <_io.FileIO [closed]>
     'ignore:invalid value encountered in (true_)?divide:RuntimeWarning',  #FIXME
     'ignore:invalid value encountered in add:RuntimeWarning',  #FIXME
-    'ignore:divide by zero encountered in (true_)?divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]
+    'ignore:divide by zero encountered in (scalar |true_)?divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]. Issue #2722
     'ignore:[A-Z]+ is deprecated and will be removed in Pillow 10:DeprecationWarning',  # keras
     "ignore:ml_dtypes.float8_e4m3b11 is deprecated.",  #FIXME: Can remove when jaxlib>=0.4.12
     "ignore:jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the:DeprecationWarning",  # Issue #2139


### PR DESCRIPTION
# Description

* Add an ignore to filterwarnings to avoid NumPy scalar divide RuntimeWarning.

> RuntimeWarning: divide by zero encountered in scalar divide

  NumPy v1.24+ emits a "scalar divide" message for np.float64/np.float64 operations.
   - c.f. https://github.com/numpy/numpy/pull/21863

---

Addresses Issue https://github.com/scikit-hep/pyhf/issues/2722 superficially, but this should be fixed at a deeper level.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add an ignore to filterwarnings to avoid NumPy scalar divide RuntimeWarning.

> RuntimeWarning: divide by zero encountered in scalar divide

  NumPy v1.24+ emits a "scalar divide" message for np.float64/np.float64 operations.
   - c.f. https://github.com/numpy/numpy/ PR 21863
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated warning handling in the test configuration to cover a broader set of NumPy divide-by-zero warnings, improving test reliability and reducing noisy failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->