### PR TITLE
fix: Ignore anyio use of pytest CallSpec2 during plugin import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ all = ["pyhf[backends,xmlio,contrib]"]
 [dependency-groups]
 test = [
     "scikit-hep-testdata>=0.4.11",
-    "pytest>=6.0",
+    "pytest>=8.4.0",
     "coverage[toml]>=6.0.0",
     "pytest-mock",
     "requests-mock>=1.9.0",
@@ -362,7 +362,7 @@ requests = ">=2.22.0"
 iminuit = ">=2.7.0"
 
 [tool.pixi.feature.test.dependencies]
-pytest = ">=6.0"
+pytest = ">=8.4.0"
 scikit-hep-testdata = ">=0.4.11"
 coverage = ">=6.0.0"
 pytest-mock = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,7 @@ filterwarnings = [
     "ignore:Hesse called with all parameters fixed:iminuit.warnings.IMinuitWarning",  # Issue #2637
     "ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",  # papermill
     "ignore:datetime.datetime.utcnow\\(\\) is deprecated:DeprecationWarning",  # papermill
+    "ignore:_pytest.python.CallSpec2 has been renamed to CallSpec",  # anyio, c.f. https://github.com/scikit-hep/pyhf/pull/2738
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
# Description

* Add a `filterwarnings` ignore for the `PytestRemovedIn10Warning` emitted when the `anyio` pytest plugin (`anyio` `v4.14.2` and below) imports the deprecated `_pytest.python.CallSpec2` alias, which was renamed to `CallSpec` in https://github.com/pytest-dev/pytest PR 14742.
   - As of https://github.com/pytest-dev/pytest PR 14776 `pytest` applies the `filterwarnings` `ini` configuration while importing plugins, so under `'filterwarnings = error'` the deprecation warning escalates to an error during plugin loading and crashes pytest at startup, before test collection.
   - Note that `pyhf` does not use `anyio`, but `anyio` is pulled in through `jupyter-server`.
* Use a message-only ignore, as the `pytest.PytestRemovedIn10Warning` class only exists for `pytest>=9.0`.
* Remove the ignore once an anyio release imports CallSpec directly.
   - This is a preventative change as this is only being caught in the HEAD of dependencies CI workflow.
* Update pytest lower bound to `v8.4.0`, which is the first pytest release to support Python 3.9+ (dropping Python 3.8 support).

Assisted-by: ClaudeCode:claude-fable-5

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add a filterwarnings ignore for the PytestRemovedIn10Warning emitted
  when the anyio pytest plugin (anyio v4.14.2 and below) imports the
  deprecated _pytest.python.CallSpec2 alias, which was renamed to
  CallSpec in https://github.com/pytest-dev/pytest PR 14742.
   - As of https://github.com/pytest-dev/pytest PR 14776 pytest applies
     the filterwarnings ini configuration while importing plugins, so under
     'filterwarnings = error' the deprecation warning escalates to an
     error during plugin loading and crashes pytest at startup, before
     test collection.
   - Note that pyhf does not use anyio, but anyio is pulled in through
     jupyter-server.
* Use a message-only ignore, as the pytest.PytestRemovedIn10Warning
  class only exists for pytest>=9.0.
* Remove the ignore once an anyio release imports CallSpec directly.
   - This is a preventative change as this is only being caught in
     the HEAD of dependencies CI workflow.
* Update pytest lower bound to v8.4.0, which is the first pytest release
  to support Python 3.9+ (dropping Python 3.8).

Assisted-by: ClaudeCode:claude-fable-5
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the testing requirements to support the latest pytest release.
  * Added compatibility handling for a renamed pytest warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->