### PR TITLE
build: Drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v7
@@ -36,11 +36,6 @@ jobs:
       run: |
         python -m pip install uv
         uv pip install --system --upgrade ".[all]" --group test
-
-    # c.f. https://github.com/scikit-hep/pyhf/issues/2653
-    - name: Guard against Python 3.9 pyparsing
-      if: matrix.python-version == '3.9'
-      run: uv pip install --system "pyparsing<3.3.0"
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         include:
           - os: macos-latest
             python-version: '3.14'
@@ -55,11 +55,6 @@ jobs:
       run: |
         python -m pip install uv
         uv pip install --system --upgrade ".[all]" --group test
-
-    # c.f. https://github.com/scikit-hep/pyhf/issues/2653
-    - name: Guard against Python 3.9 pyparsing
-      if: matrix.python-version == '3.9'
-      run: uv pip install --system "pyparsing<3.3.0"
 
     - name: List installed Python packages
       run: python -m pip list

--- a/.github/workflows/lower-bound-requirements.yml
+++ b/.github/workflows/lower-bound-requirements.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # minimum supported Python
-        python-version: ['3.9']
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         include:
           - os: macos-latest
             python-version: '3.14'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,6 @@ repos:
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v2.3.0
     # check the oldest and newest supported Pythons
-    # except skip python 3.9 for numpy, due to poor typing
     hooks:
       - id: mypy
         name: mypy with Python 3.10

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import nox
 
-ALL_PYTHONS = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+ALL_PYTHONS = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
 # Default sessions to run if no session handles are passed
 nox.options.sessions = ["lint", "tests-3.14"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -296,6 +296,7 @@ extend-select = [
 ]
 ignore = [
   "E402",
+  "B905",    # zip() without explicit strict= (revisit)
   "PLC0415", # imports not at top level (revisit)
   "PLR09",   # Too many X (complexity)
   "PLR2004", # Magic value comparison

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "jsonschema>=4.15.0",  # for utils
     "pyyaml>=5.1",  # for parsing CLI equal-delimited options
     # c.f. https://github.com/scikit-hep/pyhf/issues/2593 for excluded v1.16.x versions
-    "scipy>=1.5.4,!=1.16.0,!=1.16.1,!=1.16.2",  # requires numpy, which is required by pyhf
+    "scipy>=1.7.2,!=1.16.0,!=1.16.1,!=1.16.2",  # requires numpy, which is required by pyhf
     "rich>=12.3.0",  # for progress bars
     "numpy>=1.22.0",  # compatible versions controlled through scipy
 ]
@@ -69,7 +69,7 @@ jax = [
     "jaxlib>=0.4.1",  # c.f. PR #2079
 ]
 xmlio = ["uproot>=4.1.1"]  # c.f. PR #1567
-minuit = ["iminuit>=2.7.0"]  # c.f. PR #1895
+minuit = ["iminuit>=2.9.0"]  # first release with Python 3.10 wheels
 contrib = [
     "matplotlib>=3.0.0",
     "requests>=2.22.0",
@@ -335,7 +335,7 @@ click = ">=8.0.0"
 jsonpatch = ">=1.15"
 jsonschema = ">=4.15.0"
 pyyaml = ">=5.1"
-scipy = ">=1.5.4,!=1.16.0,!=1.16.1,!=1.16.2"
+scipy = ">=1.7.2,!=1.16.0,!=1.16.1,!=1.16.2"
 rich = ">=12.3.0"
 numpy = ">=1.22.0"
 
@@ -360,7 +360,7 @@ matplotlib = ">=3.0.0"
 requests = ">=2.22.0"
 
 [tool.pixi.feature.minuit.dependencies]
-iminuit = ">=2.7.0"
+iminuit = ">=2.9.0"
 
 [tool.pixi.feature.test.dependencies]
 pytest = ">=8.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ jax = [
     "jaxlib>=0.4.1",  # c.f. PR #2079
 ]
 xmlio = ["uproot>=4.1.1"]  # c.f. PR #1567
-minuit = ["iminuit>=2.9.0"]  # first release with Python 3.10 wheels
+minuit = ["iminuit>=2.9.0"]  # c.f. PR #2757
 contrib = [
     "matplotlib>=3.0.0",
     "requests>=2.22.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version"]
 description = "pure-Python HistFactory implementation with tensors and autodiff"
 readme = "README.rst"
 license = "Apache-2.0"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "Lukas Heinrich", email = "lukas.heinrich@cern.ch" },
     { name = "Matthew Feickert", email = "matthew.feickert@cern.ch" },
@@ -32,7 +32,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/src/pyhf/events.py
+++ b/src/pyhf/events.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import weakref
+from collections.abc import Callable
 from functools import wraps
-from typing import Callable, TypeVar, cast
+from typing import TypeVar, cast
 
 # See https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators
 TCallable = TypeVar("TCallable", bound=Callable)

--- a/src/pyhf/readxml.py
+++ b/src/pyhf/readxml.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 import logging
 import xml.etree.ElementTree as ET
-from collections.abc import Iterable, MutableMapping, MutableSequence, Sequence
+from collections.abc import (
+    Callable,
+    Iterable,
+    MutableMapping,
+    MutableSequence,
+    Sequence,
+)
 from pathlib import Path
 from typing import (
     IO,
-    Callable,
-    Union,
     cast,
 )
 
@@ -45,7 +49,7 @@ from pyhf.typing import (
 
 log = logging.getLogger(__name__)
 
-FileCacheType = MutableMapping[str, tuple[Union[IO[str], IO[bytes]], set[str]]]
+FileCacheType = MutableMapping[str, tuple[IO[str] | IO[bytes], set[str]]]
 MountPathType = Iterable[tuple[Path, Path]]
 ResolverType = Callable[[str], Path]
 

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping, Sequence
-from typing import Callable, Generic, TypeVar, Union, cast
+from collections.abc import Callable, Mapping, Sequence
+from typing import Generic, TypeVar, Union, cast
 
 import numpy as np
 from numpy.typing import ArrayLike, DTypeLike, NBitBase, NDArray
@@ -200,8 +200,7 @@ class numpy_backend(Generic[T]):
 
     def tolist(self, tensor_in: Tensor[T] | list[T]) -> list[T]:
         try:
-            # unused-ignore for [no-any-return] in python 3.9
-            return tensor_in.tolist()  # type: ignore[union-attr,no-any-return,unused-ignore]
+            return tensor_in.tolist()  # type: ignore[union-attr,no-any-return]
         except AttributeError:
             if isinstance(tensor_in, list):
                 return tensor_in

--- a/src/pyhf/typing.py
+++ b/src/pyhf/typing.py
@@ -6,7 +6,6 @@ from typing import (
     Protocol,
     SupportsIndex,
     TypedDict,
-    Union,
 )
 
 __all__ = (
@@ -33,10 +32,10 @@ __all__ = (
 )
 
 
-PathOrStr = Union[str, os.PathLike[str]]
+PathOrStr = str | os.PathLike[str]
 
 Shape = tuple[int, ...]
-ShapeLike = Union[SupportsIndex, Sequence[SupportsIndex]]
+ShapeLike = SupportsIndex | Sequence[SupportsIndex]
 
 
 class ParameterBase(TypedDict, total=False):
@@ -111,9 +110,9 @@ class LumiSys(TypedDict):
     data: None
 
 
-Modifier = Union[
-    NormSys, NormFactor, HistoSys, StatError, ShapeSys, ShapeFactor, LumiSys
-]
+Modifier = (
+    NormSys | NormFactor | HistoSys | StatError | ShapeSys | ShapeFactor | LumiSys
+)
 
 
 class SampleBase(TypedDict, total=False):

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -156,9 +156,7 @@ def environment_info():
     os_version = "Cannot be determined"
     if sys.platform == "linux":
         try:
-            from platform import freedesktop_os_release
-
-            os_release = freedesktop_os_release()
+            os_release = platform.freedesktop_os_release()
         # ValueError covers UnicodeDecodeError from a non-UTF-8 os-release file
         except (OSError, ValueError):
             pass

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -156,35 +156,8 @@ def environment_info():
     os_version = "Cannot be determined"
     if sys.platform == "linux":
         try:
-            # platform.freedesktop_os_release added in Python 3.10
-            # FIXME: Remove when Python 3.9 support dropped
             from platform import freedesktop_os_release
-        except ImportError:
-            # c.f. https://docs.python.org/3/library/platform.html#platform.freedesktop_os_release
-            from pathlib import Path
 
-            def freedesktop_os_release():
-                # Values may contain "=" and files may contain comment lines
-                # c.f. https://www.freedesktop.org/software/systemd/man/os-release.html
-                for os_release_path in (
-                    Path("/etc/os-release"),
-                    Path("/usr/lib/os-release"),
-                ):
-                    try:
-                        with os_release_path.open(encoding="utf8") as read_file:
-                            return {
-                                key: value.strip("\"'")
-                                for key, _, value in (
-                                    line.strip().partition("=")
-                                    for line in read_file
-                                    if "=" in line and not line.lstrip().startswith("#")
-                                )
-                            }
-                    except OSError:  # noqa: PERF203
-                        continue
-                raise OSError
-
-        try:
             os_release = freedesktop_os_release()
         # ValueError covers UnicodeDecodeError from a non-UTF-8 os-release file
         except (OSError, ValueError):

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,5 +1,5 @@
 # core
-scipy==1.7.2  # first release with Python 3.10 wheels
+scipy==1.7.2  # c.f. PR #2757
 click==8.0.0  # c.f. PR #1958, #1909
 rich==12.3.0  # c.f. PR #2650
 jsonschema==4.15.0  # c.f. PR #1979
@@ -9,7 +9,7 @@ numpy==1.22.0  # c.f. PR #2652
 # xmlio
 uproot==4.1.1
 # minuit
-iminuit==2.9.0  # first release with Python 3.10 wheels
+iminuit==2.9.0  # c.f. PR #2757
 # jax
 # Use Google Cloud Storage buckets for long term wheel support
 # c.f. https://github.com/google/jax/discussions/7608#discussioncomment-1269342

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -1,16 +1,15 @@
 # core
-scipy==1.5.4  # c.f. PR #2469
+scipy==1.7.2  # first release with Python 3.10 wheels
 click==8.0.0  # c.f. PR #1958, #1909
 rich==12.3.0  # c.f. PR #2650
 jsonschema==4.15.0  # c.f. PR #1979
 jsonpatch==1.15
 pyyaml==5.1
-importlib_resources==1.4.0  # c.f. PR #1979
 numpy==1.22.0  # c.f. PR #2652
 # xmlio
 uproot==4.1.1
 # minuit
-iminuit==2.7.0  # c.f. PR #1895
+iminuit==2.9.0  # first release with Python 3.10 wheels
 # jax
 # Use Google Cloud Storage buckets for long term wheel support
 # c.f. https://github.com/google/jax/discussions/7608#discussioncomment-1269342

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,4 @@
 import importlib.metadata
-import io
-import pathlib
 import platform
 import sys
 
@@ -114,51 +112,6 @@ def test_environment_info_linux_oserror(monkeypatch):
     )
     info = pyhf.utils.environment_info()
     assert "* os version: Cannot be determined" in info
-
-
-def test_environment_info_linux_fallback_no_os_release_file(monkeypatch):
-    # Simulate Python 3.9 (no platform.freedesktop_os_release) with no os-release file
-    monkeypatch.setattr(sys, "platform", "linux")
-    monkeypatch.delattr(platform, "freedesktop_os_release", raising=False)
-
-    original_open = pathlib.Path.open
-
-    def mock_open(self, *args, **kwargs):
-        if "os-release" in str(self):
-            raise FileNotFoundError(str(self))
-        return original_open(self, *args, **kwargs)
-
-    monkeypatch.setattr(pathlib.Path, "open", mock_open)
-    info = pyhf.utils.environment_info()
-    assert "* os version: Cannot be determined" in info
-
-
-def test_environment_info_linux_fallback_parses_os_release(monkeypatch):
-    # Simulate Python 3.9 with an os-release file exercising what the spec
-    # permits: comment lines, quoted values, values containing "=", and no
-    # NAME/VERSION so the reported value is PRETTY_NAME, whose embedded "="
-    # pins that values are only split on the first "="
-    monkeypatch.setattr(sys, "platform", "linux")
-    monkeypatch.delattr(platform, "freedesktop_os_release", raising=False)
-
-    os_release_content = (
-        "# This file is part of systemd\n"
-        'PRETTY_NAME="Arch Linux (build=rolling)"\n'
-        "ID=arch\n"
-        'BUG_REPORT_URL="https://bugs.example.org/?product=arch"\n'
-        "\n"
-    )
-
-    original_open = pathlib.Path.open
-
-    def mock_open(self, *args, **kwargs):
-        if "os-release" in str(self):
-            return io.StringIO(os_release_content)
-        return original_open(self, *args, **kwargs)
-
-    monkeypatch.setattr(pathlib.Path, "open", mock_open)
-    info = pyhf.utils.environment_info()
-    assert "* os version: Arch Linux (build=rolling)" in info
 
 
 def test_environment_info_linux_version_id_fallback(monkeypatch):


### PR DESCRIPTION
# Description

* Support Python 3.10+, dropping support for Python 3.9 which is EOL.
* Simplify code by removing components that existed to support pre Python 3.10 features or solutions.
* Remove Python 3.9 trove classifier.
* Remove Python 3.9 from CI/CD workflows.
* Remove the tests for the pre-Python 3.10 `freedesktop_os_release` fallback and call `platform.freedesktop_os_release` directly.
* Ignore ruff rule `B905` (zip without explicit strict=) to be dealt with in a follow up.
* Require `scipy>=1.7.2` and `iminuit>=2.9.0`, the first releases with Python 3.10 wheels, as the previous minimums can not be installed on Python 3.10+.
* Update tests/constraints.txt to match and remove the `importlib_resources pin`, which is no longer a dependency.

Assisted-by: ClaudeCode:claude-fable-5-1

---

```
pixi global install norwegianblue
eol python
```

| cycle |  release   | latest  | latest release |  support   |    eol     |   pep    |
| :-----| :--------: | :-------| :------------: | :--------: | :--------: | :------: |
| 3.14  | 2025-10-07 | 3.14.7  |   2026-08-05   | 2027-10-01 | 2030-10-31 | PEP-0745 |
| 3.13  | 2024-10-07 | 3.13.15 |   2026-08-05   | 2026-10-01 | 2029-10-31 | PEP-0719 |
| 3.12  | 2023-10-02 | 3.12.14 |   2026-08-12   | 2025-04-02 | 2028-10-31 | PEP-0693 |
| 3.11  | 2022-10-24 | 3.11.16 |   2026-08-13   | 2024-04-01 | 2027-10-31 | PEP-0664 |
| 3.10  | 2021-10-04 | 3.10.21 |   2026-08-13   | 2023-04-05 | 2026-10-31 | PEP-0619 |
| 3.9   | 2020-10-05 | 3.9.25  |   2025-10-31   | 2022-05-17 | 2025-10-31 | PEP-0596 |
| 3.8   | 2019-10-14 | 3.8.20  |   2024-09-06   | 2021-05-03 | 2024-10-07 | PEP-0569 |
| 3.7   | 2018-06-27 | 3.7.17  |   2023-06-05   | 2020-06-27 | 2023-06-27 | PEP-0537 |
| 3.6   | 2016-12-23 | 3.6.15  |   2021-09-03   | 2018-12-24 | 2021-12-23 | PEP-0494 |
| 3.5   | 2015-09-13 | 3.5.10  |   2020-09-05   |   False    | 2020-09-30 | PEP-0478 |
| 3.4   | 2014-03-16 | 3.4.10  |   2019-03-18   |   False    | 2019-03-18 | PEP-0429 |
| 3.3   | 2012-09-29 | 3.3.7   |   2017-09-19   |   False    | 2017-09-29 | PEP-0398 |
| 3.2   | 2011-02-20 | 3.2.6   |   2014-10-12   |   False    | 2016-02-20 | PEP-0392 |
| 2.7   | 2010-07-03 | 2.7.18  |   2020-04-19   |   False    | 2020-01-01 | PEP-0373 |
| 3.1   | 2009-06-27 | 3.1.5   |   2012-04-06   |   False    | 2012-04-09 | PEP-0375 |
| 3.0   | 2008-12-03 | 3.0.1   |   2009-02-12   |   False    | 2009-06-27 | PEP-0361 |
| 2.6   | 2008-10-01 | 2.6.9   |   2013-10-29   |   False    | 2013-10-29 | PEP-0361 |



# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Support Python 3.10+, dropping support for Python 3.9.
   - Python 3.9 is EOL as of 2025-10-31.
* Simplify code by removing components that existed to support pre Python 3.10
  features or solutions.
* Remove Python 3.9 trove classifier.
* Remove Python 3.9 from CI/CD workflows.
* Remove the tests for the pre-Python 3.10 freedesktop_os_release fallback and
  call platform.freedesktop_os_release directly.
* Ignore ruff rule B905 (zip without explicit strict=) to be dealt with in a follow up.
* Require scipy>=1.7.2 and iminuit>=2.9.0, the first releases with Python
  3.10 wheels, as the previous minimums can not be installed on Python 3.10+.
* Update tests/constraints.txt to match and remove the importlib_resources pin,
  which is no longer a dependency.

Assisted-by: ClaudeCode:claude-fable-5-1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Python 3.9 is no longer supported; supported versions now start with Python 3.10.
  - Minimum supported SciPy and iminuit versions have been raised.

- **Bug Fixes**
  - Linux environment detection now relies on the platform-provided operating-system release information.

- **Maintenance**
  - Updated release and test coverage to target Python 3.10–3.14.
  - Refreshed dependency constraints and modernized internal type annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->