### PR TITLE
fix: Restore poi_test keyword argument for AsymptoticCalculator.distributions

### DIFF
--- a/docs/examples/notebooks/binderexample/StatisticalAnalysis.ipynb
+++ b/docs/examples/notebooks/binderexample/StatisticalAnalysis.ipynb
@@ -206,7 +206,7 @@
     "    )\n",
     "\n",
     "\n",
-    "def animate(_ax=None, fig=None, **par_settings):\n",
+    "def animate(ax=None, fig=None, **par_settings):  # noqa: ARG001\n",
     "    global animate_plot_pieces\n",
     "    items, _ = animate_plot_pieces\n",
     "    pars = pyhf.tensorlib.astensor(pdf.config.suggested_init())\n",

--- a/src/pyhf/infer/calculators.py
+++ b/src/pyhf/infer/calculators.py
@@ -298,7 +298,7 @@ class AsymptoticCalculator:
         self.sqrtqmuA_v = None
         self.fitted_pars = None
 
-    def distributions(self, _poi_test):
+    def distributions(self, poi_test):  # noqa: ARG002
         r"""
         Probability distributions of the test statistic, as defined in
         :math:`\S` 3 of :xref:`arXiv:1007.1727` under the Wald approximation,

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -513,6 +513,21 @@ def test_calculator_distributions_without_teststatistic(test_stat):
         calc.distributions(1.0)
 
 
+@pytest.mark.parametrize("calculator", ["AsymptoticCalculator", "ToyCalculator"])
+def test_calculator_distributions_poi_test_keyword(calculator):
+    # Regression test for PR #2688: ``poi_test`` must stay a public keyword
+    model = pyhf.simplemodels.uncorrelated_background(
+        signal=[12.0, 11.0], bkg=[50.0, 52.0], bkg_uncertainty=[3.0, 7.0]
+    )
+    data = [51, 48] + model.config.auxdata
+    kwargs = {"ntoys": 10} if calculator == "ToyCalculator" else {}
+    calc = getattr(pyhf.infer.calculators, calculator)(data, model, **kwargs)
+    calc.teststatistic(poi_test=1.0)
+    sig_plus_bkg_dist, bkg_dist = calc.distributions(poi_test=1.0)
+    assert sig_plus_bkg_dist is not None
+    assert bkg_dist is not None
+
+
 @pytest.mark.parametrize(
     ("nsigma", "expected_pval"),
     [


### PR DESCRIPTION
# Description

PR https://github.com/scikit-hep/pyhf/pull/2688 renamed the poi_test parameter of `AsymptoticCalculator.distributions` to `_poi_test` to satisfy Ruff ARG002, which broke callers passing it by keyword (e.g. `docs/examples/notebooks/learn/UsingCalculators.ipynb`) and made the signature inconsistent with `ToyCalculator.distributions` and the docstring. Restore the public name and suppress the lint inline, and add a regression test that calls `distributions(poi_test=...)` on both calculators.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* PR 2688 renamed the poi_test parameter of AsymptoticCalculator.distributions
  to _poi_test to satisfy Ruff ARG002, which broke callers passing it by
  keyword (e.g. docs/examples/notebooks/learn/UsingCalculators.ipynb) and made
  the signature inconsistent with ToyCalculator.distributions and the
  docstring. Restore the public name and suppress the lint inline.
   - Amends PR https://github.com/scikit-hep/pyhf/pull/2688
* Add a regression test that calls distributions(poi_test=...) on both calculators.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved support for the `poi_test` keyword when calculating test statistics and distributions.
  - Added regression coverage to ensure this keyword continues to work across supported calculator types.

- **Maintenance**
  - Improved parameter naming consistency and lint compliance in statistical analysis examples and calculation workflows.
  - No changes to calculation results or other user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->