### PR TITLE
ci: Restrict NumPy for Python 3.10 mypy pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,15 +53,20 @@ repos:
     # check the oldest and newest supported Pythons
     # except skip python 3.9 for numpy, due to poor typing
     hooks:
-      - &mypy
-        id: mypy
+      - id: mypy
         name: mypy with Python 3.10
         files: src
+        # NumPy v2.5.0+ is Python 3.12+ and uses PEP 695 'type' statements in
+        # its stubs, which mypy cannot parse under --python-version=3.10
         additional_dependencies:
-          ['numpy', 'rich', 'click', 'types-jsonpatch', 'types-pyyaml', 'types-jsonschema', 'importlib_metadata', 'packaging']
+          ["numpy<2.5.0", "rich", "click", "types-jsonpatch", "types-pyyaml", "types-jsonschema", "importlib_metadata", "packaging"]
         args: ["--python-version=3.10"]
-      - <<: *mypy
+
+      - id: mypy
         name: mypy with Python 3.13
+        files: src
+        additional_dependencies:
+          ["numpy", "rich", "click", "types-jsonpatch", "types-pyyaml", "types-jsonschema", "importlib_metadata", "packaging"]
         args: ["--python-version=3.13"]
 
 -   repo: https://github.com/codespell-project/codespell


### PR DESCRIPTION
# Description

* Restrict numpy<2.5.0 for the Python 3.10 mypy pre-commit hook as NumPy v2.5.0 uses the PEP 695 'type' statements which are Python 3.12+ and so cannot be be parsed by '--python-version=3.10'. This avoids

```
error: Type statement is only supported in Python 3.12 and greater [syntax]
```

* Split the mypy pre-commit anchor by Python version so that Python 3.13 is not restricted by the cap on NumPy.

This will fail the tests given an ongoing issue but this is known and accepted.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Restrict numpy<2.5.0 for the Python 3.10 mypy pre-commit hook as NumPy v2.5.0
  uses the PEP 695 'type' statements which are Python 3.12+ and so cannot be
  be parsed by '--python-version=3.10'. This avoids

    error: Type statement is only supported in Python 3.12 and greater [syntax]

* Split the mypy pre-commit anchor by Python version so that Python 3.13 is not
  restricted by the cap on NumPy.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Python type-checking setup to use separate configurations for Python 3.10 and 3.13.
  * Improved compatibility for the Python 3.10 type-checking path by pinning a NumPy version that avoids known stub parsing issues.
  * Kept the Python 3.13 type-checking setup aligned with the latest NumPy package behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->