### PR TITLE
fix: Ignore pytest-benchmark use of argparse.FileType during plugin import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,7 @@ filterwarnings = [
     "ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",  # papermill
     "ignore:datetime.datetime.utcnow\\(\\) is deprecated:DeprecationWarning",  # papermill
     "ignore:_pytest.python.CallSpec2 has been renamed to CallSpec",  # anyio, c.f. https://github.com/scikit-hep/pyhf/pull/2738
+    "ignore:FileType is deprecated. Simply open files after parsing arguments.:PendingDeprecationWarning",  # pytest-benchmark, c.f. https://github.com/scikit-hep/pyhf/pull/2739
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
# Description

* Add a filterwarnings ignore for the PendingDeprecationWarning emitted on Python 3.14 when the pytest-benchmark pytest plugin (v5.2.3 and below) constructs argparse.FileType for its --benchmark-json option during plugin registration. argparse.FileType is deprecated as of Python 3.14.
   - Fixed upstream in https://github.com/ionelmc/pytest-benchmark/pull/310. Remove the ignore once a pytest-benchmark release newer than v5.2.3 is available.
* Amends PR https://github.com/scikit-hep/pyhf/pull/2738

Assisted-by: ClaudeCode:claude-fable-5

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add a filterwarnings ignore for the PendingDeprecationWarning emitted on
  Python 3.14 when the pytest-benchmark pytest plugin (v5.2.3 and below)
  constructs argparse.FileType for its --benchmark-json option during plugin
  registration. argparse.FileType is deprecated as of Python 3.14.
   - Fixed upstream in https://github.com/ionelmc/pytest-benchmark PR 310.
     Remove the ignore once a pytest-benchmark release newer than v5.2.3
     is available.
* Amends PR https://github.com/scikit-hep/pyhf/pull/2738

Assisted-by: ClaudeCode:claude-fable-5
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to suppress known `FileType` deprecation warnings during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->