### PR TITLE
docs: Use Sphinx v9.0+ hyphenated version change directives

### DIFF
--- a/src/pyhf/infer/intervals/__init__.py
+++ b/src/pyhf/infer/intervals/__init__.py
@@ -13,7 +13,7 @@ def upperlimit(
     data, model, scan=None, level=0.05, return_results=False, **hypotest_kwargs
 ):
     """
-    .. deprecated:: 0.7.0
+    .. version-deprecated:: 0.7.0
        Use :func:`~pyhf.infer.intervals.upper_limits.upper_limit` instead.
     .. warning:: :func:`~pyhf.infer.intervals.upperlimit` will be removed in
      ``pyhf`` ``v0.9.0``.

--- a/src/pyhf/infer/intervals/upper_limits.py
+++ b/src/pyhf/infer/intervals/upper_limits.py
@@ -73,7 +73,7 @@ def toms748_scan(
             - Tensor: The observed upper limit on the POI.
             - Tensor: The expected upper limits on the POI.
 
-    .. versionadded:: 0.7.0
+    .. version-added:: 0.7.0
     """
     # When return_tail_probs=True, hypotest inserts (CLsb, CLb) at index 1,
     # shifting the expected band from index 1 to index 2.
@@ -188,7 +188,7 @@ def linear_grid_scan(
               :class:`~pyhf.infer.hypotest` results at each test POI.
               Only returned when ``return_results`` is ``True``.
 
-    .. versionadded:: 0.7.0
+    .. version-added:: 0.7.0
     """
     # When return_tail_probs=True, hypotest inserts (CLsb, CLb) at index 1,
     # shifting the expected band from index 1 to index 2.
@@ -255,7 +255,7 @@ def upper_limit(
               :class:`~pyhf.infer.hypotest` results at each test POI.
               Only returned when ``return_results`` is ``True``.
 
-    .. versionadded:: 0.7.0
+    .. version-added:: 0.7.0
     """
     if scan is not None:
         return linear_grid_scan(

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -367,7 +367,7 @@ class _ModelConfig(_ChannelSummaryMixin):
             >>> model.config.par_names
             ['mu', 'uncorr_bkguncrt[0]', 'uncorr_bkguncrt[1]']
 
-        .. versionchanged:: 0.7.0 Changed from method to property attribute.
+        .. version-changed:: 0.7.0 Changed from method to property attribute.
         """
         _names = []
         for name in self.par_order:

--- a/src/pyhf/simplemodels.py
+++ b/src/pyhf/simplemodels.py
@@ -33,7 +33,7 @@ def correlated_background(
     Returns:
         ~pyhf.pdf.Model: The statistical model adhering to the :obj:`model.json` schema.
 
-    .. versionchanged:: 0.8.0 Added ``poi_name`` argument.
+    .. version-changed:: 0.8.0 Added ``poi_name`` argument.
 
     Example:
         >>> import pyhf
@@ -124,7 +124,7 @@ def uncorrelated_background(
     Returns:
         ~pyhf.pdf.Model: The statistical model adhering to the :obj:`model.json` schema
 
-    .. versionchanged:: 0.8.0 Added ``poi_name`` argument.
+    .. version-changed:: 0.8.0 Added ``poi_name`` argument.
     """
     spec = {
         "channels": [

--- a/src/pyhf/tensor/jax_backend.py
+++ b/src/pyhf/tensor/jax_backend.py
@@ -327,7 +327,7 @@ class jax_backend:
         Returns:
             JAX ndarray: The value of the :math:`q`-th percentile of the tensor along the specified axis.
 
-        .. versionadded:: 0.7.0
+        .. version-added:: 0.7.0
         .. version-changed:: 0.8.0
            Argument renamed from *interpolation* to *method* to align with NumPy and JAX.
         """
@@ -633,6 +633,6 @@ class jax_backend:
         Returns:
             JAX ndarray: The transpose of the input tensor.
 
-        .. versionadded:: 0.7.0
+        .. version-added:: 0.7.0
         """
         return tensor_in.transpose()

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -336,7 +336,7 @@ class numpy_backend(Generic[T]):
         Returns:
             NumPy ndarray: The value of the :math:`q`-th percentile of the tensor along the specified axis.
 
-        .. versionadded:: 0.7.0
+        .. version-added:: 0.7.0
         .. version-changed:: 0.8.0
            Argument renamed from *interpolation* to *method* to align with NumPy.
         """
@@ -640,7 +640,7 @@ class numpy_backend(Generic[T]):
         Returns:
             :class:`numpy.ndarray`: The transpose of the input tensor.
 
-        .. versionadded:: 0.7.0
+        .. version-added:: 0.7.0
         """
         # TODO: Casting needed for Python 3.10 mypy but not Python 3.13+?
         return cast("ArrayLike", tensor_in.transpose())


### PR DESCRIPTION
# Description

* Use the version-added, version-changed, and version-deprecated directive names in docstrings, which Sphinx v9.0 introduced as the primary names for the versionadded, versionchanged, and deprecated directives.
   - c.f. https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#describing-changes-between-versions
* The docs dependency group and Pixi docs feature already require sphinx>=9.0.3.

Assisted-by: ClaudeCode:claude-fable-5-1

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use the version-added, version-changed, and version-deprecated directive
  names in docstrings, which Sphinx v9.0 introduced as the primary names for
  the versionadded, versionchanged, and deprecated directives.
   - c.f. https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#describing-changes-between-versions

Assisted-by: ClaudeCode:claude-fable-5-1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected Sphinx version-history directives throughout the API documentation.
  - Improved rendering and consistency of deprecation, addition, and change notices.
  - No changes to functionality, public APIs, or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->