### PR TITLE
revert: Remove filterwarnings ignore for pytest-benchmark

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,6 @@ filterwarnings = [
     "ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",  # papermill
     "ignore:datetime.datetime.utcnow\\(\\) is deprecated:DeprecationWarning",  # papermill
     "ignore:_pytest.python.CallSpec2 has been renamed to CallSpec",  # anyio, c.f. https://github.com/scikit-hep/pyhf/pull/2738
-    "ignore:FileType is deprecated. Simply open files after parsing arguments.:PendingDeprecationWarning",  # pytest-benchmark, c.f. https://github.com/scikit-hep/pyhf/pull/2739
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
# Description

* Remove filterwarnings ignore for pytest-benchmark as the upstream issue was fixed in pytest-benchmark v5.3.0.
   - c.f. https://github.com/ionelmc/pytest-benchmark/releases/tag/v5.3.0
* Reverts PR https://github.com/scikit-hep/pyhf/pull/2739

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove filterwarnings ignore for pytest-benchmark as the upstream issue was
  fixed in pytest-benchmark v5.3.0.
   - c.f. https://github.com/ionelmc/pytest-benchmark/releases/tag/v5.3.0
* Reverts PR https://github.com/scikit-hep/pyhf/pull/2739
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Pytest no longer suppresses the pending deprecation warning related to pytest-benchmark’s `FileType` usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->