### PR TITLE
docs: Add llms.txt and Markdown page versions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -243,7 +243,7 @@ pygments_style = "sphinx"
 todo_include_todos = False
 
 
-# -- Options for LLM-friendly output ----------------------------------------
+# Options for LLM-friendly output
 
 # The default is the full README, which is too long for the summary block
 llms_txt_description = (

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,7 @@ extensions = [
     "sphinx_copybutton",
     "xref",
     "jupyterlite_sphinx",
+    "sphinx_llm.txt",
 ]
 bibtex_bibfiles = [
     "bib/docs.bib",
@@ -240,6 +241,16 @@ pygments_style = "sphinx"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
+
+
+# -- Options for LLM-friendly output ----------------------------------------
+
+# The default is the full README, which is too long for the summary block
+llms_txt_description = (
+    "Documentation for pyhf, a pure-Python implementation of the HistFactory"
+    " statistical model for multi-bin histogram-based analysis, with support"
+    " for automatic differentiation and GPU-accelerated computational backends."
+)
 
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
-.. pyhf documentation master file, created by
-   sphinx-quickstart on Fri Feb  9 11:58:49 2018.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root ``toctree`` directive.
+.. meta::
+   :description: pyhf is a pure-Python implementation of the HistFactory
+      statistical model, with support for automatic differentiation and GPU
+      acceleration.
 
 .. toctree::
    :hidden:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -420,6 +420,7 @@ jupyterlite-sphinx = ">=0.13.1"
 jupyterlite-pyodide-kernel = ">=0.0.7"
 jupytext = ">=1.14.0"
 ipython = "!=8.7.0"
+sphinx-llm = ">=1.0.0"
 rsync = ">=3.4.1,<4"
 
 [tool.pixi.feature.docs.tasks.build-docs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ docs = [
     "jupyterlite-pyodide-kernel>=0.0.7",
     "jupytext>=1.14.0",
     "ipython!=8.7.0",  # c.f. https://github.com/scikit-hep/pyhf/pull/2068
+    "sphinx-llm",
 ]
 dev = [
     "pyhf[all]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ docs = [
     "jupyterlite-pyodide-kernel>=0.0.7",
     "jupytext>=1.14.0",
     "ipython!=8.7.0",  # c.f. https://github.com/scikit-hep/pyhf/pull/2068
-    "sphinx-llm",
+    "sphinx-llm>=1.0.0",
 ]
 dev = [
     "pyhf[all]",


### PR DESCRIPTION
# Pull Request Description

Adds LLM-friendly docs output, mirroring https://github.com/scikit-hep/uhi/pull/252. Uses NVIDIA's `sphinx-llm` extension (`sphinx_llm.txt`) alongside the existing HTML build to produce:

- `llms.txt` — a sitemap with a one-line description per page.
- `llms-full.txt` — all docs concatenated into one file.
- A `.md` twin next to each `.html` page.

`llms_txt_description` in `docs/conf.py` overrides the default summary (the full README, which is too long for the summary block). The stale sphinx-quickstart comment in `docs/index.rst` becomes a `.. meta:: :description:` directive, which `llms.txt` uses as the one-line description for the index page.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add LLM-friendly docs output (llms.txt, llms-full.txt, per-page .md twins)
  using sphinx-llm extension.
   - c.f. https://github.com/scikit-hep/uhi/ PR 252
* Add sphinx-llm to 'docs' requirements.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added concise metadata describing pyhf as a pure-Python HistFactory implementation with automatic differentiation and GPU acceleration.
  - Enabled LLM-friendly documentation output with a focused project summary.
  - Improved documentation context for automated tools and readers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->