### PR TITLE
chore: Migrate Pixi system-requirements to rich platforms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,8 +319,8 @@ flake8-tidy-imports.ban-relative-imports = "all"
 
 [tool.pixi.workspace]
 channels = ["conda-forge"]
-platforms = ["linux-64", "osx-arm64"]
-requires-pixi = ">=0.63.0"
+platforms = ["linux-64", "osx-arm64", { name = "linux-64-cuda", platform = "linux-64", cuda = "12" }]
+requires-pixi = ">=0.71.0"
 
 [tool.pixi.pypi-dependencies]
 pyhf = { path = ".", editable = true }
@@ -346,11 +346,11 @@ jax = ">=0.4.1"
 jax = ">=0.4.1"
 jaxlib = { version = "*", build = "cpu*" }
 
+[tool.pixi.feature.jax-gpu]
+platforms = ["linux-64-cuda"]
+
 [tool.pixi.feature.jax-gpu.dependencies]
 jax = ">=0.4.1"
-
-[tool.pixi.feature.jax-gpu.system-requirements]
-cuda = "12.0"
 
 [tool.pixi.feature.contrib.dependencies]
 matplotlib = ">=3.0.0"


### PR DESCRIPTION
# Description

* In Pixi `v0.71.0` the `system-requirements` table was deprecated for rich platforms in the main workspace table. Add a `linux-64-cuda` platform to support the `jax-gpu` feature.
   - c.f. https://pixi.prefix.dev/v0.71.3/workspace/system_requirements/
* Update `requires-pixi` to `0.71.0` to ensure rich platform support.

## Comparison

### Using Pixi post `v0.71.0` with current `HEAD` (826a0416a985fa326de39f29e2dff166a5a46ff7)

```
 WARN Encountered 1 warning while parsing the manifest:
  ⚠ the `[system-requirements]` table is deprecated in favor of virtual packages on `platforms`
     ╭─[/home/feickert/Code/GitHub/scikit-hep/pyhf/pyproject.toml:352:1]
 351 │     
 352 │ ╭─▶ [tool.pixi.feature.jax-gpu.system-requirements]
 353 │ ├─▶ cuda = "12.0"
     · ╰──── declare these on the `platforms` entries instead
 354 │     
     ╰────
  help: e.g. platforms = [{ platform = "linux-64", cuda = "12" }]
```

### Using Pixi post `v0.71.0` with this PR

```console
$ pixi run -e jax-cpu 'curl -sL https://raw.githubusercontent.com/matthewfeickert/nvidia-gpu-ml-library-test/refs/heads/main/jax_detect_GPU.py | python'
An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.
XLA backend type: cpu

Number of GPUs found on system: 0
$ pixi run -e jax-gpu 'curl -sL https://raw.githubusercontent.com/matthewfeickert/nvidia-gpu-ml-library-test/refs/heads/main/jax_detect_GPU.py | python'
XLA backend type: gpu

Number of GPUs found on system: 1

Active GPU index: 0
Active GPU name: NVIDIA GeForce RTX 4060 Laptop GPU
$ pixi shell -e jax-gpu

(pyhf:jax-gpu) feickert@feickert-XPS-15-9530:~/Code/GitHub/scikit-hep/pyhf$ curl -sL https://raw.githubusercontent.com/matthewfeickert/nvidia-gpu-ml-library-test/refs/heads/main/jax_detect_GPU.py | python
XLA backend type: gpu

Number of GPUs found on system: 1

Active GPU index: 0
Active GPU name: NVIDIA GeForce RTX 4060 Laptop GPU
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* In Pixi v0.71.0 the system-requirements table was deprecated for rich
  platforms in the main workspace table. Add a 'linux-64-cuda' platform
  to support the 'jax-gpu' feature.
   - c.f. https://pixi.prefix.dev/v0.71.3/workspace/system_requirements/
* Update requires-pixi to 0.71.0 to ensure rich platform support.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Expanded GPU platform support to include a CUDA 12–compatible Linux option.
  * Updated the JAX GPU setup to target the CUDA 12 Linux platform only.

* **Chores**
  * Increased the minimum required Pixi version for the workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->