### PR TITLE
fix: Return tuple from jax_backend.simple_broadcast for JAX v0.11.1+

### DIFF
--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -365,15 +365,19 @@ class jax_backend:
             ...   pyhf.tensorlib.astensor([1]),
             ...   pyhf.tensorlib.astensor([2, 3, 4]),
             ...   pyhf.tensorlib.astensor([5, 6, 7]))
-            [Array([1., 1., 1.], dtype=float64), Array([2., 3., 4.], dtype=float64), Array([5., 6., 7.], dtype=float64)]
+            (Array([1., 1., 1.], dtype=float64), Array([2., 3., 4.], dtype=float64), Array([5., 6., 7.], dtype=float64))
 
         Args:
             args (Array of Tensors): Sequence of arrays
 
         Returns:
-            list of Tensors: The sequence broadcast together.
+            tuple of Tensors: The sequence broadcast together.
         """
-        return jnp.broadcast_arrays(*args)
+        # jax.numpy.broadcast_arrays returns a list for jax < v0.11.1 and a
+        # tuple for jax >= v0.11.1 (c.f. https://github.com/jax-ml/jax/pull/39802).
+        # Normalize to a tuple to match numpy_backend.simple_broadcast
+        # TODO: Drop once pyhf is Python 3.12+ only
+        return tuple(jnp.broadcast_arrays(*args))
 
     def shape(self, tensor):
         return tensor.shape

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -383,7 +383,7 @@ class numpy_backend(Generic[T]):
             args (Array of Tensors): Sequence of arrays
 
         Returns:
-            list of Tensors: The sequence broadcast together.
+            tuple of Tensors: The sequence broadcast together.
         """
         return np.broadcast_arrays(*args)
 


### PR DESCRIPTION
# Description

* JAX v0.11.1 changed jax.numpy.broadcast_arrays to return a tuple rather than a list to align with NumPy 2.0 and the Array API specification, which broke the simple_broadcast doctest in jax_backend.
   - c.f. https://github.com/jax-ml/jax/pull/39802
* Normalize the return value to a tuple for all supported JAX versions so that the doctest is stable across JAX versions and the JAX backend matches the numpy backend, which has returned a tuple since NumPy 2.0.
* Update the docstrings of both backends to document the tuple return.

Assisted-by: ClaudeCode:claude-fable-5-1

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* JAX v0.11.1 changed jax.numpy.broadcast_arrays to return a tuple rather
  than a list to align with NumPy 2.0 and the Array API specification, which
  broke the simple_broadcast doctest in jax_backend.
   - c.f. https://github.com/jax-ml/jax/ PR 39802
* Normalize the return value to a tuple for all supported JAX versions so that
  the doctest is stable across JAX versions and the JAX backend matches the
  numpy backend, which has returned a tuple since NumPy 2.0.
* Update the docstrings of both backends to document the tuple return.

Assisted-by: ClaudeCode:claude-fable-5-1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized tensor broadcasting results across supported JAX versions, ensuring they consistently return as tuples.
  * Improved compatibility between JAX and NumPy backend behavior.

* **Documentation**
  * Updated broadcasting documentation and examples to accurately describe tuple-based results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->