### PR TITLE
fix: Avoid divide-by-zero in qtilde test statistic for poi_test == asimov_mu

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,7 @@ filterwarnings = [
     'ignore: Exception ignored in:pytest.PytestUnraisableExceptionWarning',  #FIXME: Exception ignored in: <_io.FileIO [closed]>
     'ignore:invalid value encountered in (true_)?divide:RuntimeWarning',  #FIXME
     'ignore:invalid value encountered in add:RuntimeWarning',  #FIXME
-    'ignore:divide by zero encountered in (scalar |true_)?divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]. Issue #2722
+    'ignore:divide by zero encountered in (true_)?divide:RuntimeWarning',  #FIXME: pytest tests/test_tensor.py::test_pdf_calculations[numpy]
     'ignore:[A-Z]+ is deprecated and will be removed in Pillow 10:DeprecationWarning',  # keras
     "ignore:ml_dtypes.float8_e4m3b11 is deprecated.",  #FIXME: Can remove when jaxlib>=0.4.12
     "ignore:jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the:DeprecationWarning",  # Issue #2139

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -440,9 +440,15 @@ class AsymptoticCalculator:
                 qmu_A = tensorlib.power(self.sqrtqmuA_v, 2)
                 return (qmu - qmu_A) / (2 * self.sqrtqmuA_v)
 
-            # Use '<=' rather than '<' to avoid Issue #1992
+            # Use '<=' rather than '<' to avoid Issue #1992.
+            # sqrtqmuA_v == 0 when poi_test == asimov_mu (e.g. the poi=0 scan
+            # point); the q̃_mu > q̃_mu,A branch of arXiv:1007.1727 Eq. 16 is then
+            # 0/0, so route to the Gaussian-regime expression instead of
+            # dividing by zero (Issue #2722).
             teststat = tensorlib.conditional(
-                (sqrtqmu_v <= self.sqrtqmuA_v), _true_case, _false_case
+                (sqrtqmu_v <= self.sqrtqmuA_v) | (self.sqrtqmuA_v == 0),
+                _true_case,
+                _false_case,
             )
         return tensorlib.astensor(teststat)
 

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -441,10 +441,13 @@ class AsymptoticCalculator:
                 return (qmu - qmu_A) / (2 * self.sqrtqmuA_v)
 
             # Use '<=' rather than '<' to avoid Issue #1992.
-            # sqrtqmuA_v == 0 when poi_test == asimov_mu (e.g. the poi=0 scan
-            # point); the q̃_mu > q̃_mu,A branch of arXiv:1007.1727 Eq. 16 is then
-            # 0/0, so route to the Gaussian-regime expression instead of
-            # dividing by zero (Issue #2722).
+            #
+            # sqrtqmuA_v == 0 happens when poi_test == asimov_mu
+            # (the poi=0 scan point) which results in the muhat < 0 branch
+            # of Equation 16 from https://arxiv.org/abs/1007.1727 (_false_case)
+            # being 0/0. To avoid this route this degenerate case to muhat >= 0
+            # (_true_case) (using bitwise OR) instead of dividing by zero
+            # (avoids Issue #2722).
             teststat = tensorlib.conditional(
                 (sqrtqmu_v <= self.sqrtqmuA_v) | (self.sqrtqmuA_v == 0),
                 _true_case,

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -445,7 +445,7 @@ class AsymptoticCalculator:
             # sqrtqmuA_v == 0 happens when poi_test == asimov_mu
             # (the poi=0 scan point) which results in the muhat < 0 branch
             # of Equation 16 from https://arxiv.org/abs/1007.1727 (_false_case)
-            # being 0/0. To avoid this route this degenerate case to muhat >= 0
+            # being 0/0. To avoid this, route this degenerate case to muhat >= 0
             # (_true_case) (using bitwise OR) instead of dividing by zero
             # (avoids Issue #2722).
             teststat = tensorlib.conditional(

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -683,6 +683,29 @@ def test_teststat_nan_guard():
     assert all(~np.isnan(result) for result in test_results)
 
 
+def test_teststatistic_poi0_no_divide_by_zero(hypotest_args):
+    # Issue #2722: at poi_test == asimov_mu (poi=0 for qtilde) sqrtqmuA_v == 0,
+    # so the q̃_mu > q̃_mu,A branch of arXiv:1007.1727 Eq. 16 is 0/0. The
+    # divide-by-zero only surfaces when the observed q̃_0 rounds to a tiny
+    # positive (e.g. macOS arm64); promote it to an error here independently of
+    # the project filterwarnings so the guard does not regress.
+    _, data, model = hypotest_args
+
+    calc = pyhf.infer.calculators.AsymptoticCalculator(data, model, test_stat="qtilde")
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", "divide by zero encountered")
+        teststat = calc.teststatistic(0.0)
+    assert np.isfinite(np.asarray(teststat))
+
+    # CLs at the background-only point must be finite and ~1 (mu=0 is never
+    # excluded), not NaN from a +inf test statistic.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", "divide by zero encountered")
+        CLs_obs = pyhf.infer.hypotest(0.0, data, model, test_stat="qtilde")
+    assert np.isfinite(CLs_obs)
+    assert CLs_obs == pytest.approx(1.0, abs=1e-3)
+
+
 # TODO: Remove after pyhf v0.9.0 is released
 def test_deprecated_upperlimit(hypotest_args):
     with warnings.catch_warnings(record=True) as _warning:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -688,7 +688,7 @@ def test_teststatistic_poi0_no_divide_by_zero(hypotest_args):
     # At poi_test == asimov_mu (poi=0 for qtilde) sqrtqmuA_v == 0,
     # results in the muhat < 0 branch of Equation 16 from
     # https://arxiv.org/abs/1007.1727 being 0/0. This only occurs when the
-    # observed q̃_0 rounds to a tiny positive (happens on macOS amr64).
+    # observed q̃_0 rounds to a tiny positive (happens on macOS arm64).
     # Raise as an error to ensure this guard does not regress.
     _, data, model = hypotest_args
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -684,11 +684,12 @@ def test_teststat_nan_guard():
 
 
 def test_teststatistic_poi0_no_divide_by_zero(hypotest_args):
-    # Issue #2722: at poi_test == asimov_mu (poi=0 for qtilde) sqrtqmuA_v == 0,
-    # so the q̃_mu > q̃_mu,A branch of arXiv:1007.1727 Eq. 16 is 0/0. The
-    # divide-by-zero only surfaces when the observed q̃_0 rounds to a tiny
-    # positive (e.g. macOS arm64); promote it to an error here independently of
-    # the project filterwarnings so the guard does not regress.
+    # Issue https://github.com/scikit-hep/pyhf/issues/2722
+    # At poi_test == asimov_mu (poi=0 for qtilde) sqrtqmuA_v == 0,
+    # results in the muhat < 0 branch of Equation 16 from
+    # https://arxiv.org/abs/1007.1727 being 0/0. This only occurs when the
+    # observed q̃_0 rounds to a tiny positive (happens on macOS amr64).
+    # Raise as an error to ensure this guard does not regress.
     _, data, model = hypotest_args
 
     calc = pyhf.infer.calculators.AsymptoticCalculator(data, model, test_stat="qtilde")


### PR DESCRIPTION
# Description

* Add a bitwise OR to the `tensorlib.conditional` call in `pyhf.infer.calculators.AsymptoticCalculator.teststatistic` to avoid taking a branch that could result in division by 0. This happens in the case that `sqrtqmuA_v == 0` which occurs when `poi_test == asimov_mu` (the poi=0 scan point) which results in the `muhat < 0` branch of Equation 16 from https://arxiv.org/abs/1007.1727 (`_false_case`) being `0/0`. To avoid this, route this degenerate case to `muhat >= 0` (`_true_case`) instead of dividing by zero, which avoids Issue https://github.com/scikit-hep/pyhf/issues/2722.
* Add a test (test_teststatistic_poi0_no_divide_by_zero) to `tests/test_infer.py` to cover regression of Issue https://github.com/scikit-hep/pyhf/issues/2722.
* Revert PR https://github.com/scikit-hep/pyhf/pull/2723 as this was a temporary
  measure to have the CI pass.

---

* Resolves https://github.com/scikit-hep/pyhf/issues/2722
* Related to https://github.com/scikit-hep/pyhf/issues/1992

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add a bitwise OR to the 'tensorlib.conditional' call in
  'pyhf.infer.calculators.AsymptoticCalculator.teststatistic' to avoid taking
  a branch that could result in division by 0. This happens in the case that
  'sqrtqmuA_v == 0' which occurs when 'poi_test == asimov_mu'
  (the poi=0 scan point) which results in the 'muhat < 0' branch of Equation 16
  from https://arxiv.org/abs/1007.1727 (_false_case) being 0/0. To avoid this,
  route this degenerate case to 'muhat >= 0' (_true_case) instead of dividing
  by zero, which avoids https://github.com/scikit-hep/pyhf/ Issue 2722.
* Add a test (test_teststatistic_poi0_no_divide_by_zero) to
  tests/test_infer.py to cover regression of https://github.com/scikit-hep/pyhf/
  Issue 2722.
* Revert PR https://github.com/scikit-hep/pyhf/pull/2723 as this was a temporary
  measure to have the CI pass.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a rare divide-by-zero path during hypothesis test `qtilde` evaluation, ensuring finite results at the background-only point.
  * Improved the warning-filter pattern for a tensor PDF calculation test to better match the expected runtime warning.
* **Tests**
  * Added a regression test covering evaluation at POI `0.0`, asserting outputs stay finite and `CLs_obs` remains ~`1.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->