### PR TITLE
fix: Properly close files during reads

### DIFF
--- a/src/pyhf/cli/infer.py
+++ b/src/pyhf/cli/infer.py
@@ -99,10 +99,10 @@ def fit(
     with click.open_file(workspace, "r", encoding="utf-8") as specstream:
         spec = json.load(specstream)
     ws = Workspace(spec)
-    patches = [
-        json.loads(click.open_file(pfile, "r", encoding="utf-8").read())
-        for pfile in patch
-    ]
+    patches = []
+    for pfile in patch:
+        with click.open_file(pfile, "r", encoding="utf-8") as patch_file:
+            patches.append(json.loads(patch_file.read()))
 
     model = ws.model(
         measurement_name=measurement,
@@ -195,10 +195,10 @@ def cls(
 
     ws = Workspace(spec)
 
-    patches = [
-        json.loads(click.open_file(pfile, "r", encoding="utf-8").read())
-        for pfile in patch
-    ]
+    patches = []
+    for pfile in patch:
+        with click.open_file(pfile, "r", encoding="utf-8") as patch_file:
+            patches.append(json.loads(patch_file.read()))
     model = ws.model(
         measurement_name=measurement,
         patches=patches,

--- a/src/pyhf/cli/rootio.py
+++ b/src/pyhf/cli/rootio.py
@@ -94,8 +94,9 @@ def json2xml(workspace, output_dir, specroot, dataroot, resultprefix, patch):
     with click.open_file(workspace, "r", encoding="utf-8") as specstream:
         spec = json.load(specstream)
         for pfile in patch:
-            patch = json.loads(click.open_file(pfile, "r", encoding="utf-8").read())
-            spec = jsonpatch.JsonPatch(patch).apply(spec)
+            with click.open_file(pfile, "r", encoding="utf-8") as patch_file:
+                patch_data = json.loads(patch_file.read())
+            spec = jsonpatch.JsonPatch(patch_data).apply(spec)
         Path(output_dir).joinpath(specroot).mkdir(parents=True, exist_ok=True)
         Path(output_dir).joinpath(dataroot).mkdir(parents=True, exist_ok=True)
         with click.open_file(

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -120,7 +120,7 @@ def test_import_prepHistFactory_and_fit(tmp_path, script_runner):
         command += f" --output-file {tmp_out}"
         ret = script_runner.run(shlex.split(command))
         assert ret.success
-        ret_json = json.load(tmp_out.open())
+        ret_json = json.loads(tmp_out.read_text())
         assert "mle_parameters" in ret_json
         assert "twice_nll" in ret_json
 
@@ -159,7 +159,7 @@ def test_import_prepHistFactory_and_cls(tmp_path, script_runner):
         command += f" --output-file {tmp_out}"
         ret = script_runner.run(shlex.split(command))
         assert ret.success
-        d = json.load(tmp_out.open())
+        d = json.loads(tmp_out.read_text())
         assert "CLs_obs" in d
         assert "CLs_exp" in d
 
@@ -260,14 +260,16 @@ def test_patch(tmp_path, script_runner):
 
     command = f"pyhf cls {temp} --patch -"
 
-    ret = script_runner.run(shlex.split(command), stdin=patch.open())
+    with patch.open() as patch_stdin:
+        ret = script_runner.run(shlex.split(command), stdin=patch_stdin)
     assert ret.success
 
     output_dir_path = tmp_path / "output_2"
     output_dir_path.mkdir(exist_ok=True)
 
     command = f"pyhf json2xml {temp} --output-dir {output_dir_path} --patch -"
-    ret = script_runner.run(shlex.split(command), stdin=patch.open())
+    with patch.open() as patch_stdin:
+        ret = script_runner.run(shlex.split(command), stdin=patch_stdin)
     assert ret.success
 
 
@@ -594,7 +596,7 @@ def test_workspace_digest(tmp_path, script_runner, algorithms, do_json):
 def test_patchset_download(
     tmp_path, script_runner, requests_mock, tarfile_path, archive
 ):
-    requests_mock.get(archive, content=tarfile_path.open("rb").read())
+    requests_mock.get(archive, content=tarfile_path.read_bytes())
     command = f"pyhf contrib download {archive} {tmp_path.joinpath('likelihoods')}"
     ret = script_runner.run(shlex.split(command))
     assert ret.success
@@ -716,8 +718,8 @@ def test_patchset_extract(datadir, tmp_path, script_runner, output_file, with_me
     else:
         assert (
             extracted_output
-            == json.load(
-                datadir.joinpath("example_patchset.json").open(encoding="utf-8")
+            == json.loads(
+                datadir.joinpath("example_patchset.json").read_text(encoding="utf-8")
             )["patches"][0]["patch"]
         )
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -247,6 +247,10 @@ def test_patch(tmp_path, script_runner):
     command = f"pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {temp}"
     ret = script_runner.run(shlex.split(command))
 
+    command = f"pyhf fit {temp} --patch {patch}"
+    ret = script_runner.run(shlex.split(command))
+    assert ret.success
+
     command = f"pyhf cls {temp} --patch {patch}"
     ret = script_runner.run(shlex.split(command))
     assert ret.success


### PR DESCRIPTION
# Description

* The cls, fit, and json2xml CLI commands currently read each `--patch` file with `click.open_file(pfile, "r").read()` but never close the handle. In Python 3.14 the leaked file is reported during finalization as

```
PytestUnraisableExceptionWarning: Exception ignored while finalizing file
```

along with a `ResourceWarning: unclosed file`, which is caught by the pytest config and raised as an error. Wrap the reads in a `with` block so the handle is closed.
* In `tests/test_scripts.py` tests passed an open file object to `json.load(...)`, `script_runner` stdin, and `requests_mock` without closing the file, also raising the `PytestUnraisableExceptionWarning` in Python 3.14. Read the file objects with `Path.read_text()/read_bytes()` and `with` blocks so the files are closed deterministically.
* Required for PR https://github.com/scikit-hep/pyhf/pull/2657 to pass.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* The cls, fit, and json2xml CLI commands currently read each --patch file with
  'click.open_file(pfile, "r").read()' but never close the handle. In Python
  3.14 the leaked file is reported during finalization as

    PytestUnraisableExceptionWarning: Exception ignored while finalizing file

  along with a 'ResourceWarning: unclosed file', which is caught by the pytest
  config and raised as an error. Wrap the reads in a 'with' block so the handle
  is closed.
* In tests/test_scripts.py tests passed an open file object to 'json.load(...)',
  script_runner stdin, and requests_mock without closing the file, also raising
  the PytestUnraisableExceptionWarning in Python 3.14. Read the file objects with
  'Path.read_text()/read_bytes()' and 'with' blocks so the files are closed
  deterministically.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved patch JSON loading in CLI commands when using patch inputs, ensuring more consistent file handling.
  * Refined JSON/tarball and stdin-based patch handling in CLI workflows.
* **Tests**
  * Updated CLI integration tests to use safer `Path` read helpers and clearer stdin/file streaming patterns.
  * Adjusted assertions for JSON patchset and tarball download behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->