### PR TITLE
refactor: Remove code kept for Python 3.9 and earlier support

### DIFF
--- a/src/pyhf/contrib/viz/brazil.py
+++ b/src/pyhf/contrib/viz/brazil.py
@@ -25,9 +25,7 @@ def __dir__():
     return __all__
 
 
-# TODO: Once pyhf is Python 3.10+ use slots
-# @dataclass(slots=True)
-@dataclass
+@dataclass(frozen=True, slots=True)
 class BrazilBandCollection:
     r"""
     :obj:`collections.namedtuple` containing the

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Mapping, Sequence
-from typing import Generic, TypeVar, Union, cast
+from typing import Generic, TypeVar, cast
 
 import numpy as np
 from numpy.typing import ArrayLike, DTypeLike, NBitBase, NDArray
@@ -16,7 +16,7 @@ from pyhf.typing import Literal, Shape
 
 T = TypeVar("T", bound=NBitBase)
 
-Tensor = Union["NDArray[np.number[T]]", "NDArray[np.bool_]"]
+Tensor = NDArray[np.number[T]] | NDArray[np.bool_]
 FloatIntOrBool = Literal["float", "int", "bool"]
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Description

* Use a frozen slotted dataclass for pyhf.contrib.viz.brazil.BrazilBandCollection now that Python 3.10+ is required, restoring the fixed field set and immutability of the namedtuple it replaced.
* Use PEP 604 union syntax for the pyhf.tensor.numpy_backend.Tensor type alias in place of typing.Union with string forward references.
   - c.f. https://docs.python.org/3/library/stdtypes.html#types-union

Assisted-by: ClaudeCode:claude-fable-5-1

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use a frozen slotted dataclass for pyhf.contrib.viz.brazil.BrazilBandCollection
  now that Python 3.10+ is required, restoring the fixed field set and
  immutability of the namedtuple it replaced.
* Use PEP 604 union syntax for the pyhf.tensor.numpy_backend.Tensor type alias
  in place of typing.Union with string forward references.
   - c.f. https://docs.python.org/3/library/stdtypes.html#types-union

Assisted-by: ClaudeCode:claude-fable-5-1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Visualization result collections are now immutable, helping prevent accidental changes after creation.
  - Internal data structures use a more memory-efficient representation.

- **Maintenance**
  - Updated numerical type annotations to use modern Python syntax without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->