### PR TITLE
docs: Document BrazilBandCollection as frozen dataclass

### DIFF
--- a/src/pyhf/contrib/viz/brazil.py
+++ b/src/pyhf/contrib/viz/brazil.py
@@ -28,7 +28,7 @@ def __dir__():
 @dataclass(frozen=True, slots=True)
 class BrazilBandCollection:
     r"""
-    :obj:`collections.namedtuple` containing the
+    Frozen :func:`~dataclasses.dataclass` containing the
     :class:`matplotlib.artist.Artist` objects of the
     "Brazil Band" and the observed :math:`\mathrm{CL}_{s+b}` and
     :math:`\mathrm{CL}_{b}` --- the components of the


### PR DESCRIPTION
# Description

* Update the BrazilBandCollection docstring to note that it is a frozen dataclass, and no longer a collections.namedtuple.
   - Amends PR https://github.com/scikit-hep/pyhf/pull/2761

Assisted-by: ClaudeCode:claude-fable-5-1

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update the BrazilBandCollection docstring to note that it is a
  frozen dataclass, and no longer a collections.namedtuple.
   - Amends PR https://github.com/scikit-hep/pyhf/pull/2761

Assisted-by: ClaudeCode:claude-fable-5-1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `BrazilBandCollection` documentation to accurately describe its implementation as a frozen dataclass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->