### PR TITLE
docs: Declutter start of README and add conda-forge information

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -281,7 +281,7 @@ or to install it with ``conda`` run
 
    conda install --channel conda-forge pyhf
 
-The conda-forge package does not provide the additional backends as extras, so install the backend packages (e.g. ``jax`` or ``pytorch``) from conda-forge alongside ``pyhf`` as needed.
+The conda-forge package does not provide the additional backends as extras, so install the backend packages (e.g. ``jax``) from conda-forge alongside ``pyhf`` as needed.
 
 Docker
 ~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -6,16 +6,7 @@
 pure-python fitting/limit-setting/interval estimation HistFactory-style
 =======================================================================
 
-|GitHub Project| |DOI| |JOSS DOI| |Scikit-HEP| |NSF Award Number IRIS-HEP v1| |NSF Award Number IRIS-HEP v2| |NumFOCUS Affiliated Project|
-
-|Docs from latest| |Docs from main| |Jupyter Book tutorial| |Binder|
-
-|PyPI version| |Conda-forge version| |Supported Python versions| |Docker Hub pyhf| |Docker Hub pyhf CUDA|
-
-|Code Coverage| |CodeFactor| |pre-commit.ci Status| |Code style: ruff|
-
-|GitHub Actions Status: CI| |GitHub Actions Status: Docs| |GitHub Actions Status: Publish|
-|GitHub Actions Status: Docker|
+|PyPI version| |Conda-forge version| |Supported Python versions| |DOI| |JOSS DOI|
 
 The HistFactory p.d.f. template
 [`CERN-OPEN-2012-016 <https://cds.cern.ch/record/1456844>`__] is per-se
@@ -270,10 +261,15 @@ To uninstall run
 
    python -m pip uninstall pyhf
 
+Docker images with ``pyhf`` preinstalled are also published to Docker Hub:
+|Docker Hub pyhf| |Docker Hub pyhf CUDA|
+
 Documentation
 -------------
 
 For model specification, API reference, examples, and answers to FAQs visit the |pyhf documentation|_.
+
+|Docs from latest| |Docs from main| |Jupyter Book tutorial| |Binder|
 
 .. |pyhf documentation| replace:: ``pyhf`` documentation
 .. _pyhf documentation: https://pyhf.readthedocs.io/
@@ -351,8 +347,8 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
 
 ``pyhf`` is a `NumFOCUS Affiliated Project <https://numfocus.org/sponsored-projects/affiliated-projects>`__.
 
-.. |GitHub Project| image:: https://img.shields.io/badge/GitHub--blue?style=social&logo=GitHub
-   :target: https://github.com/scikit-hep/pyhf
+|Scikit-HEP| |NSF Award Number IRIS-HEP v1| |NSF Award Number IRIS-HEP v2| |NumFOCUS Affiliated Project|
+
 .. |DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1169739.svg
    :target: https://doi.org/10.5281/zenodo.1169739
 .. |JOSS DOI| image:: https://joss.theoj.org/papers/10.21105/joss.02823/status.svg
@@ -384,22 +380,3 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
    :target: https://hub.docker.com/r/pyhf/pyhf/tags
 .. |Docker Hub pyhf CUDA| image:: https://img.shields.io/badge/pyhf-CUDA-blue?logo=Docker
    :target: https://hub.docker.com/r/pyhf/cuda/tags
-
-.. |Code Coverage| image:: https://codecov.io/gh/scikit-hep/pyhf/graph/badge.svg?branch=main
-   :target: https://codecov.io/gh/scikit-hep/pyhf?branch=main
-.. |CodeFactor| image:: https://www.codefactor.io/repository/github/scikit-hep/pyhf/badge
-   :target: https://www.codefactor.io/repository/github/scikit-hep/pyhf
-.. |pre-commit.ci Status| image:: https://results.pre-commit.ci/badge/github/scikit-hep/pyhf/main.svg
-  :target: https://results.pre-commit.ci/latest/github/scikit-hep/pyhf/main
-  :alt: pre-commit.ci status
-.. |Code style: ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
-   :target: https://github.com/astral-sh/ruff
-
-.. |GitHub Actions Status: CI| image:: https://github.com/scikit-hep/pyhf/actions/workflows/ci.yml/badge.svg
-   :target: https://github.com/scikit-hep/pyhf/actions/workflows/ci.yml?query=branch%3Amain
-.. |GitHub Actions Status: Docs| image:: https://github.com/scikit-hep/pyhf/actions/workflows/docs.yml/badge.svg
-   :target: https://github.com/scikit-hep/pyhf/actions/workflows/docs.yml?query=branch%3Amain
-.. |GitHub Actions Status: Publish| image:: https://github.com/scikit-hep/pyhf/actions/workflows/publish-package.yml/badge.svg
-   :target: https://github.com/scikit-hep/pyhf/actions/workflows/publish-package.yml?query=branch%3Amain
-.. |GitHub Actions Status: Docker| image:: https://github.com/scikit-hep/pyhf/actions/workflows/docker.yml/badge.svg
-   :target: https://github.com/scikit-hep/pyhf/actions/workflows/docker.yml?query=branch%3Amain

--- a/README.rst
+++ b/README.rst
@@ -269,7 +269,13 @@ To uninstall run
 conda-forge
 ~~~~~~~~~~~
 
-To install ``pyhf`` from conda-forge with the NumPy backend run
+To add ``pyhf`` from conda-forge with the NumPy backend to a `Pixi <https://pixi.sh/>`__ project run
+
+.. code:: bash
+
+   pixi add pyhf
+
+or to install it with ``conda`` run
 
 .. code:: bash
 
@@ -281,7 +287,7 @@ Docker
 ~~~~~~
 
 Docker images with ``pyhf`` preinstalled are also published to Docker Hub:
-|Docker Hub pyhf| |Docker Hub pyhf CUDA|
+|Docker Hub pyhf|
 
 Documentation
 -------------
@@ -397,5 +403,3 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
    :target: https://pypi.org/project/pyhf/
 .. |Docker Hub pyhf| image:: https://img.shields.io/badge/pyhf-v0.7.6-blue?logo=Docker
    :target: https://hub.docker.com/r/pyhf/pyhf/tags
-.. |Docker Hub pyhf CUDA| image:: https://img.shields.io/badge/pyhf-CUDA-blue?logo=Docker
-   :target: https://hub.docker.com/r/pyhf/cuda/tags

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@
 pure-python fitting/limit-setting/interval estimation HistFactory-style
 =======================================================================
 
-|PyPI version| |Conda-forge version| |Supported Python versions| |DOI| |JOSS DOI|
+|Scikit-HEP| |PyPI version| |Conda-forge version| |Supported Python versions| |DOI| |JOSS DOI|
 
 The HistFactory p.d.f. template
 [`CERN-OPEN-2012-016 <https://cds.cern.ch/record/1456844>`__] is per-se
@@ -241,6 +241,11 @@ A two bin example
 Installation
 ------------
 
+``pyhf`` is distributed on both `PyPI <https://pypi.org/project/pyhf/>`__ and `conda-forge <https://prefix.dev/channels/conda-forge/packages/pyhf>`__.
+
+PyPI
+~~~~
+
 To install ``pyhf`` from PyPI with the NumPy backend run
 
 .. code:: bash
@@ -260,6 +265,20 @@ To uninstall run
 .. code:: bash
 
    python -m pip uninstall pyhf
+
+conda-forge
+~~~~~~~~~~~
+
+To install ``pyhf`` from conda-forge with the NumPy backend run
+
+.. code:: bash
+
+   conda install --channel conda-forge pyhf
+
+The conda-forge package does not provide the additional backends as extras, so install the backend packages (e.g. ``jax`` or ``pytorch``) from conda-forge alongside ``pyhf`` as needed.
+
+Docker
+~~~~~~
 
 Docker images with ``pyhf`` preinstalled are also published to Docker Hub:
 |Docker Hub pyhf| |Docker Hub pyhf CUDA|
@@ -347,7 +366,7 @@ and grant `OAC-1450377 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=1450377
 
 ``pyhf`` is a `NumFOCUS Affiliated Project <https://numfocus.org/sponsored-projects/affiliated-projects>`__.
 
-|Scikit-HEP| |NSF Award Number IRIS-HEP v1| |NSF Award Number IRIS-HEP v2| |NumFOCUS Affiliated Project|
+|NSF Award Number IRIS-HEP v1| |NSF Award Number IRIS-HEP v2| |NumFOCUS Affiliated Project|
 
 .. |DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1169739.svg
    :target: https://doi.org/10.5281/zenodo.1169739

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@
 pure-python fitting/limit-setting/interval estimation HistFactory-style
 =======================================================================
 
-|Scikit-HEP| |PyPI version| |Conda-forge version| |Supported Python versions| |DOI| |JOSS DOI|
+|PyPI version| |Conda-forge version| |Supported Python versions| |DOI| |JOSS DOI| |Scikit-HEP|
 
 The HistFactory p.d.f. template
 [`CERN-OPEN-2012-016 <https://cds.cern.ch/record/1456844>`__] is per-se

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -2,6 +2,13 @@
 Developing
 ==========
 
+Project Status
+--------------
+
+|GitHub Project| |GitHub Actions Status: CI| |GitHub Actions Status: Docs| |GitHub Actions Status: Publish| |GitHub Actions Status: Docker|
+
+|Code Coverage| |CodeFactor| |pre-commit.ci Status| |Code style: ruff|
+
 Developer Environment
 ---------------------
 
@@ -348,3 +355,24 @@ the dev team (probably every release).
 .. _Tag release: https://github.com/scikit-hep/pyhf/actions/workflows/release-tag.yml
 .. _PyPI: https://pypi.org/project/pyhf/
 .. _TestPyPI: https://test.pypi.org/project/pyhf/
+
+.. |GitHub Project| image:: https://img.shields.io/badge/GitHub--blue?style=social&logo=GitHub
+   :target: https://github.com/scikit-hep/pyhf
+.. |Code Coverage| image:: https://codecov.io/gh/scikit-hep/pyhf/graph/badge.svg?branch=main
+   :target: https://codecov.io/gh/scikit-hep/pyhf?branch=main
+.. |CodeFactor| image:: https://www.codefactor.io/repository/github/scikit-hep/pyhf/badge
+   :target: https://www.codefactor.io/repository/github/scikit-hep/pyhf
+.. |pre-commit.ci Status| image:: https://results.pre-commit.ci/badge/github/scikit-hep/pyhf/main.svg
+  :target: https://results.pre-commit.ci/latest/github/scikit-hep/pyhf/main
+  :alt: pre-commit.ci status
+.. |Code style: ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
+   :target: https://github.com/astral-sh/ruff
+
+.. |GitHub Actions Status: CI| image:: https://github.com/scikit-hep/pyhf/actions/workflows/ci.yml/badge.svg
+   :target: https://github.com/scikit-hep/pyhf/actions/workflows/ci.yml?query=branch%3Amain
+.. |GitHub Actions Status: Docs| image:: https://github.com/scikit-hep/pyhf/actions/workflows/docs.yml/badge.svg
+   :target: https://github.com/scikit-hep/pyhf/actions/workflows/docs.yml?query=branch%3Amain
+.. |GitHub Actions Status: Publish| image:: https://github.com/scikit-hep/pyhf/actions/workflows/publish-package.yml/badge.svg
+   :target: https://github.com/scikit-hep/pyhf/actions/workflows/publish-package.yml?query=branch%3Amain
+.. |GitHub Actions Status: Docker| image:: https://github.com/scikit-hep/pyhf/actions/workflows/docker.yml/badge.svg
+   :target: https://github.com/scikit-hep/pyhf/actions/workflows/docker.yml?query=branch%3Amain

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -56,6 +56,14 @@ Install latest stable release from `conda-forge <https://prefix.dev/channels/con
 ... with NumPy backend
 ++++++++++++++++++++++
 
+Using `Pixi <https://pixi.sh/>`__
+
+.. code-block:: console
+
+    pixi add pyhf
+
+or using :code:`conda`
+
 .. code-block:: console
 
     conda install --channel conda-forge pyhf
@@ -65,6 +73,12 @@ Install latest stable release from `conda-forge <https://prefix.dev/channels/con
 
 The conda-forge package does not provide the additional backends as extras, so install
 the backend packages from conda-forge alongside :code:`pyhf`. For example, for the JAX backend
+
+.. code-block:: console
+
+    pixi add pyhf jax
+
+or
 
 .. code-block:: console
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -50,6 +50,27 @@ Install latest stable release from `PyPI <https://pypi.org/project/pyhf/>`__...
     python -m pip install 'pyhf[xmlio]'
 
 
+Install latest stable release from `conda-forge <https://prefix.dev/channels/conda-forge/packages/pyhf>`__...
+-------------------------------------------------------------------------------------------------------------
+
+... with NumPy backend
+++++++++++++++++++++++
+
+.. code-block:: console
+
+    conda install --channel conda-forge pyhf
+
+... with additional backends
+++++++++++++++++++++++++++++
+
+The conda-forge package does not provide the additional backends as extras, so install
+the backend packages from conda-forge alongside :code:`pyhf`. For example, for the JAX backend
+
+.. code-block:: console
+
+    conda install --channel conda-forge pyhf jax
+
+
 Install latest development version from `GitHub <https://github.com/scikit-hep/pyhf>`__...
 ------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
# Description

* Declutter the README by moving informational badges to relevant sections in the README and in the development docs.
   - Move Docker badge to Docker install subsection.
   - Move docs versions and user guide page badges to documentation section.
   - Move funding and NumFOCUS affiliated badges to acknowledgements section.
* Add install information for conda-forge.

Assisted-by: ClaudeCode:claude-fable-5-1

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR


```
* Declutter the README by moving informational badges to relevant
  sections in the README and in the development docs.
   - Move Docker badge to Docker install subsection.
   - Move docs versions and user guide page badges to documentation
     section.
   - Move funding and NumFOCUS affiliated badges to acknowledgements
     section.
* Add install information for conda-forge.

Assisted-by: ClaudeCode:claude-fable-5-1
```

# Summary by CodeRabbit

* Documentation
   - Expanded installation guidance with conda-forge options using Pixi and conda, including additional backend setup.
   - Added Docker installation instructions.
   - Reorganized README badges and moved the Documentation section.
   - Added project status, build, coverage, and code quality badges to the development documentation.