### PR TITLE
fix: Properly close test files during reads

### DIFF
--- a/tests/contrib/test_contrib_utils.py
+++ b/tests/contrib/test_contrib_utils.py
@@ -73,15 +73,15 @@ def test_download_archive_type(
     archive_url = "https://www.hepdata.net/record/resource/1408476?view=true"
     output_directory = tmp_path.joinpath("likelihoods")
     # Give BytesIO a tarfile
-    requests_mock.get(archive_url, content=tarfile_path.open("rb").read())
+    requests_mock.get(archive_url, content=tarfile_path.read_bytes())
     download(archive_url, output_directory)
 
     # Give BytesIO an uncompressed tarfile
-    requests_mock.get(archive_url, content=tarfile_uncompressed_path.open("rb").read())
+    requests_mock.get(archive_url, content=tarfile_uncompressed_path.read_bytes())
     download(archive_url, output_directory)
 
     # Give BytesIO a zipfile
-    requests_mock.get(archive_url, content=zipfile_path.open("rb").read())
+    requests_mock.get(archive_url, content=zipfile_path.read_bytes())
     # Run without and with existing output_directory to cover both
     # cases of the shutil.rmtree logic
     rmtree(output_directory)
@@ -97,9 +97,7 @@ def test_download_archive_type(
 
 def test_download_archive_force(tmp_path, requests_mock, tarfile_path):
     archive_url = "https://www.cern.ch/record/resource/123456789"
-    requests_mock.get(
-        archive_url, content=tarfile_path.open("rb").read(), status_code=200
-    )
+    requests_mock.get(archive_url, content=tarfile_path.read_bytes(), status_code=200)
 
     with pytest.raises(InvalidArchiveHost):
         download(archive_url, tmp_path.joinpath("likelihoods"), force=False)

--- a/tests/contrib/test_viz.py
+++ b/tests/contrib/test_viz.py
@@ -13,7 +13,9 @@ from pyhf.contrib.viz import brazil
 
 
 def test_brazil_band_collection(datadir):
-    data = json.load(datadir.joinpath("hypotest_results.json").open(encoding="utf-8"))
+    data = json.loads(
+        datadir.joinpath("hypotest_results.json").read_text(encoding="utf-8")
+    )
 
     fig = Figure()
     ax = fig.subplots()
@@ -31,8 +33,8 @@ def test_brazil_band_collection(datadir):
     assert brazil_band_collection.clb is None
     assert brazil_band_collection.axes == ax
 
-    data = json.load(
-        datadir.joinpath("tail_probs_hypotest_results.json").open(encoding="utf-8")
+    data = json.loads(
+        datadir.joinpath("tail_probs_hypotest_results.json").read_text(encoding="utf-8")
     )
 
     fig = Figure()
@@ -54,7 +56,9 @@ def test_brazil_band_collection(datadir):
 
 @pytest.mark.mpl_image_compare(tolerance=25)
 def test_plot_results(datadir):
-    data = json.load(datadir.joinpath("hypotest_results.json").open(encoding="utf-8"))
+    data = json.loads(
+        datadir.joinpath("hypotest_results.json").read_text(encoding="utf-8")
+    )
 
     fig = Figure()
     ax = fig.subplots()
@@ -68,7 +72,9 @@ def test_plot_results(datadir):
 
 @pytest.mark.mpl_image_compare(tolerance=25)
 def test_plot_results_no_axis(datadir):
-    data = json.load(datadir.joinpath("hypotest_results.json").open(encoding="utf-8"))
+    data = json.loads(
+        datadir.joinpath("hypotest_results.json").read_text(encoding="utf-8")
+    )
 
     mpl.use("agg")  # Use non-gui backend
     fig, ax = plt.subplots()
@@ -80,8 +86,8 @@ def test_plot_results_no_axis(datadir):
 
 @pytest.mark.mpl_image_compare(tolerance=25)
 def test_plot_results_components(datadir):
-    data = json.load(
-        datadir.joinpath("tail_probs_hypotest_results.json").open(encoding="utf-8")
+    data = json.loads(
+        datadir.joinpath("tail_probs_hypotest_results.json").read_text(encoding="utf-8")
     )
 
     fig = Figure()
@@ -94,8 +100,8 @@ def test_plot_results_components(datadir):
 
 @pytest.mark.mpl_image_compare(tolerance=25)
 def test_plot_results_components_no_clb(datadir):
-    data = json.load(
-        datadir.joinpath("tail_probs_hypotest_results.json").open(encoding="utf-8")
+    data = json.loads(
+        datadir.joinpath("tail_probs_hypotest_results.json").read_text(encoding="utf-8")
     )
 
     fig = Figure()
@@ -116,8 +122,8 @@ def test_plot_results_components_no_clb(datadir):
 
 @pytest.mark.mpl_image_compare(tolerance=25)
 def test_plot_results_components_no_clsb(datadir):
-    data = json.load(
-        datadir.joinpath("tail_probs_hypotest_results.json").open(encoding="utf-8")
+    data = json.loads(
+        datadir.joinpath("tail_probs_hypotest_results.json").read_text(encoding="utf-8")
     )
 
     fig = Figure()
@@ -138,8 +144,8 @@ def test_plot_results_components_no_clsb(datadir):
 
 @pytest.mark.mpl_image_compare(tolerance=25)
 def test_plot_results_components_no_cls(datadir):
-    data = json.load(
-        datadir.joinpath("tail_probs_hypotest_results.json").open(encoding="utf-8")
+    data = json.loads(
+        datadir.joinpath("tail_probs_hypotest_results.json").read_text(encoding="utf-8")
     )
 
     fig = Figure()
@@ -168,7 +174,9 @@ def test_plot_results_components_data_structure(datadir):
     """
     test results should have format of: [CLs_obs, [CLsb, CLb], [CLs_exp band]]
     """
-    data = json.load(datadir.joinpath("hypotest_results.json").open(encoding="utf-8"))
+    data = json.loads(
+        datadir.joinpath("hypotest_results.json").read_text(encoding="utf-8")
+    )
 
     fig = Figure()
     ax = fig.subplots()
@@ -184,7 +192,9 @@ def test_plot_results_wrong_axis_labels(datadir, mocker):
     values in label_part will be wrong, causing `next` to fail on the iterator
     for label_idx.
     """
-    data = json.load(datadir.joinpath("hypotest_results.json").open(encoding="utf-8"))
+    data = json.loads(
+        datadir.joinpath("hypotest_results.json").read_text(encoding="utf-8")
+    )
 
     fig = Figure()
     ax = fig.subplots()


### PR DESCRIPTION
# Description

* Needed for PR https://github.com/scikit-hep/pyhf/pull/2657
* Amends PR https://github.com/scikit-hep/pyhf/pull/2730

---

* `tests/contrib/test_viz.py` opened JSON files via `json.load(path.open(...))` and `tests/contrib/test_contrib_utils.py` read archives via `path.open("rb").read()`, never closing the file objects. When garbage collection finalized them, CPython emitted `ResourceWarning: unclosed file` and in Python 3.14 the leaked files raise the pytest warning

```
PytestUnraisableExceptionWarning: Exception ignored while finalizing file <_io.FileIO
```

Replace the leaking calls with `json.loads(path.read_text(...))` and `path.read_bytes()`, matching conventions in `tests/test_scripts.py`.

Assisted-by: ClaudeCode:claude-fable-5

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* tests/contrib/test_viz.py opened JSON files via json.load(path.open(...)) and
  tests/contrib/test_contrib_utils.py read archives via path.open("rb").read(),
  never closing the file objects. When garbage collection finalized them,
  CPython emitted 'ResourceWarning: unclosed file' and in Python 3.14 the leaked
  files raise the pytest warning

  PytestUnraisableExceptionWarning: Exception ignored while finalizing file <_io.FileIO

  Replace the leaking calls with 'json.loads(path.read_text(...))' and
  'path.read_bytes()', matching conventions in tests/test_scripts.py.
* Amends PR https://github.com/scikit-hep/pyhf/pull/2730

Assisted-by: ClaudeCode:claude-fable-5
```