### PR TITLE
docs: Fetch SciPy intersphinx inventory from static mirror

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,6 +94,13 @@ intersphinx_mapping = get_intersphinx_mapping(
         "jsonpatch",
     }
 )
+# docs.scipy.org is slow and unreliable, so fetch the inventory from the static mirror
+# while keeping link targets pointing at the stable docs.
+# c.f. https://github.com/scipy/docs.scipy.org/issues/102#issuecomment-5547829643
+intersphinx_mapping["scipy"] = (
+    "https://docs.scipy.org/doc/scipy/",
+    "https://static.scipy.org/doc/scipy/objects.inv",
+)
 
 # GitHub repo
 issues_github_path = "scikit-hep/pyhf"


### PR DESCRIPTION
# Description

* docs.scipy.org has been slow and intermittently failing, which breaks intersphinx inventory downloads during docs builds. The SciPy team now mirrors objects.inv at static.scipy.org, but not the rendered HTML. Override the intersphinx-registry entry for scipy to fetch the inventory from the mirror while keeping link targets pointing at the stable docs at docs.scipy.org.
   - c.f. https://github.com/scipy/docs.scipy.org/issues/102#issuecomment-5547829643

Assisted-by: ClaudeCode:claude-fable-5-1

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* docs.scipy.org has been slow and intermittently failing, which breaks
  intersphinx inventory downloads during docs builds. The SciPy team now
  mirrors objects.inv at static.scipy.org, but not the rendered HTML.
  Override the intersphinx-registry entry for scipy to fetch the inventory
  from the mirror while keeping link targets pointing at the stable docs at
  docs.scipy.org.

Assisted-by: ClaudeCode:claude-fable-5-1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated SciPy documentation links to use the stable documentation site.
  - Improved reliability and speed when resolving external SciPy references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->