### PR TITLE
ci: harden GitHub Actions security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
-      actions:
+      github-actions:
         patterns:
           - "*"
     labels:
@@ -14,6 +14,8 @@ updates:
       - "dependencies"
     reviewers:
       - "matthewfeickert"
+    cooldown:
+      default-days: 7
 
   # Ignore all pip dependencies to avoid PRs to update tests/constraints.txt
   - package-ecosystem: "pip"
@@ -22,3 +24,5 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -33,11 +33,17 @@ on:
         description: 'Perform a dry run to check'
         default: true
 
+concurrency:
+  # Queue rather than cancel-in-progress: this job pushes tags, and an in-flight
+  # push should not be interrupted by a subsequent trigger.
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   contents: read
 
 jobs:
   bump-version:
+    name: Bump version
     permissions:
       contents: write  # for Git to git push
     runs-on: ubuntu-latest
@@ -46,11 +52,12 @@ jobs:
     steps:
     # Use GitHub PAT to authenticate so other workflows trigger
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ github.event.inputs.target_branch }}
         fetch-depth: 0
         token: ${{ secrets.ACCESS_TOKEN }}
+        persist-credentials: false
 
     - name: Check target branch is intended for release
       if: github.event.inputs.force == 'false'
@@ -77,13 +84,13 @@ jobs:
         echo "* Current version: ${current_tag}"
         echo "* Latest stable version: ${latest_stable_tag}"
 
-        if [ ${{ github.event.inputs.release_candidate }} == 'true' ]; then
-            echo "* Attempting a ${{ github.event.inputs.part }} version release candidate bump from ${current_tag} to: ${{ github.event.inputs.new_version }}"
+        if [ ${GITHUB_EVENT_INPUTS_RELEASE_CANDIDATE} == 'true' ]; then
+            echo "* Attempting a ${GITHUB_EVENT_INPUTS_PART} version release candidate bump from ${current_tag} to: ${GITHUB_EVENT_INPUTS_NEW_VERSION}"
         else
             # For ease of use, set current tag to latest stable
             current_tag="${latest_stable_tag}"
 
-            echo "* Attempting a ${{ github.event.inputs.part }} version bump from ${current_tag} to: ${{ github.event.inputs.new_version }}"
+            echo "* Attempting a ${GITHUB_EVENT_INPUTS_PART} version bump from ${current_tag} to: ${GITHUB_EVENT_INPUTS_NEW_VERSION}"
         fi
 
         echo "* Validating bump target version matches SemVer..."
@@ -102,7 +109,7 @@ jobs:
 
         # IFS is single charecter, so split on the 'r' in "rc"
         IFS='r' read bump_version bump_rc <<EOF
-        ${{ github.event.inputs.new_version }}
+        ${GITHUB_EVENT_INPUTS_NEW_VERSION}
         EOF
         bump_rc="${bump_rc:1}"
 
@@ -113,91 +120,95 @@ jobs:
         unset bump_version
 
         # Check release candidates are valid before proceeding
-        if [ ${{ github.event.inputs.release_candidate }} == 'true' ]; then
+        if [ ${GITHUB_EVENT_INPUTS_RELEASE_CANDIDATE} == 'true' ]; then
             if [ -z "${current_rc}" ]; then
                 current_rc=0
             fi
             if [ "${bump_rc}" != "$((${current_rc} + 1))" ]; then
-                echo "ERROR: ${{ github.event.inputs.new_version }} is more than 1 release candidate version greater then ${current_tag}"
+                echo "ERROR: ${GITHUB_EVENT_INPUTS_NEW_VERSION} is more than 1 release candidate version greater then ${current_tag}"
                 exit 1
             fi
         else
             if [ ! -z "${bump_rc}" ]; then
-                echo "ERROR: ${{ github.event.inputs.new_version }} contains a release candidate signature rc${bump_rc} but was marked as stable release."
+                echo "ERROR: ${GITHUB_EVENT_INPUTS_NEW_VERSION} contains a release candidate signature rc${bump_rc} but was marked as stable release."
                 exit 1
             fi
         fi
 
-        if [ ${{ github.event.inputs.part }} == "major" ]; then
+        if [ ${GITHUB_EVENT_INPUTS_PART} == "major" ]; then
             # Minor version should be zero
             if [ "${bump_minor}" != "0" ]; then
-                echo "ERROR: ${{ github.event.inputs.part }} release attempted, ${{ github.event.inputs.new_version }} minor version should equal 0."
+                echo "ERROR: ${GITHUB_EVENT_INPUTS_PART} release attempted, ${GITHUB_EVENT_INPUTS_NEW_VERSION} minor version should equal 0."
                 exit 1
             fi
             # Patch version should be zero
             if [ "${bump_patch}" != "0" ]; then
-                echo "ERROR: ${{ github.event.inputs.part }} release attempted, ${{ github.event.inputs.new_version }} patch version should equal 0."
+                echo "ERROR: ${GITHUB_EVENT_INPUTS_PART} release attempted, ${GITHUB_EVENT_INPUTS_NEW_VERSION} patch version should equal 0."
                 exit 1
             fi
             if [ "${bump_major}" != "$((${current_major} + 1))" ]; then
-                if ! ([ "${bump_major}" == "${current_major}" ] && [ ${{ github.event.inputs.release_candidate }} == 'true' ]); then
-                    echo "ERROR: ${{ github.event.inputs.part }} release candidate release attempted, but ${{ github.event.inputs.new_version }} is more than 1 ${{ github.event.inputs.part }} version greater then ${current_tag}."
+                if ! ([ "${bump_major}" == "${current_major}" ] && [ ${GITHUB_EVENT_INPUTS_RELEASE_CANDIDATE} == 'true' ]); then
+                    echo "ERROR: ${GITHUB_EVENT_INPUTS_PART} release candidate release attempted, but ${GITHUB_EVENT_INPUTS_NEW_VERSION} is more than 1 ${GITHUB_EVENT_INPUTS_PART} version greater then ${current_tag}."
                     exit 1
                 fi
             fi
         fi
 
-        if [ ${{ github.event.inputs.part }} == "minor" ]; then
+        if [ ${GITHUB_EVENT_INPUTS_PART} == "minor" ]; then
             # Major versions should be equal
             if [ "${bump_major}" != "${current_major}" ]; then
-                echo "ERROR: ${{ github.event.inputs.part }} release attempted, but ${{ github.event.inputs.new_version }} major version not equal to ${current_tag}."
+                echo "ERROR: ${GITHUB_EVENT_INPUTS_PART} release attempted, but ${GITHUB_EVENT_INPUTS_NEW_VERSION} major version not equal to ${current_tag}."
                 exit 1
             fi
             # Patch version should be zero
             if [ "${bump_patch}" != "0" ]; then
-                echo "ERROR: ${{ github.event.inputs.part }} release attempted, ${{ github.event.inputs.new_version }} patch version should equal 0."
+                echo "ERROR: ${GITHUB_EVENT_INPUTS_PART} release attempted, ${GITHUB_EVENT_INPUTS_NEW_VERSION} patch version should equal 0."
                 exit 1
             fi
             if [ "${bump_minor}" != "$((${current_minor} + 1))" ]; then
-                if ! ([ "${bump_minor}" == "${current_minor}" ] && [ ${{ github.event.inputs.release_candidate }} == 'true' ]); then
-                    echo "ERROR: ${{ github.event.inputs.part }} release candidate release attempted, but ${{ github.event.inputs.new_version }} is more than 1 ${{ github.event.inputs.part }} version greater then ${current_tag}."
+                if ! ([ "${bump_minor}" == "${current_minor}" ] && [ ${GITHUB_EVENT_INPUTS_RELEASE_CANDIDATE} == 'true' ]); then
+                    echo "ERROR: ${GITHUB_EVENT_INPUTS_PART} release candidate release attempted, but ${GITHUB_EVENT_INPUTS_NEW_VERSION} is more than 1 ${GITHUB_EVENT_INPUTS_PART} version greater then ${current_tag}."
                     exit 1
                 fi
             fi
         fi
 
-        if [ ${{ github.event.inputs.part }} == "patch" ]; then
+        if [ ${GITHUB_EVENT_INPUTS_PART} == "patch" ]; then
             # Major versions should be equal
             if [ "${bump_major}" != "${current_major}" ]; then
-                echo "ERROR: ${{ github.event.inputs.part }} release attempted, but ${{ github.event.inputs.new_version }} major version not equal to ${current_tag}."
+                echo "ERROR: ${GITHUB_EVENT_INPUTS_PART} release attempted, but ${GITHUB_EVENT_INPUTS_NEW_VERSION} major version not equal to ${current_tag}."
                 exit 1
             fi
             # Minor versions should be equal
             if [ "${bump_minor}" != "${current_minor}" ]; then
-                echo "ERROR: ${{ github.event.inputs.part }} release attempted, but ${{ github.event.inputs.new_version }} minor version not equal to ${current_tag}."
+                echo "ERROR: ${GITHUB_EVENT_INPUTS_PART} release attempted, but ${GITHUB_EVENT_INPUTS_NEW_VERSION} minor version not equal to ${current_tag}."
                 exit 1
             fi
             if [ "${bump_patch}" != "$((${current_patch} + 1))" ]; then
-                if ! ([ "${bump_patch}" == "${current_patch}" ] && [ ${{ github.event.inputs.release_candidate }} == 'true' ]); then
-                    echo "ERROR: ${{ github.event.inputs.part }} release candidate release attempted, but ${{ github.event.inputs.new_version }} is more than 1 ${{ github.event.inputs.part }} version greater then ${current_tag}."
+                if ! ([ "${bump_patch}" == "${current_patch}" ] && [ ${GITHUB_EVENT_INPUTS_RELEASE_CANDIDATE} == 'true' ]); then
+                    echo "ERROR: ${GITHUB_EVENT_INPUTS_PART} release candidate release attempted, but ${GITHUB_EVENT_INPUTS_NEW_VERSION} is more than 1 ${GITHUB_EVENT_INPUTS_PART} version greater then ${current_tag}."
                     exit 1
                 fi
             fi
         fi
 
         echo "  ...version bump validated!"
-        if [ ${{ github.event.inputs.release_candidate }} == 'true' ]; then
-            echo "* Bumping version ${current_tag} to ${{ github.event.inputs.part }} version release candidate ${{ github.event.inputs.new_version }}"
+        if [ ${GITHUB_EVENT_INPUTS_RELEASE_CANDIDATE} == 'true' ]; then
+            echo "* Bumping version ${current_tag} to ${GITHUB_EVENT_INPUTS_PART} version release candidate ${GITHUB_EVENT_INPUTS_NEW_VERSION}"
         else
-            echo "* Bumping version ${current_tag} to ${{ github.event.inputs.part }} version ${{ github.event.inputs.new_version }}"
+            echo "* Bumping version ${current_tag} to ${GITHUB_EVENT_INPUTS_PART} version ${GITHUB_EVENT_INPUTS_NEW_VERSION}"
         fi
 
         echo "steps.script.outputs.old_tag=v${current_tag}"
         echo "old_tag=v${current_tag}" >> $GITHUB_OUTPUT
+      env:
+        GITHUB_EVENT_INPUTS_RELEASE_CANDIDATE: ${{ github.event.inputs.release_candidate }}
+        GITHUB_EVENT_INPUTS_PART: ${{ github.event.inputs.part }}
+        GITHUB_EVENT_INPUTS_NEW_VERSION: ${{ github.event.inputs.new_version }}
 
     - name: Set up Python
       if: success()
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.14'
 
@@ -222,16 +233,18 @@ jobs:
         )
       shell: bash
       run: |
-        tbump --non-interactive --no-push ${{ github.event.inputs.new_version }}
+        tbump --non-interactive --no-push ${GITHUB_EVENT_INPUTS_NEW_VERSION}
+      env:
+        GITHUB_EVENT_INPUTS_NEW_VERSION: ${{ github.event.inputs.new_version }}
 
     - name: Update the Git tag annotation
-      if: ${{ github.event.inputs.dry_run }} == 'false'
+      if: github.event.inputs.dry_run == 'false'
       shell: bash
       run: |
-        OLD_TAG=${{ steps.script.outputs.old_tag }}
+        OLD_TAG=${STEPS_SCRIPT_OUTPUTS_OLD_TAG}
         git tag -n99 --list "${OLD_TAG}"
 
-        NEW_TAG=v${{ github.event.inputs.new_version }}
+        NEW_TAG=v${GITHUB_EVENT_INPUTS_NEW_VERSION}
         git tag -n99 --list "${NEW_TAG}"
 
         CHANGES=$(git log --pretty=format:'%s' "${OLD_TAG}"..HEAD --regexp-ignore-case --extended-regexp --grep='^([a-z]*?):')
@@ -245,24 +258,34 @@ jobs:
         SANITIZED_CHANGES=$(echo "${CHANGES}" | sed -e 's/^/<li>/' -e 's|$|</li>|' -e 's/(#[0-9]\+)//' -e 's/"/'"'"'/g')
         NUM_CHANGES=$(echo -n "${CHANGES}" | grep -c '^')
 
-        if [ ${{ github.event.inputs.release_candidate }} == 'true' ]; then
-            git tag "${NEW_TAG}" "${NEW_TAG}"^{} -f -m "$(printf "This is a ${{ github.event.inputs.part }} release candidate from ${OLD_TAG} → ${NEW_TAG}.\n\nChanges:\n${CHANGES_NEWLINE}")"
+        if [ ${GITHUB_EVENT_INPUTS_RELEASE_CANDIDATE} == 'true' ]; then
+            git tag "${NEW_TAG}" "${NEW_TAG}"^{} -f -m "$(printf "This is a ${GITHUB_EVENT_INPUTS_PART} release candidate from ${OLD_TAG} → ${NEW_TAG}.\n\nChanges:\n${CHANGES_NEWLINE}")"
         else
-            git tag "${NEW_TAG}" "${NEW_TAG}"^{} -f -m "$(printf "This is a ${{ github.event.inputs.part }} release from ${OLD_TAG} → ${NEW_TAG}.\n\nChanges:\n${CHANGES_NEWLINE}")"
+            git tag "${NEW_TAG}" "${NEW_TAG}"^{} -f -m "$(printf "This is a ${GITHUB_EVENT_INPUTS_PART} release from ${OLD_TAG} → ${NEW_TAG}.\n\nChanges:\n${CHANGES_NEWLINE}")"
         fi
 
         git tag -n99 --list "${NEW_TAG}"
+      env:
+        STEPS_SCRIPT_OUTPUTS_OLD_TAG: ${{ steps.script.outputs.old_tag }}
+        GITHUB_EVENT_INPUTS_NEW_VERSION: ${{ github.event.inputs.new_version }}
+        GITHUB_EVENT_INPUTS_RELEASE_CANDIDATE: ${{ github.event.inputs.release_candidate }}
+        GITHUB_EVENT_INPUTS_PART: ${{ github.event.inputs.part }}
 
     - name: Show annotated Git tag
       shell: bash
       run: |
-        git show v${{ github.event.inputs.new_version }}
+        git show v${GITHUB_EVENT_INPUTS_NEW_VERSION}
+      env:
+        GITHUB_EVENT_INPUTS_NEW_VERSION: ${{ github.event.inputs.new_version }}
 
     - name: Push new tag back to GitHub
       shell: bash
       run: |
-        if [ ${{ github.event.inputs.dry_run }} == 'true' ]; then
+        if [ ${GITHUB_EVENT_INPUTS_DRY_RUN} == 'true' ]; then
             echo "# DRY RUN"
         else
-            git push origin ${{ github.event.inputs.target_branch }} --tags
+            git push origin ${GITHUB_EVENT_INPUTS_TARGET_BRANCH} --tags
         fi
+      env:
+        GITHUB_EVENT_INPUTS_DRY_RUN: ${{ github.event.inputs.dry_run }}
+        GITHUB_EVENT_INPUTS_TARGET_BRANCH: ${{ github.event.inputs.target_branch }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   test:
+    name: Test on Windows
 
     runs-on: ${{ matrix.os }}
     strategy:
@@ -23,10 +24,12 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   test:
+    name: Test
 
     runs-on: ${{ matrix.os }}
     # On push events run the CI only on main by default, but run on any branch if the commit message contains '[ci all]'
@@ -39,10 +40,12 @@ jobs:
             python-version: '3.13'
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -65,7 +68,7 @@ jobs:
 
     - name: Launch a tmate session if tests fail
       if: failure() && github.event_name == 'workflow_dispatch'
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113 # v3.24
 
     - name: Coverage report for core project
       run: |
@@ -78,7 +81,7 @@ jobs:
         github.event_name != 'schedule' &&
         matrix.os == 'ubuntu-latest' &&
         github.repository == 'scikit-hep/pyhf'
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         fail_ci_if_error: true
         files: ./coverage.xml
@@ -96,7 +99,7 @@ jobs:
 
     - name: Report contrib coverage with Codecov
       if: github.event_name != 'schedule' && matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest' && github.repository == 'scikit-hep/pyhf'
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         fail_ci_if_error: true
         files: ./coverage.xml
@@ -116,7 +119,7 @@ jobs:
 
     - name: Report doctest coverage with Codecov
       if: github.event_name != 'schedule' && matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest' && github.repository == 'scikit-hep/pyhf'
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         fail_ci_if_error: true
         files: doctest-coverage.xml

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,11 +29,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.6
+      uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       with:
         languages: python
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -42,4 +44,4 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.37.6
+      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/dependencies-head.yml
+++ b/.github/workflows/dependencies-head.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   release-candidates:
+    name: Test with release candidate dependencies
 
     if: github.repository == 'scikit-hep/pyhf'
     runs-on: ${{ matrix.os }}
@@ -24,10 +25,12 @@ jobs:
         python-version: ['3.14']
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -46,6 +49,7 @@ jobs:
         pytest --ignore tests/contrib --ignore tests/benchmarks --ignore tests/test_notebooks.py
 
   scipy:
+    name: Test with scipy HEAD
 
     if: github.repository == 'scikit-hep/pyhf'
     runs-on: ${{ matrix.os }}
@@ -55,10 +59,12 @@ jobs:
         python-version: ['3.14']
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -76,6 +82,7 @@ jobs:
         pytest --ignore tests/contrib --ignore tests/benchmarks --ignore tests/test_notebooks.py
 
   iminuit:
+    name: Test with iminuit HEAD
 
     if: github.repository == 'scikit-hep/pyhf'
     runs-on: ${{ matrix.os }}
@@ -85,9 +92,11 @@ jobs:
         python-version: ['3.14']
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -103,6 +112,7 @@ jobs:
         pytest --ignore tests/contrib --ignore tests/benchmarks --ignore tests/test_notebooks.py
 
   uproot5:
+    name: Test with uproot5 HEAD
 
     if: github.repository == 'scikit-hep/pyhf'
     runs-on: ${{ matrix.os }}
@@ -112,9 +122,11 @@ jobs:
         python-version: ['3.14']
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -129,6 +141,7 @@ jobs:
         pytest --ignore tests/contrib --ignore tests/benchmarks --ignore tests/test_notebooks.py
 
   matplotlib:
+    name: Test with matplotlib nightly
 
     if: github.repository == 'scikit-hep/pyhf'
     runs-on: ${{ matrix.os }}
@@ -138,10 +151,12 @@ jobs:
         python-version: ['3.14']
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -168,6 +183,7 @@ jobs:
         pytest tests/contrib
 
   pytest:
+    name: Test with pytest HEAD
 
     if: github.repository == 'scikit-hep/pyhf'
     runs-on: ${{ matrix.os }}
@@ -177,9 +193,11 @@ jobs:
         python-version: ['3.14']
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,9 +32,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Prepare
         id: prep
         run: |
@@ -43,13 +44,14 @@ jobs:
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF_NAME}
           elif [[ $GITHUB_REF == refs/pull/* ]]; then
-            VERSION=pr-${{ github.event.number }}
+            VERSION=pr-${GITHUB_EVENT_NUMBER}
           fi
           TAGS="${DOCKER_IMAGE}:${VERSION}"
           TAGS="$TAGS,${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
           # Releases also have GITHUB_REFs that are tags, so reuse VERSION
-          if [ "${{ github.event_name }}" = "release" ]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable,ghcr.io/${{github.repository}}:latest-stable,ghcr.io/${{github.repository}}:${VERSION}"
+          # GITHUB_EVENT_NAME and GITHUB_REPOSITORY are default runner environment variables
+          if [ "${GITHUB_EVENT_NAME}" = "release" ]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable,ghcr.io/${GITHUB_REPOSITORY}:latest-stable,ghcr.io/${GITHUB_REPOSITORY}:${VERSION}"
           fi
           echo "steps.prep.outputs.version=${VERSION}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
@@ -57,23 +59,25 @@ jobs:
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
           echo "steps.prep.outputs.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_EVENT_NUMBER: ${{ github.event.number }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to DockerHub
         if: github.event_name != 'pull_request' && github.repository == 'scikit-hep/pyhf'
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request' && github.repository == 'scikit-hep/pyhf'
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -81,7 +85,7 @@ jobs:
 
       - name: Test build
         id: docker_build_test
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: docker/Dockerfile
@@ -94,7 +98,9 @@ jobs:
           push: false
 
       - name: Image digest
-        run: echo ${{ steps.docker_build_test.outputs.digest }}
+        run: echo ${STEPS_DOCKER_BUILD_TEST_OUTPUTS_DIGEST}
+        env:
+          STEPS_DOCKER_BUILD_TEST_OUTPUTS_DIGEST: ${{ steps.docker_build_test.outputs.digest }}
 
       - name: List built images
         run: docker images
@@ -117,7 +123,7 @@ jobs:
         # every PR will trigger a push event on main, so check the push event is actually coming from main
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'scikit-hep/pyhf'
         id: docker_build_latest
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: docker/Dockerfile
@@ -134,7 +140,7 @@ jobs:
       - name: Build and publish to registry with release tag
         if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf'
         id: docker_build_release
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: docker/Dockerfile

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,12 +20,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.14'
 
@@ -63,7 +64,7 @@ jobs:
         jsonschema <(curl -sL "https://citation-file-format.github.io/1.2.0/schema.json") --instance <(cat CITATION.cff | yq)
 
     - name: Check for broken links
-      uses: lycheeverse/lychee-action@v2
+      uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
       with:
         args: docs/
 
@@ -91,7 +92,7 @@ jobs:
         done
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v5
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       with:
         path: 'docs/_build/html'
 
@@ -102,8 +103,8 @@ jobs:
     # Set permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
     permissions:
       contents: read
-      pages: write
-      id-token: write
+      pages: write  # for actions/deploy-pages to deploy to GitHub Pages
+      id-token: write  # for actions/deploy-pages to verify deployment origin
 
     environment:
       name: github-pages
@@ -113,8 +114,8 @@ jobs:
 
     steps:
     - name: Setup Pages
-      uses: actions/configure-pages@v6
+      uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v5
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,9 +18,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Lint Dockerfile
-      uses: hadolint/hadolint-action@v3.4.0
+      uses: hadolint/hadolint-action@2a66e89f53d0771bb131a7fa31f3136336094aa6 # v3.4.0
       with:
         dockerfile: docker/Dockerfile

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -6,11 +6,16 @@ on:
   - cron:  '1 0 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   test:
+    name: Test with minimum supported dependencies
 
     runs-on: ${{ matrix.os }}
     strategy:
@@ -20,10 +25,12 @@ jobs:
         python-version: ['3.9']
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -5,6 +5,10 @@ on:
     types: [closed]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -14,7 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Trigger Binder build
       run: |
         # Use Binder build API to trigger repo2docker to build image on Google Cloud and Turing Institute Binder Federation clusters

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   test:
+    name: Test example notebooks
 
     runs-on: ubuntu-latest
     strategy:
@@ -22,10 +23,12 @@ jobs:
         python-version: ['3.14']
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -33,16 +33,17 @@ jobs:
     name: Build Python distribution
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      attestations: write
+      id-token: write  # for actions/attest-build-provenance to sign the attestation
+      attestations: write  # for actions/attest-build-provenance to upload the attestation
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.14'
 
@@ -114,7 +115,7 @@ jobs:
         subject-path: "dist/pyhf-*"
 
     - name: Upload distribution artifact
-      uses: actions/upload-artifact@v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: dist-artifact
         path: dist
@@ -127,14 +128,14 @@ jobs:
     # Mandatory for publishing with a trusted publisher
     # c.f. https://docs.pypi.org/trusted-publishers/using-a-publisher/
     permissions:
-      id-token: write
+      id-token: write  # for pypa/gh-action-pypi-publish trusted publishing
     # Restrict to the environment set for the trusted publisher
     environment:
       name: publish-package
 
     steps:
     - name: Download distribution artifact
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: dist-artifact
         path: dist
@@ -150,7 +151,7 @@ jobs:
         || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf')
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh attestation verify dist/pyhf-*.tar.gz --repo ${{ github.repository }}
+      run: gh attestation verify dist/pyhf-*.tar.gz --repo "$GITHUB_REPOSITORY"
 
     - name: Verify wheel artifact attestation
       # If publishing to TestPyPI or PyPI
@@ -160,7 +161,7 @@ jobs:
         || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf')
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh attestation verify dist/pyhf-*.whl --repo ${{ github.repository }}
+      run: gh attestation verify dist/pyhf-*.whl --repo "$GITHUB_REPOSITORY"
 
     - name: Publish distribution 📦 to Test PyPI
       # Publish to TestPyPI on tag events of if manually triggered
@@ -168,13 +169,13 @@ jobs:
       if: >-
         (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'scikit-hep/pyhf')
         || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'scikit-hep/pyhf')
-      uses: pypa/gh-action-pypi-publish@v1.14.2
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
       with:
         repository-url: https://test.pypi.org/legacy/
         print-hash: true
 
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf'
-      uses: pypa/gh-action-pypi-publish@v1.14.2
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
       with:
         print-hash: true

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
 
   pypi_release:
+    name: Test current PyPI release
 
     if: github.repository == 'scikit-hep/pyhf'
     runs-on: ${{ matrix.os }}
@@ -32,10 +33,12 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,6 +14,10 @@ on:
   push:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Declare default permissions as read only.
 permissions: read-all
 
@@ -22,17 +26,15 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
-      id-token: write
+      security-events: write  # to upload the results to code-scanning dashboard
+      id-token: write  # to publish results and get a badge (see publish_results below)
       # Uncomment the permissions below if installing in a private repository.
       # contents: read
       # actions: read
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@b9e0990d219a03df7633c93f6f005a8fecbcab22 # v4.1.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -59,7 +61,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.3.7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
@@ -68,6 +70,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@7d9249f5a57288b8a472ddd9cc3ece1921f7dc38 # v3.30.8
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,16 @@
+rules:
+  excessive-permissions:
+    ignore:
+      # OSSF Scorecard's official starter workflow, which recommends
+      # `permissions: read-all` at the workflow level as a documented default;
+      # the analysis job below already scopes its own write permissions down
+      # to only security-events and id-token.
+      - scorecard.yml:22
+
+  dangerous-triggers:
+    ignore:
+      # pull_request_target is required here so amannn/action-semantic-pull-request
+      # can check PR titles on PRs from forks using the workflow definition from
+      # the default branch. The workflow never checks out or executes PR content
+      # and permissions are restricted to pull-requests: read (see in-file comment).
+      - semantic-pr-check.yml:9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,3 +84,9 @@ repos:
     - id: check-github-workflows
       args: ["--verbose"]
 
+- repo: https://github.com/zizmorcore/zizmor-pre-commit
+  rev: 451b56af716f9f0d0c2b816503a3fd0cf8b036fa  # frozen: v1.29.0
+  hooks:
+    - id: zizmor
+      files: "^\\.github"
+      args: [--persona=pedantic]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
     - id: check-added-large-files
     - id: check-case-conflict
@@ -29,27 +29,27 @@ repos:
       exclude: ^validation/|\.dtd$|\.xml$
 
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: "v1.10.0"
+  rev: "3a6eb0fadf60b3cccfd80bad9dbb6fae7e47b316"  # frozen: v1.10.0
   hooks:
     - id: rst-backticks
     - id: rst-directive-colons
     - id: rst-inline-touching-normal
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: "v0.16.1"
+  rev: "39d9ac5938dadb73df0564a45f163e25ff9fa6e2"  # frozen: v0.16.1
   hooks:
     - id: ruff-check
       args: ["--fix", "--show-fixes"]
     - id: ruff-format
 
 - repo: https://github.com/adamchainz/blacken-docs
-  rev: "1.20.0"
+  rev: "fda77690955e9b63c6687d8806bafd56a526e45f"  # frozen: 1.20.0
   hooks:
     - id: blacken-docs
       additional_dependencies: [black==26.3.1]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.3.0
+    rev: 41e691678310dfd3833f7ab4e180ddb014310356  # frozen: v2.3.0
     # check the oldest and newest supported Pythons
     # except skip python 3.9 for numpy, due to poor typing
     hooks:
@@ -70,16 +70,17 @@ repos:
         args: ["--python-version=3.14"]
 
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.4.3
+    rev: 57b21406f092110c18776e39b0bda50d37c945c8  # frozen: v2.4.3
     hooks:
     - id: codespell
       files: ^.*\.(py|md|rst)$
       args: ["-w", "-L", "hist,gaus"]
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.37.4
+  rev: 6b63472e72e1a91ed8a2f6d483790dfb644fa1d3  # frozen: 0.37.4
   hooks:
     - id: check-readthedocs
       args: ["--verbose"]
     - id: check-github-workflows
       args: ["--verbose"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -320,10 +320,14 @@ flake8-tidy-imports.ban-relative-imports = "all"
 "tests/**" = ["NPY002"]
 "validation/**" = ["T20", "NPY002"]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.pixi.workspace]
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-arm64", { name = "linux-64-cuda", platform = "linux-64", cuda = "12" }]
 requires-pixi = ">=0.71.0"
+exclude-newer = "7d"
 
 [tool.pixi.pypi-dependencies]
 pyhf = { path = ".", editable = true }


### PR DESCRIPTION
## Summary

CI security hardening pass over `.github/` (workflows, dependabot) and the pre-commit/uv/pixi config. No source, lint, or test code changed.

- Fully pinned every GitHub Action to a commit SHA with a version comment (via `actions-up`, `--min-age=7`).
- Froze every pre-commit hook rev to its SHA (via `prek auto-update --freeze --cooldown-days 7`); no hook versions changed, only SHA-pinned.
- Added a `zizmor` pre-commit hook (pedantic persona, scoped to `.github`) plus `.github/zizmor.yml`.
- Fixed everything `zizmor --persona=pedantic` reported:
  - `persist-credentials: false` added to checkout steps that don't need to push.
  - Inline explanatory comments added to all job/workflow `permissions:` entries.
  - `concurrency:` group added to every workflow missing one (`bump-version.yml`, `merged.yml`, `lower-bound-requirements.yml`, `scorecard.yml`).
  - Explicit `name:` added to previously-anonymous jobs.
  - `${{ github.event.* }}` / `${{ steps.*.outputs.* }}` values that were interpolated directly into `run:` shell blocks are now passed through `env:` instead (template-injection): `bump-version.yml`, `docker.yml`, `publish-package.yml`.
  - Fixed an always-true `if:` in `bump-version.yml` (`if: ${{ github.event.inputs.dry_run }} == 'false'` mixed `${{ }}` expansion with a string comparison). Corrected to `if: github.event.inputs.dry_run == 'false'`. **Behavior change**: previously the "Update the Git tag annotation" step ran even during dry runs (it only mutates the local runner's tag, never pushes — the actual `git push` step already gated correctly on `dry_run`), so the practical impact was minimal, but please double check this is the intended fix.
  - Corrected a garbled version comment in `scorecard.yml` (`actions/upload-artifact@043fb46...  # v4.3.7.0.1` — the SHA was already current for `v7.0.1`, only the comment was wrong, presumably left over from an earlier bad update).
- `.github/dependabot.yml`: renamed the `github-actions` group from `actions` to `github-actions`, switched its schedule from weekly to monthly, and added a 7-day cooldown to both update blocks.
- Added `exclude-newer = "7 days"` under `[tool.uv]` and `exclude-newer = "7d"` under `[tool.pixi.workspace]` in `pyproject.toml` so both resolvers skip packages published in the last 7 days.

## Major version changes

- `scorecard.yml`: `actions/checkout` v4.1.1 → v7.0.1, and `github/codeql-action/upload-sarif` v3.30.8 → v4.37.7. Both now match the SHAs already pinned everywhere else in the repo (this workflow appears to not have been kept in sync by dependabot).

## Held-back items (not changed, need a maintainer decision)

- **`docker.yml` build/deploy isolation**: the skill's guidance is to run deploy jobs separately from build jobs (build artifact → upload → separate job downloads → deploys), which `docs.yml` and `publish-package.yml` already do. `docker.yml`'s single `docker` job builds *and* pushes to Docker Hub/GHCR in the same job (with `packages: write` and Docker Hub credentials present for the whole job, including the pre-push test build). Splitting this out safely means restructuring the multi-arch (`linux/amd64,linux/arm64`) buildx push flow around artifact-transferred images or digest/manifest-list assembly, which is easy to get subtly wrong and risks breaking the Docker publishing pipeline. Left as-is; flagging for a dedicated follow-up rather than guessing at a fix.

## zizmor ignores added (`.github/zizmor.yml`)

- `excessive-permissions` on `scorecard.yml:22` (`permissions: read-all`) — this is OSSF Scorecard's own recommended starter-workflow default; the `analysis` job below it already scopes its actual write permissions down to `security-events` and `id-token`.
- `dangerous-triggers` on `semantic-pr-check.yml:9` (`pull_request_target`) — already justified by the in-file comment from #2741: required for `amannn/action-semantic-pull-request` to check fork PR titles, never checks out or executes PR content, permissions restricted to `pull-requests: read`.

## Verification

- `uvx zizmor --persona=pedantic .github` → **no findings** (2 ignored, 6 suppressed, both documented above).
- `prek run --all-files` → **all hooks pass**, including the new `zizmor` hook.
- Every `uses:` in `.github/workflows/` is pinned to a 40-character SHA with a version comment; spot-checked each SHA against the action repo's tags via the GitHub API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automation reliability by pinning workflow tools to immutable versions.
  * Added concurrency controls to reduce redundant or conflicting workflow runs.
  * Strengthened credential handling and dependency update safeguards.
  * Added automated security scanning for workflow configuration.
  * Configured package managers to use recently published dependency versions only.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->