### PR TITLE
ci: Harden semantic PR check against pull_request_target risks

### DIFF
--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -1,5 +1,11 @@
 name: Semantic Pull Request
 
+# SECURITY: pull_request_target is required by amannn/action-semantic-pull-request
+# so the check works on PRs from forks and uses this workflow definition from the
+# default branch (PR authors can't alter the check). It runs with an elevated
+# GITHUB_TOKEN, which is safe here ONLY because this workflow never checks out or
+# executes anything from the PR and token permissions are restricted below.
+# c.f. https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/
 on:
   pull_request_target:
     types:
@@ -11,20 +17,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   main:
 
     permissions:
-      pull-requests: read  # for amannn/action-semantic-pull-request to analyze PRs
-      statuses: write  # for amannn/action-semantic-pull-request to mark status of analyzed PR
+      pull-requests: read  # for amannn/action-semantic-pull-request to read PR titles
     name: Validate PR title
     runs-on: ubuntu-latest
 
     steps:
       - name: Check PR title matches Conventional Commits spec
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

* While the `pull_request_target trigger` is required by https://github.com/amannn/action-semantic-pull-request to validate PRs from forks with the workflow definition taken from the default branch, its elevated `GITHUB_TOKEN` is hardened.
   -  Pin `amannn/action-semantic-pull-request` to the full commit SHA so a moved tag can't run unreviewed code with the elevated token.
   -  Removed `'statuses: write'` job permission as unused in `v6+` of the action, and so use `'pull-requests: read'`.
   -  Set the workflow-level default permissions to deny-all (`'{}'`). The only job declares its own permissions block, so this only guards any future jobs added without one.
   -  Note why the trigger is acceptable here (no checkout or execution of PR-controlled content) and that future revisions must not change this.
* GitHub actions have also hardened pull_request_target in general so that it
  is no longer a direct security threat.
   - https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/

Assisted-by: ClaudeCode:claude-fable-5

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
ci: Harden semantic PR check against pull_request_target risks 

* While the pull_request_target trigger is required by
  amannn/action-semantic-pull-request to validate PRs from forks with the
  workflow definition taken from the default branch, its elevated
  GITHUB_TOKEN is hardened.
   -  Pin amannn/action-semantic-pull-request to the full commit SHA so a
      moved tag can't run unreviewed code with the elevated token.
   -  Removed 'statuses: write' job permission as unused in v6+ of the action,
      and so use 'pull-requests: read'.
   -  Set the workflow-level default permissions to deny-all ('{}'). The only
      job declares its own permissions block, so this only guards any
      future jobs added without one.
   -  Note why the trigger is acceptable here (no checkout or execution of
      PR-controlled content) and that future revisions must not change this.
* GitHub actions have also hardened pull_request_target in general so that it
  is no longer a direct security threat.
   - https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/

Assisted-by: ClaudeCode:claude-fable-5
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Improved pull request validation workflow security.
  * Restricted workflow permissions to the minimum required access.
  * Pinned the validation action to a specific version for more predictable execution.
  * Added documentation clarifying security considerations.
  * Reduced the risk of unintended access during automated validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->