### PR TITLE
chore: Use prek instead of pre-commit for local development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,10 +58,10 @@ You can install the development environment (which includes a number of extra) l
 python -m pip install --upgrade --editable . --group dev
 ```
 
-To make the PR process much smoother we also strongly recommend that you setup the Git pre-commit hook for [Ruff](https://github.com/astral-sh/ruff) by running
+To make the PR process much smoother we also strongly recommend that you setup the Git pre-commit hook for [Ruff](https://github.com/astral-sh/ruff) with [prek](https://github.com/j178/prek) by running
 
 ```console
-pre-commit install
+prek install
 ```
 
 This will run `ruff` over your code each time you attempt to make a commit and warn you if there is an error, canceling the commit.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -22,16 +22,17 @@ and install all necessary packages for development
 
     python -m pip install --upgrade --editable . --group dev
 
-Then setup the Git `pre-commit <https://pre-commit.com/>`__ hooks by running
+Then setup the Git pre-commit hooks with `prek <https://github.com/j178/prek>`__
+by running
 
 .. code-block:: console
 
-    pre-commit install
+    prek install
 
 inside of the virtual environment.
 `pre-commit.ci <https://pre-commit.ci/>`__ keeps the pre-commit hooks updated
-through time, so pre-commit will automatically update itself when you run it
-locally after the hooks were updated.
+through time, so the hooks will automatically be updated when you run ``prek``
+locally after the hook revisions were updated.
 
 It is then suggested that you use ``nox`` to actually run all development operations
 in "sessions" defined in ``noxfile.py``.
@@ -44,12 +45,12 @@ To list all of the available sessions run
 Linting
 -------
 
-Linting and code formatting is handled by ``pre-commit``.
-To run the linting either run ``pre-commit``
+Linting and code formatting is handled by ``prek``.
+To run the linting either run ``prek``
 
 .. code-block:: console
 
-    pre-commit run --all-files
+    prek run --all-files
 
 or use ``nox``
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,10 +17,10 @@ DIR = Path(__file__).parent.resolve()
 @nox.session(reuse_venv=True)
 def lint(session):
     """
-    Lint with pre-commit.
+    Lint with prek.
     """
-    session.install("--upgrade", "pre-commit")
-    session.run("pre-commit", "run", "--all-files", *session.posargs)
+    session.install("--upgrade", "prek")
+    session.run("prek", "run", "--all-files", *session.posargs)
 
 
 @nox.session(python=ALL_PYTHONS, reuse_venv=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ docs = [
 dev = [
     "pyhf[all]",
     "tbump>=6.7.0",
-    "pre-commit",
+    "prek",
     "nox",
     "sphinx-autobuild>=2025.8.25",
     { include-group = "test" },
@@ -437,14 +437,14 @@ default-environment = "docs"
 
 [tool.pixi.feature.dev.dependencies]
 tbump = ">=6.7.0"
-pre-commit = ">=4.5.1"
+prek = ">=0.4.13"
 nox = ">=2025.11.12"
 # docs environment should contain only required dependencies for deploying docs
 sphinx-autobuild = ">=2025.8.25"
 
 [tool.pixi.feature.dev.tasks.lint]
-description = "Run pre-commit"
-cmd = "pre-commit run --all-files"
+description = "Run prek"
+cmd = "prek run --all-files"
 
 [tool.pixi.feature.dev.tasks.watch-docs]
 description = "Build the pyhf documentation and auto-reload on changes"


### PR DESCRIPTION
# Description

* Use [`prek`](https://github.com/j178/prek) for all local developer workflows instead of `pre-commit`.
   - Update the 'dev' dependency group, the Pixi dev feature and lint task, the nox lint session.
* Update the developer documentation to indicate use of `prek`.
* Continue to use pre-commit.ci as the CI service, as both `pre-commit` and `prek` use `.pre-commit-config.yaml`.

Assisted-by: ClaudeCode:claude-fable-5

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use prek (https://github.com/j178/prek) for all local developer workflows
  instead of pre-commit.
   - Update the 'dev' dependency group, the Pixi dev feature and lint task, the
     nox lint session.
* Update the developer documentation to indicate use of prek.
* Continue to use pre-commit.ci as the CI service, as both pre-commit and prek
  use .pre-commit-config.yaml.

Assisted-by: ClaudeCode:claude-fable-5
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup and linting instructions to use `prek` for Git hooks and code checks.

* **Chores**
  * Replaced the previous hook and linting tool with `prek` across the development workflow.
  * Updated automated lint sessions and development requirements accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->