### PR TITLE
ci: Re-pin scorecard.yml actions to release tag commits

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@b9e0990d219a03df7633c93f6f005a8fecbcab22 # v4.1.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.3.7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
@@ -68,6 +68,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@7d9249f5a57288b8a472ddd9cc3ece1921f7dc38 # v3.30.8
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
# Description

Closes https://github.com/scikit-hep/pyhf/pull/2746

* Re-pin actions/checkout to the v7.0.1 release commit. Since 2025-09 (PR 2599) dependabot had been bumping this pin to untagged actions/checkout branch commits (most recently a merge commit on 'main') while the version comment stayed frozen at v4.1.1.
* Correct the actions/upload-artifact version comment to v7.0.1 (the pinned SHA was already the v7.0.1 release commit; the comment had been progressively mangled to v4.3.7.0.1).
* Re-pin github/codeql-action/upload-sarif to the v4.37.7 release commit; dependabot had been bumping it weekly to untagged releases/v3 branch commits with the comment frozen at v3.30.8.
* Root cause: once a SHA pin no longer matches a release tag, dependabot updates to the containing branch's HEAD instead of the latest tag and stops updating version comments.
   - c.f. https://github.com/dependabot/dependabot-core/issues/14716

Assisted-by: ClaudeCode:claude-fable-5

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Re-pin actions/checkout to the v7.0.1 release commit. Since 2025-09
  (PR 2599) dependabot had been bumping this pin to untagged
  actions/checkout branch commits (most recently a merge commit on
  'main') while the version comment stayed frozen at v4.1.1.
* Correct the actions/upload-artifact version comment to v7.0.1 (the
  pinned SHA was already the v7.0.1 release commit; the comment had
  been progressively mangled to v4.3.7.0.1).
* Re-pin github/codeql-action/upload-sarif to the v4.37.7 release
  commit. Dependabot had been bumping it weekly to untagged
  releases/v3 branch commits with the comment frozen at v3.30.8.
* Root cause: once a SHA pin no longer matches a release tag,
  dependabot updates to the containing branch's HEAD instead of the
  latest tag and stops updating version comments.
   - c.f. https://github.com/dependabot/dependabot-core/ Issue 14716
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security workflow action versions to newer pinned releases.
  * Corrected the documented version for artifact uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->